### PR TITLE
fix(AWS API Gateway): Correctly recognize `type` for `authorizerId`

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/method/authorization.js
@@ -15,9 +15,20 @@ module.exports = {
 
     if (http.authorizer) {
       if (http.authorizer.type && http.authorizer.authorizerId) {
+        const authorizationType = (() => {
+          if (
+            http.authorizer.type.toUpperCase() === 'TOKEN' ||
+            http.authorizer.type.toUpperCase() === 'REQUEST'
+          ) {
+            return 'CUSTOM';
+          }
+
+          return http.authorizer.type;
+        })();
+
         const authReturn = {
           Properties: {
-            AuthorizationType: http.authorizer.type,
+            AuthorizationType: authorizationType,
             AuthorizerId: http.authorizer.authorizerId,
           },
         };

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -1772,4 +1772,48 @@ describe('#compileMethods v2()', () => {
       );
     });
   });
+
+  describe('method authorization', () => {
+    it('should correctly set method authorization properties', async () => {
+      const {
+        awsNaming,
+        cfTemplate: { Resources: cfResources },
+      } = await runServerless({
+        fixture: 'apiGateway',
+        configExt: {
+          functions: {
+            foo: {
+              events: [
+                {
+                  http: {
+                    authorizer: {
+                      type: 'REQUEST',
+                      authorizerId: 'some-id',
+                    },
+                  },
+                },
+                {
+                  http: {
+                    authorizer: {
+                      type: 'TOKEN',
+                      authorizerId: 'another-id',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+        command: 'package',
+      });
+      const apiGatewayRequestMethodConfig = cfResources[awsNaming.getMethodLogicalId('Foo', 'GET')];
+      expect(apiGatewayRequestMethodConfig.Properties.AuthorizationType).to.equal('CUSTOM');
+      expect(apiGatewayRequestMethodConfig.Properties.AuthorizerId).to.deep.equal('some-id');
+
+      const apiGatewayTokenMethodConfig =
+        cfResources[awsNaming.getMethodLogicalId('SomeDashpost', 'POST')];
+      expect(apiGatewayTokenMethodConfig.Properties.AuthorizationType).to.equal('CUSTOM');
+      expect(apiGatewayTokenMethodConfig.Properties.AuthorizerId).to.deep.equal('another-id');
+    });
+  });
 });


### PR DESCRIPTION
For provided `authorizerId` we did not correctly resolve `AuthorizationType` for `AWS::ApiGateway::Method` resource

Closes: #9294 