### PR TITLE
Avoid re-registration of ts-node ~and interop default when config is exported using ES6 module syntax~

### DIFF
--- a/lib/configuration/read.js
+++ b/lib/configuration/read.js
@@ -89,27 +89,29 @@ const parseConfigurationFile = async (configurationPath) => {
       }
     }
     case '.ts': {
-      const tsNodePath = await (async () => {
+      if (!process[Symbol.for('ts-node.register.instance')]) {
+        const tsNodePath = await (async () => {
+          try {
+            return await resolveTsNode(path.dirname(configurationPath));
+          } catch (error) {
+            throw new ServerlessError(
+              `Cannot parse "${path.basename(
+                configurationPath
+              )}": Resolution of "ts-node" failed with: ${error.message}`,
+              'CONFIGURATION_RESOLUTION_ERROR'
+            );
+          }
+        })();
         try {
-          return await resolveTsNode(path.dirname(configurationPath));
+          require(tsNodePath).register();
         } catch (error) {
           throw new ServerlessError(
             `Cannot parse "${path.basename(
               configurationPath
-            )}": Resolution of "ts-node" failed with: ${error.message}`,
+            )}": Register of "ts-node" failed with: ${error.message}`,
             'CONFIGURATION_RESOLUTION_ERROR'
           );
         }
-      })();
-      try {
-        require(tsNodePath).register();
-      } catch (error) {
-        throw new ServerlessError(
-          `Cannot parse "${path.basename(configurationPath)}": Register of "ts-node" failed with: ${
-            error.message
-          }`,
-          'CONFIGURATION_RESOLUTION_ERROR'
-        );
       }
     }
     // fallthrough

--- a/lib/configuration/read.js
+++ b/lib/configuration/read.js
@@ -118,7 +118,8 @@ const parseConfigurationFile = async (configurationPath) => {
     case '.js': {
       const configurationEventuallyDeferred = (() => {
         try {
-          return require(configurationPath);
+          const configuration = require(configurationPath);
+          return configuration.default || configuration;
         } catch (error) {
           if (isModuleNotFoundError(error, configurationPath)) {
             throw new ServerlessError(

--- a/lib/configuration/read.js
+++ b/lib/configuration/read.js
@@ -118,8 +118,7 @@ const parseConfigurationFile = async (configurationPath) => {
     case '.js': {
       const configurationEventuallyDeferred = (() => {
         try {
-          const configuration = require(configurationPath);
-          return configuration.default || configuration;
+          return require(configurationPath);
         } catch (error) {
           if (isModuleNotFoundError(error, configurationPath)) {
             throw new ServerlessError(

--- a/test/unit/lib/configuration/read.test.js
+++ b/test/unit/lib/configuration/read.test.js
@@ -84,6 +84,22 @@ describe('test/unit/lib/configuration/read.test.js', () => {
     }
   });
 
+  it('should register ts-node only if it is not already registered', async () => {
+    try {
+      expect(process[Symbol.for('ts-node.register.instance')]).to.be.undefined;
+      process[Symbol.for('ts-node.register.instance')] = 'foo';
+      configurationPath = 'serverless.ts';
+      const configuration = {
+        service: 'test-ts',
+        provider: { name: 'aws' },
+      };
+      await fs.writeFile(configurationPath, `module.exports = ${JSON.stringify(configuration)}`);
+      expect(await readConfiguration(configurationPath)).to.deep.equal(configuration);
+    } finally {
+      delete process[Symbol.for('ts-node.register.instance')];
+    }
+  });
+
   it('should support deferred configuration result', async () => {
     // JS configurations are required (so immune to modules caching).
     // In this tests we cannot use same JS configuration path twice for testing

--- a/test/unit/lib/configuration/read.test.js
+++ b/test/unit/lib/configuration/read.test.js
@@ -100,16 +100,6 @@ describe('test/unit/lib/configuration/read.test.js', () => {
     }
   });
 
-  it('should interop default if config is exported using ES6 modules', async () => {
-    configurationPath = 'serverless.js';
-    const configuration = {
-      service: 'test-js',
-      provider: { name: 'aws' },
-    };
-    await fs.writeFile(configurationPath, `export default ${JSON.stringify(configuration)}`);
-    expect(await readConfiguration(configurationPath)).to.deep.equal(configuration);
-  });
-
   it('should support deferred configuration result', async () => {
     // JS configurations are required (so immune to modules caching).
     // In this tests we cannot use same JS configuration path twice for testing

--- a/test/unit/lib/configuration/read.test.js
+++ b/test/unit/lib/configuration/read.test.js
@@ -100,6 +100,16 @@ describe('test/unit/lib/configuration/read.test.js', () => {
     }
   });
 
+  it('should interop default if config is exported using ES6 modules', async () => {
+    configurationPath = 'serverless.js';
+    const configuration = {
+      service: 'test-js',
+      provider: { name: 'aws' },
+    };
+    await fs.writeFile(configurationPath, `export default ${JSON.stringify(configuration)}`);
+    expect(await readConfiguration(configurationPath)).to.deep.equal(configuration);
+  });
+
   it('should support deferred configuration result', async () => {
     // JS configurations are required (so immune to modules caching).
     // In this tests we cannot use same JS configuration path twice for testing


### PR DESCRIPTION
When `ts-node` is registered multiple times (e.g. by multiple packages) then errors occur since already-compiled Typescript will be fed through ts-node again. See [this issue](https://www.github.com/TypeStrong/ts-node/issues/409) for details.

Additionally, when exporting config using ES6 module syntax (`export default ...`) - which is typical of TS environments - serverless fails to load the configuration. This is resolved by attempting to interop `.default` before falling back.