### PR TITLE
CLI & Variables improvements

### DIFF
--- a/lib/cli/ensure-supported-command.js
+++ b/lib/cli/ensure-supported-command.js
@@ -25,7 +25,14 @@ const getCommandSuggestion = (command, commandsSchema) => {
 };
 
 module.exports = (configuration = null) => {
-  const { command, options, commandSchema, commandsSchema, isContainerCommand } = resolveInput();
+  const {
+    command,
+    options,
+    commandSchema,
+    commandsSchema,
+    isContainerCommand,
+    isHelpRequest,
+  } = resolveInput();
 
   if (!commandSchema && !isContainerCommand) {
     throw new ServerlessError(
@@ -35,6 +42,7 @@ module.exports = (configuration = null) => {
       'UNRECOGNIZED_CLI_COMMAND'
     );
   }
+  if (isHelpRequest) return;
   const supportedOptions = new Set(Object.keys((commandSchema && commandSchema.options) || {}));
   const unrecognizedOptions = Object.keys(options).filter(
     (optionName) => !supportedOptions.has(optionName)
@@ -48,6 +56,13 @@ module.exports = (configuration = null) => {
     );
   }
   if (isContainerCommand) return;
+  if (commandSchema.serviceDependencyMode === 'required' && !configuration) {
+    throw new ServerlessError(
+      'This command can only be run in a Serverless service directory. ' +
+        "Make sure to reference a valid config file in the current working directory if you're using a custom config file",
+      'MISSING_SERVICE_CONTEXT'
+    );
+  }
   const missingOptions = [];
   for (const [optionName, { required }] of Object.entries(commandSchema.options || {})) {
     if (!required) continue;

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -280,7 +280,7 @@ const processSpanPromise = (async () => {
           // Resolve all unresolved configuration properties
           resolverConfiguration.fulfilledSources.add('env');
 
-          if (isHelpRequest) {
+          if (isHelpRequest || commands[0] === 'plugin') {
             // We do not need full config resolved, we just need to know what
             // provider is service setup with, and with what eventual plugins Framework is extended
             // as that influences what CLI commands and options could be used,
@@ -362,7 +362,8 @@ const processSpanPromise = (async () => {
     serverless = new Serverless({
       configuration,
       configurationPath: configuration && configurationPath,
-      isConfigurationResolved: Boolean(variablesMeta && !variablesMeta.size),
+      isConfigurationResolved:
+        commands[0] === 'plugin' || Boolean(variablesMeta && !variablesMeta.size),
       hasResolvedCommandsExternally: true,
       commands,
       options,

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -413,7 +413,7 @@ const processSpanPromise = (async () => {
           ));
         }
 
-        require('../lib/cli/ensure-supported-command')();
+        require('../lib/cli/ensure-supported-command')(configuration);
         if (isHelpRequest) return;
         if (!_.get(variablesMeta, 'size')) return;
 

--- a/test/unit/lib/cli/ensure-supported-command.test.js
+++ b/test/unit/lib/cli/ensure-supported-command.test.js
@@ -13,7 +13,7 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
     triggeredDeprecations.clear();
     overrideArgv(
       {
-        args: ['serverless', 'info'],
+        args: ['serverless', 'login'],
       },
       () => resolveInput()
     );
@@ -53,7 +53,7 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
     triggeredDeprecations.clear();
     overrideArgv(
       {
-        args: ['serverless', 'info', '--hadsfa'],
+        args: ['serverless', 'login', '--hadsfa'],
       },
       () => resolveInput()
     );
@@ -66,7 +66,7 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
     triggeredDeprecations.clear();
     overrideArgv(
       {
-        args: ['serverless', 'deploy', 'function'],
+        args: ['serverless', 'config', 'credentials'],
       },
       () => resolveInput()
     );


### PR DESCRIPTION
- Ensure to respect `disabledDeprecations` when displaying CLI command usage related deprecation
- Validate command service dependency in CLI context
- Do not resolve variables in configuration in case of `plugin..` commands (fixes #5774)