### PR TITLE
fix(AWS API Gateway): Do not attempt to remove `aws:` tags during update

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -323,7 +323,7 @@ function handleTags() {
   );
   const currentTags = this.apiGatewayStageState.tags || {};
   const tagKeysToBeRemoved = Object.keys(currentTags).filter(
-    (currentKey) => typeof tagsMerged[currentKey] !== 'string'
+    (currentKey) => !currentKey.startsWith('aws:') && typeof tagsMerged[currentKey] !== 'string'
   );
 
   const restApiId = this.apiGatewayRestApiId;


### PR DESCRIPTION
Note: Not all AWS Accounts are yet affected by this change.

Closes: #9223 

