### PR TITLE
fix(AWS API Gateway): Deprecate invalid `apiGateway` settings

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -370,4 +370,4 @@ Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2
 
 Deprecation code: `AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS`
 
-When `provider.apiGateway.restApiId` is set along `provider.tracing.apiGateway` or `provider.logs.restApi` these options are ignored as the API Gateway service has been created outside of serverless.
+When external API Gateway resource is used and imported via `provider.apiGateway.restApiId` setting, both `provider.logs.restApi` and `provider.tracing.apiGateway` will be ignored. These settings are applicable only if API Gateway resource is provisioned by Serverless Framework.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -364,10 +364,10 @@ Deprecation code: `BIN_SERVERLESS`
 
 Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0
 
-<a name="NON_APPLICABLE_SETTINGS_ARE_CONFIGURED"><div>&nbsp;</div></a>
+<a name="AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS"><div>&nbsp;</div></a>
 
-## Non-applicable settings configured
+## Non-applicable settings configured for API Gateway
 
-Deprecation code: `NON_APPLICABLE_SETTINGS_ARE_CONFIGURED`
+Deprecation code: `AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS`
 
-When `provider.tracing.apiGateway` or `provider.logs.restApi` are set along with `provider.apiGateway.restApiId`, these are ignored when the API Gateway is created without a stack.
+When `provider.apiGateway.restApiId` is set along `provider.tracing.apiGateway` or `provider.logs.restApi` these options are ignored as the API Gateway service has been created outside of serverless.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -370,4 +370,4 @@ Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2
 
 Deprecation code: `NON_APPLICABLE_SETTINGS_ARE_CONFIGURED`
 
-When `provider.tracing.apiGateway` and `provider.logs.restApi` cannot be set without a stack.
+When `provider.tracing.apiGateway` or `provider.logs.restApi` are set along with `provider.apiGateway.restApiId`, these are ignored when the API Gateway is created without a stack.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -366,7 +366,7 @@ Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2
 
 <a name="AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS"><div>&nbsp;</div></a>
 
-## Non-applicable settings configured for API Gateway
+## AWS API Gateway non-applicable settings configured
 
 Deprecation code: `AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS`
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -17,6 +17,14 @@ disabledDeprecations:
   - '*' # To disable all deprecation messages
 ```
 
+<a name="AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS"><div>&nbsp;</div></a>
+
+## AWS API Gateway non-applicable settings configured
+
+Deprecation code: `AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS`
+
+When external API Gateway resource is used and imported via `provider.apiGateway.restApiId` setting, both `provider.logs.restApi` and `provider.tracing.apiGateway` will be ignored. These settings are applicable only if API Gateway resource is provisioned by Serverless Framework.
+
 <a name="CLI_OPTIONS_SCHEMA'"><div>&nbsp;</div></a>
 
 ## CLI Options extensions, `type` requirement
@@ -363,11 +371,3 @@ Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be re
 Deprecation code: `BIN_SERVERLESS`
 
 Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0
-
-<a name="AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS"><div>&nbsp;</div></a>
-
-## AWS API Gateway non-applicable settings configured
-
-Deprecation code: `AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS`
-
-When external API Gateway resource is used and imported via `provider.apiGateway.restApiId` setting, both `provider.logs.restApi` and `provider.tracing.apiGateway` will be ignored. These settings are applicable only if API Gateway resource is provisioned by Serverless Framework.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -363,3 +363,11 @@ Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be re
 Deprecation code: `BIN_SERVERLESS`
 
 Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0
+
+<a name="NON_APPLICABLE_SETTINGS_ARE_CONFIGURED"><div>&nbsp;</div></a>
+
+## Non-applicable settings configured
+
+Deprecation code: `NON_APPLICABLE_SETTINGS_ARE_CONFIGURED`
+
+When `provider.tracing.apiGateway` and `provider.logs.restApi` cannot be set without a stack.

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1741,7 +1741,7 @@ provider:
     restApi: true
 ```
 
-The log streams will be generated in a dedicated log group which follows the naming schema `/aws/api-gateway/{service}-{stage}`.
+The log streams will be generated in a dedicated log group which follows the naming schema `/aws/api-gateway/{service}-{stage}`. Note the property `restApi` can only be true if the API Gateway service has been created inside the stack.
 
 To be able to write logs, API Gateway [needs a CloudWatch role configured](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html). This setting is per region, shared by all the APIs. There are three approaches for handling it:
 

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1714,6 +1714,8 @@ provider:
     apiGateway: true
 ```
 
+**Note:** If external API Gateway resource is used and imported via `provider.apiGateway.restApiId` setting, `provider.tracing.apiGateway` setting will be ignored.
+
 ## Tags / Stack Tags
 
 API Gateway stages will be tagged with the `tags` and `stackTags` values defined at the `provider` level:

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1743,7 +1743,9 @@ provider:
     restApi: true
 ```
 
-The log streams will be generated in a dedicated log group which follows the naming schema `/aws/api-gateway/{service}-{stage}`. **Note:** If external API Gateway resource is used and imported via `provider.apiGateway.restApiId` setting, `provider.logs.restApi` setting will be ignored.
+The log streams will be generated in a dedicated log group which follows the naming schema `/aws/api-gateway/{service}-{stage}`.
+
+**Note:** If external API Gateway resource is used and imported via `provider.apiGateway.restApiId` setting, `provider.logs.restApi` setting will be ignored.
 
 To be able to write logs, API Gateway [needs a CloudWatch role configured](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html). This setting is per region, shared by all the APIs. There are three approaches for handling it:
 

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1741,7 +1741,7 @@ provider:
     restApi: true
 ```
 
-The log streams will be generated in a dedicated log group which follows the naming schema `/aws/api-gateway/{service}-{stage}`. Note the property `restApi` can only be true if the API Gateway service has been created inside the stack.
+The log streams will be generated in a dedicated log group which follows the naming schema `/aws/api-gateway/{service}-{stage}`. **Note:** If external API Gateway resource is used and imported via `provider.apiGateway.restApiId` setting, `provider.logs.restApi` setting will be ignored.
 
 To be able to write logs, API Gateway [needs a CloudWatch role configured](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html). This setting is per region, shared by all the APIs. There are three approaches for handling it:
 

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -257,10 +257,10 @@ provider:
     foo: bar
     baz: qux
   tracing:
-    apiGateway: true
+    apiGateway: true # Can only be true if API Gateway is inside a stack.
     lambda: true # Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'
   logs:
-    restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to `true` to use defaults, or configured via subproperties.
+    restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to `true` to use defaults, or configured via subproperties. Can only be true if API Gateway is inside a stack.
       accessLogging: true # Optional configuration which enables or disables access logging. Defaults to true.
       format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use for access logging.
       executionLogging: true # Optional configuration which enables or disables execution logging. Defaults to true.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -260,7 +260,7 @@ provider:
     apiGateway: true # Can only be true if API Gateway is inside a stack.
     lambda: true # Optional, can be true (true equals 'Active'), 'Active' or 'PassThrough'
   logs:
-    restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to `true` to use defaults, or configured via subproperties. Can only be true if API Gateway is inside a stack.
+    restApi: # Optional configuration which specifies if API Gateway logs are used. This can either be set to `true` to use defaults, or configured via subproperties. Can only be configured if API Gateway is inside a stack.
       accessLogging: true # Optional configuration which enables or disables access logging. Defaults to true.
       format: 'requestId: $context.requestId' # Optional configuration which specifies the log format to use for access logging.
       executionLogging: true # Optional configuration which enables or disables execution logging. Defaults to true.

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -251,8 +251,22 @@ class AwsCompileApigEvents {
               'to "provider.apiGateway"'
           );
         }
+
         if (
           this.serverless.service.provider.name === 'aws' &&
+          Object.values(this.serverless.service.functions).some(({ events }) =>
+            events.some(({ http }) => _.get(http, 'request.schema'))
+          )
+        ) {
+          this.serverless._logDeprecation(
+            'AWS_API_GATEWAY_SCHEMAS',
+            'Starting with next major version, "http.request.schema" property will be replaced by "http.request.schemas".'
+          );
+        }
+
+        if (
+          this.serverless.service.provider.name === 'aws' &&
+          this.serverless.service.provider.apiGateway &&
           this.serverless.service.provider.apiGateway.restApiId &&
           this.serverless.service.provider.tracing &&
           this.serverless.service.provider.tracing.apiGateway != null
@@ -265,6 +279,7 @@ class AwsCompileApigEvents {
         }
         if (
           this.serverless.service.provider.name === 'aws' &&
+          this.serverless.service.provider.apiGateway &&
           this.serverless.service.provider.apiGateway.restApiId &&
           this.serverless.service.provider.logs &&
           this.serverless.service.provider.logs.restApi != null
@@ -273,18 +288,6 @@ class AwsCompileApigEvents {
             'AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS',
             'Property "provider.logs.restApi" is configured and is not ' +
               'applicable unless API gateway is created with a stack.'
-          );
-        }
-
-        if (
-          this.serverless.service.provider.name === 'aws' &&
-          Object.values(this.serverless.service.functions).some(({ events }) =>
-            events.some(({ http }) => _.get(http, 'request.schema'))
-          )
-        ) {
-          this.serverless._logDeprecation(
-            'AWS_API_GATEWAY_SCHEMAS',
-            'Starting with next major version, "http.request.schema" property will be replaced by "http.request.schemas".'
           );
         }
       },

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -251,6 +251,30 @@ class AwsCompileApigEvents {
               'to "provider.apiGateway"'
           );
         }
+        if (
+          this.serverless.service.provider.name === 'aws' &&
+          this.serverless.service.provider.apiGateway.restApiId &&
+          this.serverless.service.provider.tracing &&
+          this.serverless.service.provider.tracing.apiGateway != null
+        ) {
+          this.serverless._logDeprecation(
+            'AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS',
+            'Property "provider.tracing.apiGateway" is configured and is' +
+              ' not applicable unless API gateway is created with a stack.'
+          );
+        }
+        if (
+          this.serverless.service.provider.name === 'aws' &&
+          this.serverless.service.provider.apiGateway.restApiId &&
+          this.serverless.service.provider.logs &&
+          this.serverless.service.provider.logs.restApi != null
+        ) {
+          this.serverless._logDeprecation(
+            'AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS',
+            'Property "provider.logs.restApi" is configured and is not ' +
+              'applicable unless API gateway is created with a stack.'
+          );
+        }
 
         if (
           this.serverless.service.provider.name === 'aws' &&

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -273,8 +273,9 @@ class AwsCompileApigEvents {
         ) {
           this.serverless._logDeprecation(
             'AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS',
-            'Property "provider.tracing.apiGateway" is configured and is' +
-              ' not applicable unless API gateway is created with a stack.'
+            'When external API Gateway resource is imported via ' +
+              '`provider.apiGateway.restApiId`, property ' +
+              '"provider.tracing.apiGateway" will be ignored.'
           );
         }
         if (
@@ -286,8 +287,9 @@ class AwsCompileApigEvents {
         ) {
           this.serverless._logDeprecation(
             'AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS',
-            'Property "provider.logs.restApi" is configured and is not ' +
-              'applicable unless API gateway is created with a stack.'
+            'When external API Gateway resource is imported via ' +
+              '`provider.apiGateway.restApiId`, property ' +
+              '"provider.logs.restApi" will be ignored.'
           );
         }
       },

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -69,6 +69,10 @@ module.exports = {
 
             if (!this.hasTracingConfigured && !this.hasLogsConfigured) {
               // Do crash if there are no API Gateway customizations to apply
+              this.serverless._logDeprecation(
+                'NON_APPLICABLE_SETTINGS_ARE_CONFIGURED',
+                'There are setting configured that are only applicable when API gateway is created with a stack.'
+              );
               return null;
             }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -55,7 +55,23 @@ module.exports = {
         .call(this)
         .then(resolveRestApiId.bind(this))
         .then(() => {
-          if (this.apiGatewayRestApiId) return resolveDeploymentId.call(this);
+          if (this.apiGatewayRestApiId) {
+            if (this.hasTracingConfigured) {
+              this.serverless._logDeprecation(
+                'NON_APPLICABLE_SETTINGS_ARE_CONFIGURED',
+                'Property "provider.tracing.apiGateway" is configured and is' +
+                  ' not applicable unless API gateway is created with a stack.'
+              );
+            }
+            if (this.hasLogsConfigured) {
+              this.serverless._logDeprecation(
+                'NON_APPLICABLE_SETTINGS_ARE_CONFIGURED',
+                'Property "provider.logs.restApi" is configured and is not ' +
+                  'applicable unless API gateway is created with a stack.'
+              );
+            }
+            return resolveDeploymentId.call(this);
+          }
           return null;
         })
         .then(() => {
@@ -69,10 +85,6 @@ module.exports = {
 
             if (!this.hasTracingConfigured && !this.hasLogsConfigured) {
               // Do crash if there are no API Gateway customizations to apply
-              this.serverless._logDeprecation(
-                'NON_APPLICABLE_SETTINGS_ARE_CONFIGURED',
-                'There are setting configured that are only applicable when API gateway is created with a stack.'
-              );
               return null;
             }
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -55,23 +55,7 @@ module.exports = {
         .call(this)
         .then(resolveRestApiId.bind(this))
         .then(() => {
-          if (this.apiGatewayRestApiId) {
-            if (this.hasTracingConfigured) {
-              this.serverless._logDeprecation(
-                'NON_APPLICABLE_SETTINGS_ARE_CONFIGURED',
-                'Property "provider.tracing.apiGateway" is configured and is' +
-                  ' not applicable unless API gateway is created with a stack.'
-              );
-            }
-            if (this.hasLogsConfigured) {
-              this.serverless._logDeprecation(
-                'NON_APPLICABLE_SETTINGS_ARE_CONFIGURED',
-                'Property "provider.logs.restApi" is configured and is not ' +
-                  'applicable unless API gateway is created with a stack.'
-              );
-            }
-            return resolveDeploymentId.call(this);
-          }
+          if (this.apiGatewayRestApiId) return resolveDeploymentId.call(this);
           return null;
         })
         .then(() => {


### PR DESCRIPTION
Closes: #9139 #8921 
