### PR TITLE
docs: specify correct deprecation code for new `patterns` pattern

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -17,11 +17,11 @@ disabledDeprecations:
   - '*' # To disable all deprecation messages
 ```
 
-<a name="NEW_PACKAGING_PATTERNS"><div>&nbsp;</div></a>
+<a name="NEW_PACKAGE_PATTERNS"><div>&nbsp;</div></a>
 
 ## New way to define packaging patterns
 
-Deprecation code: `NEW_PACKAGING_PATTERNS`
+Deprecation code: `NEW_PACKAGE_PATTERNS`
 
 Please use `package.patterns`. `package.include` and `package.exclude` will be removed with v3.0.0
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

#8581 added `patterns`, which deprecated `package.include` & `package.exclude`, but the docs specifies the wrong deprecation code.
