### PR TITLE
fix(AWS IAM): Support for CF functions for `provider.iam.role`

### DIFF
--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -149,6 +149,7 @@ provider:
       Fn::GetAtt:
         - myRole
         - Arn
+    role: !Sub arn:aws:iam::${AWS::AccountId}:role/roleInMyAccount
 
 functions:
   func0: # will assume 'myDefaultRole'

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -86,7 +86,7 @@ class AwsCompileFunctions {
       compiledFunction.Properties.Role = role;
       compiledFunction.DependsOn = (compiledFunction.DependsOn || []).concat(role['Fn::GetAtt'][0]);
     } else {
-      // role is an "Fn::ImportValue" object
+      // role is an "Fn::ImportValue" or "Fn::Sub" object
       compiledFunction.Properties.Role = role;
     }
   }

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -39,8 +39,8 @@ module.exports = {
 
     const iamRole = _.get(this.serverless.service.provider.iam, 'role', {});
 
-    // resolve early if provider level role is provided
-    if (typeof iamRole === 'string') {
+    // resolve early if provider level role is provided as a reference to existing role
+    if (this.provider.isExistingRoleProvided(iamRole)) {
       return;
     }
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -456,6 +456,7 @@ class AwsProvider {
           awsLambdaRole: {
             anyOf: [
               { type: 'string', minLength: 1 },
+              { $ref: '#/definitions/awsCfSub' },
               { $ref: '#/definitions/awsCfImport' },
               { $ref: '#/definitions/awsCfGetAtt' },
             ],
@@ -1508,13 +1509,22 @@ class AwsProvider {
     return _.get(provider, 'iam.deploymentRole', provider.cfnRole);
   }
 
+  // Check if role is provided as a string or a CF function reference to existing role
+  isExistingRoleProvided(role) {
+    return (
+      typeof role === 'string' ||
+      (_.isObject(role) && Object.keys(role).some((key) => key.includes('::')))
+    );
+  }
+
   getCustomExecutionRole(functionObj) {
     const { provider } = this.serverless.service;
 
     if (functionObj.role) return functionObj.role;
 
     const role = _.get(provider, 'iam.role');
-    if (typeof role === 'string') return role;
+
+    if (this.isExistingRoleProvided(role)) return role;
 
     return provider.role;
   }

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -366,6 +366,24 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         const iamResource = cfResources[IamRoleLambdaExecution];
         expect(iamResource.Properties.Tags).to.eql([{ Key: 'sweet', Value: 'potato' }]);
       });
+
+      it('should not create default role when `provider.iam.role` defined with CF intrinsic functions', async () => {
+        const { cfTemplate, awsNaming } = await runServerless({
+          fixture: 'function',
+          cliArgs: ['package'],
+          configExt: {
+            provider: {
+              iam: {
+                role: {
+                  'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:role/someRole',
+                },
+              },
+            },
+          },
+        });
+
+        expect(cfTemplate.Resources[awsNaming.getRoleLogicalId()]).to.be.undefined;
+      });
     });
 
     describe('Function properties', () => {


### PR DESCRIPTION
When checking out the issue report I've discovered that support for CF functions is broken for `provider.iam.role` and we're silently creating default role that is used by functions. 

Closes: #9199 