### PR TITLE
refactor(AWS Credentials): Remove undocumented `provider.credentials` setting support

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -154,26 +154,6 @@ class Variables {
           value: this.service.provider.profile,
           path: 'serverless.service.provider.profile',
         },
-        {
-          name: 'credentials',
-          value: this.service.provider.credentials,
-          path: 'serverless.service.provider.credentials',
-        },
-        {
-          name: 'credentials.accessKeyId',
-          value: _.get(this, 'service.provider.credentials.accessKeyId'),
-          path: 'serverless.service.provider.credentials.accessKeyId',
-        },
-        {
-          name: 'credentials.secretAccessKey',
-          value: _.get(this, 'service.provider.credentials.secretAccessKey'),
-          path: 'serverless.service.provider.credentials.secretAccessKey',
-        },
-        {
-          name: 'credentials.sessionToken',
-          value: _.get(this, 'service.provider.credentials.sessionToken'),
-          path: 'serverless.service.provider.credentials.sessionToken',
-        },
       ];
       return this.disableDepedentServices(() => {
         const prepopulations = requiredConfigs.map((config) =>

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1386,7 +1386,6 @@ class AwsProvider {
     } catch (err) {
       if (err.code !== 'UNRECOGNIZED_AWS_PROFILE') throw err;
     }
-    impl.addCredentials(result, this.serverless.service.provider.credentials); // config creds
     if (this.serverless.service.provider.profile && !this.options['aws-profile']) {
       // config profile
       impl.addProfileCredentials(result, this.serverless.service.provider.profile);

--- a/test/unit/lib/classes/Variables.test.js
+++ b/test/unit/lib/classes/Variables.test.js
@@ -347,22 +347,6 @@ describe('Variables', () => {
       { name: 'region', getter: (provider) => provider.getRegion() },
       { name: 'stage', getter: (provider) => provider.getStage() },
       { name: 'profile', getter: (provider) => provider.getProfile() },
-      {
-        name: 'credentials',
-        getter: (provider) => provider.serverless.service.provider.credentials,
-      },
-      {
-        name: 'credentials.accessKeyId',
-        getter: (provider) => provider.serverless.service.provider.credentials.accessKeyId,
-      },
-      {
-        name: 'credentials.secretAccessKey',
-        getter: (provider) => provider.serverless.service.provider.credentials.secretAccessKey,
-      },
-      {
-        name: 'credentials.sessionToken',
-        getter: (provider) => provider.serverless.service.provider.credentials.sessionToken,
-      },
     ];
     describe('basic population tests', () => {
       prepopulatedProperties.forEach((property) => {

--- a/test/unit/lib/plugins/aws/invokeLocal/index.test.js
+++ b/test/unit/lib/plugins/aws/invokeLocal/index.test.js
@@ -240,7 +240,6 @@ describe('AwsInvokeLocal', () => {
   describe('#getCredentialEnvVars()', () => {
     it('returns empty object when credentials is not set', () => {
       provider.cachedCredentials = null;
-      serverless.service.provider.credentials = null;
 
       const credentialEnvVars = awsInvokeLocal.getCredentialEnvVars();
 
@@ -254,24 +253,6 @@ describe('AwsInvokeLocal', () => {
           secretAccessKey: 'SECRET',
           sessionToken: 'TOKEN',
         },
-      };
-      serverless.service.provider.credentials = null;
-
-      const credentialEnvVars = awsInvokeLocal.getCredentialEnvVars();
-
-      expect(credentialEnvVars).to.be.eql({
-        AWS_ACCESS_KEY_ID: 'ID',
-        AWS_SECRET_ACCESS_KEY: 'SECRET',
-        AWS_SESSION_TOKEN: 'TOKEN',
-      });
-    });
-
-    it('returns credential env vars from credentials config', () => {
-      provider.cachedCredentials = null;
-      serverless.service.provider.credentials = {
-        accessKeyId: 'ID',
-        secretAccessKey: 'SECRET',
-        sessionToken: 'TOKEN',
       };
 
       const credentialEnvVars = awsInvokeLocal.getCredentialEnvVars();


### PR DESCRIPTION
Removes support for undocumented setting `provider.credentials`. 

Addresses: #8356 