### PR TITLE
fix(AWS HTTP API): Adjust schema for correct `typescript` generation

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -211,7 +211,9 @@ class HttpApiEvents {
         Properties: {
           ApiId: this.getApiIdConfig(),
           Name: authorizer.name,
-          IdentitySource: authorizer.identitySource,
+          IdentitySource: Array.isArray(authorizer.identitySource)
+            ? authorizer.identitySource
+            : [authorizer.identitySource],
         },
       };
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -776,12 +776,7 @@ class AwsProvider {
                         properties: {
                           type: { const: 'jwt' },
                           name: { type: 'string' },
-                          identitySource: {
-                            type: 'array',
-                            minItems: 1,
-                            maxItems: 1,
-                            items: { $ref: '#/definitions/awsCfInstruction' },
-                          },
+                          identitySource: { $ref: '#/definitions/awsCfInstruction' },
                           issuerUrl: { $ref: '#/definitions/awsCfInstruction' },
                           audience: {
                             anyOf: [
@@ -808,8 +803,13 @@ class AwsProvider {
                           enableSimpleResponses: { type: 'boolean' },
                           payloadVersion: { type: 'string', enum: ['1.0', '2.0'] },
                           identitySource: {
-                            type: 'array',
-                            items: { $ref: '#/definitions/awsCfInstruction' },
+                            anyOf: [
+                              { $ref: '#/definitions/awsCfInstruction' },
+                              {
+                                type: 'array',
+                                items: { $ref: '#/definitions/awsCfInstruction' },
+                              },
+                            ],
                           },
                         },
                         required: ['type'],


### PR DESCRIPTION
Slightly adjust schema to not rely on automatic coercion to `array`, which can produce invalid `serverless/typescript` types. 

Closes: #9269