### PR TITLE
Documentation: Add note on support of AWS CF specific variables

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -682,3 +682,12 @@ ${strToBool(2)} => Error
 ${strToBool(null)} => Error
 ${strToBool(anything)} => Error
 ```
+
+## AWS CloudFormation Pseudo Parameters and Intrinsic functions
+
+[AWS Pseudo Parameters](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html)
+can be used in values which are passed through as is to CloudFormation template properties.
+
+Otherwise Serverless Framework has no implied understanding of them and does not try to resolve them on its own.
+
+Same handling applies to [CloudFormation Intrinsic functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)


### PR DESCRIPTION
We've recent changes I removed note on AWS pseudo parameters from our variables doc (as resolution of them is not part of our Variables resolver).

Still it appeared to be confusing: https://github.com/serverless/serverless/commit/7e8c202dd02bb641ecde5ffea5ee9bfeeef69720#r48982426

With this update, I bring back notice, that we allow to use them, still there's no implied resolution mechanism on Framework side for them.


