### PR TITLE
fix(AWS API Gateway): Proper stage resolution for custom resource

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -21,7 +21,6 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
   let customResourceFunctionLogicalId;
 
   const { serverless } = awsProvider;
-  const { cliOptions } = serverless.pluginManager;
   const providerConfig = serverless.service.provider;
   const shouldWriteLogs = providerConfig.logs && providerConfig.logs.frameworkLambda;
   const { Resources } = providerConfig.compiledCloudFormationTemplate;
@@ -31,7 +30,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     '.serverless',
     awsProvider.naming.getCustomResourcesArtifactName()
   );
-  const funcPrefix = `${serverless.service.service}-${cliOptions.stage}`;
+  const funcPrefix = `${serverless.service.service}-${awsProvider.getStage()}`;
 
   // check which custom resource should be used
   if (resourceName === 's3') {

--- a/test/unit/lib/plugins/aws/customResources/index.test.js
+++ b/test/unit/lib/plugins/aws/customResources/index.test.js
@@ -355,3 +355,42 @@ describe('#addCustomResourceToService()', () => {
     });
   });
 });
+
+describe('test/unit/lib/plugins/aws/customResources/index.test.js', () => {
+  it('correctly takes stage from cli into account when constructing apiGatewayCloudWatchRole resource', async () => {
+    const { cfTemplate } = await runServerless({
+      fixture: 'apiGateway',
+      cliArgs: ['package', '--stage', 'testing'],
+      configExt: {
+        provider: {
+          logs: {
+            restApi: true,
+          },
+        },
+      },
+    });
+
+    const properties =
+      cfTemplate.Resources.CustomDashresourceDashapigwDashcwDashroleLambdaFunction.Properties;
+    expect(properties.FunctionName.endsWith('testing-custom-resource-apigw-cw-role')).to.be.true;
+  });
+
+  it('correctly takes stage from config into account when constructing apiGatewayCloudWatchRole resource', async () => {
+    const { cfTemplate } = await runServerless({
+      fixture: 'apiGateway',
+      cliArgs: ['package'],
+      configExt: {
+        provider: {
+          stage: 'testing',
+          logs: {
+            restApi: true,
+          },
+        },
+      },
+    });
+
+    const properties =
+      cfTemplate.Resources.CustomDashresourceDashapigwDashcwDashroleLambdaFunction.Properties;
+    expect(properties.FunctionName.endsWith('testing-custom-resource-apigw-cw-role')).to.be.true;
+  });
+});


### PR DESCRIPTION
After recent changes the bug surfaced where the `stage` for custom resource needed for API Gateway logs did not take into account setting from `provider.stage` 

Closes: #9240, #9268