### PR TITLE
CLI: Fix help output when provider.name is missing

### DIFF
--- a/lib/configuration/resolve-provider-name.js
+++ b/lib/configuration/resolve-provider-name.js
@@ -3,13 +3,19 @@
 const ensureString = require('type/string/ensure');
 const isObject = require('type/object/is');
 const ServerlessError = require('../serverless-error');
+const resolveCliInput = require('../cli/resolve-input');
 
 module.exports = (configuration) => {
-  return ensureString(
-    isObject(configuration.provider) ? configuration.provider.name : configuration.provider,
-    {
-      Error: ServerlessError,
-      errorMessage: 'Invalid service configuration: "provider.name" property is missing',
-    }
-  );
+  try {
+    return ensureString(
+      isObject(configuration.provider) ? configuration.provider.name : configuration.provider,
+      {
+        Error: ServerlessError,
+        errorMessage: 'Invalid service configuration: "provider.name" property is missing',
+      }
+    );
+  } catch (error) {
+    if (resolveCliInput().isHelpRequest) return null;
+    throw error;
+  }
 };

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -178,6 +178,10 @@ const processSpanPromise = (async () => {
 
           if (isPropertyResolved(variablesMeta, 'provider\0name')) {
             providerName = resolveProviderName(configuration);
+            if (providerName == null) {
+              variablesMeta = null;
+              return;
+            }
           }
           if (!commandSchema && providerName === 'aws') {
             // If command was not recognized in first resolution phase
@@ -224,6 +228,10 @@ const processSpanPromise = (async () => {
 
             if (!providerName && isPropertyResolved(variablesMeta, 'provider\0name')) {
               providerName = resolveProviderName(configuration);
+              if (providerName == null) {
+                variablesMeta = null;
+                return;
+              }
               if (!commandSchema && providerName === 'aws') {
                 // If command was not recognized in previous resolution phases
                 // Parse args again also against schemas of commands which work in context of an AWS
@@ -296,6 +304,10 @@ const processSpanPromise = (async () => {
           if (!providerName) {
             if (!ensureResolvedProperty('provider\0name')) return;
             providerName = resolveProviderName(configuration);
+            if (providerName == null) {
+              variablesMeta = null;
+              return;
+            }
             if (!commandSchema && providerName === 'aws') {
               resolveInput.clear();
               ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(

--- a/test/unit/lib/classes/CLI.test.js
+++ b/test/unit/lib/classes/CLI.test.js
@@ -3,15 +3,10 @@
 const chai = require('chai');
 const sinon = require('sinon');
 const CLI = require('../../../../lib/classes/CLI');
-const fse = require('fs-extra');
-const spawn = require('child-process-ext/spawn');
-const resolveAwsEnv = require('@serverless/test/resolve-env');
 const overrideArgv = require('process-utils/override-argv');
 const stripAnsi = require('strip-ansi');
 const Serverless = require('../../../../lib/Serverless');
 const resolveInput = require('../../../../lib/cli/resolve-input');
-const { getTmpDirPath } = require('../../../utils/fs');
-const runServerless = require('../../../utils/run-serverless');
 
 const { expect } = chai;
 chai.use(require('sinon-chai'));
@@ -177,54 +172,5 @@ describe('CLI', () => {
       expect(consoleLogSpy.callCount).to.equal(1);
       expect(stripAnsi(consoleLogSpy.firstCall.args[0])).to.equal('Serverless: Hello World!');
     });
-  });
-
-  describe('Integration tests', function () {
-    this.timeout(1000 * 60 * 10);
-    const serverlessExec = require('../../../serverlessBinary');
-    const env = resolveAwsEnv();
-
-    before(() => {
-      const tmpDir = getTmpDirPath();
-
-      this.cwd = process.cwd();
-
-      fse.mkdirsSync(tmpDir);
-      process.chdir(tmpDir);
-    });
-
-    after(() => {
-      process.chdir(this.cwd);
-    });
-
-    it('should print general --help to stdout', () =>
-      spawn(serverlessExec, ['--help'], { env }).then(({ stdoutBuffer }) =>
-        expect(String(stdoutBuffer)).to.contain('contextual help')
-      ));
-
-    it('should print command --help to stdout', () =>
-      spawn(serverlessExec, ['deploy', '--help'], { env }).then(({ stdoutBuffer }) => {
-        const stdout = String(stdoutBuffer);
-        expect(stdout).to.contain('deploy');
-        expect(stdout).to.contain('--stage');
-      }));
-  });
-});
-
-describe('CLI [new tests]', () => {
-  it('Should show help when requested and in context of invalid service configuration', () =>
-    runServerless({
-      fixture: 'configInvalid',
-      cliArgs: ['--help'],
-    }).then(({ stdoutData }) => {
-      expect(stdoutData).to.include('Documentation: http://slss.io/docs');
-    }));
-
-  it('Should handle incomplete command configurations', async () => {
-    const { stdoutData } = await runServerless({
-      fixture: 'plugin',
-      cliArgs: ['customCommand', '--help'],
-    });
-    expect(stdoutData).to.include('Description of custom command');
   });
 });

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -160,4 +160,26 @@ describe('test/unit/scripts/serverless.test.js', () => {
       expect(String(error.stdoutBuffer)).to.include('"plugins" property is not accessible');
     }
   });
+
+  it('should show help when requested and in context of invalid service configuration', async () => {
+    const output = String(
+      (
+        await spawn('node', [serverlessPath, '--help'], {
+          cwd: path.resolve(fixturesPath, 'configInvalid'),
+        })
+      ).stdoutBuffer
+    );
+    expect(output).to.include('Documentation: http://slss.io/docs');
+  });
+
+  it('should print general --help to stdout', async () => {
+    const output = String((await spawn('node', [serverlessPath, '--help'])).stdoutBuffer);
+    expect(output).to.include('Documentation: http://slss.io/docs');
+  });
+
+  it('should print command --help to stdout', async () => {
+    const output = String((await spawn('node', [serverlessPath, 'deploy', '--help'])).stdoutBuffer);
+    expect(output).to.include('deploy');
+    expect(output).to.include('stage');
+  });
 });


### PR DESCRIPTION
When `sls --help` is run in context of service which does not have set `provider.name`. The error about property being missing is shown instead of help output.

This patch fixes that
