### PR TITLE
CLI: Fix handling of options definition plugin extensions 

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -17,6 +17,20 @@ disabledDeprecations:
   - '*' # To disable all deprecation messages
 ```
 
+<a name="CLI_OPTIONS_SCHEMA'"><div>&nbsp;</div></a>
+
+## CLI Options extensions, `type` requirement
+
+Deprecation code: `CLI_OPTIONS_SCHEMA'`
+
+Internal handling of CLI arguments was improved with type awareness for options. Now each option definition is expected have `type` defined in its settings.
+
+Possible values are `string`, `boolean` and `multiple`. Check [Defining options](/framework/docs/providers/aws/guide/plugins#defining-options) documentation for more info.
+
+If you rely on a plugin which does not set types (yet) please report the issue at its issue tracker.
+
+Starting with v3.0.0 any option extensions which does not have `type` defined will be communicated with a thrown error
+
 <a name="NEW_PACKAGE_PATTERNS"><div>&nbsp;</div></a>
 
 ## New way to define packaging patterns

--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -273,6 +273,8 @@ The `options` object will be passed in as the second parameter to the constructo
 
 In it, you can optionally add a `shortcut` property, as well as a `required` property. The Framework will return an error if a `required` Option is not included. You can also set a `default` property if your option is not required.
 
+Additionally `type` for each option should be set. Supported types are `string`, `boolean` and `multiple` (multiple strings).
+
 **Note:** At this time, the Serverless Framework does not use parameters.
 
 ```javascript
@@ -291,6 +293,7 @@ class MyPlugin {
             usage: 'Specify the function you want to handle (e.g. "--function myFunction")',
             shortcut: 'f',
             required: true,
+            type: 'string', // Possible options: "string", "boolean", "multiple"
           },
         },
       },
@@ -335,6 +338,7 @@ class ProviderX {
           function: {
             usage: 'Specify the function you want to handle (e.g. "--function myFunction")',
             required: true,
+            type: 'string', // Possible options: "string", "boolean", "multiple"
           },
         },
       },

--- a/docs/providers/aws/guide/plugins.md
+++ b/docs/providers/aws/guide/plugins.md
@@ -133,7 +133,7 @@ Code which defines _Commands_, any _Events_ within a _Command_, and any _Hooks_ 
 
 #### Command
 
-A CLI _Command_ that can be called by a user, e.g. `serverless deploy`. A Command has no logic, but simply defines the CLI configuration (e.g. command, parameters) and the _Lifecycle Events_ for the command. Every command defines its own lifecycle events.
+A CLI _Command_ that can be called by a user, e.g. `serverless foo`. A Command has no logic, but simply defines the CLI configuration (e.g. command, parameters) and the _Lifecycle Events_ for the command. Every command defines its own lifecycle events.
 
 ```javascript
 'use strict';
@@ -141,7 +141,7 @@ A CLI _Command_ that can be called by a user, e.g. `serverless deploy`. A Comman
 class MyPlugin {
   constructor() {
     this.commands = {
-      deploy: {
+      foo: {
         lifecycleEvents: ['resources', 'functions'],
       },
     };
@@ -155,12 +155,12 @@ module.exports = MyPlugin;
 
 Events that fire sequentially during a Command. The above example lists two Events. However, for each Event, an additional `before` and `after` event is created. Therefore, six Events exist in the above example:
 
-- `before:deploy:resources`
-- `deploy:resources`
-- `after:deploy:resources`
-- `before:deploy:functions`
-- `deploy:functions`
-- `after:deploy:functions`
+- `before:foo:resources`
+- `foo:resources`
+- `after:foo:resources`
+- `before:foo:functions`
+- `foo:functions`
+- `after:foo:functions`
 
 The name of the command in front of lifecycle events when they are used for Hooks.
 
@@ -171,35 +171,35 @@ A Hook binds code to any lifecycle event from any command.
 ```javascript
 'use strict';
 
-class Deploy {
+class MyPugin {
   constructor() {
     this.commands = {
-      deploy: {
+      foo: {
         lifecycleEvents: ['resources', 'functions'],
       },
     };
 
     this.hooks = {
-      'before:deploy:resources': this.beforeDeployResources,
-      'deploy:resources': this.deployResources,
-      'after:deploy:functions': this.afterDeployFunctions,
+      'before:foo:resources': this.beforeFooResources,
+      'foo:resources': this.fooResources,
+      'after:foo:functions': this.afterFooFunctions,
     };
   }
 
-  beforeDeployResources() {
-    console.log('Before Deploy Resources');
+  beforeFooResources() {
+    console.log('Before Foo Resources');
   }
 
-  deployResources() {
-    console.log('Deploy Resources');
+  fooResources() {
+    console.log('Foo Resources');
   }
 
-  afterDeployFunctions() {
-    console.log('After Deploy Functions');
+  afterFooFunctions() {
+    console.log('After Foo Functions');
   }
 }
 
-module.exports = Deploy;
+module.exports = MyPlugin;
 ```
 
 ### Custom Variable Types
@@ -265,9 +265,9 @@ plugins:
 
 Each command can have multiple Options.
 
-Options are passed in with a double dash (`--`) like this: `serverless function deploy --function functionName`.
+Options are passed in with a double dash (`--`) like this: `serverless foo --function functionName`.
 
-Option Shortcuts are passed in with a single dash (`-`) like this: `serverless function deploy -f functionName`.
+Option Shortcuts are passed in with a single dash (`-`) like this: `serverless foo -f functionName`.
 
 The `options` object will be passed in as the second parameter to the constructor of your plugin.
 
@@ -278,40 +278,35 @@ In it, you can optionally add a `shortcut` property, as well as a `required` pro
 ```javascript
 'use strict';
 
-class Deploy {
+class MyPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
 
     this.commands = {
-      deploy: {
+      foo: {
         lifecycleEvents: ['functions'],
         options: {
           function: {
-            usage: 'Specify the function you want to deploy (e.g. "--function myFunction")',
+            usage: 'Specify the function you want to handle (e.g. "--function myFunction")',
             shortcut: 'f',
             required: true,
-          },
-          stage: {
-            usage: 'Specify the stage you want to deploy to. (e.g. "--stage prod")',
-            shortcut: 's',
-            default: 'dev',
           },
         },
       },
     };
 
     this.hooks = {
-      'deploy:functions': this.deployFunction.bind(this),
+      'foo:functions': this.fooFunction.bind(this),
     };
   }
 
-  deployFunction() {
-    console.log('Deploying function: ', this.options.function);
+  fooFunction() {
+    console.log('Foo function: ', this.options.function);
   }
 }
 
-module.exports = Deploy;
+module.exports = MyPlugin;
 ```
 
 ### Provider Specific Plugins
@@ -325,20 +320,20 @@ The provider definition should be added inside the plugins constructor:
 ```javascript
 'use strict';
 
-class ProviderDeploy {
+class ProviderX {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
 
     // set the providers name here
-    this.provider = this.serverless.getProvider('providerName');
+    this.provider = this.serverless.getProvider('providerX');
 
     this.commands = {
-      deploy: {
+      foo: {
         lifecycleEvents: ['functions'],
         options: {
           function: {
-            usage: 'Specify the function you want to deploy (e.g. "--function myFunction")',
+            usage: 'Specify the function you want to handle (e.g. "--function myFunction")',
             required: true,
           },
         },
@@ -346,16 +341,16 @@ class ProviderDeploy {
     };
 
     this.hooks = {
-      'deploy:functions': this.deployFunction.bind(this),
+      'foo:functions': this.fooFunction.bind(this),
     };
   }
 
-  deployFunction() {
-    console.log('Deploying function: ', this.options.function);
+  fooFunction() {
+    console.log('Foo function: ', this.options.function);
   }
 }
 
-module.exports = ProviderDeploy;
+module.exports = ProviderX;
 ```
 
 The Plugin's functionality will now only be executed when the Serverless Service's provider matches the provider name which is defined inside the plugins constructor.

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -291,6 +291,10 @@ for (const schema of commands.values()) {
   schema.serviceDependencyMode = 'required';
   schema.hasAwsExtension = true;
   if (!schema.options) schema.options = {};
+  for (const optionSchema of Object.values(schema.options)) {
+    if (!optionSchema.type) optionSchema.type = 'string';
+  }
+
   Object.assign(schema.options, awsServiceOptions);
 }
 

--- a/lib/cli/commands-schema/common-options/aws-service.js
+++ b/lib/cli/commands-schema/common-options/aws-service.js
@@ -15,3 +15,7 @@ module.exports = {
   },
   ...require('./service'),
 };
+
+for (const optionSchema of Object.values(module.exports)) {
+  if (!optionSchema.type) optionSchema.type = 'string';
+}

--- a/lib/cli/commands-schema/common-options/global.js
+++ b/lib/cli/commands-schema/common-options/global.js
@@ -4,3 +4,7 @@ module.exports = {
   help: { usage: 'Show this message', shortcut: 'h', type: 'boolean' },
   version: { usage: 'Show version info', type: 'boolean' },
 };
+
+for (const optionSchema of Object.values(module.exports)) {
+  if (!optionSchema.type) optionSchema.type = 'string';
+}

--- a/lib/cli/commands-schema/common-options/service.js
+++ b/lib/cli/commands-schema/common-options/service.js
@@ -11,3 +11,7 @@ module.exports = {
   },
   ...require('./global'),
 };
+
+for (const optionSchema of Object.values(module.exports)) {
+  if (!optionSchema.type) optionSchema.type = 'string';
+}

--- a/lib/cli/commands-schema/no-service.js
+++ b/lib/cli/commands-schema/no-service.js
@@ -272,6 +272,9 @@ commands.set('slstats', {
 
 for (const [name, schema] of commands) {
   if (!schema.options) schema.options = {};
+  for (const optionSchema of Object.values(schema.options)) {
+    if (!optionSchema.type) optionSchema.type = 'string';
+  }
   if (schema.serviceDependencyMode) {
     Object.assign(schema.options, schema.hasAwsExtension ? awsServiceOptions : serviceOptions);
   } else {

--- a/lib/cli/commands-schema/resolve-final.js
+++ b/lib/cli/commands-schema/resolve-final.js
@@ -8,10 +8,11 @@ const serviceCommands = require('./service');
 const awsServiceCommands = require('./aws-service');
 const serviceOptions = require('./common-options/service');
 const awsServiceOptions = require('./common-options/aws-service');
+const logDeprecation = require('../../utils/logDeprecation');
 
 const deprecatedEventPattern = /^deprecated#(.*?)(?:->(.*?))?$/;
 
-module.exports = (loadedPlugins, { providerName }) => {
+module.exports = (loadedPlugins, { providerName, configuration }) => {
   const commands = new Map(providerName === 'aws' ? awsServiceCommands : serviceCommands);
 
   if (providerName !== 'aws') {
@@ -63,6 +64,7 @@ module.exports = (loadedPlugins, { providerName }) => {
     }
   }
 
+  const missingOptionTypes = new Map();
   const resolveCommands = (loadedPlugin, config, commandPrefix = '') => {
     if (!config.commands) return;
     for (const [commandName, commandConfig] of Object.entries(config.commands)) {
@@ -83,7 +85,15 @@ module.exports = (loadedPlugins, { providerName }) => {
         if (commandConfig.lifecycleEvents) schema.lifecycleEvents = commandConfig.lifecycleEvents;
         if (commandConfig.options) {
           for (const [optionName, optionConfig] of Object.entries(commandConfig.options)) {
-            if (!schema.options[optionName]) schema.options[optionName] = optionConfig;
+            if (!schema.options[optionName]) {
+              schema.options[optionName] = optionConfig;
+              if (!optionConfig.type) {
+                if (!missingOptionTypes.has(loadedPlugin)) {
+                  missingOptionTypes.set(loadedPlugin, new Set());
+                }
+                missingOptionTypes.get(loadedPlugin).add(optionName);
+              }
+            }
           }
         }
 
@@ -100,6 +110,22 @@ module.exports = (loadedPlugins, { providerName }) => {
   };
 
   for (const loadedPlugin of loadedPlugins) resolveCommands(loadedPlugin, loadedPlugin);
+
+  if (missingOptionTypes.size) {
+    logDeprecation(
+      'CLI_OPTIONS_SCHEMA',
+      'CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). ' +
+        'Below listed plugins do not predefine type for introduced options:\n' +
+        ` - ${Array.from(
+          missingOptionTypes,
+          ([plugin, optionNames]) =>
+            `${plugin.constructor.name} for "${Array.from(optionNames).join('", "')}"`
+        ).join('\n - ')}\n` +
+        'Please report this issue in plugin issue tracker.\n' +
+        'Starting with next major release, this will be communicated with a thrown error.',
+      { serviceConfig: configuration }
+    );
+  }
 
   return commands;
 };

--- a/lib/cli/commands-schema/service.js
+++ b/lib/cli/commands-schema/service.js
@@ -71,6 +71,9 @@ commands.set('print', {
 for (const schema of commands.values()) {
   schema.serviceDependencyMode = 'required';
   if (!schema.options) schema.options = {};
+  for (const optionSchema of Object.values(schema.options)) {
+    if (!optionSchema.type) optionSchema.type = 'string';
+  }
   Object.assign(schema.options, schema.hasAwsExtension ? awsServiceOptions : serviceOptions);
 }
 

--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -25,8 +25,10 @@ const resolveArgsSchema = (commandOptionsSchema) => {
       case 'multiple':
         options.multiple.add(name);
         break;
-      default:
+      case 'string':
         options.string.add(name);
+        break;
+      default:
     }
     if (optionSchema.shortcut) options.alias.set(optionSchema.shortcut, name);
   }

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -377,7 +377,7 @@ const processSpanPromise = (async () => {
               // might have defined extra commands and options
               const commandsSchema = require('../lib/cli/commands-schema/resolve-final')(
                 serverless.pluginManager.externalPlugins,
-                { providerName: providerName || 'aws' }
+                { providerName: providerName || 'aws', configuration }
               );
               resolveInput.clear();
               ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Addresses: https://github.com/dherault/serverless-offline/issues/1203

With recent changes type awareness was introduced to CLI options parsing. Options which do not have _type_ defined were unconditionally assumed as _string_ type, and that introduced errors in handling of _boolean_ options with no type set.

While all Framework commands had types property set, we could not expect that in external plugins.

This patch ensures we do not assume any type for an option, if no type is explicitly defined, and additionaly we communicate lack of type with deprecation
