### PR TITLE
feat(Analytics): Send all telemetry events with single request

### DIFF
--- a/lib/utils/analytics/index.js
+++ b/lib/utils/analytics/index.js
@@ -18,6 +18,7 @@ const isUuid = RegExp.prototype.test.bind(
   /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/
 );
 
+// TODO: CLEAN UP THESE
 let serverlessRunEndTime;
 let ongoingRequestsCount = 0;
 
@@ -25,8 +26,6 @@ const logError = (type, error) => {
   if (!process.env.SLS_STATS_DEBUG) return;
   log(format('User stats error: %s: %O', type, error));
 };
-
-const markServerlessRunEnd = () => (serverlessRunEndTime = Date.now());
 
 const processResponseBody = async (response, id, startTime) => {
   let result;
@@ -123,9 +122,6 @@ async function report(payload, options = {}) {
 async function sendPending(options = {}) {
   const isForced = options && options.isForced;
   serverlessRunEndTime = null; // Needed for testing
-  if (options.serverlessExecutionSpan) {
-    options.serverlessExecutionSpan.then(markServerlessRunEnd, markServerlessRunEnd);
-  }
   if (areAnalyticsDisabled && !isForced) return;
   if (!cacheDirPath) return;
   const limit = pLimit(3);
@@ -136,8 +132,6 @@ async function sendPending(options = {}) {
     if (readdirError.code !== 'ENOENT') logError('Cannot access cache dir', readdirError);
     return;
   }
-
-  if (!options.serverlessExecutionSpan) process.nextTick(markServerlessRunEnd);
 
   await Promise.all(
     dirFilenames.map((dirFilename) =>

--- a/lib/utils/analytics/index.js
+++ b/lib/utils/analytics/index.js
@@ -3,7 +3,6 @@
 const { join } = require('path');
 const { format } = require('util');
 const ensurePlainObject = require('type/plain-object/ensure');
-const _ = require('lodash');
 const { v1: uuid } = require('uuid');
 const fetch = require('node-fetch');
 const fse = require('fs-extra');
@@ -123,8 +122,12 @@ async function report(payload, options = {}) {
 async function sendPending(options = {}) {
   const isForced = options && options.isForced;
   serverlessRunEndTime = null; // Needed for testing
+  if (options.serverlessExecutionSpan) {
+    options.serverlessExecutionSpan.then(markServerlessRunEnd, markServerlessRunEnd);
+  }
   if (areAnalyticsDisabled && !isForced) return null;
   if (!cacheDirPath) return null;
+  if (!analyticsUrl) return null;
   let dirFilenames;
   try {
     dirFilenames = await fse.readdir(cacheDirPath);
@@ -132,8 +135,6 @@ async function sendPending(options = {}) {
     if (readdirError.code !== 'ENOENT') logError('Cannot access cache dir', readdirError);
     return null;
   }
-
-  process.nextTick(markServerlessRunEnd);
 
   const payloadsWithIds = (
     await Promise.all(
@@ -174,7 +175,7 @@ async function sendPending(options = {}) {
         return null;
       })
     )
-  ).filter((item) => _.isPlainObject(item));
+  ).filter(Boolean);
 
   return request(
     payloadsWithIds.map((item) => item.payload),

--- a/lib/utils/analytics/index.js
+++ b/lib/utils/analytics/index.js
@@ -120,7 +120,7 @@ async function report(payload, options = {}) {
         return null;
       }
     })(),
-    request(payload, { ids: [id] }),
+    request([payload], { ids: [id] }),
   ]);
   return requestResult;
 }

--- a/lib/utils/analytics/index.js
+++ b/lib/utils/analytics/index.js
@@ -18,9 +18,7 @@ const isUuid = RegExp.prototype.test.bind(
   /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/
 );
 
-// TODO: CLEAN UP THESE
 let serverlessRunEndTime;
-let ongoingRequestsCount = 0;
 
 const logError = (type, error) => {
   if (!process.env.SLS_STATS_DEBUG) return;
@@ -37,12 +35,10 @@ const processResponseBody = async (response, ids, startTime) => {
   } catch (error) {
     logError(`Response processing error for ${ids || '<no id>'}`, error);
     return null;
-  } finally {
-    --ongoingRequestsCount;
   }
 
   const endTime = Date.now();
-  if (serverlessRunEndTime && !ongoingRequestsCount && process.env.SLS_STATS_DEBUG) {
+  if (serverlessRunEndTime && process.env.SLS_STATS_DEBUG) {
     log(
       format(
         'Stats request prevented process from exiting for %dms (request time: %dms)',
@@ -55,7 +51,6 @@ const processResponseBody = async (response, ids, startTime) => {
 };
 
 async function request(payload, { ids, timeout } = {}) {
-  ++ongoingRequestsCount;
   const startTime = Date.now();
   let response;
   const body = JSON.stringify(payload);
@@ -100,7 +95,7 @@ async function report(payload, options = {}) {
   if (!analyticsUrl) return null;
   const isForced = options && options.isForced;
   if (areAnalyticsDisabled && !isForced) return null;
-  if (!cacheDirPath) return request(payload);
+  if (!cacheDirPath) return request([payload]);
   const id = uuid();
 
   const [, requestResult] = await Promise.all([
@@ -140,8 +135,6 @@ async function sendPending(options = {}) {
 
   process.nextTick(markServerlessRunEnd);
 
-  // TODO: TESTS
-  // TODO: CHANGE NAME
   const payloadsWithIds = (
     await Promise.all(
       dirFilenames.map(async (dirFilename) => {

--- a/lib/utils/analytics/index.js
+++ b/lib/utils/analytics/index.js
@@ -3,8 +3,8 @@
 const { join } = require('path');
 const { format } = require('util');
 const ensurePlainObject = require('type/plain-object/ensure');
+const _ = require('lodash');
 const { v1: uuid } = require('uuid');
-const pLimit = require('p-limit');
 const fetch = require('node-fetch');
 const fse = require('fs-extra');
 const analyticsUrl = require('@serverless/utils/analytics-and-notfications-url');
@@ -27,13 +27,15 @@ const logError = (type, error) => {
   log(format('User stats error: %s: %O', type, error));
 };
 
-const processResponseBody = async (response, id, startTime) => {
+const markServerlessRunEnd = () => (serverlessRunEndTime = Date.now());
+
+const processResponseBody = async (response, ids, startTime) => {
   let result;
 
   try {
     result = await response.json();
   } catch (error) {
-    logError(`Response processing error for ${id || '<no id>'}`, error);
+    logError(`Response processing error for ${ids || '<no id>'}`, error);
     return null;
   } finally {
     --ongoingRequestsCount;
@@ -52,7 +54,7 @@ const processResponseBody = async (response, id, startTime) => {
   return result;
 };
 
-async function request(payload, { id, timeout } = {}) {
+async function request(payload, { ids, timeout } = {}) {
   ++ongoingRequestsCount;
   const startTime = Date.now();
   let response;
@@ -74,19 +76,23 @@ async function request(payload, { id, timeout } = {}) {
 
   if (response.status < 200 || response.status >= 300) {
     logError('Unexpected request response', response);
-    return processResponseBody(response, id, startTime);
+    return processResponseBody(response, ids, startTime);
   }
 
-  if (!id) return processResponseBody(response, id, startTime);
+  if (!ids) return processResponseBody(response, ids, startTime);
 
-  const cachePath = join(cacheDirPath, id);
-  try {
-    await fse.unlink(cachePath);
-  } catch (error) {
-    logError(`Could not remove cache file ${id}`, error);
-  }
+  await Promise.all(
+    ids.map(async (id) => {
+      const cachePath = join(cacheDirPath, id);
+      try {
+        await fse.unlink(cachePath);
+      } catch (error) {
+        logError(`Could not remove cache file ${id}`, error);
+      }
+    })
+  );
 
-  return processResponseBody(response, id, startTime);
+  return processResponseBody(response, ids, startTime);
 }
 
 async function report(payload, options = {}) {
@@ -114,7 +120,7 @@ async function report(payload, options = {}) {
         return null;
       }
     })(),
-    request(payload, { id }),
+    request(payload, { ids: [id] }),
   ]);
   return requestResult;
 }
@@ -122,21 +128,23 @@ async function report(payload, options = {}) {
 async function sendPending(options = {}) {
   const isForced = options && options.isForced;
   serverlessRunEndTime = null; // Needed for testing
-  if (areAnalyticsDisabled && !isForced) return;
-  if (!cacheDirPath) return;
-  const limit = pLimit(3);
+  if (areAnalyticsDisabled && !isForced) return null;
+  if (!cacheDirPath) return null;
   let dirFilenames;
   try {
     dirFilenames = await fse.readdir(cacheDirPath);
   } catch (readdirError) {
     if (readdirError.code !== 'ENOENT') logError('Cannot access cache dir', readdirError);
-    return;
+    return null;
   }
 
-  await Promise.all(
-    dirFilenames.map((dirFilename) =>
-      limit(async () => {
-        if (serverlessRunEndTime) return null;
+  process.nextTick(markServerlessRunEnd);
+
+  // TODO: TESTS
+  // TODO: CHANGE NAME
+  const payloadsWithIds = (
+    await Promise.all(
+      dirFilenames.map(async (dirFilename) => {
         if (!isUuid(dirFilename)) return null;
         let data;
         try {
@@ -155,11 +163,10 @@ async function sendPending(options = {}) {
         if (data && data.payload) {
           const timestamp = Number(data.timestamp);
           if (timestamp > timestampWeekBefore) {
-            if (!analyticsUrl) return null;
-            return request(data.payload, {
+            return {
+              payload: data.payload,
               id: dirFilename,
-              timeout: 3000,
-            });
+            };
           }
         } else {
           logError(`Invalid cached data ${dirFilename}`, data);
@@ -174,8 +181,15 @@ async function sendPending(options = {}) {
         return null;
       })
     )
+  ).filter((item) => _.isPlainObject(item));
+
+  return request(
+    payloadsWithIds.map((item) => item.payload),
+    {
+      ids: payloadsWithIds.map((item) => item.id),
+      timeout: 3000,
+    }
   );
-  return;
 }
 
 module.exports = { report, sendPending };

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "ncjsm": "^4.1.0",
     "node-fetch": "^2.6.1",
     "object-hash": "^2.1.1",
-    "p-limit": "^3.1.0",
     "promise-queue": "^2.2.5",
     "replaceall": "^0.1.6",
     "semver": "^7.3.5",

--- a/test/unit/lib/utils/analytics/index.test.js
+++ b/test/unit/lib/utils/analytics/index.test.js
@@ -23,7 +23,7 @@ describe('analytics', () => {
   };
 
   const cacheEvent = async (timestamp = Date.now()) => {
-    fse.writeJson(path.join(cacheDirPath, uuid()), { payload: {}, timestamp });
+    await fse.writeJson(path.join(cacheDirPath, uuid()), { payload: {}, timestamp });
   };
 
   before(() => {

--- a/test/unit/lib/utils/analytics/index.test.js
+++ b/test/unit/lib/utils/analytics/index.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const path = require('path');
-const BbPromise = require('bluebird');
 const fse = require('fs-extra');
 const proxyquire = require('proxyquire');
 const { expect } = require('chai');
 const { v1: uuid } = require('uuid');
+const wait = require('timers-ext/promise/sleep');
 const cacheDirPath = require('../../../../../lib/utils/analytics/cache-path');
 
 const analyticsUrl = 'https://..';
@@ -17,14 +17,12 @@ describe('analytics', () => {
   let expectedState = 'success';
   let usedUrl;
   let usedOptions;
-  let pendingRequests = 0;
-  let concurrentRequestsMax = 0;
 
-  const sendReport = () => {
+  const sendReport = async () => {
     return report({});
   };
 
-  const cacheEvent = (timestamp = Date.now()) => {
+  const cacheEvent = async (timestamp = Date.now()) => {
     fse.writeJson(path.join(cacheDirPath, uuid()), { payload: {}, timestamp });
   };
 
@@ -33,64 +31,55 @@ describe('analytics', () => {
     ({ report, sendPending } = proxyquire('../../../../../lib/utils/analytics/index.js', {
       '@serverless/utils/analytics-and-notfications-url': analyticsUrl,
       './areDisabled': false,
-      'node-fetch': (url, options) => {
+      'node-fetch': async (url, options) => {
         usedUrl = url;
         usedOptions = options;
-        ++pendingRequests;
-        if (pendingRequests > concurrentRequestsMax) concurrentRequestsMax = pendingRequests;
-        return new BbPromise((resolve, reject) => {
-          setTimeout(() => {
-            switch (expectedState) {
-              case 'success':
-                return resolve({ status: 200, json: () => Promise.resolve([]) });
-              case 'networkError':
-                return reject(Object.assign(new Error('Network error'), { code: 'NETWORK_ERROR' }));
-              case 'responseBodyError':
-                return resolve({
-                  status: 200,
-                  json: () =>
-                    Promise.reject(
-                      Object.assign(new Error('Response body error'), {
-                        code: 'RESPONSE_BODY_ERROR',
-                      })
-                    ),
+        await wait(500);
+        switch (expectedState) {
+          case 'success':
+            return { status: 200, json: async () => [] };
+          case 'networkError':
+            throw Object.assign(new Error('Network error'), { code: 'NETWORK_ERROR' });
+          case 'responseBodyError':
+            return {
+              status: 200,
+              json: async () => {
+                throw Object.assign(new Error('Response body error'), {
+                  code: 'RESPONSE_BODY_ERROR',
                 });
-              default:
-                throw new Error(`Unexpected state: ${expectedState}`);
-            }
-          }, 500);
-        }).finally(() => --pendingRequests);
+              },
+            };
+          default:
+            throw new Error(`Unexpected state: ${expectedState}`);
+        }
       },
     }));
   });
 
-  it('Should ignore missing cacheDirPath', () =>
-    sendPending().then((sendPendingResult) => {
-      expect(sendPendingResult).to.be.null;
-      return sendReport().then(() => {
-        expect(usedUrl).to.equal(analyticsUrl);
-        return fse.readdir(cacheDirPath).then((dirFilenames) => {
-          expect(dirFilenames.filter(isFilename).length).to.equal(0);
-        });
-      });
-    }));
+  it('Should ignore missing cacheDirPath', async () => {
+    const sendPendingResult = await sendPending();
+    expect(sendPendingResult).to.be.null;
+    await sendReport();
+    expect(usedUrl).to.equal(analyticsUrl);
+    const dirFilenames = await fse.readdir(cacheDirPath);
+    expect(dirFilenames.filter(isFilename).length).to.equal(0);
+    expect(JSON.parse(usedOptions.body)).to.have.lengthOf(1);
+  });
 
-  it('Should cache failed requests and rerun then with sendPending', () => {
+  it('Should cache failed requests and rerun then with sendPending', async () => {
     expectedState = 'networkError';
-    return sendReport()
-      .then(() => {
-        expect(usedUrl).to.equal(analyticsUrl);
-        return fse.readdir(cacheDirPath);
-      })
-      .then((dirFilenames) => {
-        expect(dirFilenames.filter(isFilename).length).to.equal(1);
-        expectedState = 'success';
-        return sendPending();
-      })
-      .then(() => fse.readdir(cacheDirPath))
-      .then((dirFilenames) => {
-        expect(dirFilenames.filter(isFilename).length).to.equal(0);
-      });
+    await sendReport();
+    expect(usedUrl).to.equal(analyticsUrl);
+    const dirFilenames = await fse.readdir(cacheDirPath);
+    expect(dirFilenames.filter(isFilename).length).to.equal(1);
+
+    expectedState = 'success';
+    await sendPending();
+    const dirFilenamesAfterSend = await fse.readdir(cacheDirPath);
+    expect(dirFilenamesAfterSend.filter(isFilename).length).to.equal(0);
+
+    // Check that one event was send with request
+    expect(JSON.parse(usedOptions.body)).to.have.lengthOf(1);
   });
 
   it('Should ditch stale events at sendPending', async () => {
@@ -105,14 +94,10 @@ describe('analytics', () => {
     expect(JSON.parse(usedOptions.body)).to.have.lengthOf(2);
   });
 
-  it('Should ignore body procesing error', () => {
+  it('Should ignore body procesing error', async () => {
     expectedState = 'responseBodyError';
-    return sendReport()
-      .then(() => {
-        return fse.readdir(cacheDirPath);
-      })
-      .then((dirFilenames) => {
-        expect(dirFilenames.filter(isFilename).length).to.equal(0);
-      });
+    await sendReport();
+    const dirFilenames = await fse.readdir(cacheDirPath);
+    expect(dirFilenames.filter(isFilename).length).to.equal(0);
   });
 });

--- a/test/unit/lib/utils/analytics/index.test.js
+++ b/test/unit/lib/utils/analytics/index.test.js
@@ -94,10 +94,6 @@ describe('analytics', () => {
   it('Should limit concurrent requests at sendPending', () => {
     expectedState = 'networkError';
     expect(pendingRequests).to.equal(0);
-    let resolveServerlessExecutionSpan;
-    const serverlessExecutionSpan = new BbPromise(
-      (resolve) => (resolveServerlessExecutionSpan = resolve)
-    );
     return Promise.all([
       sendReport(),
       sendReport(),
@@ -115,50 +111,18 @@ describe('analytics', () => {
         expectedState = 'success';
         expect(pendingRequests).to.equal(0);
         concurrentRequestsMax = 0;
-        return sendPending({ serverlessExecutionSpan });
+        return sendPending();
       })
       .then(() => fse.readdir(cacheDirPath))
       .then((dirFilenames) => {
         expect(dirFilenames.filter(isFilename).length).to.equal(0);
         expect(concurrentRequestsMax).to.equal(3);
-        resolveServerlessExecutionSpan();
-        return serverlessExecutionSpan;
-      });
-  });
-
-  it('Should not issue further requests after serverless execution ends', () => {
-    expectedState = 'networkError';
-    return Promise.all([
-      sendReport(),
-      sendReport(),
-      sendReport(),
-      sendReport(),
-      sendReport(),
-      sendReport(),
-      sendReport(),
-    ])
-      .then(() => {
-        return fse.readdir(cacheDirPath);
-      })
-      .then((dirFilenames) => {
-        expect(dirFilenames.filter(isFilename).length).to.equal(7);
-        expectedState = 'success';
-        return sendPending();
-      })
-      .then(() => fse.readdir(cacheDirPath))
-      .then((dirFilenames) => {
-        expect(dirFilenames.filter(isFilename).length).to.equal(4);
-        return fse.emptyDir(cacheDirPath);
       });
   });
 
   it('Should ditch stale events at sendPending', () => {
     expectedState = 'networkError';
     expect(pendingRequests).to.equal(0);
-    let resolveServerlessExecutionSpan;
-    const serverlessExecutionSpan = new BbPromise(
-      (resolve) => (resolveServerlessExecutionSpan = resolve)
-    );
     return Promise.all([
       cacheEvent(0),
       cacheEvent(0),
@@ -176,14 +140,12 @@ describe('analytics', () => {
         expectedState = 'success';
         expect(pendingRequests).to.equal(0);
         concurrentRequestsMax = 0;
-        return sendPending({ serverlessExecutionSpan });
+        return sendPending();
       })
       .then(() => fse.readdir(cacheDirPath))
       .then((dirFilenames) => {
         expect(dirFilenames.filter(isFilename).length).to.equal(0);
         expect(concurrentRequestsMax).to.equal(2);
-        resolveServerlessExecutionSpan();
-        return serverlessExecutionSpan;
       });
   });
 


### PR DESCRIPTION
Addresses 2 from #9257 

Additionally, it includes cleanup/refactoring for tests 