### PR TITLE
Minor patches to CLI & Variables refactor

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -166,7 +166,9 @@ class Serverless {
     this.pluginManager.setCliOptions(this.processedInput.options);
     this.pluginManager.setCliCommands(this.processedInput.commands);
 
+    // TODO: Remove with next major
     await this.loadEnvVariables();
+
     await this.service.load(this.processedInput.options);
     // load all plugins
     await this.pluginManager.loadAllPlugins(this.service.plugins);

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -212,7 +212,7 @@ class Serverless {
       configuration: this.configurationInput,
       isConfigurationResolved: this.isConfigurationInputResolved,
       hasResolvedCommandsExternally: this.hasResolvedCommandsExternally,
-      commands: this.processedInput.commmands,
+      commands: this.processedInput.commands,
       options: this.processedInput.options,
       _isInvokedByGlobalInstallation: true,
     });

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -516,7 +516,10 @@ const processSpanPromise = (async () => {
         }
 
         await resolveVariables(resolverConfiguration);
-        if (!variablesMeta.size) return;
+        if (!variablesMeta.size) {
+          serverless.isConfigurationInputResolved = true;
+          return;
+        }
         if (
           eventuallyReportVariableResolutionErrors(configurationPath, configuration, variablesMeta)
         ) {


### PR DESCRIPTION
- Ensure that `commands` are passed to local installation (due to typo they weren't it - it wasn't breaking as then internal logic attempts to resolve commands on they're own, but that's definitive logic leak
- Ensure to not trigger old variables resolver when all variables are resolved with new resolver (forgot to add that when registering revolvers for final sources) - More optimization, than actual fix
