### PR TITLE
fix(AWS Local Invocation): Strip `null` envvars for local invoke

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -140,7 +140,13 @@ class AwsInvokeLocal {
   getConfiguredEnvVars() {
     const providerEnvVars = this.serverless.service.provider.environment || {};
     const functionEnvVars = this.options.functionObj.environment || {};
-    return _.pickBy(_.merge(providerEnvVars, functionEnvVars), (v) => v !== null);
+    const mergedVars = _.merge(providerEnvVars, functionEnvVars);
+    return Object.keys(mergedVars)
+      .filter((k) => mergedVars[k] != null)
+      .reduce((m, k) => {
+        m[k] = mergedVars[k];
+        return m;
+      }, {});
   }
 
   async loadEnvVars() {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -140,7 +140,7 @@ class AwsInvokeLocal {
   getConfiguredEnvVars() {
     const providerEnvVars = this.serverless.service.provider.environment || {};
     const functionEnvVars = this.options.functionObj.environment || {};
-    return _.pickBy(_.merge(providerEnvVars, functionEnvVars), function(v, k) { return v !== null });
+    return _.pickBy(_.merge(providerEnvVars, functionEnvVars), (v) => v !== null);
   }
 
   async loadEnvVars() {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -140,7 +140,7 @@ class AwsInvokeLocal {
   getConfiguredEnvVars() {
     const providerEnvVars = this.serverless.service.provider.environment || {};
     const functionEnvVars = this.options.functionObj.environment || {};
-    return _.merge(providerEnvVars, functionEnvVars);
+    return _.pickBy(_.merge(providerEnvVars, functionEnvVars), function(v, k) { return v !== null });
   }
 
   async loadEnvVars() {

--- a/test/unit/lib/plugins/aws/invokeLocal/index.test.js
+++ b/test/unit/lib/plugins/aws/invokeLocal/index.test.js
@@ -395,6 +395,13 @@ describe('AwsInvokeLocal', () => {
       await awsInvokeLocal.loadEnvVars();
       expect(process.env.providerVar).to.be.equal('providerValueOverwritten');
     });
+
+    it('it should not pass null env vars to handler', async () => {
+      awsInvokeLocal.options.functionObj.environment.providerVar = null;
+
+      await awsInvokeLocal.loadEnvVars();
+      expect(process.env.providerVar).to.be.equal(undefined);
+    });
   });
 
   describe('#invokeLocal()', () => {

--- a/test/unit/lib/plugins/aws/invokeLocal/index.test.js
+++ b/test/unit/lib/plugins/aws/invokeLocal/index.test.js
@@ -395,13 +395,6 @@ describe('AwsInvokeLocal', () => {
       await awsInvokeLocal.loadEnvVars();
       expect(process.env.providerVar).to.be.equal('providerValueOverwritten');
     });
-
-    it('it should not pass null env vars to handler', async () => {
-      awsInvokeLocal.options.functionObj.environment.providerVar = null;
-
-      await awsInvokeLocal.loadEnvVars();
-      expect(process.env.providerVar).to.be.equal(undefined);
-    });
   });
 
   describe('#invokeLocal()', () => {
@@ -1571,6 +1564,36 @@ describe('test/unit/lib/plugins/aws/invokeLocal/index.test.js', () => {
       xit('TODO: should resolve region from `service.provider` if not provided via option', () => {
         // Replaces
         // https://github.com/serverless/serverless/blob/95c0bc09421b869ae1d8fc5dea42a2fce1c2023e/test/unit/lib/plugins/aws/invokeLocal/index.test.js#L426-L441
+      });
+
+      it('should not expose null environment variables', async () => {
+        const response = await runServerless({
+          fixture: 'invocation',
+          cliArgs: [
+            'invoke',
+            'local',
+            '--function',
+            'async',
+          ],
+          configExt: {
+            provider: {
+              environment: {
+                PROVIDER_LEVEL_VAR: null,
+              },
+            },
+            functions: {
+              fn: {
+                environment: {
+                  FUNCTION_LEVEL_VAR: null,
+                },
+              },
+            },
+	  }
+        });
+        const stdoutAsJson = JSON.parse(response.stdoutData);
+        const stdoutBodyAsJson = JSON.parse(stdoutAsJson.body);
+        expect(stdoutBodyAsJson.env.PROVIDER_LEVEL_VAR).to.be.undefined;
+        expect(stdoutBodyAsJson.env.FUNCTION_LEVEL_VAR).to.be.undefined;
       });
     });
   };

--- a/test/unit/lib/plugins/aws/invokeLocal/index.test.js
+++ b/test/unit/lib/plugins/aws/invokeLocal/index.test.js
@@ -1569,12 +1569,7 @@ describe('test/unit/lib/plugins/aws/invokeLocal/index.test.js', () => {
       it('should not expose null environment variables', async () => {
         const response = await runServerless({
           fixture: 'invocation',
-          cliArgs: [
-            'invoke',
-            'local',
-            '--function',
-            'async',
-          ],
+          cliArgs: ['invoke', 'local', '--function', 'async'],
           configExt: {
             provider: {
               environment: {
@@ -1588,7 +1583,7 @@ describe('test/unit/lib/plugins/aws/invokeLocal/index.test.js', () => {
                 },
               },
             },
-	  }
+          },
         });
         const stdoutAsJson = JSON.parse(response.stdoutData);
         const stdoutBodyAsJson = JSON.parse(stdoutAsJson.body);


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{9261}
