### PR TITLE
feat(AWS ALB): Make it possible to specify the TargetGroup name

### DIFF
--- a/docs/providers/aws/events/alb.md
+++ b/docs/providers/aws/events/alb.md
@@ -196,6 +196,29 @@ functions:
             path: /hello
 ```
 
+## Specifying explicitly the target group names
+
+If you want full control over the name used for the target group you can specify it using the `targetGroupName` property. Note that the name must be unique accross the entire region and is limited to 32 characters.
+
+When used in conjunction with the `provider.alb.targetGroupPrefix` setting, the prefix will be used. You should also make sure that the total string length is below 32 characters.
+
+```yml
+provider:
+  alb:
+    targetGroupPrefix: my-prefix
+
+functions:
+  albEventConsumer:
+    handler: handler.hello
+    events:
+      - alb:
+          listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/
+          priority: 1
+          targetGroupName: helloTargetGroup
+          conditions:
+            path: /hello
+```
+
 ## Configuring Health Checks
 
 Health checks for target groups with a _lambda_ target type are disabled by default.

--- a/docs/providers/aws/events/alb.md
+++ b/docs/providers/aws/events/alb.md
@@ -198,15 +198,11 @@ functions:
 
 ## Specifying explicitly the target group names
 
-If you want full control over the name used for the target group you can specify it using the `targetGroupName` property. Note that the name must be unique accross the entire region and is limited to 32 characters.
+If you want full control over the name used for the target group you can specify it using the `targetGroupName` property. Note that the name must be unique accross the entire region and is limited to 32 characters with only alphanumerics and hyphens allowed.
 
-When used in conjunction with the `provider.alb.targetGroupPrefix` setting, the prefix will be used. You should also make sure that the total string length is below 32 characters.
+This setting is exclusive with the `provider.alb.targetGroupPrefix` setting.
 
 ```yml
-provider:
-  alb:
-    targetGroupPrefix: my-prefix
-
 functions:
   albEventConsumer:
     handler: handler.hello

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -487,6 +487,7 @@ functions:
       - alb:
           listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/
           priority: 1
+          targetGroupName: helloTargetGroup # optional
           conditions:
             host: example.com
             path: /hello

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -448,11 +448,7 @@ module.exports = {
       multiValueHeaders ? 'multi-value-' : ''
     }${this.provider.getStage()}`;
   },
-  getAlbTargetGroupName(targetGroupName, functionName, albId, multiValueHeaders) {
-    if (targetGroupName) {
-      return this.provider.getAlbTargetGroupPrefix() + targetGroupName;
-    }
-
+  generateAlbTargetGroupName(functionName, albId, multiValueHeaders) {
     const hash = crypto
       .createHash('md5')
       .update(this.getAlbTargetGroupNameTagValue(functionName, albId, multiValueHeaders))

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -448,7 +448,11 @@ module.exports = {
       multiValueHeaders ? 'multi-value-' : ''
     }${this.provider.getStage()}`;
   },
-  getAlbTargetGroupName(functionName, albId, multiValueHeaders) {
+  getAlbTargetGroupName(targetGroupName, functionName, albId, multiValueHeaders) {
+    if (targetGroupName) {
+      return this.provider.getAlbTargetGroupPrefix() + targetGroupName;
+    }
+
     const hash = crypto
       .createHash('md5')
       .update(this.getAlbTargetGroupNameTagValue(functionName, albId, multiValueHeaders))

--- a/lib/plugins/aws/package/compile/events/alb/index.js
+++ b/lib/plugins/aws/package/compile/events/alb/index.js
@@ -101,7 +101,12 @@ class AwsCompileAlbEvents {
         },
         multiValueHeaders: { type: 'boolean' },
         priority: { type: 'integer', minimum: 1, maximum: 50000 },
-        targetGroupName: { type: 'string', minLength: 1, maxLength: 32 },
+        targetGroupName: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 32,
+          pattern: '^[a-zA-Z0-9-]+$',
+        },
       },
       required: ['listenerArn', 'priority', 'conditions'],
       additionalProperties: false,

--- a/lib/plugins/aws/package/compile/events/alb/index.js
+++ b/lib/plugins/aws/package/compile/events/alb/index.js
@@ -101,6 +101,7 @@ class AwsCompileAlbEvents {
         },
         multiValueHeaders: { type: 'boolean' },
         priority: { type: 'integer', minimum: 1, maximum: 50000 },
+        targetGroupName: { type: 'string', minLength: 1, maxLength: 32 },
       },
       required: ['listenerArn', 'priority', 'conditions'],
       additionalProperties: false,

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
@@ -15,7 +15,13 @@ const healthCheckDefaults = {
 module.exports = {
   compileTargetGroups() {
     this.validated.events.forEach((event) => {
-      const { functionName, albId, multiValueHeaders = false, healthCheck } = event;
+      const {
+        functionName,
+        albId,
+        multiValueHeaders = false,
+        healthCheck,
+        targetGroupName,
+      } = event;
 
       const targetGroupLogicalId = this.provider.naming.getAlbTargetGroupLogicalId(
         functionName,
@@ -62,7 +68,12 @@ module.exports = {
               Id: resolveLambdaTarget(functionName, functionObj),
             },
           ],
-          Name: this.provider.naming.getAlbTargetGroupName(functionName, albId, multiValueHeaders),
+          Name: this.provider.naming.getAlbTargetGroupName(
+            targetGroupName,
+            functionName,
+            albId,
+            multiValueHeaders
+          ),
           Tags: [
             {
               Key: 'Name',

--- a/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.js
@@ -68,12 +68,9 @@ module.exports = {
               Id: resolveLambdaTarget(functionName, functionObj),
             },
           ],
-          Name: this.provider.naming.getAlbTargetGroupName(
-            targetGroupName,
-            functionName,
-            albId,
-            multiValueHeaders
-          ),
+          Name:
+            targetGroupName ||
+            this.provider.naming.generateAlbTargetGroupName(functionName, albId, multiValueHeaders),
           Tags: [
             {
               Key: 'Name',

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -63,6 +63,9 @@ module.exports = {
             if (event.alb.multiValueHeaders) {
               albObj.multiValueHeaders = event.alb.multiValueHeaders;
             }
+            if (event.alb.targetGroupName) {
+              albObj.targetGroupName = event.alb.targetGroupName;
+            }
 
             if (event.alb.authorizer) {
               albObj.authorizers = this.validateEventAuthorizers(event, authorizers, functionName);

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -64,10 +64,12 @@ module.exports = {
               albObj.multiValueHeaders = event.alb.multiValueHeaders;
             }
             if (event.alb.targetGroupName) {
-              albObj.targetGroupName = this.validateTargetGroupName(
-                event.alb.targetGroupName,
-                this.provider.getAlbTargetGroupPrefix()
-              );
+              if (this.provider.getAlbTargetGroupPrefix()) {
+                throw new ServerlessError(
+                  'ALB "targetGroupName" setting is exclusive with "provider.alb.targetGroupPrefix": Please specify only one.'
+                );
+              }
+              albObj.targetGroupName = event.alb.targetGroupName;
             }
 
             if (event.alb.authorizer) {
@@ -174,14 +176,5 @@ module.exports = {
       return Object.assign(eventHealthCheck, { enabled: true });
     }
     return { enabled: true };
-  },
-
-  validateTargetGroupName(targetGroupName, targetGroupPrefix) {
-    if (targetGroupPrefix) {
-      throw new ServerlessError(
-        'ALB "targetGroupName" setting is exclusive with "provider.alb.targetGroupPrefix": Please specify only one.'
-      );
-    }
-    return targetGroupName;
   },
 };

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -66,7 +66,8 @@ module.exports = {
             if (event.alb.targetGroupName) {
               if (this.provider.getAlbTargetGroupPrefix()) {
                 throw new ServerlessError(
-                  'ALB "targetGroupName" setting is exclusive with "provider.alb.targetGroupPrefix": Please specify only one.'
+                  'ALB "targetGroupName" setting is exclusive with "provider.alb.targetGroupPrefix": Please specify only one.',
+                  'ALB_TARGET_GROUP_NAME_EXCLUSIVE'
                 );
               }
               albObj.targetGroupName = event.alb.targetGroupName;

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -64,7 +64,10 @@ module.exports = {
               albObj.multiValueHeaders = event.alb.multiValueHeaders;
             }
             if (event.alb.targetGroupName) {
-              albObj.targetGroupName = event.alb.targetGroupName;
+              albObj.targetGroupName = this.validateTargetGroupName(
+                event.alb.targetGroupName,
+                this.provider.getAlbTargetGroupPrefix()
+              );
             }
 
             if (event.alb.authorizer) {
@@ -171,5 +174,14 @@ module.exports = {
       return Object.assign(eventHealthCheck, { enabled: true });
     }
     return { enabled: true };
+  },
+
+  validateTargetGroupName(targetGroupName, targetGroupPrefix) {
+    if (targetGroupPrefix) {
+      throw new ServerlessError(
+        'ALB "targetGroupName" setting is exclusive with "provider.alb.targetGroupPrefix": Please specify only one.'
+      );
+    }
+    return targetGroupName;
   },
 };

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -779,37 +779,21 @@ describe('#naming()', () => {
     });
   });
 
-  describe('#getAlbTargetGroupName()', () => {
-    it('should use the targetGroupName value if set', () => {
+  describe('#generateAlbTargetGroupName()', () => {
+    it('should return a unique identifier based on the service name, function name, alb id, multi-value attribute and stage', () => {
       serverless.service.service = 'myService';
-      expect(
-        sdk.naming.getAlbTargetGroupName('userProvidedValue', 'functionName', 'abc123', true)
-      ).to.equal('userProvidedValue');
-    });
-
-    it('should return a unique identifier based on the service name, function name, alb id, multi-value attribute and stage if no targetGroupName is set', () => {
-      serverless.service.service = 'myService';
-      expect(sdk.naming.getAlbTargetGroupName(undefined, 'functionName', 'abc123', true)).to.equal(
+      expect(sdk.naming.generateAlbTargetGroupName('functionName', 'abc123', true)).to.equal(
         '79039bd239ac0b3f6ff6d9296f23e27c'
       );
     });
 
-    it('should return a prefixed unique identifer of not longer than 32 characters if alb.targetGroupPrefix is set and no targetGroupName is set', () => {
+    it('should return a prefixed unique identifer of not longer than 32 characters if alb.targetGroupPrefix is set', () => {
       serverless.service.service = 'myService';
       serverless.service.provider.alb = {};
       serverless.service.provider.alb.targetGroupPrefix = 'myPrefix-';
-      expect(sdk.naming.getAlbTargetGroupName(undefined, 'functionName', 'abc123', true)).to.equal(
+      expect(sdk.naming.generateAlbTargetGroupName('functionName', 'abc123', true)).to.equal(
         'myPrefix-79039bd239ac0b3f6ff6d92'
       );
-    });
-
-    it('should use the prefixe alb.targetGroupPrefix if specified in conjunction with targetGroupName', () => {
-      serverless.service.service = 'myService';
-      serverless.service.provider.alb = {};
-      serverless.service.provider.alb.targetGroupPrefix = 'myPrefix-';
-      expect(
-        sdk.naming.getAlbTargetGroupName('userProvidedValue', 'functionName', 'abc123', true)
-      ).to.equal('myPrefix-userProvidedValue');
     });
   });
 

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -780,20 +780,36 @@ describe('#naming()', () => {
   });
 
   describe('#getAlbTargetGroupName()', () => {
-    it('should return a unique identifier based on the service name, function name, alb id, multi-value attribute and stage', () => {
+    it('should use the targetGroupName value if set', () => {
       serverless.service.service = 'myService';
-      expect(sdk.naming.getAlbTargetGroupName('functionName', 'abc123', true)).to.equal(
+      expect(
+        sdk.naming.getAlbTargetGroupName('userProvidedValue', 'functionName', 'abc123', true)
+      ).to.equal('userProvidedValue');
+    });
+
+    it('should return a unique identifier based on the service name, function name, alb id, multi-value attribute and stage if no targetGroupName is set', () => {
+      serverless.service.service = 'myService';
+      expect(sdk.naming.getAlbTargetGroupName(undefined, 'functionName', 'abc123', true)).to.equal(
         '79039bd239ac0b3f6ff6d9296f23e27c'
       );
     });
 
-    it('should return a prefixed unique identifer of not longer than 32 characters if alb.targetGroupPrefix is set', () => {
+    it('should return a prefixed unique identifer of not longer than 32 characters if alb.targetGroupPrefix is set and no targetGroupName is set', () => {
       serverless.service.service = 'myService';
       serverless.service.provider.alb = {};
       serverless.service.provider.alb.targetGroupPrefix = 'myPrefix-';
-      expect(sdk.naming.getAlbTargetGroupName('functionName', 'abc123', true)).to.equal(
+      expect(sdk.naming.getAlbTargetGroupName(undefined, 'functionName', 'abc123', true)).to.equal(
         'myPrefix-79039bd239ac0b3f6ff6d92'
       );
+    });
+
+    it('should use the prefixe alb.targetGroupPrefix if specified in conjunction with targetGroupName', () => {
+      serverless.service.service = 'myService';
+      serverless.service.provider.alb = {};
+      serverless.service.provider.alb.targetGroupPrefix = 'myPrefix-';
+      expect(
+        sdk.naming.getAlbTargetGroupName('userProvidedValue', 'functionName', 'abc123', true)
+      ).to.equal('myPrefix-userProvidedValue');
     });
   });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js
@@ -81,6 +81,18 @@ describe('test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js', (
               },
             ],
           },
+          fnAlbTargetGroupName: {
+            handler: 'index.handler',
+            events: [
+              {
+                alb: {
+                  ...validBaseEventConfig,
+                  priority: 7,
+                  targetGroupName: 'custom-targetgroup-name',
+                },
+              },
+            ],
+          },
         },
       },
     });
@@ -220,34 +232,13 @@ describe('test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js', (
 
   describe('should support `functions[].events[].alb.targetGroupName` property', () => {
     it('should use it if defined', async () => {
-      const result = await runServerless({
-        fixture: 'function',
-        command: 'package',
-        configExt: {
-          functions: {
-            fnTargetGroupName: {
-              handler: 'index.handler',
-              events: [
-                {
-                  alb: {
-                    ...validBaseEventConfig,
-                    priority: 1,
-                    targetGroupName: 'custom-targetgroup-name',
-                  },
-                },
-              ],
-            },
-          },
-        },
-      });
-
       const albListenerRuleLogicalId = naming.getAlbTargetGroupLogicalId(
-        'fnTargetGroupName',
+        'fnAlbTargetGroupName',
         albId,
         false
       );
 
-      expect(result.cfTemplate.Resources[albListenerRuleLogicalId].Properties.Name).to.equal(
+      expect(cfResources[albListenerRuleLogicalId].Properties.Name).to.equal(
         'custom-targetgroup-name'
       );
     });

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js
@@ -222,7 +222,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js', (
     it('should use it if defined', async () => {
       const result = await runServerless({
         fixture: 'function',
-        cliArgs: ['package'],
+        command: 'package',
         configExt: {
           functions: {
             fnTargetGroupName: {
@@ -256,7 +256,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js', (
       const runServerlessAction = () =>
         runServerless({
           fixture: 'function',
-          cliArgs: ['package'],
+          command: 'package',
           configExt: {
             provider: {
               alb: {
@@ -282,10 +282,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/alb/index.test.js', (
 
       await expect(runServerlessAction())
         .to.eventually.be.rejectedWith(ServerlessError)
-        .and.have.property(
-          'message',
-          'ALB "targetGroupName" setting is exclusive with "provider.alb.targetGroupPrefix": Please specify only one.'
-        );
+        .and.have.property('code', 'ALB_TARGET_GROUP_NAME_EXCLUSIVE');
     });
   });
 });

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -258,20 +258,4 @@ describe('#validate()', () => {
       );
     });
   });
-
-  describe('#validateTargetGroupName()', () => {
-    it('should throw if both targetGroupName and targetGroup prefix are provided', () => {
-      expect(() =>
-        awsCompileAlbEvents.validateTargetGroupName('targetGroupName', 'targetGroupPrefix')
-      ).to.throw(
-        'ALB "targetGroupName" setting is exclusive with "provider.alb.targetGroupPrefix": Please specify only one.'
-      );
-    });
-
-    it('should return the targetGroup when no targetGroupPrefix is specified', () => {
-      expect(awsCompileAlbEvents.validateTargetGroupName('targetGroupName', undefined)).to.equal(
-        'targetGroupName'
-      );
-    });
-  });
 });

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -258,4 +258,20 @@ describe('#validate()', () => {
       );
     });
   });
+
+  describe('#validateTargetGroupName()', () => {
+    it('should throw if both targetGroupName and targetGroup prefix are provided', () => {
+      expect(() =>
+        awsCompileAlbEvents.validateTargetGroupName('targetGroupName', 'targetGroupPrefix')
+      ).to.throw(
+        'ALB "targetGroupName" setting is exclusive with "provider.alb.targetGroupPrefix": Please specify only one.'
+      );
+    });
+
+    it('should return the targetGroup when no targetGroupPrefix is specified', () => {
+      expect(awsCompileAlbEvents.validateTargetGroupName('targetGroupName', undefined)).to.equal(
+        'targetGroupName'
+      );
+    });
+  });
 });


### PR DESCRIPTION
Corresponding issue : https://github.com/serverless/serverless/issues/9213

@pgrzesik I'm not sure about the `getAlbTargetGroupNameTagValue` function. For example today it doesn't uses the `provider.alb.targetPrefix` property and creates a name which is more aligned with other generated names by serverless. Also it doesn't require to be less than 32 characters, nor to be unique. So I guess it's a good place to have a more precise name with less constraints. What do you think ?

I didn't modify it but if you want me to change it and juste return  `provider.alb.targetPrefix + targetGroupName` when it's defined I will.

I'm having issues with the master branch of serverless (`pathType.dirSync is not a function` ? it still works with 2.32.1. Or maybe it's not supposed to work using npm link ?) so I couldn't deploy it, but when using the `package` command I have the expected cloudformation template.

Closes: 9213