### PR TITLE
API: Introduce `serviceDir` and `configurationFilename` constructor options

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -125,13 +125,19 @@ _Note: Applies only to eventual programmatic usage of the Framework_
 
 <a name="MISSING_SERVICE_CONFIGURATION"><div>&nbsp;</div></a>
 
-## `Serverless` constructor `config.configuration` requirement
+## `Serverless` constructor service configuration dependency
 
 Deprecation code: `MISSING_SERVICE_CONFIGURATION`
 
 _Note: Applies only to eventual programmatic usage of the Framework_
 
-`Serverless` constructor was refactored to depend on service configuration being resolved externally and passed to its constructor with `config.configuration`. Starting from v3.0.0 configuration will not be resolved internally.
+`Serverless` constructor was refactored to depend on service configuration being resolved externally and passed to its constructor with following options:
+
+- `configuration` - Service configuration (JSON serializable plain object)
+- `serviceDir` - Directory in which service is placed (All path references in service configuration will be resolved against this path)
+- `configurationFilename` - Name of configuration file (e.g. `serverless.yml`).
+
+Starting from v3.0.0 configuration data will not be resolved internally, and if `Serverless` is invoked in service context, all three options will have to be provided
 
 <a name="NESTED_CUSTOM_CONFIGURATION_PATH"><div>&nbsp;</div></a>
 
@@ -148,13 +154,19 @@ To avoid confusing behavior starting with v3.0.0 Framework will no longer permit
 
 <a name="MISSING_SERVICE_CONFIGURATION_PATH"><div>&nbsp;</div></a>
 
-## `Serverless` constructor `config.configurationPath` requirement
+## `Serverless` constructor service configuration dependency
 
 Deprecation code: `MISSING_SERVICE_CONFIGURATION_PATH`
 
 _Note: Applies only to eventual programmatic usage of the Framework_
 
-`Serverless` constructor was refactored to depend on service configuration path being resolved externally and passed to its constructor with `config.configurationPath`. Starting from v3.0.0 this path will not be resolved internally.
+`Serverless` constructor was refactored to depend on service configuration being resolved externally and passed to its constructor with following options:
+
+- `configuration` - Service configuration (JSON serializable plain object)
+- `serviceDir` - Directory in which service is placed (All path references in service configuration will be resolved against this path)
+- `configurationFilename` - Name of configuration file (e.g. `serverless.yml`).
+
+Starting from v3.0.0 configuration data will not be resolved internally, and if `Serverless` is invoked in service context, all three options will have to be provided
 
 <a name="VARIABLES_ERROR_ON_UNRESOLVED"><div>&nbsp;</div></a>
 

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -30,13 +30,15 @@ class Serverless {
     let configObject = config;
     configObject = configObject || {};
     this._isInvokedByGlobalInstallation = Boolean(configObject._isInvokedByGlobalInstallation);
-    this.configurationPath = ensureString(configObject.configurationPath, {
+    let configurationPath = ensureString(configObject.configurationPath, {
       isOptional: true,
       name: 'config.configurationPath',
       Error: ServerlessError,
     });
-    if (this.configurationPath) {
-      this.configurationPath = path.resolve(this.configurationPath);
+    if (configurationPath) {
+      configurationPath = path.resolve(configurationPath);
+      this.serviceDir = configObject.servicePath = process.cwd();
+      this.configurationFilename = configurationPath.slice(this.serviceDir.length + 1);
       this.configurationInput = ensurePlainObject(configObject.configuration, {
         isOptional: true,
         name: 'config.configuration',
@@ -83,11 +85,6 @@ class Serverless {
     this.pluginManager = new PluginManager(this);
     this.configSchemaHandler = new ConfigSchemaHandler(this);
 
-    if (this.configurationPath) {
-      // TODO: With a new major release switch resolution to `path.dirname(this.configurationPath)`
-      configObject.servicePath = process.cwd();
-    }
-
     this.config = new Config(this, configObject);
 
     this.classes = {};
@@ -129,9 +126,10 @@ class Serverless {
       }
     }
     if (this._shouldResolveConfigurationInternally) {
-      this.configurationPath = await resolveConfigurationPath();
-      if (this.configurationPath) {
-        this.config.servicePath = process.cwd();
+      const configurationPath = await resolveConfigurationPath();
+      if (configurationPath) {
+        this.serviceDir = this.config.servicePath = process.cwd();
+        this.configurationFilename = configurationPath.slice(this.serviceDir.length + 1);
         if (!this._isInvokedByGlobalInstallation) {
           this._logDeprecation(
             'MISSING_SERVICE_CONFIGURATION_PATH',
@@ -142,10 +140,10 @@ class Serverless {
         }
       }
     }
-    if (this.configurationPath && !this.configurationInput) {
+    if (this.configurationFilename && !this.configurationInput) {
       this.configurationInput = await (async () => {
         try {
-          return await readConfiguration(this.configurationPath);
+          return await readConfiguration(path.resolve(this.serviceDir, this.configurationFilename));
         } catch (error) {
           if (resolveCliInput().isHelpRequest) return null;
           throw error;
@@ -210,7 +208,8 @@ class Serverless {
     this.isOverridenByLocal = true;
     const ServerlessLocal = require(localServerlessPath);
     const serverlessLocal = new ServerlessLocal({
-      configurationPath: this.configurationPath,
+      configurationPath:
+        this.configurationFilename && path.resolve(this.serviceDir, this.configurationFilename),
       configuration: this.configurationInput,
       isConfigurationResolved: this.isConfigurationInputResolved,
       hasResolvedCommandsExternally: this.hasResolvedCommandsExternally,

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -30,13 +30,37 @@ class Serverless {
     let configObject = config;
     configObject = configObject || {};
     this._isInvokedByGlobalInstallation = Boolean(configObject._isInvokedByGlobalInstallation);
-    let configurationPath = ensureString(configObject.configurationPath, {
-      isOptional: true,
-      name: 'config.configurationPath',
-      Error: ServerlessError,
-    });
-    if (configurationPath) {
-      configurationPath = path.resolve(configurationPath);
+
+    if (configObject.serviceDir != null) {
+      // Modern intialization way, to be the only supported way with v3
+      this.serviceDir = path.resolve(
+        ensureString(configObject.serviceDir, {
+          name: 'config.serviceDir',
+          Error: ServerlessError,
+        })
+      );
+      this.configurationFilename = ensureString(configObject.configurationFilename, {
+        name: 'config.configurationFilename',
+        Error: ServerlessError,
+      });
+      if (path.isAbsolute(this.configurationFilename)) {
+        throw new ServerlessError(
+          `"config.configurationFilename" cannot be absolute path. Received: ${configObject.configurationFilename}`
+        );
+      }
+      this.configurationInput = ensurePlainObject(configObject.configuration, {
+        name: 'config.configuration',
+        Error: ServerlessError,
+      });
+      this.isConfigurationInputResolved = Boolean(configObject.isConfigurationResolved);
+    } else if (configObject.configurationPath != null) {
+      // Semi-modern initialization way, mid-step introduced over the course of v2 refactor
+      const configurationPath = path.resolve(
+        ensureString(configObject.configurationPath, {
+          name: 'config.configurationPath',
+          Error: ServerlessError,
+        })
+      );
       this.serviceDir = configObject.servicePath = process.cwd();
       this.configurationFilename = configurationPath.slice(this.serviceDir.length + 1);
       this.configurationInput = ensurePlainObject(configObject.configuration, {
@@ -46,11 +70,15 @@ class Serverless {
       });
       if (this.configurationInput) {
         this.isConfigurationInputResolved = Boolean(configObject.isConfigurationResolved);
-      } else if (!this._isInvokedByGlobalInstallation) {
-        this._shouldReportMissingServiceDeprecation = true;
       }
-    } else if (configObject.configurationPath === undefined) {
+      this._shouldReportMissingServiceDeprecation = true;
+    } else if (
+      configObject.configurationPath === undefined &&
+      configObject.serviceDir === undefined
+    ) {
+      // Old intialization way
       this._shouldResolveConfigurationInternally = true;
+      this._shouldReportMissingServiceDeprecation = true;
     }
     const commands = ensureArray(configObject.commands, { isOptional: true });
     const options = ensurePlainObject(configObject.options, { isOptional: true });
@@ -111,9 +139,8 @@ class Serverless {
       if (this._shouldReportMissingServiceDeprecation) {
         this._logDeprecation(
           'MISSING_SERVICE_CONFIGURATION',
-          'Serverless constructor expects resolved service configuration to be provided ' +
-            'via "config.configuration".\n' +
-            'Starting from next major Serverless will no longer auto resolve it.'
+          'Serverless constructor expects service configuration details to be provided.\n' +
+            'Starting from next major Serverless will no longer auto resolve it internally.'
         );
       }
       if (this._shouldReportCommandsDeprecation) {
@@ -130,14 +157,6 @@ class Serverless {
       if (configurationPath) {
         this.serviceDir = this.config.servicePath = process.cwd();
         this.configurationFilename = configurationPath.slice(this.serviceDir.length + 1);
-        if (!this._isInvokedByGlobalInstallation) {
-          this._logDeprecation(
-            'MISSING_SERVICE_CONFIGURATION_PATH',
-            'Serverless constructor expects resolved service configuration path to be provided ' +
-              'via "config.configurationPath".\n' +
-              'Starting from next major Serverless will no longer auto resolve that path internally.'
-          );
-        }
       }
     }
     if (this.configurationFilename && !this.configurationInput) {
@@ -208,8 +227,11 @@ class Serverless {
     this.isOverridenByLocal = true;
     const ServerlessLocal = require(localServerlessPath);
     const serverlessLocal = new ServerlessLocal({
+      serviceDir: this.serviceDir || null,
+      configurationFilename: this.configurationFilename,
       configurationPath:
-        this.configurationFilename && path.resolve(this.serviceDir, this.configurationFilename),
+        (this.configurationFilename && path.resolve(this.serviceDir, this.configurationFilename)) ||
+        null,
       configuration: this.configurationInput,
       isConfigurationResolved: this.isConfigurationInputResolved,
       hasResolvedCommandsExternally: this.hasResolvedCommandsExternally,

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -284,7 +284,7 @@ class Serverless {
     this.service.setFunctionNames(this.processedInput.options);
 
     // If in context of service, validate the service configuration
-    if (this.config.servicePath) this.service.validate();
+    if (this.serviceDir) this.service.validate();
 
     // trigger the plugin lifecycle when there's something which should be processed
     await this.pluginManager.run(this.processedInput.commands);

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -13,7 +13,7 @@ const getCacheFilePath = require('../utils/getCacheFilePath');
 const getCommandSuggestion = require('../utils/getCommandSuggestion');
 const renderCommandHelp = require('../cli/render-help/command');
 
-const requireServicePlugin = (servicePath, pluginPath, localPluginsPath) => {
+const requireServicePlugin = (serviceDir, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
     // TODO (BREAKING): Consider removing support for localPluginsPath with next major
     const absoluteLocalPluginPath = path.resolve(localPluginsPath, pluginPath);
@@ -25,7 +25,7 @@ const requireServicePlugin = (servicePath, pluginPath, localPluginsPath) => {
     }
   }
   try {
-    return require(cjsResolve(servicePath, pluginPath).realPath);
+    return require(cjsResolve(serviceDir, pluginPath).realPath);
   } catch (error) {
     if (!isModuleNotFoundError(error, pluginPath) || pluginPath.startsWith('.')) {
       throw error;
@@ -160,13 +160,13 @@ class PluginManager {
 
   resolveServicePlugins(servicePlugs) {
     const pluginsObject = this.parsePluginsObject(servicePlugs);
-    const servicePath = this.serverless.serviceDir;
+    const serviceDir = this.serverless.serviceDir;
     return pluginsObject.modules
       .filter((name) => name !== '@serverless/enterprise-plugin')
       .map((name) => {
         let Plugin;
         try {
-          Plugin = requireServicePlugin(servicePath, name, pluginsObject.localPath);
+          Plugin = requireServicePlugin(serviceDir, name, pluginsObject.localPath);
         } catch (error) {
           if (!isModuleNotFoundError(error, name)) throw error;
 

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -160,7 +160,7 @@ class PluginManager {
 
   resolveServicePlugins(servicePlugs) {
     const pluginsObject = this.parsePluginsObject(servicePlugs);
-    const servicePath = this.serverless.config.servicePath;
+    const servicePath = this.serverless.serviceDir;
     return pluginsObject.modules
       .filter((name) => name !== '@serverless/enterprise-plugin')
       .map((name) => {
@@ -206,9 +206,8 @@ class PluginManager {
   parsePluginsObject(servicePlugs) {
     let localPath =
       this.serverless &&
-      this.serverless.config &&
-      this.serverless.config.servicePath &&
-      path.join(this.serverless.config.servicePath, '.serverless_plugins');
+      this.serverless.serviceDir &&
+      path.join(this.serverless.serviceDir, '.serverless_plugins');
     let modules = [];
 
     if (Array.isArray(servicePlugs)) {
@@ -666,7 +665,7 @@ class PluginManager {
       .update(JSON.stringify(this.serverless.configurationInput || null))
       .digest('hex');
     cacheFile.validationHash = serverlessConfigFileHash;
-    const cacheFilePath = getCacheFilePath(this.serverless.config.servicePath);
+    const cacheFilePath = getCacheFilePath(this.serverless.serviceDir);
 
     return writeFile(cacheFilePath, cacheFile);
   }

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -37,11 +37,11 @@ class Service {
     const options = rawOptions || {};
     if (!options.stage && options.s) options.stage = options.s;
     if (!options.region && options.r) options.region = options.r;
-    const servicePath = this.serverless.serviceDir;
+    const serviceDir = this.serverless.serviceDir;
 
     // skip if the service path is not found
     // because the user might be creating a new service
-    if (!servicePath) return;
+    if (!serviceDir) return;
 
     try {
       this.loadServiceFileParam();

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -37,7 +37,7 @@ class Service {
     const options = rawOptions || {};
     if (!options.stage && options.s) options.stage = options.s;
     if (!options.region && options.r) options.region = options.r;
-    const servicePath = this.serverless.config.servicePath;
+    const servicePath = this.serverless.serviceDir;
 
     // skip if the service path is not found
     // because the user might be creating a new service

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { ServerlessError, logWarning } = require('./Error');
-const path = require('path');
 const util = require('util');
 const _ = require('lodash');
 const semver = require('semver');
@@ -54,7 +53,6 @@ class Service {
 
   loadServiceFileParam() {
     const serverlessFileParam = this.serverless.configurationInput;
-    this.serviceFilename = path.basename(this.serverless.configurationPath);
 
     const serverlessFile = serverlessFileParam;
     // basic service level validation
@@ -86,19 +84,19 @@ class Service {
     ) {
       const errorMessage = [
         `The Serverless version (${version}) does not satisfy the`,
-        ` "frameworkVersion" (${ymlVersion}) in ${this.serviceFilename}`,
+        ` "frameworkVersion" (${ymlVersion}) in ${this.serverless.configurationFilename}`,
       ].join('');
       throw new ServerlessError(errorMessage, 'FRAMEWORK_VERSION_MISMATCH');
     }
     if (!serverlessFile.service) {
       throw new ServerlessError(
-        `"service" property is missing in ${this.serviceFilename}`,
+        `"service" property is missing in ${this.serverless.configurationFilename}`,
         'SERVICE_NAME_MISSING'
       );
     }
     if (!serverlessFile.provider) {
       throw new ServerlessError(
-        `"provider" property is missing in ${this.serviceFilename}`,
+        `"provider" property is missing in ${this.serverless.configurationFilename}`,
         'PROVIDER_NAME_MISSING'
       );
     }

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -661,7 +661,7 @@ class Variables {
 
     let referencedFileFullPath = path.isAbsolute(referencedFileRelativePath)
       ? referencedFileRelativePath
-      : path.join(this.serverless.config.servicePath, referencedFileRelativePath);
+      : path.join(this.serverless.serviceDir, referencedFileRelativePath);
 
     // Get real path to handle potential symlinks (but don't fatal error)
     referencedFileFullPath = fse.existsSync(referencedFileFullPath)

--- a/lib/cli/resolve-configuration-path.js
+++ b/lib/cli/resolve-configuration-path.js
@@ -44,10 +44,6 @@ module.exports = async () => {
       );
     }
     if (process.cwd() !== path.dirname(customConfigPath)) {
-      // TODO:
-      // When clearing this deprecation for a new major also ensure that servicePath
-      // (currently set on serverless.config.servicePath) is resolved from configurationPath and not
-      // current working directory
       logDeprecation(
         'NESTED_CUSTOM_CONFIGURATION_PATH',
         'Service configuration is expected to be placed in a root of a service (working directory). All paths, function handlers in a configuration are resolved against service directory".\n' +

--- a/lib/configuration/variables/index.js
+++ b/lib/configuration/variables/index.js
@@ -32,8 +32,9 @@ const reportEventualErrors = (variablesMeta) => {
   );
 };
 
-module.exports = async ({ servicePath, configuration, options }) => {
-  servicePath = ensureString(servicePath);
+module.exports = async ({ serviceDir, servicePath, configuration, options }) => {
+  // TODO: Remove support for `servicePath` with next major
+  serviceDir = ensureString(serviceDir || servicePath);
   ensurePlainObject(configuration);
   options = ensurePlainObject(options, { default: {} });
 
@@ -41,7 +42,7 @@ module.exports = async ({ servicePath, configuration, options }) => {
   reportEventualErrors(variablesMeta);
 
   await resolve({
-    servicePath,
+    serviceDir,
     configuration,
     variablesMeta,
     sources,

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -29,7 +29,7 @@ let lastResolutionBatchId = 0;
 
 class VariablesResolver {
   constructor({
-    servicePath,
+    serviceDir,
     configuration,
     variablesMeta,
     sources,
@@ -37,7 +37,7 @@ class VariablesResolver {
     fulfilledSources,
     propertyPathsToResolve,
   }) {
-    this.servicePath = servicePath;
+    this.serviceDir = serviceDir;
     this.configuration = configuration;
     this.variablesMeta = variablesMeta;
     this.sources = sources;
@@ -465,7 +465,9 @@ Object.defineProperties(
           address: sourceData.address && sourceData.address.value,
           options: this.options,
           isSourceFulfilled: this.fulfilledSources.has(sourceData.type),
-          servicePath: this.servicePath,
+          serviceDir: this.serviceDir,
+          // TOOD: Remove `servicePath` with next major
+          servicePath: this.serviceDir,
           resolveConfigurationProperty: async (dependencyPropertyPathKeys) =>
             this.resolveDependentProperty(
               resolutionBatchId,
@@ -538,7 +540,7 @@ module.exports = async (data) => {
   // Input sanity check
   // Note: this function is considered private, if there's a crash here, it signals an internal bug
   data = { ...ensurePlainObject(data) };
-  data.servicePath = path.resolve(ensureString(data.servicePath));
+  data.serviceDir = path.resolve(ensureString(data.serviceDir));
   ensurePlainObject(data.configuration);
   ensureMap(data.variablesMeta);
   ensurePlainObject(data.sources);

--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -8,20 +8,20 @@ const yaml = require('js-yaml');
 const cloudformationSchema = require('@serverless/utils/cloudformation-schema');
 const ServerlessError = require('../../../serverless-error');
 
-const readFile = async (filePath, servicePath) => {
+const readFile = async (filePath, serviceDir) => {
   try {
     return await fs.readFile(filePath, 'utf8');
   } catch (error) {
     if (error.code === 'ENOENT') return null;
     throw new ServerlessError(
-      `Cannot parse "${filePath.slice(servicePath.length + 1)}": ${error.message}`,
+      `Cannot parse "${filePath.slice(serviceDir.length + 1)}": ${error.message}`,
       'FILE_NOT_ACCESSIBLE'
     );
   }
 };
 
 module.exports = {
-  resolve: async ({ servicePath, params, address, resolveConfigurationProperty, options }) => {
+  resolve: async ({ serviceDir, params, address, resolveConfigurationProperty, options }) => {
     if (!params || !params[0]) {
       throw new ServerlessError(
         'Missing path argument in variable "file" source',
@@ -29,13 +29,13 @@ module.exports = {
       );
     }
     const filePath = path.resolve(
-      servicePath,
+      serviceDir,
       ensureString(params[0], {
         Error: ServerlessError,
         errorMessage: 'Non-string path argument in variable "file" source: %v',
       })
     );
-    if (!filePath.startsWith(`${servicePath}${path.sep}`)) {
+    if (!filePath.startsWith(`${serviceDir}${path.sep}`)) {
       throw new ServerlessError(
         'Cannot load file from outside of service folder',
         'FILE_SOURCE_PATH_OUTSIDE_OF_SERVICE'
@@ -54,7 +54,7 @@ module.exports = {
       switch (path.extname(filePath)) {
         case '.yml':
         case '.yaml': {
-          const yamlContent = await readFile(filePath, servicePath);
+          const yamlContent = await readFile(filePath, serviceDir);
           if (yamlContent == null) return null;
           try {
             return yaml.load(yamlContent, {
@@ -63,7 +63,7 @@ module.exports = {
             });
           } catch (error) {
             throw new ServerlessError(
-              `Cannot parse "${filePath.slice(servicePath.length + 1)}": ${error.message}`,
+              `Cannot parse "${filePath.slice(serviceDir.length + 1)}": ${error.message}`,
               'FILE_PARSE_ERROR'
             );
           }
@@ -71,13 +71,13 @@ module.exports = {
         case '.tfstate':
         // fallthrough
         case '.json': {
-          const jsonContent = await readFile(filePath, servicePath);
+          const jsonContent = await readFile(filePath, serviceDir);
           if (jsonContent == null) return null;
           try {
             return JSON.parse(jsonContent);
           } catch (error) {
             throw new ServerlessError(
-              `Cannot parse "${filePath.slice(servicePath.length + 1)}": JSON parse error: ${
+              `Cannot parse "${filePath.slice(serviceDir.length + 1)}": JSON parse error: ${
                 error.message
               }`,
               'FILE_PARSE_ERROR'
@@ -95,7 +95,7 @@ module.exports = {
             result = require(filePath);
           } catch (error) {
             throw new ServerlessError(
-              `Cannot load "${filePath.slice(servicePath.length + 1)}": Initialization error: ${
+              `Cannot load "${filePath.slice(serviceDir.length + 1)}": Initialization error: ${
                 error && error.stack ? error.stack : error
               }`,
               'FILE_CONTENT_RESOLUTION_ERROR'
@@ -138,7 +138,7 @@ module.exports = {
         }
         default:
           // Anything else support as plain text
-          return readFile(filePath, servicePath);
+          return readFile(filePath, serviceDir);
       }
     })();
 

--- a/lib/plugins/aws/common/lib/artifacts.js
+++ b/lib/plugins/aws/common/lib/artifacts.js
@@ -8,11 +8,11 @@ module.exports = {
     const packagePath =
       this.options.package ||
       this.serverless.service.package.path ||
-      path.join(this.serverless.config.servicePath || '.', '.serverless');
+      path.join(this.serverless.serviceDir || '.', '.serverless');
 
     // Only move the artifacts if it was requested by the user
-    if (this.serverless.config.servicePath && !packagePath.endsWith('.serverless')) {
-      const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+    if (this.serverless.serviceDir && !packagePath.endsWith('.serverless')) {
+      const serverlessTmpDirPath = path.join(this.serverless.serviceDir, '.serverless');
 
       if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
         if (this.serverless.utils.dirExistsSync(packagePath)) {
@@ -29,11 +29,11 @@ module.exports = {
     const packagePath =
       this.options.package ||
       this.serverless.service.package.path ||
-      path.join(this.serverless.config.servicePath || '.', '.serverless');
+      path.join(this.serverless.serviceDir || '.', '.serverless');
 
     // Only move the artifacts if it was requested by the user
-    if (this.serverless.config.servicePath && !packagePath.endsWith('.serverless')) {
-      const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+    if (this.serverless.serviceDir && !packagePath.endsWith('.serverless')) {
+      const serverlessTmpDirPath = path.join(this.serverless.serviceDir, '.serverless');
 
       if (this.serverless.utils.dirExistsSync(packagePath)) {
         if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {

--- a/lib/plugins/aws/common/lib/cleanupTempDir.js
+++ b/lib/plugins/aws/common/lib/cleanupTempDir.js
@@ -5,8 +5,8 @@ const fse = require('fs-extra');
 
 module.exports = {
   async cleanupTempDir() {
-    if (this.serverless.config.servicePath) {
-      const serverlessTmpDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+    if (this.serverless.serviceDir) {
+      const serverlessTmpDirPath = path.join(this.serverless.serviceDir, '.serverless');
 
       if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
         fse.removeSync(serverlessTmpDirPath);

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -26,7 +26,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
   const { Resources } = providerConfig.compiledCloudFormationTemplate;
   const customResourcesRoleLogicalId = awsProvider.naming.getCustomResourcesRoleLogicalId();
   const zipFilePath = path.join(
-    serverless.config.servicePath,
+    serverless.serviceDir,
     '.serverless',
     awsProvider.naming.getCustomResourcesArtifactName()
   );

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -18,7 +18,7 @@ class AwsDeploy {
     this.serverless = serverless;
     this.options = options;
     this.provider = this.serverless.getProvider('aws');
-    this.servicePath = this.serverless.config.servicePath || '';
+    this.servicePath = this.serverless.serviceDir || '';
     this.packagePath =
       this.options.package ||
       this.serverless.service.package.path ||

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -142,7 +142,7 @@ module.exports = {
     if (objects && objects.length) {
       const remoteHashes = objects.map((object) => object.Metadata.filesha256 || '');
 
-      const serverlessDirPath = path.join(this.serverless.config.servicePath, '.serverless');
+      const serverlessDirPath = path.join(this.serverless.serviceDir, '.serverless');
 
       // create a hash of the CloudFormation body
       const compiledCfTemplate = this.serverless.service.provider.compiledCloudFormationTemplate;
@@ -156,7 +156,7 @@ module.exports = {
       const zipFiles = globby.sync(['**.zip'], { cwd: serverlessDirPath, dot: true, silent: true });
       if (this.serverless.service.package.artifact) {
         zipFiles.push(
-          path.resolve(this.serverless.config.servicePath, this.serverless.service.package.artifact)
+          path.resolve(this.serverless.serviceDir, this.serverless.service.package.artifact)
         );
       }
       // resolve paths and ensure we only hash each unique file once.

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -10,7 +10,7 @@ module.exports = {
     // Restore state
     const serviceStateFileName = this.provider.naming.getServiceStateFileName();
     const serviceStateFilePath = path.join(
-      this.serverless.config.servicePath,
+      this.serverless.serviceDir,
       '.serverless',
       serviceStateFileName
     );
@@ -29,7 +29,7 @@ module.exports = {
     // only restore the default artifact path if the user is not using a custom path
     if (state.package.artifact && this.serverless.service.artifact) {
       this.serverless.service.package.artifact = path.join(
-        this.serverless.config.servicePath,
+        this.serverless.serviceDir,
         '.serverless',
         state.package.artifact
       );

--- a/lib/plugins/aws/deploy/lib/uploadArtifacts.js
+++ b/lib/plugins/aws/deploy/lib/uploadArtifacts.js
@@ -155,7 +155,7 @@ module.exports = {
 
   async uploadCustomResources() {
     const artifactFilePath = path.join(
-      this.serverless.config.servicePath,
+      this.serverless.serviceDir,
       '.serverless',
       this.provider.naming.getCustomResourcesArtifactName()
     );

--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -16,7 +16,7 @@ class AwsDeployFunction {
     this.packagePath =
       this.options.package ||
       this.serverless.service.package.path ||
-      path.join(this.serverless.config.servicePath || '.', '.serverless');
+      path.join(this.serverless.serviceDir || '.', '.serverless');
     this.provider = this.serverless.getProvider('aws');
 
     Object.assign(this, validate);

--- a/lib/plugins/aws/invoke.js
+++ b/lib/plugins/aws/invoke.js
@@ -24,7 +24,7 @@ class AwsInvoke {
   }
 
   async validateFile(key) {
-    const absolutePath = path.resolve(this.serverless.config.servicePath, this.options[key]);
+    const absolutePath = path.resolve(this.serverless.serviceDir, this.options[key]);
     try {
       return await this.serverless.utils.readFile(absolutePath);
     } catch (err) {

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -62,7 +62,7 @@ class AwsInvokeLocal {
   async validateFile(filePath, key) {
     const absolutePath = path.isAbsolute(filePath)
       ? filePath
-      : path.join(this.serverless.config.servicePath, filePath);
+      : path.join(this.serverless.serviceDir, filePath);
 
     const exists = await fileExists(absolutePath);
 
@@ -392,7 +392,7 @@ class AwsInvokeLocal {
         'build',
         '-t',
         imageName,
-        `${this.serverless.config.servicePath}`,
+        `${this.serverless.serviceDir}`,
         '-f',
         dockerfilePath,
       ]);
@@ -412,10 +412,10 @@ class AwsInvokeLocal {
       _.get(this.serverless.service, 'package.artifact')
     );
     if (!artifact) {
-      return this.serverless.config.servicePath;
+      return this.serverless.serviceDir;
     }
     const destination = path.join(
-      this.serverless.config.servicePath,
+      this.serverless.serviceDir,
       '.serverless',
       'invokeLocal',
       'artifact'
@@ -443,7 +443,7 @@ class AwsInvokeLocal {
     if (this.options['skip-package']) {
       try {
         await fse.access(
-          path.join(this.serverless.config.servicePath, '.serverless', 'serverless-state.json')
+          path.join(this.serverless.serviceDir, '.serverless', 'serverless-state.json')
         );
         return;
       } catch {
@@ -734,7 +734,7 @@ class AwsInvokeLocal {
        * which the user has to supply by passing the function name
        */
       pathToHandler = path.join(
-        this.serverless.config.servicePath,
+        this.serverless.serviceDir,
         this.options.extraServicePath || '',
         handlerPath
       );

--- a/lib/plugins/aws/lib/getServiceState.js
+++ b/lib/plugins/aws/lib/getServiceState.js
@@ -5,7 +5,7 @@ const path = require('path');
 module.exports = {
   getServiceState() {
     const stateFileName = this.provider.naming.getServiceStateFileName();
-    const servicePath = this.serverless.config.servicePath;
+    const servicePath = this.serverless.serviceDir;
     const packageDirName = this.options.package || '.serverless';
 
     const stateFilePath = path.resolve(servicePath, packageDirName, stateFileName);

--- a/lib/plugins/aws/lib/getServiceState.js
+++ b/lib/plugins/aws/lib/getServiceState.js
@@ -5,10 +5,10 @@ const path = require('path');
 module.exports = {
   getServiceState() {
     const stateFileName = this.provider.naming.getServiceStateFileName();
-    const servicePath = this.serverless.serviceDir;
+    const serviceDir = this.serverless.serviceDir;
     const packageDirName = this.options.package || '.serverless';
 
-    const stateFilePath = path.resolve(servicePath, packageDirName, stateFileName);
+    const stateFilePath = path.resolve(serviceDir, packageDirName, stateFileName);
     return this.serverless.utils.readFileSync(stateFilePath);
   },
 };

--- a/lib/plugins/aws/lib/validate.js
+++ b/lib/plugins/aws/lib/validate.js
@@ -4,7 +4,7 @@ const ServerlessError = require('../../../serverless-error');
 
 module.exports = {
   validate() {
-    if (!this.serverless.config.servicePath) {
+    if (!this.serverless.serviceDir) {
       throw new ServerlessError('This command can only be run inside a service directory');
     }
 

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -14,9 +14,9 @@ class AwsCompileFunctions {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    const servicePath = this.serverless.serviceDir || '';
+    const serviceDir = this.serverless.serviceDir || '';
     this.packagePath =
-      this.serverless.service.package.path || path.join(servicePath || '.', '.serverless');
+      this.serverless.service.package.path || path.join(serviceDir || '.', '.serverless');
 
     this.provider = this.serverless.getProvider('aws');
 

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -14,7 +14,7 @@ class AwsCompileFunctions {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    const servicePath = this.serverless.config.servicePath || '';
+    const servicePath = this.serverless.serviceDir || '';
     this.packagePath =
       this.serverless.service.package.path || path.join(servicePath || '.', '.serverless');
 
@@ -209,11 +209,7 @@ class AwsCompileFunctions {
           artifactFileName = functionArtifactFileName;
         }
 
-        artifactFilePath = path.join(
-          this.serverless.config.servicePath,
-          '.serverless',
-          artifactFileName
-        );
+        artifactFilePath = path.join(this.serverless.serviceDir, '.serverless', artifactFileName);
       }
 
       functionObject.runtime = this.provider.getRuntime(functionObject.runtime);

--- a/lib/plugins/aws/package/compile/layers.js
+++ b/lib/plugins/aws/package/compile/layers.js
@@ -11,9 +11,9 @@ class AwsCompileLayers {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    const servicePath = this.serverless.serviceDir || '';
+    const serviceDir = this.serverless.serviceDir || '';
     this.packagePath =
-      this.serverless.service.package.path || path.join(servicePath || '.', '.serverless');
+      this.serverless.service.package.path || path.join(serviceDir || '.', '.serverless');
 
     this.provider = this.serverless.getProvider('aws');
 

--- a/lib/plugins/aws/package/compile/layers.js
+++ b/lib/plugins/aws/package/compile/layers.js
@@ -11,7 +11,7 @@ class AwsCompileLayers {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    const servicePath = this.serverless.config.servicePath || '';
+    const servicePath = this.serverless.serviceDir || '';
     this.packagePath =
       this.serverless.service.package.path || path.join(servicePath || '.', '.serverless');
 

--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -14,7 +14,7 @@ class AwsPackage {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.servicePath = this.serverless.config.servicePath || '';
+    this.servicePath = this.serverless.serviceDir || '';
     this.packagePath =
       this.options.package ||
       this.serverless.service.package.path ||

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -126,7 +126,7 @@ module.exports = {
     const coreTemplateFileName = this.provider.naming.getCoreTemplateFileName();
 
     const coreTemplateFilePath = path.join(
-      this.serverless.config.servicePath,
+      this.serverless.serviceDir,
       '.serverless',
       coreTemplateFileName
     );

--- a/lib/plugins/aws/package/lib/saveCompiledTemplate.js
+++ b/lib/plugins/aws/package/lib/saveCompiledTemplate.js
@@ -7,7 +7,7 @@ module.exports = {
     const compiledTemplateFileName = this.provider.naming.getCompiledTemplateFileName();
 
     const compiledTemplateFilePath = path.join(
-      this.serverless.config.servicePath,
+      this.serverless.serviceDir,
       '.serverless',
       compiledTemplateFileName
     );

--- a/lib/plugins/aws/package/lib/saveServiceState.js
+++ b/lib/plugins/aws/package/lib/saveServiceState.js
@@ -9,7 +9,7 @@ module.exports = {
     const serviceStateFileName = this.provider.naming.getServiceStateFileName();
 
     const serviceStateFilePath = path.join(
-      this.serverless.config.servicePath,
+      this.serverless.serviceDir,
       '.serverless',
       serviceStateFileName
     );

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1573,7 +1573,7 @@ class AwsProvider {
     return serverlessLayerObject.package && serverlessLayerObject.package.artifact
       ? serverlessLayerObject.package.artifact
       : path.join(
-          this.serverless.config.servicePath,
+          this.serverless.serviceDir,
           '.serverless',
           this.provider.naming.getLayerArtifactName(layerName)
         );
@@ -1856,11 +1856,7 @@ Object.defineProperties(
         await this.ensureDockerIsAvailable();
 
         let isDockerfileAvailable = false;
-        const pathToDockerfile = path.resolve(
-          this.serverless.config.servicePath,
-          imagePath,
-          imageFilename
-        );
+        const pathToDockerfile = path.resolve(this.serverless.serviceDir, imagePath, imageFilename);
 
         try {
           const stats = await fs.promises.stat(pathToDockerfile);

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -162,6 +162,7 @@ class Create {
       });
     }
 
+    this.serverless.serviceDir = process.cwd();
     this.serverless.config.update({ servicePath: process.cwd() });
 
     return createFromTemplate(this.options.template, process.cwd(), { name: serviceName }).then(

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -70,18 +70,18 @@ class Create {
         });
     } else if ('template-path' in this.options) {
       // Copying template from a local directory
-      const servicePath = this.options.path
+      const serviceDir = this.options.path
         ? path.resolve(process.cwd(), untildify(this.options.path))
         : path.join(process.cwd(), this.options.name);
-      if (dirExistsSync(servicePath)) {
-        const errorMessage = `A folder named "${servicePath}" already exists.`;
+      if (dirExistsSync(serviceDir)) {
+        const errorMessage = `A folder named "${serviceDir}" already exists.`;
         throw new ServerlessError(errorMessage);
       }
-      copyDirContentsSync(untildify(this.options['template-path']), servicePath, {
+      copyDirContentsSync(untildify(this.options['template-path']), serviceDir, {
         noLinks: true,
       });
       if (this.options.name) {
-        renameService(this.options.name, servicePath);
+        renameService(this.options.name, serviceDir);
       }
     } else {
       const errorMessage = [

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -163,7 +163,7 @@ class Create {
     }
 
     this.serverless.serviceDir = process.cwd();
-    this.serverless.config.update({ servicePath: process.cwd() });
+    this.serverless.config.servicePath = process.cwd();
 
     return createFromTemplate(this.options.template, process.cwd(), { name: serviceName }).then(
       () => {

--- a/lib/plugins/interactiveCli/initializeService.js
+++ b/lib/plugins/interactiveCli/initializeService.js
@@ -57,7 +57,7 @@ const projectNameInput = async (workingDir) =>
 module.exports = {
   initializeProjectChoices,
   check(serverless) {
-    return !serverless.config.servicePath;
+    return !serverless.serviceDir;
   },
   async run(serverless) {
     const workingDir = process.cwd();
@@ -82,7 +82,7 @@ module.exports = {
 
     process.chdir(projectDir);
     const configurationPath = await resolveConfigurationPath();
-    serverless.serviceDir = serverless.config.servicePath = projectDir;
+    serverless.serviceDir = serverless.serviceDir = projectDir;
     serverless.configurationFilename = configurationPath.slice(serverless.serviceDir.length + 1);
     serverless.configurationInput = await readConfiguration(configurationPath);
     await serverless.service.load();

--- a/lib/plugins/interactiveCli/initializeService.js
+++ b/lib/plugins/interactiveCli/initializeService.js
@@ -81,9 +81,10 @@ module.exports = {
     );
 
     process.chdir(projectDir);
-    serverless.configurationPath = await resolveConfigurationPath();
-    serverless.config.servicePath = projectDir;
-    serverless.configurationInput = await readConfiguration(serverless.configurationPath);
+    const configurationPath = await resolveConfigurationPath();
+    serverless.serviceDir = serverless.config.servicePath = projectDir;
+    serverless.configurationFilename = configurationPath.slice(serverless.serviceDir.length + 1);
+    serverless.configurationInput = await readConfiguration(configurationPath);
     await serverless.service.load();
     await serverless.variables.populateService();
     serverless.service.mergeArrays();

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -120,7 +120,7 @@ module.exports = {
 
     // use the artifact in function config if provided
     if (funcPackageConfig.artifact) {
-      const filePath = path.resolve(this.serverless.config.servicePath, funcPackageConfig.artifact);
+      const filePath = path.resolve(this.serverless.serviceDir, funcPackageConfig.artifact);
       functionObject.package.artifact = filePath;
       return filePath;
     }
@@ -129,7 +129,7 @@ module.exports = {
     // and if the function is not set to be packaged individually
     if (this.serverless.service.package.artifact && !funcPackageConfig.individually) {
       const filePath = path.resolve(
-        this.serverless.config.servicePath,
+        this.serverless.serviceDir,
         this.serverless.service.package.artifact
       );
       funcPackageConfig.artifact = filePath;
@@ -236,7 +236,7 @@ module.exports = {
     // rather than doing it the other way round!
     // see https://github.com/serverless/serverless/pull/5825 for more information
     return globby(['**'].concat(params.include), {
-      cwd: path.join(this.serverless.config.servicePath, prefix || ''),
+      cwd: path.join(this.serverless.serviceDir, prefix || ''),
       dot: true,
       silent: true,
       follow: true,

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -31,7 +31,6 @@ module.exports = {
   },
 
   getExcludes(exclude, excludeLayers) {
-    const configFilePath = this.serverless.configurationPath;
     const packageExcludes = this.serverless.service.package.exclude || [];
     // add local service plugins Path
     const pluginsLocalPath = this.serverless.pluginManager.parsePluginsObject(
@@ -46,7 +45,9 @@ module.exports = {
       : [];
     // add defaults for exclude
 
-    const serverlessConfigFileExclude = configFilePath ? [path.basename(configFilePath)] : [];
+    const serverlessConfigFileExclude = this.serverless.configurationFilename
+      ? [this.serverless.configurationFilename]
+      : [];
 
     const configurationInput = this.serverless.configurationInput;
     const envFilesExclude = configurationInput && configurationInput.useDotenv ? ['.env*'] : [];

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   async excludeDevDependencies(params) {
-    const servicePath = this.serverless.serviceDir;
+    const serviceDir = this.serverless.serviceDir;
 
     let excludeDevDependencies = this.serverless.service.package.excludeDevDependencies;
     if (excludeDevDependencies === undefined || excludeDevDependencies === null) {
@@ -34,7 +34,7 @@ module.exports = {
     if (excludeDevDependencies) {
       this.serverless.cli.log('Excluding development dependencies...');
 
-      const exAndInNode = await excludeNodeDevDependenciesMemoized(servicePath);
+      const exAndInNode = await excludeNodeDevDependenciesMemoized(serviceDir);
       params.exclude = _.union(params.exclude, exAndInNode.exclude);
       params.include = _.union(params.include, exAndInNode.include);
       params.devDependencyExcludeSet = new Set(exAndInNode.exclude);
@@ -128,7 +128,7 @@ module.exports = {
   },
 };
 
-function excludeNodeDevDependencies(servicePath) {
+function excludeNodeDevDependencies(serviceDir) {
   const exAndIn = {
     include: [],
     exclude: [],
@@ -147,7 +147,7 @@ function excludeNodeDevDependencies(servicePath) {
         // TODO add glob for node_modules filtering
       ],
       {
-        cwd: servicePath,
+        cwd: serviceDir,
         dot: true,
         silent: true,
         follow: true,
@@ -169,7 +169,7 @@ function excludeNodeDevDependencies(servicePath) {
     return (
       BbPromise.mapSeries(packageJsonPaths, (packageJsonPath) => {
         // the path where the package.json file lives
-        const fullPath = path.join(servicePath, packageJsonPath);
+        const fullPath = path.join(serviceDir, packageJsonPath);
         const dirWithPackageJson = fullPath.replace(path.join(path.sep, 'package.json'), '');
 
         // we added a catch which resolves so that npm commands with an exit code of 1
@@ -214,11 +214,11 @@ function excludeNodeDevDependencies(servicePath) {
 
           if (dependencies.length) {
             return BbPromise.map(dependencies, (item) =>
-              item.replace(path.join(servicePath, path.sep), '')
+              item.replace(path.join(serviceDir, path.sep), '')
             )
               .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
               .reduce((globs, item) => {
-                const packagePath = path.join(servicePath, item, 'package.json');
+                const packagePath = path.join(serviceDir, item, 'package.json');
                 return fs.readFileAsync(packagePath, 'utf-8').then(
                   (packageJsonFile) => {
                     const lastIndex = item.lastIndexOf(path.sep) + 1;

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   async excludeDevDependencies(params) {
-    const servicePath = this.serverless.config.servicePath;
+    const servicePath = this.serverless.serviceDir;
 
     let excludeDevDependencies = this.serverless.service.package.excludeDevDependencies;
     if (excludeDevDependencies === undefined || excludeDevDependencies === null) {
@@ -64,11 +64,7 @@ module.exports = {
 
     const zip = archiver.create('zip');
     // Create artifact in temp path and move it to the package path (if any) later
-    const artifactFilePath = path.join(
-      this.serverless.config.servicePath,
-      '.serverless',
-      zipFileName
-    );
+    const artifactFilePath = path.join(this.serverless.serviceDir, '.serverless', zipFileName);
     this.serverless.utils.writeFileDir(artifactFilePath);
 
     const output = fs.createWriteStream(artifactFilePath);
@@ -108,7 +104,7 @@ module.exports = {
   },
 
   getFileContentAndStat(filePath) {
-    const fullPath = path.resolve(this.serverless.config.servicePath, filePath);
+    const fullPath = path.resolve(this.serverless.serviceDir, filePath);
 
     return BbPromise.all([
       // Get file contents and stat in parallel

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -10,7 +10,7 @@ class Package {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
-    this.servicePath = this.serverless.config.servicePath || '';
+    this.servicePath = this.serverless.serviceDir || '';
     this.packagePath =
       this.options.package ||
       this.serverless.service.package.path ||

--- a/lib/plugins/plugin/install.js
+++ b/lib/plugins/plugin/install.js
@@ -60,7 +60,7 @@ class PluginInstall {
   }
 
   pluginInstall() {
-    const servicePath = this.serverless.config.servicePath;
+    const servicePath = this.serverless.serviceDir;
     const packageJsonFilePath = path.join(servicePath, 'package.json');
 
     return fileExists(packageJsonFilePath)
@@ -142,7 +142,7 @@ class PluginInstall {
 
   installPeerDependencies() {
     const pluginPackageJsonFilePath = path.join(
-      this.serverless.config.servicePath,
+      this.serverless.serviceDir,
       'node_modules',
       this.options.pluginName,
       'package.json'

--- a/lib/plugins/plugin/install.js
+++ b/lib/plugins/plugin/install.js
@@ -60,8 +60,8 @@ class PluginInstall {
   }
 
   pluginInstall() {
-    const servicePath = this.serverless.serviceDir;
-    const packageJsonFilePath = path.join(servicePath, 'package.json');
+    const serviceDir = this.serverless.serviceDir;
+    const packageJsonFilePath = path.join(serviceDir, 'package.json');
 
     return fileExists(packageJsonFilePath)
       .then((exists) => {

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const fetch = require('node-fetch');
 const BbPromise = require('bluebird');
 const HttpsProxyAgent = require('https-proxy-agent');
@@ -18,7 +19,9 @@ module.exports = {
   },
 
   getServerlessFilePath() {
-    if (this.serverless.configurationPath) return this.serverless.configurationPath;
+    if (this.serverless.configurationFilename) {
+      return path.resolve(this.serverless.serviceDir, this.serverless.configurationFilename);
+    }
     throw new ServerlessError('Could not find any serverless service definition file.');
   },
 

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -11,7 +11,7 @@ const ServerlessError = require('../../../serverless-error');
 
 module.exports = {
   validate() {
-    if (!this.serverless.config.servicePath) {
+    if (!this.serverless.serviceDir) {
       throw new ServerlessError('This command can only be run inside a service directory');
     }
 

--- a/lib/plugins/plugin/uninstall.js
+++ b/lib/plugins/plugin/uninstall.js
@@ -105,7 +105,7 @@ class PluginUninstall {
 
   uninstallPeerDependencies() {
     const pluginPackageJsonFilePath = path.join(
-      this.serverless.config.servicePath,
+      this.serverless.serviceDir,
       'node_modules',
       this.options.pluginName,
       'package.json'

--- a/lib/utils/autocomplete.js
+++ b/lib/utils/autocomplete.js
@@ -35,7 +35,7 @@ const cacheFileValid = (configurationInput, validationHash) => {
 
 const autocomplete = async () => {
   const configurationPath = await resolveConfigurationPath();
-  const servicePath = process.cwd();
+  const serviceDir = process.cwd();
   const configurationInput = configurationPath
     ? await (async () => {
         try {
@@ -45,11 +45,11 @@ const autocomplete = async () => {
         }
       })()
     : null;
-  let cacheFile = await getCacheFile(servicePath);
+  let cacheFile = await getCacheFile(serviceDir);
   if (!cacheFile || !cacheFileValid(configurationInput, cacheFile.validationHash)) {
     const serverless = new Serverless();
     await serverless.init();
-    cacheFile = await getCacheFile(servicePath);
+    cacheFile = await getCacheFile(serviceDir);
   }
   if (!cacheFile || !cacheFileValid(configurationInput, cacheFile.validationHash)) {
     return null;

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -272,7 +272,7 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
       downloadServicePath = path.join(process.cwd(), dirName);
     }
 
-    const servicePath = path.join(process.cwd(), dirName);
+    const serviceDir = path.join(process.cwd(), dirName);
     const renamed = dirName !== repoInformation.repo;
 
     if (dirExistsSync(path.join(process.cwd(), dirName))) {
@@ -284,7 +284,7 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
 
     if (isPlainGitURL(inputUrl)) {
       return spawn('git', ['clone', inputUrl, downloadServicePath]).then(() => {
-        if (renamed) renameService(dirName, servicePath);
+        if (renamed) renameService(dirName, serviceDir);
         return serviceName;
       });
     }
@@ -302,12 +302,12 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
         // if it's a directory inside of git
         if (repoInformation.isSubdirectory) {
           const directory = path.join(downloadServicePath, repoInformation.pathToDirectory);
-          copyDirContentsSync(directory, servicePath);
+          copyDirContentsSync(directory, serviceDir);
           fse.removeSync(downloadServicePath);
         }
       })
       .then(() => {
-        if (renamed) renameService(dirName, servicePath);
+        if (renamed) renameService(dirName, serviceDir);
 
         return BbPromise.resolve(serviceName);
       });

--- a/lib/utils/getCacheFile.js
+++ b/lib/utils/getCacheFile.js
@@ -4,8 +4,8 @@ const fileExists = require('./fs/fileExists');
 const readFile = require('./fs/readFile');
 const getCacheFilePath = require('./getCacheFilePath');
 
-const getCacheFile = function (servicePath) {
-  const cacheFilePath = getCacheFilePath(servicePath);
+const getCacheFile = function (serviceDir) {
+  const cacheFilePath = getCacheFilePath(serviceDir);
   return fileExists(cacheFilePath).then((exists) => {
     if (!exists) {
       return false;

--- a/lib/utils/getCacheFilePath.js
+++ b/lib/utils/getCacheFilePath.js
@@ -5,9 +5,9 @@ const path = require('path');
 const crypto = require('crypto');
 
 const getCacheFilePath = function (srvcPath) {
-  const servicePath = srvcPath || process.cwd();
-  const servicePathHash = crypto.createHash('sha256').update(servicePath).digest('hex');
-  return path.join(homedir, '.serverless', 'cache', servicePathHash, 'autocomplete.json');
+  const serviceDir = srvcPath || process.cwd();
+  const serviceDirHash = crypto.createHash('sha256').update(serviceDir).digest('hex');
+  return path.join(homedir, '.serverless', 'cache', serviceDirHash, 'autocomplete.json');
 };
 
 module.exports = getCacheFilePath;

--- a/lib/utils/renameService.js
+++ b/lib/utils/renameService.js
@@ -32,31 +32,31 @@ function renameTsService(name, tsServicefile) {
   fse.writeFileSync(tsServicefile, serverlessTs);
 }
 
-function renameService(name, servicePath) {
-  const packageFile = path.join(servicePath, 'package.json');
+function renameService(name, serviceDir) {
+  const packageFile = path.join(serviceDir, 'package.json');
   if (fileExistsSync(packageFile)) {
     const json = readFileSync(packageFile);
     writeFileSync(packageFile, Object.assign(json, { name }));
   }
-  const packageLockFile = path.join(servicePath, 'package-lock.json');
+  const packageLockFile = path.join(serviceDir, 'package-lock.json');
   if (fileExistsSync(packageLockFile)) {
     const json = readFileSync(packageLockFile);
     writeFileSync(packageLockFile, Object.assign(json, { name }));
   }
 
-  const ymlServiceFile = path.join(servicePath, 'serverless.yml');
+  const ymlServiceFile = path.join(serviceDir, 'serverless.yml');
   if (fileExistsSync(ymlServiceFile)) {
     renameYmlService(name, ymlServiceFile);
     return name;
   }
 
-  const tsServiceFile = path.join(servicePath, 'serverless.ts');
+  const tsServiceFile = path.join(serviceDir, 'serverless.ts');
   if (fileExistsSync(tsServiceFile)) {
     renameTsService(name, tsServiceFile);
     return name;
   }
 
-  const errorMessage = ['serverless.yml or serverlss.ts not found in', ` ${servicePath}`].join('');
+  const errorMessage = ['serverless.yml or serverlss.ts not found in', ` ${serviceDir}`].join('');
   throw new ServerlessError(errorMessage);
 }
 

--- a/lib/utils/telemetry/generatePayload.js
+++ b/lib/utils/telemetry/generatePayload.js
@@ -25,7 +25,7 @@ const checkIsTabAutocompletionInstalled = async () => {
 };
 
 module.exports = async (serverless) => {
-  const { service: serviceConfig, config } = serverless;
+  const { service: serviceConfig, serviceDir } = serverless;
   const { provider: providerConfig } = serviceConfig;
   const provider = serverless.getProvider(providerConfig.name);
 
@@ -34,10 +34,10 @@ module.exports = async (serverless) => {
   const defaultRuntime = isAwsProvider ? provider.getRuntime() : providerConfig.runtime;
 
   const npmDependencies = (() => {
-    if (!config.servicePath) return [];
+    if (!serviceDir) return [];
     const pkgJson = (() => {
       try {
-        return require(path.resolve(config.servicePath, 'package.json'));
+        return require(path.resolve(serviceDir, 'package.json'));
       } catch (error) {
         return null;
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@commitlint/cli": "^12.1.1",
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^8.0.2",
+    "@serverless/test": "^8.1.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "cos-nodejs-sdk-v5": "^2.9.13",

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -68,6 +68,7 @@ const processSpanPromise = (async () => {
 
     let configurationPath = null;
     let configuration = null;
+    let serviceDir = null;
     let providerName;
     let variablesMeta;
     let resolverConfiguration;
@@ -121,6 +122,7 @@ const processSpanPromise = (async () => {
         : null;
 
       if (configuration) {
+        serviceDir = process.cwd();
         if (!commandSchema) {
           // If command was not recognized in first resolution phase
           // Parse args again also against schemas commands which require service to be run
@@ -198,7 +200,7 @@ const processSpanPromise = (async () => {
             // Resolve eventual variables in `provider.stage` and `useDotEnv`
             // (required for reliable .env resolution)
             resolverConfiguration = {
-              servicePath: process.cwd(),
+              servicePath: serviceDir,
               configuration,
               variablesMeta,
               sources: {
@@ -361,7 +363,8 @@ const processSpanPromise = (async () => {
 
     serverless = new Serverless({
       configuration,
-      configurationPath: configuration && configurationPath,
+      serviceDir,
+      configurationFilename: configuration && configurationPath.slice(serviceDir.length + 1),
       isConfigurationResolved:
         commands[0] === 'plugin' || Boolean(variablesMeta && !variablesMeta.size),
       hasResolvedCommandsExternally: true,

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -200,7 +200,7 @@ const processSpanPromise = (async () => {
             // Resolve eventual variables in `provider.stage` and `useDotEnv`
             // (required for reliable .env resolution)
             resolverConfiguration = {
-              servicePath: serviceDir,
+              serviceDir,
               configuration,
               variablesMeta,
               sources: {

--- a/test/fixtures/programmatic/packageArtifactInServerlessDir/package-artifact-plugin.js
+++ b/test/fixtures/programmatic/packageArtifactInServerlessDir/package-artifact-plugin.js
@@ -21,7 +21,7 @@ class PackageArtifactPlugin {
 
   async package() {
     const zipSrcPath = path.resolve(ZIP_NAME);
-    const serverlessDirPath = path.resolve(this.serverless.config.servicePath, '.serverless');
+    const serverlessDirPath = path.resolve(this.serverless.serviceDir, '.serverless');
     const zipDestPath = path.join(serverlessDirPath, ZIP_NAME);
 
     // Copy zip to `.serverless` directory

--- a/test/integration/apiGateway.test.js
+++ b/test/integration/apiGateway.test.js
@@ -13,7 +13,7 @@ describe('AWS - API Gateway Integration Test', function () {
   let serviceName;
   let endpoint;
   let stackName;
-  let servicePath;
+  let serviceDir;
   let updateConfig;
   let apiKey;
   let isDeployed = false;
@@ -29,11 +29,11 @@ describe('AWS - API Gateway Integration Test', function () {
 
   before(async () => {
     const serviceData = await fixtures.setup('apiGatewayExtended');
-    ({ servicePath, updateConfig } = serviceData);
+    ({ servicePath: serviceDir, updateConfig } = serviceData);
     serviceName = serviceData.serviceConfig.service;
     apiKey = `${serviceName}-api-key-1`;
     stackName = `${serviceName}-${stage}`;
-    await deployService(servicePath);
+    await deployService(serviceDir);
     isDeployed = true;
     return resolveEndpoint();
   });
@@ -41,7 +41,7 @@ describe('AWS - API Gateway Integration Test', function () {
   after(async () => {
     if (!isDeployed) return;
     log.notice('Removing service...');
-    await removeService(servicePath);
+    await removeService(serviceDir);
   });
 
   describe('Minimal Setup', () => {
@@ -199,7 +199,7 @@ describe('AWS - API Gateway Integration Test', function () {
           },
         },
       });
-      await deployService(servicePath);
+      await deployService(serviceDir);
     });
 
     it('should update the stage without service interruptions', () => {

--- a/test/integration/apiGatewayExternal.test.js
+++ b/test/integration/apiGatewayExternal.test.js
@@ -13,7 +13,7 @@ describe('AWS - API Gateway with External REST API Integration Test', function (
   let endpoint;
   let updateConfig;
   let stackName;
-  let servicePath;
+  let serviceDir;
   let isDeployed = false;
   let restApiId;
   const stage = 'dev';
@@ -28,7 +28,7 @@ describe('AWS - API Gateway with External REST API Integration Test', function (
 
   before(async () => {
     const serviceData = await fixtures.setup('apiGateway');
-    ({ servicePath, updateConfig } = serviceData);
+    ({ servicePath: serviceDir, updateConfig } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
     const externalRestApiName = `${stage}-${serviceName}-ext-api`;
     const restApiMeta = await createRestApi(externalRestApiName);
@@ -48,7 +48,7 @@ describe('AWS - API Gateway with External REST API Integration Test', function (
       },
     });
     stackName = `${serviceName}-${stage}`;
-    await deployService(servicePath);
+    await deployService(serviceDir);
     isDeployed = true;
     return resolveEndpoint();
   });
@@ -56,7 +56,7 @@ describe('AWS - API Gateway with External REST API Integration Test', function (
   after(async () => {
     if (!isDeployed) return;
     log.notice('Removing service...');
-    await removeService(servicePath);
+    await removeService(serviceDir);
     log.notice('Deleting external rest API...');
     await deleteRestApi(restApiId);
   });

--- a/test/integration/cognitoUserPool.test.js
+++ b/test/integration/cognitoUserPool.test.js
@@ -22,7 +22,7 @@ const { confirmCloudWatchLogs } = require('../utils/misc');
 describe('AWS - Cognito User Pool Integration Test', function () {
   this.timeout(1000 * 60 * 10); // Involves time-taking deploys
   let stackName;
-  let servicePath;
+  let serviceDir;
   let poolBasicSetup;
   let poolExistingSimpleSetup;
   let poolExistingMultiSetup;
@@ -31,7 +31,7 @@ describe('AWS - Cognito User Pool Integration Test', function () {
 
   before(async () => {
     const serviceData = await fixtures.setup('cognitoUserPool');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
     stackName = `${serviceName}-${stage}`;
 
@@ -51,15 +51,15 @@ describe('AWS - Cognito User Pool Integration Test', function () {
       createUserPool(poolExistingSimpleSetup, poolExistingSimpleSetupConfig),
       createUserPool(poolExistingMultiSetup),
     ]);
-    return deployService(servicePath);
+    return deployService(serviceDir);
   });
 
   after(async function () {
-    if (!servicePath) return null;
+    if (!serviceDir) return null;
     // Do not clean on fail, to allow further state investigation
     if (hasFailed(this.test.parent)) return null;
     log.notice('Removing service...');
-    await removeService(servicePath);
+    await removeService(serviceDir);
     log.notice('Deleting Cognito User Pools');
     return BbPromise.all([
       deleteUserPool(poolExistingSimpleSetup),

--- a/test/integration/eventBridge.test.js
+++ b/test/integration/eventBridge.test.js
@@ -19,7 +19,7 @@ describe('AWS - Event Bridge Integration Test', () => {
     this.timeout(1000 * 60 * 100); // Involves time-taking deploys
     let serviceName;
     let stackName;
-    let servicePath;
+    let serviceDir;
     let namedEventBusName;
     let arnEventBusName;
     let arnEventBusArn;
@@ -35,7 +35,7 @@ describe('AWS - Event Bridge Integration Test', () => {
 
     before(async () => {
       const serviceData = await fixtures.setup('eventBridge');
-      ({ servicePath } = serviceData);
+      ({ servicePath: serviceDir } = serviceData);
       serviceName = serviceData.serviceConfig.service;
 
       namedEventBusName = `${serviceName}-named-event-bus`;
@@ -74,12 +74,12 @@ describe('AWS - Event Bridge Integration Test', () => {
         },
       });
       // deploy the service
-      return deployService(servicePath);
+      return deployService(serviceDir);
     });
 
     after(async () => {
       log.notice('Removing service...');
-      await removeService(servicePath);
+      await removeService(serviceDir);
       log.notice(`Deleting Event Bus "${arnEventBusName}"...`);
       return deleteEventBus(arnEventBusName);
     });
@@ -152,7 +152,7 @@ describe('AWS - Event Bridge Integration Test', () => {
     this.timeout(1000 * 60 * 10); // Involves time-taking deploys
     let serviceName;
     let stackName;
-    let servicePath;
+    let serviceDir;
     let namedEventBusName;
     let arnEventBusName;
     let arnEventBusArn;
@@ -168,7 +168,7 @@ describe('AWS - Event Bridge Integration Test', () => {
 
     before(async () => {
       const serviceData = await fixtures.setup('eventBridge');
-      ({ servicePath } = serviceData);
+      ({ servicePath: serviceDir } = serviceData);
       serviceName = serviceData.serviceConfig.service;
 
       namedEventBusName = `${serviceName}-named-event-bus`;
@@ -210,12 +210,12 @@ describe('AWS - Event Bridge Integration Test', () => {
           },
         },
       });
-      return deployService(servicePath);
+      return deployService(serviceDir);
     });
 
     after(async () => {
       log.notice('Removing service...');
-      await removeService(servicePath);
+      await removeService(serviceDir);
       log.notice(`Deleting Event Bus "${arnEventBusName}"...`);
       return deleteEventBus(arnEventBusName);
     });

--- a/test/integration/functionDestinations.test.js
+++ b/test/integration/functionDestinations.test.js
@@ -10,20 +10,20 @@ const { deployService, removeService } = require('../utils/integration');
 describe('Function destinations Integration Test', function () {
   this.timeout(1000 * 60 * 20); // Involves time-taking deploys
   let stackName;
-  let servicePath;
+  let serviceDir;
   const stage = 'dev';
 
   before(async () => {
     const serviceData = await fixtures.setup('functionDestinations');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
     stackName = `${serviceName}-${stage}`;
-    await deployService(servicePath);
+    await deployService(serviceDir);
   });
 
   after(async () => {
-    if (!servicePath) return;
-    await removeService(servicePath);
+    if (!serviceDir) return;
+    await removeService(serviceDir);
   });
 
   it('on async invoke should invoke destination target', async () =>

--- a/test/integration/httpApi.test.js
+++ b/test/integration/httpApi.test.js
@@ -12,7 +12,7 @@ describe('HTTP API Integration Test', function () {
   this.timeout(1000 * 60 * 20); // Involves time-taking deploys
   let endpoint;
   let stackName;
-  let servicePath;
+  let serviceDir;
   const stage = 'dev';
 
   const resolveEndpoint = async () => {
@@ -119,17 +119,17 @@ describe('HTTP API Integration Test', function () {
           },
         },
       });
-      ({ servicePath } = serviceData);
+      ({ servicePath: serviceDir } = serviceData);
       const serviceName = serviceData.serviceConfig.service;
       stackName = `${serviceName}-${stage}`;
-      await deployService(servicePath);
+      await deployService(serviceDir);
       return resolveEndpoint();
     });
 
     after(async () => {
       await awsRequest('CognitoIdentityServiceProvider', 'deleteUserPool', { UserPoolId: poolId });
-      if (!servicePath) return;
-      await removeService(servicePath);
+      if (!serviceDir) return;
+      await removeService(serviceDir);
     });
 
     it('should expose an accessible POST HTTP endpoint', async () => {
@@ -247,10 +247,10 @@ describe('HTTP API Integration Test', function () {
   describe('Catch-all endpoints', () => {
     before(async () => {
       const serviceData = await fixtures.setup('httpApiCatchAll');
-      ({ servicePath } = serviceData);
+      ({ servicePath: serviceDir } = serviceData);
       const serviceName = serviceData.serviceConfig.service;
       stackName = `${serviceName}-${stage}`;
-      await deployService(servicePath);
+      await deployService(serviceDir);
       return resolveEndpoint();
     });
 
@@ -259,7 +259,7 @@ describe('HTTP API Integration Test', function () {
       // TODO: Remove once properly diagnosed
       if (this.test.parent.tests.some((test) => test.state === 'failed')) return;
       log.notice('Removing service...');
-      await removeService(servicePath);
+      await removeService(serviceDir);
     });
 
     it('should catch all root endpoint', async () => {
@@ -308,15 +308,15 @@ describe('HTTP API Integration Test', function () {
           provider: { httpApi: { id: httpApiId } },
         },
       });
-      ({ servicePath } = serviceData);
+      ({ servicePath: serviceDir } = serviceData);
       serviceName = serviceData.serviceConfig.service;
       stackName = `${serviceName}-${stage}`;
-      await deployService(servicePath);
+      await deployService(serviceDir);
     });
 
     after(async () => {
       if (serviceName) {
-        await removeService(servicePath);
+        await removeService(serviceDir);
       }
       await removeService(exportServicePath);
     });

--- a/test/integration/infra-dependent/fileSystemConfig.test.js
+++ b/test/integration/infra-dependent/fileSystemConfig.test.js
@@ -24,7 +24,7 @@ describe('AWS - FileSystemConfig Integration Test', function () {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys
   let stackName;
   let startTime;
-  let servicePath;
+  let serviceDir;
   const stage = 'dev';
   const filename = `/mnt/testing/${crypto.randomBytes(8).toString('hex')}.txt`;
 
@@ -55,17 +55,17 @@ describe('AWS - FileSystemConfig Integration Test', function () {
         functions: { writer: { fileSystemConfig }, reader: { fileSystemConfig } },
       },
     });
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
 
     const serviceName = serviceData.serviceConfig.service;
     stackName = `${serviceName}-${stage}`;
-    await deployService(servicePath);
+    await deployService(serviceDir);
     startTime = Date.now();
   });
 
   after(async () => {
-    if (servicePath) {
-      await removeService(servicePath);
+    if (serviceDir) {
+      await removeService(serviceDir);
     }
   });
 

--- a/test/integration/infra-dependent/msk.test.js
+++ b/test/integration/infra-dependent/msk.test.js
@@ -16,7 +16,7 @@ const { deployService, removeService } = require('../../utils/integration');
 describe('AWS - MSK Integration Test', function () {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys
   let stackName;
-  let servicePath;
+  let serviceDir;
   const stage = 'dev';
 
   const topicName = `msk-topic-${crypto.randomBytes(8).toString('hex')}`;
@@ -62,16 +62,16 @@ describe('AWS - MSK Integration Test', function () {
       },
     });
 
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
 
     const serviceName = serviceData.serviceConfig.service;
     stackName = `${serviceName}-${stage}`;
-    await deployService(servicePath);
+    await deployService(serviceDir);
   });
 
   after(async () => {
-    if (servicePath) {
-      await removeService(servicePath);
+    if (serviceDir) {
+      await removeService(serviceDir);
     }
   });
 

--- a/test/integration/iot.test.js
+++ b/test/integration/iot.test.js
@@ -10,22 +10,22 @@ const { deployService, removeService } = require('../utils/integration');
 describe('AWS - IoT Integration Test', function () {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys
   let iotTopic;
-  let servicePath;
+  let serviceDir;
   let stackName;
 
   before(async () => {
     const serviceData = await fixtures.setup('iot');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
     iotTopic = `${serviceName}/test`;
     stackName = `${serviceName}-dev`;
 
-    return deployService(servicePath);
+    return deployService(serviceDir);
   });
 
   after(() => {
     // Topics are ephemeral and IoT endpoint is part of the account
-    return removeService(servicePath);
+    return removeService(serviceDir);
   });
 
   describe('Basic Setup', () => {

--- a/test/integration/iotFleetProvisioning.test.js
+++ b/test/integration/iotFleetProvisioning.test.js
@@ -11,7 +11,7 @@ describe('test/integration/iotFleetProvisioning.test.js', function () {
   const thingName = 'IotDevice';
   const stage = 'dev';
   let stackName;
-  let servicePath;
+  let serviceDir;
   let certificateId;
   let isDeployed = false;
 
@@ -29,10 +29,10 @@ describe('test/integration/iotFleetProvisioning.test.js', function () {
 
   before(async () => {
     let serviceConfig;
-    ({ serviceConfig, servicePath } = await fixtures.setup('iotFleetProvisioning'));
+    ({ serviceConfig, servicePath: serviceDir } = await fixtures.setup('iotFleetProvisioning'));
     const serviceName = serviceConfig.service;
     stackName = `${serviceName}-${stage}`;
-    await deployService(servicePath);
+    await deployService(serviceDir);
     isDeployed = true;
   });
 
@@ -71,7 +71,7 @@ describe('test/integration/iotFleetProvisioning.test.js', function () {
         certificateId,
       }),
     ]);
-    await removeService(servicePath);
+    await removeService(serviceDir);
   });
 
   it('setup a new IoT Thing with the provisioning template', async () => {

--- a/test/integration/provisionedConcurrency.test.js
+++ b/test/integration/provisionedConcurrency.test.js
@@ -12,14 +12,14 @@ const { deployService, removeService } = require('../utils/integration');
 describe('AWS - Provisioned Concurrency Integration Test', function () {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys
   let stackName;
-  let servicePath;
+  let serviceDir;
   let queueName;
   let streamName;
   const stage = 'dev';
 
   before(async () => {
     const serviceData = await fixtures.setup('provisionedConcurrency');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
 
     streamName = `${serviceName}-kinesis`;
@@ -28,11 +28,11 @@ describe('AWS - Provisioned Concurrency Integration Test', function () {
     // NOTE: deployment can only be done once the SQS queue and Kinesis Stream is created
     log.notice(`Creating SQS queue "${queueName}" and Kinesis stream "${streamName}"...`);
     await Promise.all([createSqsQueue(queueName), createKinesisStream(streamName)]);
-    return deployService(servicePath);
+    return deployService(serviceDir);
   });
 
   after(async () => {
-    await removeService(servicePath);
+    await removeService(serviceDir);
     log.notice(`Deleting SQS queue "${queueName}" and Kinesis stream "${streamName}"...`);
     return Promise.all([deleteKinesisStream(streamName), deleteSqsQueue(queueName)]);
   });

--- a/test/integration/s3.test.js
+++ b/test/integration/s3.test.js
@@ -12,7 +12,7 @@ const { confirmCloudWatchLogs } = require('../utils/misc');
 describe('AWS - S3 Integration Test', function () {
   this.timeout(1000 * 60 * 10); // Involves time-taking deploys
   let stackName;
-  let servicePath;
+  let serviceDir;
   let bucketMinimalSetup;
   let bucketExtendedSetup;
   let bucketCustomName;
@@ -22,7 +22,7 @@ describe('AWS - S3 Integration Test', function () {
 
   before(async () => {
     const serviceData = await fixtures.setup('s3');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
     bucketMinimalSetup = `${serviceName}-s3-minimal`;
     bucketExtendedSetup = `${serviceName}-s3-extended`;
@@ -37,12 +37,12 @@ describe('AWS - S3 Integration Test', function () {
       createBucket(bucketExistingSimpleSetup),
       createBucket(bucketExistingComplexSetup),
     ]).then(() => {
-      return deployService(servicePath);
+      return deployService(serviceDir);
     });
   });
 
   after(async () => {
-    await removeService(servicePath);
+    await removeService(serviceDir);
     return BbPromise.all([
       deleteBucket(bucketExistingSimpleSetup),
       deleteBucket(bucketExistingComplexSetup),

--- a/test/integration/schedule.test.js
+++ b/test/integration/schedule.test.js
@@ -8,18 +8,18 @@ const { confirmCloudWatchLogs } = require('../utils/misc');
 
 describe('AWS - Schedule Integration Test', function () {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys
-  let servicePath;
+  let serviceDir;
   let stackName;
 
   before(async () => {
     const serviceData = await fixtures.setup('schedule');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     stackName = `${serviceData.serviceConfig.service}-dev`;
-    return deployService(servicePath);
+    return deployService(serviceDir);
   });
 
   after(async () => {
-    return removeService(servicePath);
+    return removeService(serviceDir);
   });
 
   describe('Minimal Setup', () => {

--- a/test/integration/sns.test.js
+++ b/test/integration/sns.test.js
@@ -12,7 +12,7 @@ const { deployService, removeService } = require('../utils/integration');
 describe('AWS - SNS Integration Test', function () {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys
   let stackName;
-  let servicePath;
+  let serviceDir;
   let minimalTopicName;
   let filteredTopicName;
   let existingTopicName;
@@ -20,7 +20,7 @@ describe('AWS - SNS Integration Test', function () {
 
   before(async () => {
     const serviceData = await fixtures.setup('sns');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
 
     minimalTopicName = `${serviceName}-minimal`;
@@ -32,12 +32,12 @@ describe('AWS - SNS Integration Test', function () {
     // NOTE: deployment can only be done once the SNS topics are created
     log.notice(`Creating SNS topic "${existingTopicName}"...`);
     return createSnsTopic(existingTopicName).then(() => {
-      return deployService(servicePath);
+      return deployService(serviceDir);
     });
   });
 
   after(async () => {
-    await removeService(servicePath);
+    await removeService(serviceDir);
     log.notice('Deleting SNS topics');
     return removeSnsTopic(existingTopicName);
   });

--- a/test/integration/sqs.test.js
+++ b/test/integration/sqs.test.js
@@ -12,13 +12,13 @@ const { deployService, removeService } = require('../utils/integration');
 describe('AWS - SQS Integration Test', function () {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys
   let stackName;
-  let servicePath;
+  let serviceDir;
   let queueName;
   const stage = 'dev';
 
   before(async () => {
     const serviceData = await fixtures.setup('sqs');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
 
     queueName = `${serviceName}-basic`;
@@ -27,13 +27,13 @@ describe('AWS - SQS Integration Test', function () {
     // NOTE: deployment can only be done once the SQS queue is created
     log.notice(`Creating SQS queue "${queueName}"...`);
     return createSqsQueue(queueName).then(() => {
-      return deployService(servicePath);
+      return deployService(serviceDir);
     });
   });
 
   after(async function () {
     if (hasFailed(this.test.parent)) return null;
-    await removeService(servicePath);
+    await removeService(serviceDir);
     log.notice('Deleting SQS queue');
     return deleteSqsQueue(queueName);
   });

--- a/test/integration/stream.test.js
+++ b/test/integration/stream.test.js
@@ -12,7 +12,7 @@ const { deployService, removeService } = require('../utils/integration');
 describe('AWS - Stream Integration Test', function () {
   this.timeout(1000 * 60 * 100); // Involves time-taking deploys
   let stackName;
-  let servicePath;
+  let serviceDir;
   let streamName;
   let tableName;
   const historicStreamMessage = 'Hello from the Kinesis horizon!';
@@ -20,7 +20,7 @@ describe('AWS - Stream Integration Test', function () {
 
   before(async () => {
     const serviceData = await fixtures.setup('stream');
-    ({ servicePath } = serviceData);
+    ({ servicePath: serviceDir } = serviceData);
     const serviceName = serviceData.serviceConfig.service;
 
     streamName = `${serviceName}-kinesis`;
@@ -31,11 +31,11 @@ describe('AWS - Stream Integration Test', function () {
     log.notice(`Creating Kinesis stream "${streamName}"...`);
     return createKinesisStream(streamName)
       .then(() => putKinesisRecord(streamName, historicStreamMessage))
-      .then(() => deployService(servicePath));
+      .then(() => deployService(serviceDir));
   });
 
   after(async () => {
-    await removeService(servicePath);
+    await removeService(serviceDir);
     log.notice('Deleting Kinesis stream');
     return deleteKinesisStream(streamName);
   });

--- a/test/integration/websocket.test.js
+++ b/test/integration/websocket.test.js
@@ -15,7 +15,7 @@ describe('AWS - API Gateway Websocket Integration Test', function () {
   this.timeout(1000 * 60 * 10); // Involves time-taking deploys
   let stackName;
   let serviceName;
-  let servicePath;
+  let serviceDir;
   let updateConfig;
   // TODO: Remove once occasional test fail is debugged
   let twoWayPassed;
@@ -23,15 +23,15 @@ describe('AWS - API Gateway Websocket Integration Test', function () {
 
   before(async () => {
     const serviceData = await fixtures.setup('websocket');
-    ({ servicePath, updateConfig } = serviceData);
+    ({ servicePath: serviceDir, updateConfig } = serviceData);
     serviceName = serviceData.serviceConfig.service;
     stackName = `${serviceName}-${stage}`;
-    return deployService(servicePath);
+    return deployService(serviceDir);
   });
 
   after(() => {
     if (!twoWayPassed) return null;
-    return removeService(servicePath);
+    return removeService(serviceDir);
   });
 
   async function getWebSocketServerUrl() {
@@ -140,7 +140,7 @@ describe('AWS - API Gateway Websocket Integration Test', function () {
             apiGateway: { websocketApiId },
           },
         });
-        return deployService(servicePath);
+        return deployService(serviceDir);
       });
 
       after(async () => {
@@ -155,7 +155,7 @@ describe('AWS - API Gateway Websocket Integration Test', function () {
         // otherwise CF will refuse to delete the deployment because a stage refers to that
         await deleteStage(websocketApiId, 'dev');
         // NOTE: deploying once again to get the stack into the original state
-        await deployService(servicePath);
+        await deployService(serviceDir);
         log.debug('Deleting external websocket API...');
         await deleteApi(websocketApiId);
       });

--- a/test/integrationPackage/lambda-files.tests.js
+++ b/test/integrationPackage/lambda-files.tests.js
@@ -21,7 +21,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
   });
 
   it('packages the default aws template correctly in the zip', async () => {
-    fse.copySync(fixturePaths.regular, cwd);
+    await fse.copy(fixturePaths.regular, cwd);
     execSync(`${serverlessExec} package`, { cwd });
     expect(await listZipFiles(path.join(cwd, '.serverless/aws-nodejs.zip'))).to.deep.equal([
       'handler.js',
@@ -29,7 +29,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
   });
 
   it('packages the default aws template with an npm dep correctly in the zip', async () => {
-    fse.copySync(fixturePaths.regular, cwd);
+    await fse.copy(fixturePaths.regular, cwd);
     execSync('npm init --yes', { cwd });
     execSync('npm i lodash', { cwd });
     execSync(`${serverlessExec} package`, { cwd });
@@ -43,7 +43,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
   });
 
   it("doesn't package a dev dependency in the zip", async () => {
-    fse.copySync(fixturePaths.regular, cwd);
+    await fse.copy(fixturePaths.regular, cwd);
     execSync('npm init --yes', { cwd });
     execSync('npm i --save-dev lodash', { cwd });
     execSync(`${serverlessExec} package`, { cwd });
@@ -57,7 +57,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
   });
 
   it('ignores package json files per ignore directive in the zip', async () => {
-    fse.copySync(fixturePaths.regular, cwd);
+    await fse.copy(fixturePaths.regular, cwd);
     execSync('npm init --yes', { cwd });
     execSync('echo \'package: {exclude: ["package*.json"]}\' >> serverless.yml', { cwd });
     execSync('npm i lodash', { cwd });
@@ -72,7 +72,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
   });
 
   it('handles package individually with include/excludes correctly', async () => {
-    fse.copySync(fixturePaths.individually, cwd);
+    await fse.copy(fixturePaths.individually, cwd);
     execSync(`${serverlessExec} package`, { cwd });
     expect(await listZipFiles(path.join(cwd, '.serverless/hello.zip'))).to.deep.equal([
       'handler.js',
@@ -83,7 +83,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
   });
 
   it('handles package individually on function level with include/excludes correctly', async () => {
-    fse.copySync(fixturePaths.individuallyFunction, cwd);
+    await fse.copy(fixturePaths.individuallyFunction, cwd);
     execSync(`${serverlessExec} package`, { cwd });
     expect(await listZipFiles(path.join(cwd, '.serverless/hello.zip'))).to.deep.equal([
       'handler.js',

--- a/test/integrationPackage/lambda-files.tests.js
+++ b/test/integrationPackage/lambda-files.tests.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const { expect } = require('chai');
+const fs = require('fs').promises;
 const fse = require('fs-extra');
 const { execSync } = require('../utils/childProcess');
 const serverlessExec = require('../serverlessBinary');
@@ -59,7 +60,10 @@ describe('Integration test - Packaging - Lambda Files', function () {
   it('ignores package json files per ignore directive in the zip', async () => {
     await fse.copy(fixturePaths.regular, cwd);
     execSync('npm init --yes', { cwd });
-    execSync('echo \'package: {exclude: ["package*.json"]}\' >> serverless.yml', { cwd });
+    await fs.appendFile(
+      path.resolve(cwd, 'serverless.yml'),
+      '\npackage: {exclude: ["package*.json"]}\n'
+    );
     execSync('npm i lodash', { cwd });
     execSync(`${serverlessExec} package`, { cwd });
     const zipfiles = await listZipFiles(path.join(cwd, '.serverless/aws-nodejs.zip'));

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -275,10 +275,10 @@ describe('Serverless [new tests]', () => {
 
     describe('When running local version', () => {
       it('Should run without notice', () =>
-        fixtures.setup('locallyInstalledServerless').then(({ servicePath }) =>
+        fixtures.setup('locallyInstalledServerless').then(({ servicePath: serviceDir }) =>
           runServerless({
-            serverlessDir: path.resolve(servicePath, 'node_modules/serverless'),
-            cwd: servicePath,
+            serverlessDir: path.resolve(serviceDir, 'node_modules/serverless'),
+            cwd: serviceDir,
             command: 'print',
           }).then(({ serverless }) => {
             expect(Array.from(serverless.triggeredDeprecations)).to.not.include(
@@ -305,10 +305,10 @@ describe('Serverless [new tests]', () => {
   });
 
   describe('When .env file is available', () => {
-    let servicePath;
+    let serviceDir;
 
     before(async () => {
-      servicePath = (
+      serviceDir = (
         await fixtures.setup('function', {
           configExt: {
             useDotenv: true,
@@ -321,13 +321,13 @@ describe('Serverless [new tests]', () => {
       ).servicePath;
 
       const defaultFileContent = 'DEFAULT_ENV_VARIABLE=valuefromdefault';
-      await fs.promises.writeFile(path.join(servicePath, '.env'), defaultFileContent);
+      await fs.promises.writeFile(path.join(serviceDir, '.env'), defaultFileContent);
       conditionallyLoadDotenv.clear();
     });
 
     it('Should load environment variables from default .env file if no matching stage', async () => {
       const result = await runServerless({
-        cwd: servicePath,
+        cwd: serviceDir,
         command: 'package',
         shouldUseLegacyVariablesResolver: true,
       });

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -396,14 +396,14 @@ describe('PluginManager', () => {
       case 'ServicePluginMock2':
         return { realPath: pluginPath };
       case './RelativePath/ServicePluginMock2':
-        return { realPath: `${servicePath}/RelativePath/ServicePluginMock2` };
+        return { realPath: `${serviceDir}/RelativePath/ServicePluginMock2` };
       default:
         return cjsResolve(directory, pluginPath);
     }
   };
 
   let restoreEnv;
-  let servicePath;
+  let serviceDir;
   let PluginManager = proxyquire('../../../../lib/classes/PluginManager', {
     'ncjsm/resolve/sync': resolveStub,
   });
@@ -414,7 +414,7 @@ describe('PluginManager', () => {
     serverless.cli = new CLI();
     serverless.processedInput = { commands: [], options: {} };
     pluginManager = new PluginManager(serverless);
-    servicePath = pluginManager.serverless.serviceDir = 'foo';
+    serviceDir = pluginManager.serverless.serviceDir = 'foo';
   });
 
   afterEach(() => restoreEnv());
@@ -472,8 +472,8 @@ describe('PluginManager', () => {
       });
       pluginManager = new PluginManager(serverless);
       pluginManager.serverless.config = { servicePath: 'somePath' };
-      servicePath = pluginManager.serverless.serviceDir;
-      cacheFilePath = getCacheFilePath(servicePath);
+      serviceDir = pluginManager.serverless.serviceDir;
+      cacheFilePath = getCacheFilePath(serviceDir);
       getCommandsStub = sinon.stub(pluginManager, 'getCommands');
     });
 
@@ -750,7 +750,7 @@ describe('PluginManager', () => {
     beforeEach(() => {
       mockRequire('ServicePluginMock1', ServicePluginMock1);
       // Plugins loaded via a relative path should be required relative to the service path
-      mockRequire(`${servicePath}/RelativePath/ServicePluginMock2`, ServicePluginMock2);
+      mockRequire(`${serviceDir}/RelativePath/ServicePluginMock2`, ServicePluginMock2);
     });
 
     it('should resolve the service plugins', () => {
@@ -1917,7 +1917,6 @@ describe('PluginManager', () => {
 
   describe('Plugin / Load local plugins', () => {
     const cwd = process.cwd();
-    let serviceDir;
     let tmpDir;
     beforeEach(() => {
       tmpDir = getTmpDirPath();
@@ -1998,7 +1997,6 @@ describe('PluginManager', () => {
     this.timeout(1000 * 60 * 10);
 
     let serverlessInstance;
-    let serviceDir;
     const serverlessExec = require('../../../serverlessBinary');
 
     beforeEach(() => {

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -414,7 +414,7 @@ describe('PluginManager', () => {
     serverless.cli = new CLI();
     serverless.processedInput = { commands: [], options: {} };
     pluginManager = new PluginManager(serverless);
-    servicePath = pluginManager.serverless.config.servicePath = 'foo';
+    servicePath = pluginManager.serverless.serviceDir = 'foo';
   });
 
   afterEach(() => restoreEnv());
@@ -472,7 +472,7 @@ describe('PluginManager', () => {
       });
       pluginManager = new PluginManager(serverless);
       pluginManager.serverless.config = { servicePath: 'somePath' };
-      servicePath = pluginManager.serverless.config.servicePath;
+      servicePath = pluginManager.serverless.serviceDir;
       cacheFilePath = getCacheFilePath(servicePath);
       getCommandsStub = sinon.stub(pluginManager, 'getCommands');
     });
@@ -790,7 +790,7 @@ describe('PluginManager', () => {
 
       parsePluginsObjectAndVerifyResult(servicePlugins, {
         modules: servicePlugins,
-        localPath: path.join(serverless.config.servicePath, '.serverless_plugins'),
+        localPath: path.join(serverless.serviceDir, '.serverless_plugins'),
       });
     });
 
@@ -811,7 +811,7 @@ describe('PluginManager', () => {
 
       parsePluginsObjectAndVerifyResult(servicePlugins, {
         modules: [],
-        localPath: path.join(serverless.config.servicePath, '.serverless_plugins'),
+        localPath: path.join(serverless.serviceDir, '.serverless_plugins'),
       });
     });
 
@@ -820,7 +820,7 @@ describe('PluginManager', () => {
 
       parsePluginsObjectAndVerifyResult(servicePlugins, {
         modules: [],
-        localPath: path.join(serverless.config.servicePath, '.serverless_plugins'),
+        localPath: path.join(serverless.serviceDir, '.serverless_plugins'),
       });
     });
 
@@ -832,7 +832,7 @@ describe('PluginManager', () => {
 
       parsePluginsObjectAndVerifyResult(servicePlugins, {
         modules: servicePlugins.modules,
-        localPath: path.join(serverless.config.servicePath, '.serverless_plugins'),
+        localPath: path.join(serverless.serviceDir, '.serverless_plugins'),
       });
     });
   });
@@ -1333,7 +1333,7 @@ describe('PluginManager', () => {
     beforeEach(() => {
       serverlessInstance = new Serverless();
       serverlessInstance.configurationInput = null;
-      serverlessInstance.config.servicePath = 'my-service';
+      serverlessInstance.serviceDir = 'my-service';
       pluginManagerInstance = new PluginManager(serverlessInstance);
     });
 
@@ -1924,7 +1924,7 @@ describe('PluginManager', () => {
       serviceDir = path.join(tmpDir, 'service');
       fse.mkdirsSync(serviceDir);
       process.chdir(serviceDir);
-      pluginManager.serverless.config.servicePath = serviceDir;
+      pluginManager.serverless.serviceDir = serviceDir;
     });
 
     it('should load plugins from .serverless_plugins', () => {

--- a/test/unit/lib/classes/Variables.test.js
+++ b/test/unit/lib/classes/Variables.test.js
@@ -1022,7 +1022,7 @@ describe('Variables', () => {
         beforeEach(() => {
           tmpDirPath = getTmpDirPath();
           fse.mkdirsSync(tmpDirPath);
-          serverless.config.update({ servicePath: tmpDirPath });
+          serverless.serviceDir = tmpDirPath;
         });
         afterEach(() => {
           fse.removeSync(tmpDirPath);
@@ -1823,7 +1823,7 @@ module.exports = {
         },
       };
       SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), yaml.dump(configYml));
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./config.yml)')
         .should.eventually.eql(configYml);
@@ -1831,7 +1831,7 @@ module.exports = {
 
     it('should get undefined if non existing file and the second argument is true', () => {
       const tmpDirPath = getTmpDirPath();
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       const realpathSync = sinon.spy(fse, 'realpathSync');
       const existsSync = sinon.spy(fse, 'existsSync');
       return serverless.variables
@@ -1851,7 +1851,7 @@ module.exports = {
       const SUtils = new Utils();
       const tmpDirPath = getTmpDirPath();
       SUtils.writeFileSync(path.join(tmpDirPath, 'someFile'), 'hello world');
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables.getValueFromFile('file(./someFile)').should.become('hello world');
     });
 
@@ -1867,7 +1867,7 @@ module.exports = {
         skipOnDisabledSymlinksInWindows(error, this, afterCallback);
         throw error;
       }
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./refSomeFile)')
         .should.become('hello world')
@@ -1882,7 +1882,7 @@ module.exports = {
       const SUtils = new Utils();
       const tmpDirPath = getTmpDirPath();
       SUtils.writeFileSync(path.join(tmpDirPath, 'someFile'), 'hello world \n');
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables.getValueFromFile('file(./someFile)').should.become('hello world');
     });
 
@@ -1898,7 +1898,7 @@ module.exports = {
         },
       };
       SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), yaml.dump(configYml));
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./config.yml):test2.sub')
         .should.become(configYml.test2.sub);
@@ -1909,7 +1909,7 @@ module.exports = {
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports.hello=function(){return "hello world";};';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./hello.js):hello')
         .should.become('hello world');
@@ -1920,7 +1920,7 @@ module.exports = {
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports.hello="hello world";';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./hello.js):hello')
         .should.become('hello world');
@@ -1931,7 +1931,7 @@ module.exports = {
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports=function(){return { hello: "hello world" };};';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./hello.js)')
         .should.become({ hello: 'hello world' });
@@ -1942,7 +1942,7 @@ module.exports = {
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports={ hello: "hello world" };';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./hello.js)')
         .should.become({ hello: 'hello world' });
@@ -1953,7 +1953,7 @@ module.exports = {
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports="hello world";';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables.getValueFromFile('file(./hello.js)').should.become('hello world');
     });
 
@@ -1964,7 +1964,7 @@ module.exports = {
         return {one:{two:{three: 'hello world'}}}
       };`;
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       serverless.variables.loadVariableSyntax();
       return serverless.variables
         .getValueFromFile('file(./hello.js):hello.one.two.three')
@@ -1978,7 +1978,7 @@ module.exports = {
       module.exports.one = {two: {three: 'hello world'}}
       module.exports.hello=function(){ return this; };`;
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       serverless.variables.loadVariableSyntax();
       return serverless.variables
         .getValueFromFile('file(./hello.js):hello.one.two.three')
@@ -1997,7 +1997,7 @@ module.exports = {
         },
       };
       SUtils.writeFileSync(path.join(tmpDirPath, 'config.yml'), yaml.dump(configYml));
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./config.yml).testObj.sub')
         .should.be.rejectedWith(ServerlessError);
@@ -2008,7 +2008,7 @@ module.exports = {
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports=undefined;';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./hello.js)')
         .should.be.rejectedWith(ServerlessError);
@@ -2019,7 +2019,7 @@ module.exports = {
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports=Symbol()';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./hello.js)')
         .should.be.rejectedWith(ServerlessError);
@@ -2030,7 +2030,7 @@ module.exports = {
       const tmpDirPath = getTmpDirPath();
       const jsData = 'module.exports=function(){ return function(){}; };';
       SUtils.writeFileSync(path.join(tmpDirPath, 'hello.js'), jsData);
-      serverless.config.update({ servicePath: tmpDirPath });
+      serverless.serviceDir = tmpDirPath;
       return serverless.variables
         .getValueFromFile('file(./hello.js)')
         .should.be.rejectedWith(ServerlessError);

--- a/test/unit/lib/configuration/variables/index.test.js
+++ b/test/unit/lib/configuration/variables/index.test.js
@@ -18,7 +18,7 @@ describe('test/unit/lib/configuration/variables/index.test.js', () => {
       strToBool: "${strToBool('false')}",
     };
     await resolve({
-      servicePath: process.cwd(),
+      serviceDir: process.cwd(),
       configuration,
       options: { option: 'bar' },
     });

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -155,7 +155,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     before(async () => {
       variablesMeta = resolveMeta(configuration);
       await resolve({
-        servicePath: process.cwd(),
+        serviceDir: process.cwd(),
         configuration,
         variablesMeta,
         sources,
@@ -345,7 +345,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
 
     it('should allow to re-resolve fulfilled sources', async () => {
       await resolve({
-        servicePath: process.cwd(),
+        serviceDir: process.cwd(),
         configuration,
         variablesMeta,
         sources: { ...sources, sourceIncomplete: { resolve: () => ({ value: 'complete' }) } },
@@ -414,7 +414,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     before(async () => {
       variablesMeta = resolveMeta(configuration);
       await resolve({
-        servicePath: process.cwd(),
+        serviceDir: process.cwd(),
         configuration,
         variablesMeta,
         sources,

--- a/test/unit/lib/configuration/variables/sources/env.test.js
+++ b/test/unit/lib/configuration/variables/sources/env.test.js
@@ -21,7 +21,7 @@ describe('test/unit/lib/configuration/variables/sources/env.test.js', () => {
     };
     variablesMeta = resolveMeta(configuration);
     await resolve({
-      servicePath: process.cwd(),
+      serviceDir: process.cwd(),
       configuration,
       variablesMeta,
       sources: { env: envSource, self: selfSource },

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -53,7 +53,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     };
     variablesMeta = resolveMeta(configuration);
     await resolve({
-      servicePath: serviceDir,
+      serviceDir,
       configuration,
       variablesMeta,
       sources: { file: fileSource },
@@ -181,7 +181,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     };
     variablesMeta = resolveMeta(configuration);
     await resolve({
-      servicePath: serviceDir,
+      serviceDir,
       configuration,
       variablesMeta,
       sources: { file: fileSource },

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -8,7 +8,7 @@ const resolve = require('../../../../../../lib/configuration/variables/resolve')
 const fileSource = require('../../../../../../lib/configuration/variables/sources/file');
 
 describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
-  const servicePath = path.resolve(__dirname, 'fixture');
+  const serviceDir = path.resolve(__dirname, 'fixture');
   let configuration;
   let variablesMeta;
   before(async () => {
@@ -53,7 +53,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     };
     variablesMeta = resolveMeta(configuration);
     await resolve({
-      servicePath,
+      servicePath: serviceDir,
       configuration,
       variablesMeta,
       sources: { file: fileSource },
@@ -181,7 +181,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     };
     variablesMeta = resolveMeta(configuration);
     await resolve({
-      servicePath,
+      servicePath: serviceDir,
       configuration,
       variablesMeta,
       sources: { file: fileSource },

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-cf.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-cf.test.js
@@ -50,7 +50,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-c
     };
 
     await resolve({
-      servicePath: process.cwd(),
+      serviceDir: process.cwd(),
       configuration,
       variablesMeta,
       sources: { self: selfSource, cf: getCfSource(serverlessInstance) },

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-s3.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-s3.test.js
@@ -45,7 +45,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
     };
 
     await resolve({
-      servicePath: process.cwd(),
+      serviceDir: process.cwd(),
       configuration,
       variablesMeta,
       sources: { self: selfSource, s3: getS3Source(serverlessInstance) },

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js
@@ -36,7 +36,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
     });
     serverlessInstance.init();
     await resolve({
-      servicePath: process.cwd(),
+      serviceDir: process.cwd(),
       configuration,
       variablesMeta,
       sources: { self: selfSource, sls: getSlsSource(serverlessInstance) },

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-ssm.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-ssm.test.js
@@ -66,7 +66,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
       };
 
       await resolve({
-        servicePath: process.cwd(),
+        serviceDir: process.cwd(),
         configuration,
         variablesMeta,
         sources: { self: selfSource, ssm: getSsmSource(serverlessInstance) },
@@ -187,7 +187,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
       };
 
       await resolve({
-        servicePath: process.cwd(),
+        serviceDir: process.cwd(),
         configuration,
         variablesMeta,
         sources: { self: selfSource, ssm: getSsmSource(serverlessInstance) },

--- a/test/unit/lib/configuration/variables/sources/opt.test.js
+++ b/test/unit/lib/configuration/variables/sources/opt.test.js
@@ -23,7 +23,7 @@ describe('test/unit/lib/configuration/variables/sources/opt.test.js', () => {
       };
       variablesMeta = resolveMeta(configuration);
       await resolve({
-        servicePath: process.cwd(),
+        serviceDir: process.cwd(),
         configuration,
         variablesMeta,
         sources: { opt: optSource, self: selfSource },
@@ -56,7 +56,7 @@ describe('test/unit/lib/configuration/variables/sources/opt.test.js', () => {
       };
       variablesMeta = resolveMeta(configuration);
       await resolve({
-        servicePath: process.cwd(),
+        serviceDir: process.cwd(),
         configuration,
         variablesMeta,
         sources: { opt: optSource, self: selfSource },

--- a/test/unit/lib/configuration/variables/sources/self.test.js
+++ b/test/unit/lib/configuration/variables/sources/self.test.js
@@ -22,7 +22,7 @@ describe('test/unit/lib/configuration/variables/sources/self.test.js', () => {
       nonExisting: '${self:hola.mola}',
     };
     await resolve({
-      servicePath: process.cwd(),
+      serviceDir: process.cwd(),
       configuration,
       variablesMeta: resolveMeta(configuration),
       sources: { self: selfSource },
@@ -53,7 +53,7 @@ describe('test/unit/lib/configuration/variables/sources/self.test.js', () => {
     const configuration = { foo: '${self:}' };
     const variablesMeta = resolveMeta(configuration);
     await resolve({
-      servicePath: process.cwd(),
+      serviceDir: process.cwd(),
       configuration,
       variablesMeta,
       sources: { self: selfSource },

--- a/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
+++ b/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
@@ -18,7 +18,7 @@ describe('test/unit/lib/configuration/variables/sources/str-to-bool.test.js', ()
     };
     variablesMeta = resolveMeta(configuration);
     await resolve({
-      servicePath: process.cwd(),
+      serviceDir: process.cwd(),
       configuration,
       variablesMeta,
       sources: { strToBool: strToBoolSource },

--- a/test/unit/lib/plugins/aws/common/index.test.js
+++ b/test/unit/lib/plugins/aws/common/index.test.js
@@ -15,7 +15,7 @@ describe('AwsCommon', () => {
       region: 'us-east-1',
     };
     serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.config.servicePath = 'foo';
+    serverless.serviceDir = 'foo';
     awsCommon = new AwsCommon(serverless, options);
     awsCommon.serverless.cli = new serverless.classes.CLI();
   });

--- a/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
@@ -17,7 +17,7 @@ describe('#moveArtifactsToPackage()', () => {
     serverless = new Serverless();
     awsCommon = new AWSCommon(serverless, {});
 
-    serverless.config.servicePath = moveBasePath;
+    serverless.serviceDir = moveBasePath;
     if (!serverless.utils.dirExistsSync(moveServerlessPath)) {
       serverless.utils.writeFileDir(moveServerlessPath);
     }
@@ -30,7 +30,7 @@ describe('#moveArtifactsToPackage()', () => {
   });
 
   it('should resolve if servicePath is not present', () => {
-    delete serverless.config.servicePath;
+    delete serverless.serviceDir;
     return awsCommon.moveArtifactsToPackage();
   });
 
@@ -107,7 +107,7 @@ describe('#moveArtifactsToTemp()', () => {
     serverless = new Serverless();
     awsCommon = new AWSCommon(serverless, {});
 
-    serverless.config.servicePath = moveBasePath;
+    serverless.serviceDir = moveBasePath;
     if (!serverless.utils.dirExistsSync(moveTargetPath)) {
       serverless.utils.writeFileDir(moveTargetPath);
     }
@@ -120,7 +120,7 @@ describe('#moveArtifactsToTemp()', () => {
   });
 
   it('should resolve if servicePath is not present', () => {
-    delete serverless.config.servicePath;
+    delete serverless.serviceDir;
     return awsCommon.moveArtifactsToTemp();
   });
 

--- a/test/unit/lib/plugins/aws/common/lib/cleanupTempDir.test.js
+++ b/test/unit/lib/plugins/aws/common/lib/cleanupTempDir.test.js
@@ -14,12 +14,12 @@ describe('#cleanupTempDir()', () => {
     serverless = new Serverless();
     packageService = new Package(serverless);
 
-    serverless.config.servicePath = getTmpDirPath();
+    serverless.serviceDir = getTmpDirPath();
   });
 
   it('should remove .serverless in the service directory', () => {
     const serverlessTmpDirPath = path.join(
-      packageService.serverless.config.servicePath,
+      packageService.serverless.serviceDir,
       '.serverless',
       'README'
     );
@@ -28,14 +28,14 @@ describe('#cleanupTempDir()', () => {
     return packageService.cleanupTempDir().then(() => {
       expect(
         serverless.utils.dirExistsSync(
-          path.join(packageService.serverless.config.servicePath, '.serverless')
+          path.join(packageService.serverless.serviceDir, '.serverless')
         )
       ).to.equal(false);
     });
   });
 
   it('should resolve if servicePath is not present', (done) => {
-    delete serverless.config.servicePath;
+    delete serverless.serviceDir;
     packageService.cleanupTempDir().then(() => {
       done();
     });

--- a/test/unit/lib/plugins/aws/customResources/index.test.js
+++ b/test/unit/lib/plugins/aws/customResources/index.test.js
@@ -45,7 +45,7 @@ describe('#addCustomResourceToService()', () => {
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},
     };
-    serverless.config.servicePath = tmpDirPath;
+    serverless.serviceDir = tmpDirPath;
     serverless.service.package.artifactDirectoryName = 'artifact-dir-name';
   });
 

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -28,7 +28,7 @@ describe('AwsDeploy', () => {
       region: 'us-east-1',
     };
     serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.config.servicePath = 'foo';
+    serverless.serviceDir = 'foo';
     awsDeploy = new AwsDeploy(serverless, options);
   });
 
@@ -46,7 +46,7 @@ describe('AwsDeploy', () => {
     });
 
     it('should default to an empty service path if not provided', () => {
-      serverless.config.servicePath = false;
+      serverless.serviceDir = false;
       awsDeploy = new AwsDeploy(serverless, options);
 
       expect(awsDeploy.servicePath).to.equal('');

--- a/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -34,7 +34,7 @@ describe('checkForChanges', () => {
       region: 'us-east-1',
     };
     serverless = new Serverless();
-    serverless.config.servicePath = 'my-service';
+    serverless.serviceDir = 'my-service';
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'my-service';
@@ -291,12 +291,12 @@ describe('checkForChanges', () => {
           awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         );
         expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
           dot: true,
           silent: true,
         });
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/my-service.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/my-service.zip')
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
       });
@@ -326,12 +326,12 @@ describe('checkForChanges', () => {
           awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         );
         expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
           dot: true,
           silent: true,
         });
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/my-service.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/my-service.zip')
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
       });
@@ -356,12 +356,12 @@ describe('checkForChanges', () => {
           awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         );
         expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
           dot: true,
           silent: true,
         });
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/my-service.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/my-service.zip')
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
       });
@@ -388,15 +388,15 @@ describe('checkForChanges', () => {
           awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         );
         expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
           dot: true,
           silent: true,
         });
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/func1.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/func1.zip')
         );
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/func2.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/func2.zip')
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
       });
@@ -425,12 +425,12 @@ describe('checkForChanges', () => {
           awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         );
         expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
           dot: true,
           silent: true,
         });
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/my-service.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/my-service.zip')
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
       });
@@ -455,12 +455,12 @@ describe('checkForChanges', () => {
           awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         );
         expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
           dot: true,
           silent: true,
         });
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/my-service.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/my-service.zip')
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
       });
@@ -489,12 +489,12 @@ describe('checkForChanges', () => {
             awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
           );
           expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-            cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+            cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
             dot: true,
             silent: true,
           });
           expect(readFileStub).to.have.been.calledWith(
-            path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/my-service.zip')
+            path.resolve(awsDeploy.serverless.serviceDir, '.serverless/my-service.zip')
           );
           expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
         }
@@ -523,15 +523,15 @@ describe('checkForChanges', () => {
           awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         );
         expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
           dot: true,
           silent: true,
         });
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/func1.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/func1.zip')
         );
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, '.serverless/func2.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, '.serverless/func2.zip')
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(true);
       });
@@ -560,12 +560,12 @@ describe('checkForChanges', () => {
           awsDeploy.serverless.service.provider.compiledCloudFormationTemplate
         );
         expect(globbySyncStub).to.have.been.calledWithExactly(['**.zip'], {
-          cwd: path.join(awsDeploy.serverless.config.servicePath, '.serverless'),
+          cwd: path.join(awsDeploy.serverless.serviceDir, '.serverless'),
           dot: true,
           silent: true,
         });
         expect(readFileStub).to.have.been.calledWith(
-          path.resolve(awsDeploy.serverless.config.servicePath, 'foo/bar/my-own.zip')
+          path.resolve(awsDeploy.serverless.serviceDir, 'foo/bar/my-own.zip')
         );
         expect(awsDeploy.serverless.service.provider.shouldNotDeploy).to.equal(undefined);
       });
@@ -644,7 +644,7 @@ const commonAwsSdkMock = {
 };
 
 const generateMatchingListObjectsResponse = async (serverless) => {
-  const packagePath = `${serverless.config.servicePath}/.serverless`;
+  const packagePath = `${serverless.serviceDir}/.serverless`;
   const artifactNames = await globby(packagePath, { expandDirectories: { extensions: ['zip'] } });
   artifactNames.push('compiled-cloudformation-template.json');
   return {
@@ -670,7 +670,7 @@ const generateMatchingHeadObjectResponse = async (serverless, { Key: key }) => {
   const fileHash = await (async (fileName) => {
     return new Promise((resolve) => {
       const hash = crypto.createHash('sha256');
-      const f = fs.createReadStream(`${serverless.config.servicePath}/.serverless/${fileName}`);
+      const f = fs.createReadStream(`${serverless.serviceDir}/.serverless/${fileName}`);
       f.on('data', (d) => hash.update(d));
       f.on('close', () => resolve(hash.digest('base64')));
     });

--- a/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -846,7 +846,7 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
     // https://github.com/serverless/serverless/blob/11fb14115ea47d53a61fa666a94e60d585fb3a4d/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js#L317-L350
 
     const {
-      fixtureData: { updateConfig, servicePath },
+      fixtureData: { updateConfig, servicePath: serviceDir },
     } = await runServerless({
       fixture: 'checkForChanges',
       command: 'package',
@@ -857,7 +857,7 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
 
     let serverless;
     await runServerless({
-      cwd: servicePath,
+      cwd: serviceDir,
       command: 'package',
       lastLifecycleHookName: 'aws:deploy:deploy:checkForChanges',
       env: { AWS_CONTAINER_CREDENTIALS_FULL_URI: 'ignore' },

--- a/test/unit/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
@@ -25,7 +25,7 @@ describe('cleanupS3Bucket', () => {
       region: 'us-east-1',
     };
     serverless = new Serverless();
-    serverless.config.servicePath = 'foo';
+    serverless.serviceDir = 'foo';
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'cleanupS3Bucket';

--- a/test/unit/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -33,7 +33,7 @@ describe('createStack', () => {
     const serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, {}));
     serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
-    serverless.config.servicePath = tmpDirPath;
+    serverless.serviceDir = tmpDirPath;
     const options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -44,7 +44,7 @@ describe('extendedValidate', () => {
     const serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
-    serverless.config.servicePath = tmpDirPath;
+    serverless.serviceDir = tmpDirPath;
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.serverless.service.service = `service-${new Date().getTime().toString()}`;
     awsDeploy.serverless.cli = {

--- a/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -26,7 +26,7 @@ describe('uploadArtifacts', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
-    serverless.config.servicePath = 'foo';
+    serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, {}));
     const options = {
       stage: 'dev',
@@ -225,7 +225,7 @@ describe('uploadArtifacts', () => {
     });
 
     it('should upload the service artifact file to the S3 bucket', () => {
-      awsDeploy.serverless.config.servicePath = 'some/path';
+      awsDeploy.serverless.serviceDir = 'some/path';
       awsDeploy.serverless.service.service = 'new-service';
 
       return awsDeploy.uploadFunctionsAndLayers().then(() => {
@@ -308,7 +308,7 @@ describe('uploadArtifacts', () => {
     });
 
     it('should log artifact size', () => {
-      awsDeploy.serverless.config.servicePath = 'some/path';
+      awsDeploy.serverless.serviceDir = 'some/path';
       awsDeploy.serverless.service.service = 'new-service';
 
       sinon.spy(awsDeploy.serverless.cli, 'log');
@@ -335,7 +335,7 @@ describe('uploadArtifacts', () => {
       // folder was cleaned before stream initialized fully, hence throwing uncaught
       // ENOENT exception into the air.
       sinon.stub(fs, 'createReadStream').returns({ path: customResourcesFilePath, on: () => {} });
-      serverless.config.servicePath = serviceDirPath;
+      serverless.serviceDir = serviceDirPath;
     });
 
     afterEach(() => {

--- a/test/unit/lib/plugins/aws/deploy/lib/validateTemplate.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/validateTemplate.test.js
@@ -24,7 +24,7 @@ describe('validateTemplate', () => {
       region: 'us-east-1',
     };
     serverless = new Serverless();
-    serverless.config.servicePath = 'foo';
+    serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);
     awsDeploy.bucketName = 'deployment-bucket';

--- a/test/unit/lib/plugins/aws/invoke.test.js
+++ b/test/unit/lib/plugins/aws/invoke.test.js
@@ -40,7 +40,7 @@ describe('AwsInvoke', () => {
   describe('#extendedValidate()', () => {
     let backupIsTTY;
     beforeEach(() => {
-      serverless.config.servicePath = true;
+      serverless.serviceDir = true;
       serverless.service.environment = {
         vars: {},
         stages: {
@@ -112,12 +112,12 @@ describe('AwsInvoke', () => {
     });
 
     it('it should parse file if relative file path is provided', async () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       const data = {
         testProp: 'testValue',
       };
       serverless.utils.writeFileSync(
-        path.join(serverless.config.servicePath, 'data.json'),
+        path.join(serverless.serviceDir, 'data.json'),
         JSON.stringify(data)
       );
       awsInvoke.options.path = 'data.json';
@@ -128,11 +128,11 @@ describe('AwsInvoke', () => {
     });
 
     it('it should parse file if absolute file path is provided', async () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       const data = {
         testProp: 'testValue',
       };
-      const dataFile = path.join(serverless.config.servicePath, 'data.json');
+      const dataFile = path.join(serverless.serviceDir, 'data.json');
       serverless.utils.writeFileSync(dataFile, JSON.stringify(data));
       awsInvoke.options.path = dataFile;
 
@@ -142,13 +142,10 @@ describe('AwsInvoke', () => {
     });
 
     it('it should parse a yaml file if file path is provided', async () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       const yamlContent = 'testProp: testValue';
 
-      serverless.utils.writeFileSync(
-        path.join(serverless.config.servicePath, 'data.yml'),
-        yamlContent
-      );
+      serverless.utils.writeFileSync(path.join(serverless.serviceDir, 'data.yml'), yamlContent);
       awsInvoke.options.path = 'data.yml';
 
       await expect(awsInvoke.extendedValidate()).to.be.fulfilled;
@@ -159,7 +156,7 @@ describe('AwsInvoke', () => {
     });
 
     it('it should throw error if file path does not exist', () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       awsInvoke.options.path = 'some/path';
 
       return expect(awsInvoke.extendedValidate()).to.be.rejectedWith(

--- a/test/unit/lib/plugins/aws/invokeLocal/index.test.js
+++ b/test/unit/lib/plugins/aws/invokeLocal/index.test.js
@@ -66,7 +66,7 @@ describe('AwsInvokeLocal', () => {
       'child-process-ext/spawn': spawnExtStub,
     });
     serverless = new Serverless();
-    serverless.config.servicePath = 'servicePath';
+    serverless.serviceDir = 'servicePath';
     serverless.cli = new CLI(serverless);
     serverless.processedInput = { commands: ['invoke'] };
     provider = new AwsProvider(serverless, options);
@@ -81,7 +81,7 @@ describe('AwsInvokeLocal', () => {
   describe('#extendedValidate()', () => {
     let backupIsTTY;
     beforeEach(() => {
-      serverless.config.servicePath = true;
+      serverless.serviceDir = true;
       serverless.service.environment = {
         vars: {},
         stages: {
@@ -163,12 +163,12 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('it should parse file if relative file path is provided', async () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       const data = {
         testProp: 'testValue',
       };
       serverless.utils.writeFileSync(
-        path.join(serverless.config.servicePath, 'data.json'),
+        path.join(serverless.serviceDir, 'data.json'),
         JSON.stringify(data)
       );
       awsInvokeLocal.options.contextPath = 'data.json';
@@ -178,13 +178,13 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('it should parse file if absolute file path is provided', async () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       const data = {
         event: {
           testProp: 'testValue',
         },
       };
-      const dataFile = path.join(serverless.config.servicePath, 'data.json');
+      const dataFile = path.join(serverless.serviceDir, 'data.json');
       serverless.utils.writeFileSync(dataFile, JSON.stringify(data));
       awsInvokeLocal.options.path = dataFile;
       awsInvokeLocal.options.contextPath = false;
@@ -194,13 +194,10 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('it should parse a yaml file if file path is provided', async () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       const yamlContent = 'event: data';
 
-      serverless.utils.writeFileSync(
-        path.join(serverless.config.servicePath, 'data.yml'),
-        yamlContent
-      );
+      serverless.utils.writeFileSync(path.join(serverless.serviceDir, 'data.yml'), yamlContent);
       awsInvokeLocal.options.path = 'data.yml';
 
       await expect(awsInvokeLocal.extendedValidate()).to.be.fulfilled;
@@ -208,7 +205,7 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('it should require a js file if file path is provided', async () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       const jsContent = [
         'module.exports = {',
         '  headers: { "Content-Type" : "application/json" },',
@@ -216,10 +213,7 @@ describe('AwsInvokeLocal', () => {
         '}',
       ].join('\n');
 
-      serverless.utils.writeFileSync(
-        path.join(serverless.config.servicePath, 'data.js'),
-        jsContent
-      );
+      serverless.utils.writeFileSync(path.join(serverless.serviceDir, 'data.js'), jsContent);
       awsInvokeLocal.options.path = 'data.js';
 
       await expect(awsInvokeLocal.extendedValidate()).to.be.fulfilled;
@@ -230,7 +224,7 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('it should reject error if file path does not exist', () => {
-      serverless.config.servicePath = getTmpDirPath();
+      serverless.serviceDir = getTmpDirPath();
       awsInvokeLocal.options.path = 'some/path';
 
       return expect(awsInvokeLocal.extendedValidate()).to.be.rejected;
@@ -269,7 +263,7 @@ describe('AwsInvokeLocal', () => {
     let restoreEnv;
     beforeEach(() => {
       ({ restoreEnv } = overrideEnv());
-      serverless.config.servicePath = true;
+      serverless.serviceDir = true;
       serverless.service.provider = {
         environment: {
           providerVar: 'providerValue',
@@ -537,7 +531,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('with done method', () => {
       it('should exit with error exit code', () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withErrorByDone');
 
@@ -545,7 +539,7 @@ describe('AwsInvokeLocal', () => {
       });
 
       it('should succeed if succeed', () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withMessageByDone');
 
@@ -555,7 +549,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('with Lambda Proxy with application/json response', () => {
       it('should succeed if succeed', () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withMessageByLambdaProxy');
 
@@ -567,7 +561,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('context.remainingTimeInMillis', () => {
       it('should become lower over time', () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withRemainingTime');
 
@@ -576,7 +570,7 @@ describe('AwsInvokeLocal', () => {
       });
 
       it('should start with the timeout value', () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
         awsInvokeLocal.serverless.service.provider.timeout = 5;
 
         awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withRemainingTime');
@@ -586,7 +580,7 @@ describe('AwsInvokeLocal', () => {
       });
 
       it('should never become negative', () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
         awsInvokeLocal.serverless.service.provider.timeout = 0.00001;
 
         awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithSuccess', 'withRemainingTime');
@@ -598,7 +592,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('with extraServicePath', () => {
       it('should succeed if succeed', () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
         awsInvokeLocal.options.extraServicePath = 'fixture';
 
         awsInvokeLocal.invokeLocalNodeJs('handlerWithSuccess', 'withMessageByLambdaProxy');
@@ -610,7 +604,7 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('should exit with error exit code', () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withError');
 
@@ -618,7 +612,7 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('should log Error instance when called back', () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withError');
       const logMessageContent = JSON.parse(stripAnsi(serverless.cli.consoleLog.lastCall.args[0]));
@@ -629,7 +623,7 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('should log Error object if handler crashes at initialization', async () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       try {
         await awsInvokeLocal.invokeLocalNodeJs(
@@ -646,7 +640,7 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('should log error when called back', () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithError', 'withMessage');
 
@@ -654,7 +648,7 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('should throw when module loading error', async () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       try {
         await awsInvokeLocal.invokeLocalNodeJs('fixture/handlerWithLoadingError', 'anyMethod');
@@ -683,13 +677,13 @@ describe('AwsInvokeLocal', () => {
 
     describe('with return', () => {
       it('should exit with error exit code', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
         await awsInvokeLocal.invokeLocalNodeJs('fixture/asyncHandlerWithSuccess', 'withError');
         expect(process.exitCode).to.be.equal(1);
       });
 
       it('should succeed if succeed', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         await awsInvokeLocal.invokeLocalNodeJs('fixture/asyncHandlerWithSuccess', 'withMessage');
         expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"Succeed"');
@@ -698,7 +692,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('by context.done', () => {
       it('success should trigger one response', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         await awsInvokeLocal.invokeLocalNodeJs(
           'fixture/asyncHandlerWithSuccess',
@@ -712,7 +706,7 @@ describe('AwsInvokeLocal', () => {
       });
 
       it('error should trigger one response', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         await awsInvokeLocal.invokeLocalNodeJs(
           'fixture/asyncHandlerWithSuccess',
@@ -725,7 +719,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('by callback method', () => {
       it('should succeed once if succeed if by callback', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         await awsInvokeLocal.invokeLocalNodeJs(
           'fixture/asyncHandlerWithSuccess',
@@ -741,7 +735,7 @@ describe('AwsInvokeLocal', () => {
 
     describe("by callback method even if callback isn't called syncronously", () => {
       it('should succeed once if succeed if by callback', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         await awsInvokeLocal.invokeLocalNodeJs(
           'fixture/asyncHandlerWithSuccess',
@@ -757,7 +751,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('with Lambda Proxy with application/json response', () => {
       it('should succeed if succeed', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         await awsInvokeLocal.invokeLocalNodeJs(
           'fixture/asyncHandlerWithSuccess',
@@ -771,7 +765,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('context.remainingTimeInMillis', () => {
       it('should become lower over time', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         await awsInvokeLocal.invokeLocalNodeJs(
           'fixture/asyncHandlerWithSuccess',
@@ -782,7 +776,7 @@ describe('AwsInvokeLocal', () => {
       });
 
       it('should start with the timeout value', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
         awsInvokeLocal.serverless.service.provider.timeout = 5;
 
         await awsInvokeLocal.invokeLocalNodeJs(
@@ -794,7 +788,7 @@ describe('AwsInvokeLocal', () => {
       });
 
       it('should never become negative', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
         awsInvokeLocal.serverless.service.provider.timeout = 0.00001;
 
         await awsInvokeLocal.invokeLocalNodeJs(
@@ -808,7 +802,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('with extraServicePath', () => {
       it('should succeed if succeed', async () => {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
         awsInvokeLocal.options.extraServicePath = 'fixture';
 
         await awsInvokeLocal.invokeLocalNodeJs(
@@ -822,14 +816,14 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('should exit with error exit code', async () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       await awsInvokeLocal.invokeLocalNodeJs('fixture/asyncHandlerWithError', 'withError');
       expect(process.exitCode).to.be.equal(1);
     });
 
     it('should log Error instance when called back', async () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       await awsInvokeLocal.invokeLocalNodeJs('fixture/asyncHandlerWithError', 'withError');
       expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorMessage": "failed"');
@@ -837,14 +831,14 @@ describe('AwsInvokeLocal', () => {
     });
 
     it('should log error', async () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       await awsInvokeLocal.invokeLocalNodeJs('fixture/asyncHandlerWithError', 'withMessage');
       expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorMessage": "failed"');
     });
 
     it('should log error when error is returned', async () => {
-      awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+      awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
       await awsInvokeLocal.invokeLocalNodeJs('fixture/asyncHandlerWithError', 'returnsError');
       expect(serverless.cli.consoleLog.lastCall.args[0]).to.contain('"errorMessage": "failed"');
@@ -875,7 +869,7 @@ describe('AwsInvokeLocal', () => {
           this.skip();
         }
 
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
         process.chdir(tmpServicePath);
 
         try {
@@ -921,7 +915,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('context.remainingTimeInMillis', () => {
       it('should become lower over time', async function () {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         try {
           await awsInvokeLocal.invokeLocalRuby('ruby', 'fixture/handler', 'withRemainingTime');
@@ -940,7 +934,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('calling a class method', () => {
       it('should execute', async function () {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         try {
           await awsInvokeLocal.invokeLocalRuby(
@@ -962,7 +956,7 @@ describe('AwsInvokeLocal', () => {
 
     describe('context.deadlineMs', () => {
       it('should return deadline', async function () {
-        awsInvokeLocal.serverless.config.servicePath = tmpServicePath;
+        awsInvokeLocal.serverless.serviceDir = tmpServicePath;
 
         try {
           await awsInvokeLocal.invokeLocalRuby('ruby', 'fixture/handler', 'withDeadlineMs');

--- a/test/unit/lib/plugins/aws/lib/getServiceState.test.js
+++ b/test/unit/lib/plugins/aws/lib/getServiceState.test.js
@@ -18,7 +18,7 @@ describe('#getServiceState()', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
-    serverless.config.servicePath = 'my-service';
+    serverless.serviceDir = 'my-service';
     awsPlugin.serverless = serverless;
     awsPlugin.provider = new AwsProvider(serverless, options);
     awsPlugin.options = options;

--- a/test/unit/lib/plugins/aws/lib/setBucketName.test.js
+++ b/test/unit/lib/plugins/aws/lib/setBucketName.test.js
@@ -13,7 +13,7 @@ describe('#setBucketName()', () => {
 
   beforeEach(() => {
     serverless = new Serverless();
-    serverless.config.servicePath = 'foo';
+    serverless.serviceDir = 'foo';
     const options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/lib/updateStack.test.js
+++ b/test/unit/lib/plugins/aws/lib/updateStack.test.js
@@ -18,14 +18,14 @@ describe('updateStack', () => {
       region: 'us-east-1',
     };
     serverless = new Serverless();
-    serverless.config.servicePath = 'foo';
+    serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);
 
     awsDeploy.deployedFunctions = [{ name: 'first', zipFileKey: 'zipFileOfFirstFunction' }];
     awsDeploy.bucketName = 'deployment-bucket';
     serverless.service.service = `service-${new Date().getTime().toString()}`;
-    serverless.config.servicePath = tmpDirPath;
+    serverless.serviceDir = tmpDirPath;
     awsDeploy.serverless.service.package.artifactDirectoryName = 'somedir';
     awsDeploy.serverless.cli = new serverless.classes.CLI();
   });

--- a/test/unit/lib/plugins/aws/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/lib/validate.test.js
@@ -28,7 +28,7 @@ describe('#validate', () => {
     awsPlugin.serverless = serverless;
     awsPlugin.serverless.setProvider('aws', provider);
 
-    awsPlugin.serverless.config.servicePath = true;
+    awsPlugin.serverless.serviceDir = true;
     serverless.processedInput = { commands: ['deploy'] };
 
     Object.assign(awsPlugin, validate);
@@ -39,7 +39,7 @@ describe('#validate', () => {
       expect(() => awsPlugin.validate()).not.to.throw());
 
     it('should throw error if not inside service (servicePath not defined)', () => {
-      awsPlugin.serverless.config.servicePath = false;
+      awsPlugin.serverless.serviceDir = false;
       return expect(() => awsPlugin.validate()).to.throw(
         ServerlessError,
         /can only be run inside a service directory/

--- a/test/unit/lib/plugins/aws/logs.test.js
+++ b/test/unit/lib/plugins/aws/logs.test.js
@@ -62,7 +62,7 @@ describe('AwsLogs', () => {
 
   describe('#extendedValidate()', () => {
     beforeEach(() => {
-      serverless.config.servicePath = true;
+      serverless.serviceDir = true;
       serverless.service.environment = {
         vars: {},
         stages: {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
@@ -31,7 +31,7 @@ describe('#compileStage()', () => {
       Resources: {},
       Outputs: {},
     };
-    serverless.config.servicePath = createTmpDir();
+    serverless.serviceDir = createTmpDir();
     serverless.cli = { log: () => {} };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
     awsCompileApigEvents.apiGatewayRestApiLogicalId = 'ApiGatewayRestApi';

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -28,7 +28,7 @@ describe('#compileStage()', () => {
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'my-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.config.servicePath = createTmpDir();
+    serverless.serviceDir = createTmpDir();
     serverless.cli = { log: () => {} };
 
     awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1824,7 +1824,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
 
   describe('`provider.lambdaHashingVersion` support', () => {
     it('CodeSha256 for functions should be the same for default hashing and for 20201221 version', async () => {
-      const { servicePath, updateConfig } = await fixtures.setup('function', {
+      const { servicePath: serviceDir, updateConfig } = await fixtures.setup('function', {
         configExt: {
           provider: {
             versionFunctions: true,
@@ -1833,7 +1833,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       });
 
       const { cfTemplate: originalTemplate, awsNaming } = await runServerless({
-        cwd: servicePath,
+        cwd: serviceDir,
         command: 'package',
       });
 
@@ -1851,7 +1851,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
         },
       });
       const { cfTemplate: updatedTemplate } = await runServerless({
-        cwd: servicePath,
+        cwd: serviceDir,
         command: 'package',
       });
       const updatedVersionCfConfig = Object.values(updatedTemplate.Resources).find(
@@ -2308,10 +2308,12 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       });
 
       it('should not create a different version if only function-wide configuration changed', async () => {
-        const { servicePath, updateConfig } = await fixtures.setup('function', { configExt });
+        const { servicePath: serviceDir, updateConfig } = await fixtures.setup('function', {
+          configExt,
+        });
 
         const { cfTemplate: originalTemplate } = await runServerless({
-          cwd: servicePath,
+          cwd: serviceDir,
           command: 'package',
         });
         const originalVersionArn = originalTemplate.Outputs.FooLambdaFunctionQualifiedArn.Value.Ref;
@@ -2327,7 +2329,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           },
         });
         const { cfTemplate: updatedTemplate } = await runServerless({
-          cwd: servicePath,
+          cwd: serviceDir,
           command: 'package',
         });
         const updatedVersionArn = updatedTemplate.Outputs.FooLambdaFunctionQualifiedArn.Value.Ref;
@@ -2341,7 +2343,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
 
       describe('with layers', () => {
         let firstCfTemplate;
-        let servicePath;
+        let serviceDir;
         let updateConfig;
         const mockDescribeStackResponse = {
           CloudFormation: {
@@ -2351,9 +2353,9 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
 
         beforeEach(async () => {
           const serviceData = await fixtures.setup('functionLayers', { configExt });
-          ({ servicePath, updateConfig } = serviceData);
+          ({ servicePath: serviceDir, updateConfig } = serviceData);
           const data = await runServerless({
-            cwd: servicePath,
+            cwd: serviceDir,
             command: 'package',
             awsRequestStubMap: mockDescribeStackResponse,
           });
@@ -2375,7 +2377,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           });
 
           const data = await runServerless({
-            cwd: servicePath,
+            cwd: serviceDir,
             command: 'package',
             awsRequestStubMap: mockDescribeStackResponse,
           });
@@ -2394,7 +2396,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
             firstCfTemplate.Resources.TestLayerLambdaLayer.Properties.Content.S3Key;
 
           const data = await runServerless({
-            cwd: servicePath,
+            cwd: serviceDir,
             command: 'package',
             awsRequestStubMap: mockDescribeStackResponse,
           });
@@ -2418,7 +2420,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           });
 
           const data = await runServerless({
-            cwd: servicePath,
+            cwd: serviceDir,
             command: 'package',
             awsRequestStubMap: mockDescribeStackResponse,
           });
@@ -2439,7 +2441,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           });
 
           const data = await runServerless({
-            cwd: servicePath,
+            cwd: serviceDir,
             command: 'package',
             awsRequestStubMap: mockDescribeStackResponse,
           });
@@ -2454,7 +2456,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
             firstCfTemplate.Outputs.LayerFuncLambdaFunctionQualifiedArn.Value.Ref;
 
           const data = await runServerless({
-            cwd: servicePath,
+            cwd: serviceDir,
             command: 'package',
             awsRequestStubMap: mockDescribeStackResponse,
           });
@@ -2478,7 +2480,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           });
 
           const data = await runServerless({
-            cwd: servicePath,
+            cwd: serviceDir,
             command: 'package',
             awsRequestStubMap: mockDescribeStackResponse,
           });
@@ -2494,9 +2496,9 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
           let backupLayer;
 
           beforeEach(async () => {
-            originalLayer = path.join(servicePath, 'testLayer');
-            sourceChangeLayer = path.join(servicePath, 'extra_layers', 'testLayerSourceChange');
-            backupLayer = path.join(servicePath, 'extra_layers', 'testLayerBackup');
+            originalLayer = path.join(serviceDir, 'testLayer');
+            sourceChangeLayer = path.join(serviceDir, 'extra_layers', 'testLayerSourceChange');
+            backupLayer = path.join(serviceDir, 'extra_layers', 'testLayerBackup');
 
             await fse.rename(originalLayer, backupLayer);
             await fse.rename(sourceChangeLayer, originalLayer);
@@ -2513,7 +2515,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               firstCfTemplate.Outputs.LayerFuncLambdaFunctionQualifiedArn.Value.Ref;
 
             const data = await runServerless({
-              cwd: servicePath,
+              cwd: serviceDir,
               command: 'package',
               awsRequestStubMap: mockDescribeStackResponse,
             });

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -28,7 +28,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
   let cfResources;
   let naming;
   let updateConfig;
-  let servicePath;
+  let serviceDir;
   let service;
   let cfOutputs;
 
@@ -65,7 +65,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     cfOutputs = cfTemplate.Outputs;
     naming = awsNaming;
     service = serverless.service;
-    ({ updateConfig, servicePath } = fixtureData);
+    ({ updateConfig, servicePath: serviceDir } = fixtureData);
   });
 
   it('should support `layers[].package.artifact` with `package.individually`', () => {
@@ -128,7 +128,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
       const {
         cfTemplate: { Resources: secondCfResources },
       } = await runServerless({
-        cwd: servicePath,
+        cwd: serviceDir,
         command: 'package',
         awsRequestStubMap,
       });
@@ -138,7 +138,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
       const {
         cfTemplate: { Resources: firstCfResources },
       } = await runServerless({
-        cwd: servicePath,
+        cwd: serviceDir,
         command: 'package',
         awsRequestStubMap,
       });

--- a/test/unit/lib/plugins/aws/package/index.test.js
+++ b/test/unit/lib/plugins/aws/package/index.test.js
@@ -20,7 +20,7 @@ describe('AwsPackage', () => {
       region: 'us-east-1',
     };
     serverless.setProvider('aws', new AwsProvider(serverless, options));
-    serverless.config.servicePath = 'foo';
+    serverless.serviceDir = 'foo';
     serverless.cli = new CLI(serverless);
     awsPackage = new AwsPackage(serverless, options);
   });
@@ -39,7 +39,7 @@ describe('AwsPackage', () => {
     });
 
     it('should default to an empty service path if not provided', () => {
-      serverless.config.servicePath = false;
+      serverless.serviceDir = false;
       awsPackage = new AwsPackage(serverless, options);
 
       expect(awsPackage.servicePath).to.equal('');

--- a/test/unit/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
@@ -18,7 +18,7 @@ describe('#saveCompiledTemplate()', () => {
     serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsPackage = new AwsPackage(serverless, options);
-    serverless.config.servicePath = 'my-service';
+    serverless.serviceDir = 'my-service';
     serverless.service = {
       provider: {
         compiledCloudFormationTemplate: 'compiled content',
@@ -36,11 +36,7 @@ describe('#saveCompiledTemplate()', () => {
   });
 
   it('should write the compiled template to disk', () => {
-    const filePath = path.join(
-      awsPackage.serverless.config.servicePath,
-      '.serverless',
-      'compiled.json'
-    );
+    const filePath = path.join(awsPackage.serverless.serviceDir, '.serverless', 'compiled.json');
 
     return awsPackage.saveCompiledTemplate().then(() => {
       expect(getCompiledTemplateFileNameStub.calledOnce).to.equal(true);

--- a/test/unit/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -18,7 +18,7 @@ describe('#saveServiceState()', () => {
     serverless = new Serverless();
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsPackage = new AwsPackage(serverless, options);
-    serverless.config.servicePath = 'my-service';
+    serverless.serviceDir = 'my-service';
     serverless.service = {
       provider: {
         compiledCloudFormationTemplate: 'compiled content',
@@ -42,7 +42,7 @@ describe('#saveServiceState()', () => {
 
   it('should write the service state file template to disk', () => {
     const filePath = path.join(
-      awsPackage.serverless.config.servicePath,
+      awsPackage.serverless.serviceDir,
       '.serverless',
       'service-state.json'
     );
@@ -69,7 +69,7 @@ describe('#saveServiceState()', () => {
 
   it('should remove self references correctly', () => {
     const filePath = path.join(
-      awsPackage.serverless.config.servicePath,
+      awsPackage.serverless.serviceDir,
       '.serverless',
       'service-state.json'
     );

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -1120,7 +1120,7 @@ aws_secret_access_key = CUSTOMSECRET
         const {
           awsNaming,
           cfTemplate,
-          fixtureData: { servicePath },
+          fixtureData: { servicePath: serviceDir },
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
@@ -1150,7 +1150,7 @@ aws_secret_access_key = CUSTOMSECRET
           '-t',
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
-          path.join(servicePath, 'Dockerfile'),
+          path.join(serviceDir, 'Dockerfile'),
           './',
         ]);
         expect(spawnExtStub).to.be.calledWith('docker', [
@@ -1211,7 +1211,7 @@ aws_secret_access_key = CUSTOMSECRET
         const {
           awsNaming,
           cfTemplate,
-          fixtureData: { servicePath },
+          fixtureData: { servicePath: serviceDir },
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
@@ -1235,7 +1235,7 @@ aws_secret_access_key = CUSTOMSECRET
           '-t',
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
-          path.join(servicePath, 'Dockerfile'),
+          path.join(serviceDir, 'Dockerfile'),
           './',
         ]);
         expect(innerSpawnExtStub).to.be.calledWith('docker', [
@@ -1387,7 +1387,7 @@ aws_secret_access_key = CUSTOMSECRET
         const {
           awsNaming,
           cfTemplate,
-          fixtureData: { servicePath },
+          fixtureData: { servicePath: serviceDir },
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
@@ -1424,7 +1424,7 @@ aws_secret_access_key = CUSTOMSECRET
           '-t',
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
-          path.join(servicePath, 'Dockerfile.dev'),
+          path.join(serviceDir, 'Dockerfile.dev'),
           './',
         ]);
       });
@@ -1443,7 +1443,7 @@ aws_secret_access_key = CUSTOMSECRET
         const {
           awsNaming,
           cfTemplate,
-          fixtureData: { servicePath },
+          fixtureData: { servicePath: serviceDir },
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
@@ -1481,7 +1481,7 @@ aws_secret_access_key = CUSTOMSECRET
           '-t',
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
-          path.join(servicePath, 'Dockerfile.dev'),
+          path.join(serviceDir, 'Dockerfile.dev'),
           '--cache-from',
           'my-image:latest',
           './',
@@ -1502,7 +1502,7 @@ aws_secret_access_key = CUSTOMSECRET
         const {
           awsNaming,
           cfTemplate,
-          fixtureData: { servicePath },
+          fixtureData: { servicePath: serviceDir },
         } = await runServerless({
           fixture: 'ecr',
           command: 'package',
@@ -1542,7 +1542,7 @@ aws_secret_access_key = CUSTOMSECRET
           '-t',
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
-          path.join(servicePath, 'Dockerfile.dev'),
+          path.join(serviceDir, 'Dockerfile.dev'),
           '--build-arg',
           'TESTKEY=TESTVAL',
           './',

--- a/test/unit/lib/plugins/aws/rollbackFunction.test.js
+++ b/test/unit/lib/plugins/aws/rollbackFunction.test.js
@@ -20,7 +20,6 @@ describe('AwsRollbackFunction', () => {
       'node-fetch': fetchStub,
     });
     serverless = new Serverless();
-    serverless.servicePath = true;
     serverless.service.functions = {
       hello: {
         handler: true,

--- a/test/unit/lib/plugins/create/create.test.js
+++ b/test/unit/lib/plugins/create/create.test.js
@@ -131,7 +131,7 @@ describe('Create', () => {
       process.chdir(tmpDir);
       create.options.template = 'aws-nodejs';
       return create.create().then(() => {
-        expect(create.serverless.config.servicePath).to.be.equal(process.cwd());
+        expect(create.serverless.serviceDir).to.be.equal(process.cwd());
       });
     });
 
@@ -1254,8 +1254,8 @@ describe('Create', () => {
         const dirContent = fs.readdirSync(process.cwd());
         expect(dirContent).to.include('handler.js');
         expect(dirContent).to.include('serverless.yml');
-        expect(create.serverless.config.servicePath).includes('my_good_service');
-        expect(create.serverless.config.servicePath).to.be.equal(process.cwd());
+        expect(create.serverless.serviceDir).includes('my_good_service');
+        expect(create.serverless.serviceDir).to.be.equal(process.cwd());
       });
     });
   });

--- a/test/unit/lib/plugins/install.test.js
+++ b/test/unit/lib/plugins/install.test.js
@@ -18,7 +18,7 @@ describe('Install', () => {
   let cwd;
   let logSpy;
 
-  let servicePath;
+  let serviceDir;
 
   beforeEach(() => {
     const tmpDir = getTmpDirPath();
@@ -27,7 +27,7 @@ describe('Install', () => {
     fse.mkdirsSync(tmpDir);
     process.chdir(tmpDir);
 
-    servicePath = tmpDir;
+    serviceDir = tmpDir;
 
     serverless = new Serverless();
     install = new Install(serverless);
@@ -97,7 +97,7 @@ describe('Install', () => {
     it('should throw an error if a directory with the same service name is already present', async () => {
       install.options = { url: 'https://github.com/johndoe/existing-service' };
 
-      const serviceDirName = path.join(servicePath, 'existing-service');
+      const serviceDirName = path.join(serviceDir, 'existing-service');
       fse.mkdirsSync(serviceDirName);
 
       try {

--- a/test/unit/lib/plugins/package/lib/packageService.test.js
+++ b/test/unit/lib/plugins/package/lib/packageService.test.js
@@ -39,7 +39,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
     before(async () => {
       const {
         fixtureData: {
-          servicePath,
+          servicePath: serviceDir,
           serviceConfig: { service: serviceName },
         },
         serverless: serverlessInstance,
@@ -62,17 +62,17 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
       serverless = serverlessInstance;
 
       serviceZippedFiles = await listZipFiles(
-        path.join(servicePath, '.serverless', `${serviceName}.zip`)
+        path.join(serviceDir, '.serverless', `${serviceName}.zip`)
       );
 
       fnIndividualZippedFiles = await listZipFiles(
-        path.join(servicePath, '.serverless', 'fnIndividual.zip')
+        path.join(serviceDir, '.serverless', 'fnIndividual.zip')
       );
 
-      fnLayerFiles = await listZipFiles(path.join(servicePath, '.serverless', 'layer.zip'));
+      fnLayerFiles = await listZipFiles(path.join(serviceDir, '.serverless', 'layer.zip'));
 
       fnFileProperties = await listFileProperties(
-        path.join(servicePath, '.serverless', 'fnIndividual.zip')
+        path.join(serviceDir, '.serverless', 'fnIndividual.zip')
       );
     });
 
@@ -134,7 +134,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
     it('should exclude .env files', async () => {
       const {
         fixtureData: {
-          servicePath,
+          servicePath: serviceDir,
           serviceConfig: { service: serviceName },
         },
       } = await runServerless({
@@ -147,7 +147,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
       });
 
       const zippedFiles = await listZipFiles(
-        path.join(servicePath, '.serverless', `${serviceName}.zip`)
+        path.join(serviceDir, '.serverless', `${serviceName}.zip`)
       );
 
       expect(zippedFiles).to.not.include('.env');
@@ -161,7 +161,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
 
     before(async () => {
       const {
-        fixtureData: { servicePath },
+        fixtureData: { servicePath: serviceDir },
         serverless: serverlessInstance,
       } = await runServerless({
         fixture: 'packaging',
@@ -187,7 +187,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
       serverless = serverlessInstance;
 
       fnIndividualZippedFiles = await listZipFiles(
-        path.join(servicePath, '.serverless', 'fnIndividual.zip')
+        path.join(serviceDir, '.serverless', 'fnIndividual.zip')
       );
     });
 
@@ -296,8 +296,8 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
       });
 
       it('for function', async () => {
-        const { servicePath, updateConfig } = await fixtures.setup('packageArtifact');
-        const absoluteArtifactFilePath = path.join(servicePath, 'absoluteArtifact.zip');
+        const { servicePath: serviceDir, updateConfig } = await fixtures.setup('packageArtifact');
+        const absoluteArtifactFilePath = path.join(serviceDir, 'absoluteArtifact.zip');
 
         await updateConfig({
           functions: {
@@ -310,7 +310,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
         });
 
         await runServerless({
-          cwd: servicePath,
+          cwd: serviceDir,
           command: 'deploy',
           lastLifecycleHookName: 'aws:deploy:deploy:uploadArtifacts',
           awsRequestStubMap,
@@ -323,8 +323,8 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
       });
 
       it('service-wide', async () => {
-        const { servicePath, updateConfig } = await fixtures.setup('packageArtifact');
-        const absoluteArtifactFilePath = path.join(servicePath, 'absoluteArtifact.zip');
+        const { servicePath: serviceDir, updateConfig } = await fixtures.setup('packageArtifact');
+        const absoluteArtifactFilePath = path.join(serviceDir, 'absoluteArtifact.zip');
 
         await updateConfig({
           package: {
@@ -332,7 +332,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
           },
         });
         await runServerless({
-          cwd: servicePath,
+          cwd: serviceDir,
           command: 'deploy',
           lastLifecycleHookName: 'aws:deploy:deploy:uploadArtifacts',
           awsRequestStubMap,
@@ -364,8 +364,8 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
       });
 
       it('for function', async () => {
-        const { servicePath, updateConfig } = await fixtures.setup('packageArtifact');
-        const absoluteArtifactFilePath = path.join(servicePath, 'absoluteArtifact.zip');
+        const { servicePath: serviceDir, updateConfig } = await fixtures.setup('packageArtifact');
+        const absoluteArtifactFilePath = path.join(serviceDir, 'absoluteArtifact.zip');
         const zipContent = await fs.promises.readFile(absoluteArtifactFilePath);
 
         await updateConfig({
@@ -378,7 +378,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
           },
         });
         await runServerless({
-          cwd: servicePath,
+          cwd: serviceDir,
           command: 'deploy function',
           options: { function: 'other' },
           awsRequestStubMap,
@@ -388,8 +388,8 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
       });
 
       it('service-wide', async () => {
-        const { servicePath, updateConfig } = await fixtures.setup('packageArtifact');
-        const absoluteArtifactFilePath = path.join(servicePath, 'absoluteArtifact.zip');
+        const { servicePath: serviceDir, updateConfig } = await fixtures.setup('packageArtifact');
+        const absoluteArtifactFilePath = path.join(serviceDir, 'absoluteArtifact.zip');
         const zipContent = await fs.promises.readFile(absoluteArtifactFilePath);
 
         await updateConfig({
@@ -398,7 +398,7 @@ describe('lib/plugins/package/lib/packageService.test.js', () => {
           },
         });
         await runServerless({
-          cwd: servicePath,
+          cwd: serviceDir,
           command: 'deploy function',
           options: { function: 'foo' },
           awsRequestStubMap,

--- a/test/unit/lib/plugins/package/lib/zipService.test.js
+++ b/test/unit/lib/plugins/package/lib/zipService.test.js
@@ -31,7 +31,7 @@ describe('zipService', () => {
     tmpDirPath = getTmpDirPath();
     serverless = new Serverless();
     serverless.service.service = 'first-service';
-    serverless.config.servicePath = tmpDirPath;
+    serverless.serviceDir = tmpDirPath;
     packagePlugin = new Package(serverless, {});
     packagePlugin.serverless.cli = new serverless.classes.CLI();
     params = {
@@ -73,7 +73,7 @@ describe('zipService', () => {
     let servicePath;
 
     beforeEach(() => {
-      servicePath = serverless.config.servicePath;
+      servicePath = serverless.serviceDir;
       fs.mkdirSync(servicePath);
     });
 
@@ -95,7 +95,7 @@ describe('zipService', () => {
     let servicePath;
 
     beforeEach(() => {
-      servicePath = serverless.config.servicePath;
+      servicePath = serverless.serviceDir;
       fs.mkdirSync(servicePath);
     });
 
@@ -129,7 +129,7 @@ describe('zipService', () => {
       let servicePath;
 
       beforeEach(() => {
-        servicePath = packagePlugin.serverless.config.servicePath;
+        servicePath = packagePlugin.serverless.serviceDir;
         globbySyncStub = sinon.stub(globby, 'sync');
         execAsyncStub = sinon.stub(childProcess, 'execAsync');
         readFileAsyncStub = sinon.stub(fs, 'readFileAsync');
@@ -152,7 +152,7 @@ describe('zipService', () => {
             expect(execAsyncStub).to.not.have.been.called;
             expect(readFileAsyncStub).to.not.have.been.called;
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
-              cwd: packagePlugin.serverless.config.servicePath,
+              cwd: packagePlugin.serverless.serviceDir,
               dot: true,
               silent: true,
               follow: true,
@@ -179,7 +179,7 @@ describe('zipService', () => {
             expect(execAsyncStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledTwice;
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
-              cwd: packagePlugin.serverless.config.servicePath,
+              cwd: packagePlugin.serverless.serviceDir,
               dot: true,
               silent: true,
               follow: true,
@@ -308,7 +308,7 @@ describe('zipService', () => {
               path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
-              cwd: packagePlugin.serverless.config.servicePath,
+              cwd: packagePlugin.serverless.serviceDir,
               dot: true,
               silent: true,
               follow: true,
@@ -377,7 +377,7 @@ describe('zipService', () => {
               path.join(servicePath, 'node_modules', 'module-2', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
-              cwd: packagePlugin.serverless.config.servicePath,
+              cwd: packagePlugin.serverless.serviceDir,
               dot: true,
               silent: true,
               follow: true,
@@ -440,7 +440,7 @@ describe('zipService', () => {
             expect(execAsyncStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(8);
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
-              cwd: packagePlugin.serverless.config.servicePath,
+              cwd: packagePlugin.serverless.serviceDir,
               dot: true,
               silent: true,
               follow: true,
@@ -510,7 +510,7 @@ describe('zipService', () => {
               path.join(servicePath, 'node_modules', 'module-1', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
-              cwd: packagePlugin.serverless.config.servicePath,
+              cwd: packagePlugin.serverless.serviceDir,
               dot: true,
               silent: true,
               follow: true,
@@ -651,7 +651,7 @@ describe('zipService', () => {
               );
             }
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
-              cwd: packagePlugin.serverless.config.servicePath,
+              cwd: packagePlugin.serverless.serviceDir,
               dot: true,
               silent: true,
               follow: true,
@@ -754,9 +754,7 @@ describe('zipService', () => {
       params.zipFileName = getTestArtifactFileName('whole-service');
 
       return expect(packagePlugin.zip(params))
-        .to.eventually.be.equal(
-          path.join(serverless.config.servicePath, '.serverless', params.zipFileName)
-        )
+        .to.eventually.be.equal(path.join(serverless.serviceDir, '.serverless', params.zipFileName))
         .then((artifact) => {
           const data = fs.readFileSync(artifact);
           return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -804,9 +802,7 @@ describe('zipService', () => {
       params.zipFileName = getTestArtifactFileName('file-permissions');
 
       return expect(packagePlugin.zip(params))
-        .to.eventually.be.equal(
-          path.join(serverless.config.servicePath, '.serverless', params.zipFileName)
-        )
+        .to.eventually.be.equal(path.join(serverless.serviceDir, '.serverless', params.zipFileName))
         .then((artifact) => {
           const data = fs.readFileSync(artifact);
           return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -834,9 +830,7 @@ describe('zipService', () => {
       params.exclude = ['event.json', 'lib/**', 'node_modules/directory-1/**'];
 
       return expect(packagePlugin.zip(params))
-        .to.eventually.be.equal(
-          path.join(serverless.config.servicePath, '.serverless', params.zipFileName)
-        )
+        .to.eventually.be.equal(path.join(serverless.serviceDir, '.serverless', params.zipFileName))
         .then((artifact) => {
           const data = fs.readFileSync(artifact);
           return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -879,9 +873,7 @@ describe('zipService', () => {
       ];
 
       return expect(packagePlugin.zip(params))
-        .to.eventually.be.equal(
-          path.join(serverless.config.servicePath, '.serverless', params.zipFileName)
-        )
+        .to.eventually.be.equal(path.join(serverless.serviceDir, '.serverless', params.zipFileName))
         .then((artifact) => {
           const data = fs.readFileSync(artifact);
           return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -925,9 +917,7 @@ describe('zipService', () => {
       params.include = ['event.json', 'lib/**'];
 
       return expect(packagePlugin.zip(params))
-        .to.eventually.be.equal(
-          path.join(serverless.config.servicePath, '.serverless', params.zipFileName)
-        )
+        .to.eventually.be.equal(path.join(serverless.serviceDir, '.serverless', params.zipFileName))
         .then((artifact) => {
           const data = fs.readFileSync(artifact);
           return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -967,14 +957,12 @@ describe('zipService', () => {
 
     it('should include files even if outside working dir', () => {
       params.zipFileName = getTestArtifactFileName('include-outside-working-dir');
-      serverless.config.servicePath = path.join(serverless.config.servicePath, 'lib');
+      serverless.serviceDir = path.join(serverless.serviceDir, 'lib');
       params.exclude = ['./**'];
       params.include = ['../bin/binary-**'];
 
       return expect(packagePlugin.zip(params))
-        .to.eventually.be.equal(
-          path.join(serverless.config.servicePath, '.serverless', params.zipFileName)
-        )
+        .to.eventually.be.equal(path.join(serverless.serviceDir, '.serverless', params.zipFileName))
         .then((artifact) => {
           const data = fs.readFileSync(artifact);
           return expect(zip.loadAsync(data)).to.be.fulfilled;
@@ -990,14 +978,12 @@ describe('zipService', () => {
 
     it('should include files only once', () => {
       params.zipFileName = getTestArtifactFileName('include-outside-working-dir');
-      serverless.config.servicePath = path.join(serverless.config.servicePath, 'lib');
+      serverless.serviceDir = path.join(serverless.serviceDir, 'lib');
       params.exclude = ['./**'];
       params.include = ['.././bin/**'];
 
       return expect(packagePlugin.zip(params))
-        .to.eventually.be.equal(
-          path.join(serverless.config.servicePath, '.serverless', params.zipFileName)
-        )
+        .to.eventually.be.equal(path.join(serverless.serviceDir, '.serverless', params.zipFileName))
         .then((artifact) => {
           const data = fs.readFileSync(artifact);
           return expect(zip.loadAsync(data)).to.be.fulfilled;

--- a/test/unit/lib/plugins/package/lib/zipService.test.js
+++ b/test/unit/lib/plugins/package/lib/zipService.test.js
@@ -70,16 +70,16 @@ describe('zipService', () => {
   });
 
   describe('#getFileContentAndStat()', () => {
-    let servicePath;
+    let serviceDir;
 
     beforeEach(() => {
-      servicePath = serverless.serviceDir;
-      fs.mkdirSync(servicePath);
+      serviceDir = serverless.serviceDir;
+      fs.mkdirSync(serviceDir);
     });
 
     it('should keep the file content as is', () => {
       const buf = Buffer.from([10, 20, 30, 40, 50]);
-      const filePath = path.join(servicePath, 'bin-file');
+      const filePath = path.join(serviceDir, 'bin-file');
 
       fs.writeFileSync(filePath, buf);
 
@@ -92,16 +92,16 @@ describe('zipService', () => {
   });
 
   describe('#getFileContent()', () => {
-    let servicePath;
+    let serviceDir;
 
     beforeEach(() => {
-      servicePath = serverless.serviceDir;
-      fs.mkdirSync(servicePath);
+      serviceDir = serverless.serviceDir;
+      fs.mkdirSync(serviceDir);
     });
 
     it('should keep the file content as is', () => {
       const buf = Buffer.from([10, 20, 30, 40, 50]);
-      const filePath = path.join(servicePath, 'bin-file');
+      const filePath = path.join(serviceDir, 'bin-file');
 
       fs.writeFileSync(filePath, buf);
 
@@ -126,10 +126,10 @@ describe('zipService', () => {
       let globbySyncStub;
       let execAsyncStub;
       let readFileAsyncStub;
-      let servicePath;
+      let serviceDir;
 
       beforeEach(() => {
-        servicePath = packagePlugin.serverless.serviceDir;
+        serviceDir = packagePlugin.serverless.serviceDir;
         globbySyncStub = sinon.stub(globby, 'sync');
         execAsyncStub = sinon.stub(childProcess, 'execAsync');
         readFileAsyncStub = sinon.stub(fs, 'readFileAsync');
@@ -278,10 +278,10 @@ describe('zipService', () => {
         execAsyncStub.onCall(4).resolves();
         execAsyncStub.onCall(5).resolves();
         const depPaths = [
-          path.join(servicePath, 'node_modules', 'module-1'),
-          path.join(servicePath, 'node_modules', 'module-2'),
-          path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1'),
-          path.join(servicePath, '1st', '2nd', 'node_modules', 'module-2'),
+          path.join(serviceDir, 'node_modules', 'module-1'),
+          path.join(serviceDir, 'node_modules', 'module-2'),
+          path.join(serviceDir, '1st', '2nd', 'node_modules', 'module-1'),
+          path.join(serviceDir, '1st', '2nd', 'node_modules', 'module-2'),
         ].join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
@@ -296,16 +296,16 @@ describe('zipService', () => {
             expect(execAsyncStub.callCount).to.equal(6);
             expect(readFileAsyncStub).to.have.callCount(6);
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, 'node_modules', 'module-1', 'package.json')
+              path.join(serviceDir, 'node_modules', 'module-1', 'package.json')
             );
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, 'node_modules', 'module-2', 'package.json')
+              path.join(serviceDir, 'node_modules', 'module-2', 'package.json')
             );
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json')
+              path.join(serviceDir, '1st', '2nd', 'node_modules', 'module-1', 'package.json')
             );
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json')
+              path.join(serviceDir, '1st', '2nd', 'node_modules', 'module-1', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.serviceDir,
@@ -357,8 +357,8 @@ describe('zipService', () => {
         globbySyncStub.returns(filePaths);
         execAsyncStub.resolves();
         const depPaths = [
-          path.join(servicePath, 'node_modules', 'module-1'),
-          path.join(servicePath, 'node_modules', 'module-2'),
+          path.join(serviceDir, 'node_modules', 'module-1'),
+          path.join(serviceDir, 'node_modules', 'module-2'),
         ].join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
@@ -371,10 +371,10 @@ describe('zipService', () => {
             expect(execAsyncStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.callCount(4);
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, 'node_modules', 'module-1', 'package.json')
+              path.join(serviceDir, 'node_modules', 'module-1', 'package.json')
             );
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, 'node_modules', 'module-2', 'package.json')
+              path.join(serviceDir, 'node_modules', 'module-2', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.serviceDir,
@@ -418,12 +418,12 @@ describe('zipService', () => {
         globbySyncStub.returns(filePaths);
         execAsyncStub.resolves();
         const depPaths = [
-          path.join(servicePath, 'node_modules', 'module-1'),
-          path.join(servicePath, 'node_modules', 'module-2'),
-          path.join(servicePath, '1st', 'node_modules', 'module-1'),
-          path.join(servicePath, '1st', 'node_modules', 'module-2'),
-          path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1'),
-          path.join(servicePath, '1st', '2nd', 'node_modules', 'module-2'),
+          path.join(serviceDir, 'node_modules', 'module-1'),
+          path.join(serviceDir, 'node_modules', 'module-2'),
+          path.join(serviceDir, '1st', 'node_modules', 'module-1'),
+          path.join(serviceDir, '1st', 'node_modules', 'module-2'),
+          path.join(serviceDir, '1st', '2nd', 'node_modules', 'module-1'),
+          path.join(serviceDir, '1st', '2nd', 'node_modules', 'module-2'),
         ].join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
@@ -492,12 +492,12 @@ describe('zipService', () => {
         execAsyncStub.resolves();
 
         const devDepPaths = [
-          path.join(servicePath, 'node_modules', 'module-1'),
-          path.join(servicePath, 'node_modules', 'module-2'),
+          path.join(serviceDir, 'node_modules', 'module-1'),
+          path.join(serviceDir, 'node_modules', 'module-2'),
         ].join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
 
-        const prodDepPaths = [path.join(servicePath, 'node_modules', 'module-2')];
+        const prodDepPaths = [path.join(serviceDir, 'node_modules', 'module-2')];
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves(prodDepPaths);
         readFileAsyncStub.onCall(2).resolves('{}');
 
@@ -507,7 +507,7 @@ describe('zipService', () => {
             expect(execAsyncStub).to.have.been.calledTwice;
             expect(readFileAsyncStub).to.have.been.calledThrice;
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, 'node_modules', 'module-1', 'package.json')
+              path.join(serviceDir, 'node_modules', 'module-1', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.serviceDir,
@@ -549,7 +549,7 @@ describe('zipService', () => {
         globbySyncStub.returns(filePaths);
         execAsyncStub.resolves();
 
-        const mapper = (depPath) => path.join(`${servicePath}`, depPath);
+        const mapper = (depPath) => path.join(`${serviceDir}`, depPath);
 
         const devDepPaths = devPaths.map(mapper).join(os.EOL);
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
@@ -573,13 +573,13 @@ describe('zipService', () => {
 
             expect(readFileAsyncStub).to.have.callCount(5);
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, 'node_modules', 'bro-module', 'package.json')
+              path.join(serviceDir, 'node_modules', 'bro-module', 'package.json')
             );
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, 'node_modules', 'lumo-clj', 'package.json')
+              path.join(serviceDir, 'node_modules', 'lumo-clj', 'package.json')
             );
             expect(readFileAsyncStub).to.have.been.calledWith(
-              path.join(servicePath, 'node_modules', 'meowmix', 'package.json')
+              path.join(serviceDir, 'node_modules', 'meowmix', 'package.json')
             );
 
             expect(updatedParams.exclude).to.deep.equal([
@@ -618,7 +618,7 @@ describe('zipService', () => {
           '1st/2nd/node_modules/module-1',
           '1st/2nd/node_modules/module-2',
         ];
-        const depPaths = deps.map((depPath) => path.join(`${servicePath}`, depPath));
+        const depPaths = deps.map((depPath) => path.join(`${serviceDir}`, depPath));
         readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths.join(os.EOL));
         readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
 
@@ -647,7 +647,7 @@ describe('zipService', () => {
             expect(readFileAsyncStub).to.have.callCount(8);
             for (const depPath of deps) {
               expect(readFileAsyncStub).to.have.been.calledWith(
-                path.join(servicePath, depPath, 'package.json')
+                path.join(serviceDir, depPath, 'package.json')
               );
             }
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {

--- a/test/unit/lib/plugins/plugin/install.test.js
+++ b/test/unit/lib/plugins/plugin/install.test.js
@@ -106,7 +106,7 @@ describe('PluginInstall', () => {
 
     beforeEach(() => {
       servicePath = getTmpDirPath();
-      pluginInstall.serverless.config.servicePath = servicePath;
+      pluginInstall.serverless.serviceDir = servicePath;
       fse.ensureDirSync(servicePath);
       serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
       validateStub = sinon.stub(pluginInstall, 'validate').returns(BbPromise.resolve());
@@ -248,7 +248,7 @@ describe('PluginInstall', () => {
       pluginInstall.options.pluginName = 'serverless-plugin-1';
       pluginInstall.options.pluginVersion = 'latest';
       servicePath = getTmpDirPath();
-      pluginInstall.serverless.config.servicePath = servicePath;
+      pluginInstall.serverless.serviceDir = servicePath;
       fse.ensureDirSync(servicePath);
       packageJsonFilePath = path.join(servicePath, 'package.json');
       npmInstallStub = sinon.stub(childProcess, 'execAsync').callsFake(() => {
@@ -312,7 +312,7 @@ describe('PluginInstall', () => {
 
     beforeEach(() => {
       servicePath = getTmpDirPath();
-      pluginInstall.serverless.config.servicePath = pluginInstall.serverless.serviceDir = servicePath;
+      pluginInstall.serverless.serviceDir = pluginInstall.serverless.serviceDir = servicePath;
       pluginInstall.serverless.configurationFilename = 'serverless.yml';
       serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
     });
@@ -522,7 +522,7 @@ describe('PluginInstall', () => {
       pluginInstall.options.pluginName = pluginName;
       servicePath = getTmpDirPath();
       fse.ensureDirSync(servicePath);
-      pluginInstall.serverless.config.servicePath = servicePath;
+      pluginInstall.serverless.serviceDir = servicePath;
       servicePackageJsonFilePath = path.join(servicePath, 'package.json');
       fse.writeJsonSync(servicePackageJsonFilePath, {
         devDependencies: {},

--- a/test/unit/lib/plugins/plugin/install.test.js
+++ b/test/unit/lib/plugins/plugin/install.test.js
@@ -312,11 +312,9 @@ describe('PluginInstall', () => {
 
     beforeEach(() => {
       servicePath = getTmpDirPath();
-      pluginInstall.serverless.config.servicePath = servicePath;
-      pluginInstall.serverless.configurationPath = serverlessYmlFilePath = path.join(
-        servicePath,
-        'serverless.yml'
-      );
+      pluginInstall.serverless.config.servicePath = pluginInstall.serverless.serviceDir = servicePath;
+      pluginInstall.serverless.configurationFilename = 'serverless.yml';
+      serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
     });
 
     it('should add the plugin to the service file if plugins array is not present', () => {
@@ -360,10 +358,8 @@ describe('PluginInstall', () => {
     });
 
     it('should add the plugin to serverless file path for a .yaml file', () => {
-      const serverlessYamlFilePath = (pluginInstall.serverless.configurationPath = path.join(
-        servicePath,
-        'serverless.yaml'
-      ));
+      const serverlessYamlFilePath = path.join(servicePath, 'serverless.yaml');
+      pluginInstall.serverless.configurationFilename = 'serverless.yaml';
       const serverlessYml = {
         service: 'plugin-service',
         provider: 'aws',
@@ -378,10 +374,8 @@ describe('PluginInstall', () => {
     });
 
     it('should add the plugin to serverless file path for a .json file', () => {
-      const serverlessJsonFilePath = (pluginInstall.serverless.configurationPath = path.join(
-        servicePath,
-        'serverless.json'
-      ));
+      const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+      pluginInstall.serverless.configurationFilename = 'serverless.json';
       const serverlessJson = {
         service: 'plugin-service',
         provider: 'aws',
@@ -407,10 +401,8 @@ describe('PluginInstall', () => {
     });
 
     it('should not modify serverless .js file', () => {
-      const serverlessJsFilePath = (pluginInstall.serverless.configurationPath = path.join(
-        servicePath,
-        'serverless.js'
-      ));
+      const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
+      pluginInstall.serverless.configurationFilename = 'serverless.js';
       const serverlessJson = {
         service: 'plugin-service',
         provider: 'aws',
@@ -429,10 +421,8 @@ describe('PluginInstall', () => {
     });
 
     it('should not modify serverless .ts file', () => {
-      const serverlessTsFilePath = (pluginInstall.serverless.configurationPath = path.join(
-        servicePath,
-        'serverless.ts'
-      ));
+      const serverlessTsFilePath = path.join(servicePath, 'serverless.ts');
+      pluginInstall.serverless.configurationFilename = 'serverless.ts';
       const serverlessJson = {
         service: 'plugin-service',
         provider: 'aws',
@@ -478,10 +468,8 @@ describe('PluginInstall', () => {
       });
 
       it('should add the plugin to serverless file path for a .json file', () => {
-        const serverlessJsonFilePath = (pluginInstall.serverless.configurationPath = path.join(
-          servicePath,
-          'serverless.json'
-        ));
+        const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+        pluginInstall.serverless.configurationFilename = 'serverless.json';
         const serverlessJson = {
           service: 'plugin-service',
           provider: 'aws',

--- a/test/unit/lib/plugins/plugin/install.test.js
+++ b/test/unit/lib/plugins/plugin/install.test.js
@@ -95,7 +95,7 @@ describe('PluginInstall', () => {
   });
 
   describe('#install()', () => {
-    let servicePath;
+    let serviceDir;
     let serverlessYmlFilePath;
     let pluginInstallStub;
     let validateStub;
@@ -105,10 +105,10 @@ describe('PluginInstall', () => {
     let installPeerDependenciesStub;
 
     beforeEach(() => {
-      servicePath = getTmpDirPath();
-      pluginInstall.serverless.serviceDir = servicePath;
-      fse.ensureDirSync(servicePath);
-      serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
+      serviceDir = getTmpDirPath();
+      pluginInstall.serverless.serviceDir = serviceDir;
+      fse.ensureDirSync(serviceDir);
+      serverlessYmlFilePath = path.join(serviceDir, 'serverless.yml');
       validateStub = sinon.stub(pluginInstall, 'validate').returns(BbPromise.resolve());
       pluginInstallStub = sinon.stub(pluginInstall, 'pluginInstall').returns(BbPromise.resolve());
       addPluginToServerlessFileStub = sinon
@@ -120,7 +120,7 @@ describe('PluginInstall', () => {
       getPluginsStub = sinon.stub(pluginInstall, 'getPlugins').returns(BbPromise.resolve(plugins));
       // save the cwd so that we can restore it later
       savedCwd = process.cwd();
-      process.chdir(servicePath);
+      process.chdir(serviceDir);
     });
 
     afterEach(() => {
@@ -239,7 +239,7 @@ describe('PluginInstall', () => {
   });
 
   describe('#pluginInstall()', () => {
-    let servicePath;
+    let serviceDir;
     let packageJsonFilePath;
     let npmInstallStub;
     let savedCwd;
@@ -247,10 +247,10 @@ describe('PluginInstall', () => {
     beforeEach(() => {
       pluginInstall.options.pluginName = 'serverless-plugin-1';
       pluginInstall.options.pluginVersion = 'latest';
-      servicePath = getTmpDirPath();
-      pluginInstall.serverless.serviceDir = servicePath;
-      fse.ensureDirSync(servicePath);
-      packageJsonFilePath = path.join(servicePath, 'package.json');
+      serviceDir = getTmpDirPath();
+      pluginInstall.serverless.serviceDir = serviceDir;
+      fse.ensureDirSync(serviceDir);
+      packageJsonFilePath = path.join(serviceDir, 'package.json');
       npmInstallStub = sinon.stub(childProcess, 'execAsync').callsFake(() => {
         const packageJson = serverless.utils.readFileSync(packageJsonFilePath, 'utf8');
         packageJson.devDependencies = {
@@ -262,7 +262,7 @@ describe('PluginInstall', () => {
 
       // save the cwd so that we can restore it later
       savedCwd = process.cwd();
-      process.chdir(servicePath);
+      process.chdir(serviceDir);
     });
 
     afterEach(() => {
@@ -307,14 +307,14 @@ describe('PluginInstall', () => {
   });
 
   describe('#addPluginToServerlessFile()', () => {
-    let servicePath;
+    let serviceDir;
     let serverlessYmlFilePath;
 
     beforeEach(() => {
-      servicePath = getTmpDirPath();
-      pluginInstall.serverless.serviceDir = pluginInstall.serverless.serviceDir = servicePath;
+      serviceDir = getTmpDirPath();
+      pluginInstall.serverless.serviceDir = pluginInstall.serverless.serviceDir = serviceDir;
       pluginInstall.serverless.configurationFilename = 'serverless.yml';
-      serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
+      serverlessYmlFilePath = path.join(serviceDir, 'serverless.yml');
     });
 
     it('should add the plugin to the service file if plugins array is not present', () => {
@@ -358,7 +358,7 @@ describe('PluginInstall', () => {
     });
 
     it('should add the plugin to serverless file path for a .yaml file', () => {
-      const serverlessYamlFilePath = path.join(servicePath, 'serverless.yaml');
+      const serverlessYamlFilePath = path.join(serviceDir, 'serverless.yaml');
       pluginInstall.serverless.configurationFilename = 'serverless.yaml';
       const serverlessYml = {
         service: 'plugin-service',
@@ -374,7 +374,7 @@ describe('PluginInstall', () => {
     });
 
     it('should add the plugin to serverless file path for a .json file', () => {
-      const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+      const serverlessJsonFilePath = path.join(serviceDir, 'serverless.json');
       pluginInstall.serverless.configurationFilename = 'serverless.json';
       const serverlessJson = {
         service: 'plugin-service',
@@ -401,7 +401,7 @@ describe('PluginInstall', () => {
     });
 
     it('should not modify serverless .js file', () => {
-      const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
+      const serverlessJsFilePath = path.join(serviceDir, 'serverless.js');
       pluginInstall.serverless.configurationFilename = 'serverless.js';
       const serverlessJson = {
         service: 'plugin-service',
@@ -421,7 +421,7 @@ describe('PluginInstall', () => {
     });
 
     it('should not modify serverless .ts file', () => {
-      const serverlessTsFilePath = path.join(servicePath, 'serverless.ts');
+      const serverlessTsFilePath = path.join(serviceDir, 'serverless.ts');
       pluginInstall.serverless.configurationFilename = 'serverless.ts';
       const serverlessJson = {
         service: 'plugin-service',
@@ -468,7 +468,7 @@ describe('PluginInstall', () => {
       });
 
       it('should add the plugin to serverless file path for a .json file', () => {
-        const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+        const serverlessJsonFilePath = path.join(serviceDir, 'serverless.json');
         pluginInstall.serverless.configurationFilename = 'serverless.json';
         const serverlessJson = {
           service: 'plugin-service',
@@ -509,7 +509,7 @@ describe('PluginInstall', () => {
   });
 
   describe('#installPeerDependencies()', () => {
-    let servicePath;
+    let serviceDir;
     let servicePackageJsonFilePath;
     let pluginPath;
     let pluginPackageJsonFilePath;
@@ -520,19 +520,19 @@ describe('PluginInstall', () => {
     beforeEach(() => {
       pluginName = 'some-plugin';
       pluginInstall.options.pluginName = pluginName;
-      servicePath = getTmpDirPath();
-      fse.ensureDirSync(servicePath);
-      pluginInstall.serverless.serviceDir = servicePath;
-      servicePackageJsonFilePath = path.join(servicePath, 'package.json');
+      serviceDir = getTmpDirPath();
+      fse.ensureDirSync(serviceDir);
+      pluginInstall.serverless.serviceDir = serviceDir;
+      servicePackageJsonFilePath = path.join(serviceDir, 'package.json');
       fse.writeJsonSync(servicePackageJsonFilePath, {
         devDependencies: {},
       });
-      pluginPath = path.join(servicePath, 'node_modules', pluginName);
+      pluginPath = path.join(serviceDir, 'node_modules', pluginName);
       fse.ensureDirSync(pluginPath);
       pluginPackageJsonFilePath = path.join(pluginPath, 'package.json');
       npmInstallStub = sinon.stub(childProcess, 'execAsync').returns(BbPromise.resolve());
       savedCwd = process.cwd();
-      process.chdir(servicePath);
+      process.chdir(serviceDir);
     });
 
     afterEach(() => {

--- a/test/unit/lib/plugins/plugin/lib/utils.test.js
+++ b/test/unit/lib/plugins/plugin/lib/utils.test.js
@@ -48,7 +48,7 @@ describe('PluginUtils', () => {
 
   describe('#validate()', () => {
     it('should throw an error if the the cwd is not a Serverless service', () => {
-      pluginUtils.serverless.config.servicePath = false;
+      pluginUtils.serverless.serviceDir = false;
 
       expect(() => {
         pluginUtils.validate();
@@ -56,7 +56,7 @@ describe('PluginUtils', () => {
     });
 
     it('should resolve if the cwd is a Serverless service', (done) => {
-      pluginUtils.serverless.config.servicePath = true;
+      pluginUtils.serverless.serviceDir = true;
 
       pluginUtils.validate().then(() => done());
     });

--- a/test/unit/lib/plugins/plugin/uninstall.test.js
+++ b/test/unit/lib/plugins/plugin/uninstall.test.js
@@ -90,7 +90,7 @@ describe('PluginUninstall', () => {
   });
 
   describe('#uninstall()', () => {
-    let servicePath;
+    let serviceDir;
     let serverlessYmlFilePath;
     let pluginUninstallStub;
     let validateStub;
@@ -100,10 +100,10 @@ describe('PluginUninstall', () => {
     let uninstallPeerDependenciesStub;
 
     beforeEach(() => {
-      servicePath = getTmpDirPath();
-      pluginUninstall.serverless.serviceDir = servicePath;
-      fse.ensureDirSync(servicePath);
-      serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
+      serviceDir = getTmpDirPath();
+      pluginUninstall.serverless.serviceDir = serviceDir;
+      fse.ensureDirSync(serviceDir);
+      serverlessYmlFilePath = path.join(serviceDir, 'serverless.yml');
       validateStub = sinon.stub(pluginUninstall, 'validate').returns(BbPromise.resolve());
       pluginUninstallStub = sinon
         .stub(pluginUninstall, 'pluginUninstall')
@@ -119,7 +119,7 @@ describe('PluginUninstall', () => {
         .returns(BbPromise.resolve(plugins));
       // save the cwd so that we can restore it later
       savedCwd = process.cwd();
-      process.chdir(servicePath);
+      process.chdir(serviceDir);
     });
 
     afterEach(() => {
@@ -187,21 +187,21 @@ describe('PluginUninstall', () => {
   });
 
   describe('#pluginUninstall()', () => {
-    let servicePath;
+    let serviceDir;
     let packageJsonFilePath;
     let npmUninstallStub;
     let savedCwd;
 
     beforeEach(() => {
       pluginUninstall.options.pluginName = 'serverless-plugin-1';
-      servicePath = getTmpDirPath();
-      pluginUninstall.serverless.serviceDir = servicePath;
-      fse.ensureDirSync(servicePath);
-      packageJsonFilePath = path.join(servicePath, 'package.json');
+      serviceDir = getTmpDirPath();
+      pluginUninstall.serverless.serviceDir = serviceDir;
+      fse.ensureDirSync(serviceDir);
+      packageJsonFilePath = path.join(serviceDir, 'package.json');
       npmUninstallStub = sinon.stub(childProcess, 'execAsync').returns(BbPromise.resolve());
       // save the cwd so that we can restore it later
       savedCwd = process.cwd();
-      process.chdir(servicePath);
+      process.chdir(serviceDir);
     });
 
     afterEach(() => {
@@ -235,14 +235,14 @@ describe('PluginUninstall', () => {
   });
 
   describe('#removePluginFromServerlessFile()', () => {
-    let servicePath;
+    let serviceDir;
     let serverlessYmlFilePath;
 
     beforeEach(() => {
-      servicePath = getTmpDirPath();
-      pluginUninstall.serverless.serviceDir = pluginUninstall.serverless.serviceDir = servicePath;
+      serviceDir = getTmpDirPath();
+      pluginUninstall.serverless.serviceDir = pluginUninstall.serverless.serviceDir = serviceDir;
       pluginUninstall.serverless.configurationFilename = 'serverless.yml';
-      serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
+      serverlessYmlFilePath = path.join(serviceDir, 'serverless.yml');
     });
 
     it('should only remove the given plugin from the service', () => {
@@ -282,7 +282,7 @@ describe('PluginUninstall', () => {
     });
 
     it('should remove the plugin from serverless file path for a .yaml file', () => {
-      const serverlessYamlFilePath = path.join(servicePath, 'serverless.yaml');
+      const serverlessYamlFilePath = path.join(serviceDir, 'serverless.yaml');
       pluginUninstall.serverless.configurationFilename = 'serverless.yaml';
       const serverlessYml = {
         service: 'plugin-service',
@@ -299,7 +299,7 @@ describe('PluginUninstall', () => {
     });
 
     it('should remove the plugin from serverless file path for a .json file', () => {
-      const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+      const serverlessJsonFilePath = path.join(serviceDir, 'serverless.json');
       pluginUninstall.serverless.configurationFilename = 'serverless.json';
       const serverlessJson = {
         service: 'plugin-service',
@@ -332,7 +332,7 @@ describe('PluginUninstall', () => {
     });
 
     it('should not modify serverless .js file', () => {
-      const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
+      const serverlessJsFilePath = path.join(serviceDir, 'serverless.js');
       pluginUninstall.serverless.configurationFilename = 'serverless.js';
       const serverlessJson = {
         service: 'plugin-service',
@@ -352,7 +352,7 @@ describe('PluginUninstall', () => {
     });
 
     it('should not modify serverless .ts file', () => {
-      const serverlessTsFilePath = path.join(servicePath, 'serverless.ts');
+      const serverlessTsFilePath = path.join(serviceDir, 'serverless.ts');
       pluginUninstall.serverless.configurationFilename = 'serverless.ts';
       const serverlessJson = {
         service: 'plugin-service',
@@ -420,7 +420,7 @@ describe('PluginUninstall', () => {
       });
 
       it('should remove the plugin from serverless file path for a .json file', () => {
-        const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+        const serverlessJsonFilePath = path.join(serviceDir, 'serverless.json');
         pluginUninstall.serverless.configurationFilename = 'serverless.json';
         const serverlessJson = {
           service: 'plugin-service',
@@ -465,7 +465,7 @@ describe('PluginUninstall', () => {
   });
 
   describe('#uninstallPeerDependencies()', () => {
-    let servicePath;
+    let serviceDir;
     let pluginPath;
     let pluginPackageJsonFilePath;
     let pluginName;
@@ -475,14 +475,14 @@ describe('PluginUninstall', () => {
     beforeEach(() => {
       pluginName = 'some-plugin';
       pluginUninstall.options.pluginName = pluginName;
-      servicePath = getTmpDirPath();
-      pluginUninstall.serverless.serviceDir = servicePath;
-      pluginPath = path.join(servicePath, 'node_modules', pluginName);
+      serviceDir = getTmpDirPath();
+      pluginUninstall.serverless.serviceDir = serviceDir;
+      pluginPath = path.join(serviceDir, 'node_modules', pluginName);
       fse.ensureDirSync(pluginPath);
       pluginPackageJsonFilePath = path.join(pluginPath, 'package.json');
       npmUninstallStub = sinon.stub(childProcess, 'execAsync').returns(BbPromise.resolve());
       savedCwd = process.cwd();
-      process.chdir(servicePath);
+      process.chdir(serviceDir);
     });
 
     afterEach(() => {

--- a/test/unit/lib/plugins/plugin/uninstall.test.js
+++ b/test/unit/lib/plugins/plugin/uninstall.test.js
@@ -101,7 +101,7 @@ describe('PluginUninstall', () => {
 
     beforeEach(() => {
       servicePath = getTmpDirPath();
-      pluginUninstall.serverless.config.servicePath = servicePath;
+      pluginUninstall.serverless.serviceDir = servicePath;
       fse.ensureDirSync(servicePath);
       serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
       validateStub = sinon.stub(pluginUninstall, 'validate').returns(BbPromise.resolve());
@@ -195,7 +195,7 @@ describe('PluginUninstall', () => {
     beforeEach(() => {
       pluginUninstall.options.pluginName = 'serverless-plugin-1';
       servicePath = getTmpDirPath();
-      pluginUninstall.serverless.config.servicePath = servicePath;
+      pluginUninstall.serverless.serviceDir = servicePath;
       fse.ensureDirSync(servicePath);
       packageJsonFilePath = path.join(servicePath, 'package.json');
       npmUninstallStub = sinon.stub(childProcess, 'execAsync').returns(BbPromise.resolve());
@@ -240,7 +240,7 @@ describe('PluginUninstall', () => {
 
     beforeEach(() => {
       servicePath = getTmpDirPath();
-      pluginUninstall.serverless.config.servicePath = pluginUninstall.serverless.serviceDir = servicePath;
+      pluginUninstall.serverless.serviceDir = pluginUninstall.serverless.serviceDir = servicePath;
       pluginUninstall.serverless.configurationFilename = 'serverless.yml';
       serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
     });
@@ -476,7 +476,7 @@ describe('PluginUninstall', () => {
       pluginName = 'some-plugin';
       pluginUninstall.options.pluginName = pluginName;
       servicePath = getTmpDirPath();
-      pluginUninstall.serverless.config.servicePath = servicePath;
+      pluginUninstall.serverless.serviceDir = servicePath;
       pluginPath = path.join(servicePath, 'node_modules', pluginName);
       fse.ensureDirSync(pluginPath);
       pluginPackageJsonFilePath = path.join(pluginPath, 'package.json');

--- a/test/unit/lib/plugins/plugin/uninstall.test.js
+++ b/test/unit/lib/plugins/plugin/uninstall.test.js
@@ -240,11 +240,9 @@ describe('PluginUninstall', () => {
 
     beforeEach(() => {
       servicePath = getTmpDirPath();
-      pluginUninstall.serverless.config.servicePath = servicePath;
-      pluginUninstall.serverless.configurationPath = serverlessYmlFilePath = path.join(
-        servicePath,
-        'serverless.yml'
-      );
+      pluginUninstall.serverless.config.servicePath = pluginUninstall.serverless.serviceDir = servicePath;
+      pluginUninstall.serverless.configurationFilename = 'serverless.yml';
+      serverlessYmlFilePath = path.join(servicePath, 'serverless.yml');
     });
 
     it('should only remove the given plugin from the service', () => {
@@ -284,10 +282,8 @@ describe('PluginUninstall', () => {
     });
 
     it('should remove the plugin from serverless file path for a .yaml file', () => {
-      const serverlessYamlFilePath = (pluginUninstall.serverless.configurationPath = path.join(
-        servicePath,
-        'serverless.yaml'
-      ));
+      const serverlessYamlFilePath = path.join(servicePath, 'serverless.yaml');
+      pluginUninstall.serverless.configurationFilename = 'serverless.yaml';
       const serverlessYml = {
         service: 'plugin-service',
         provider: 'aws',
@@ -303,10 +299,8 @@ describe('PluginUninstall', () => {
     });
 
     it('should remove the plugin from serverless file path for a .json file', () => {
-      const serverlessJsonFilePath = (pluginUninstall.serverless.configurationPath = path.join(
-        servicePath,
-        'serverless.json'
-      ));
+      const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+      pluginUninstall.serverless.configurationFilename = 'serverless.json';
       const serverlessJson = {
         service: 'plugin-service',
         provider: 'aws',
@@ -338,10 +332,8 @@ describe('PluginUninstall', () => {
     });
 
     it('should not modify serverless .js file', () => {
-      const serverlessJsFilePath = (pluginUninstall.serverless.configurationPath = path.join(
-        servicePath,
-        'serverless.js'
-      ));
+      const serverlessJsFilePath = path.join(servicePath, 'serverless.js');
+      pluginUninstall.serverless.configurationFilename = 'serverless.js';
       const serverlessJson = {
         service: 'plugin-service',
         provider: 'aws',
@@ -360,10 +352,8 @@ describe('PluginUninstall', () => {
     });
 
     it('should not modify serverless .ts file', () => {
-      const serverlessTsFilePath = (pluginUninstall.serverless.configurationPath = path.join(
-        servicePath,
-        'serverless.ts'
-      ));
+      const serverlessTsFilePath = path.join(servicePath, 'serverless.ts');
+      pluginUninstall.serverless.configurationFilename = 'serverless.ts';
       const serverlessJson = {
         service: 'plugin-service',
         provider: 'aws',
@@ -430,10 +420,8 @@ describe('PluginUninstall', () => {
       });
 
       it('should remove the plugin from serverless file path for a .json file', () => {
-        const serverlessJsonFilePath = (pluginUninstall.serverless.configurationPath = path.join(
-          servicePath,
-          'serverless.json'
-        ));
+        const serverlessJsonFilePath = path.join(servicePath, 'serverless.json');
+        pluginUninstall.serverless.configurationFilename = 'serverless.json';
         const serverlessJson = {
           service: 'plugin-service',
           provider: 'aws',

--- a/test/unit/lib/utils/downloadTemplateFromRepo.test.js
+++ b/test/unit/lib/utils/downloadTemplateFromRepo.test.js
@@ -25,7 +25,7 @@ describe('downloadTemplateFromRepo', () => {
   let parseRepoURL;
   let fetchStub;
 
-  let servicePath;
+  let serviceDir;
   let newServicePath;
 
   beforeEach(() => {
@@ -35,8 +35,8 @@ describe('downloadTemplateFromRepo', () => {
     fse.mkdirsSync(tmpDir);
     process.chdir(tmpDir);
 
-    servicePath = tmpDir;
-    newServicePath = path.join(servicePath, 'new-service-name');
+    serviceDir = tmpDir;
+    newServicePath = path.join(serviceDir, 'new-service-name');
 
     fetchStub = sinon.stub().resolves({
       json: () => ({
@@ -83,7 +83,7 @@ describe('downloadTemplateFromRepo', () => {
     });
 
     it('should reject an error if a directory with the same service name is already present', () => {
-      const serviceDirName = path.join(servicePath, 'existing-service');
+      const serviceDirName = path.join(serviceDir, 'existing-service');
       fse.mkdirsSync(serviceDirName);
 
       return expect(
@@ -220,7 +220,7 @@ describe('downloadTemplateFromRepo', () => {
 
     it('should throw an error if the same service name exists as directory in Github', () => {
       const url = 'https://github.com/serverless/examples/tree/master/rest-api-with-dynamodb';
-      const serviceDirName = path.join(servicePath, 'rest-api-with-dynamodb');
+      const serviceDirName = path.join(serviceDir, 'rest-api-with-dynamodb');
       fse.mkdirsSync(serviceDirName);
 
       return expect(downloadTemplateFromRepo(null, url)).to.be.rejectedWith(Error);

--- a/test/unit/lib/utils/renameService.test.js
+++ b/test/unit/lib/utils/renameService.test.js
@@ -12,7 +12,7 @@ describe('renameService', () => {
   let serverless;
   let cwd;
 
-  let servicePath;
+  let serviceDir;
 
   beforeEach(() => {
     const tmpDir = getTmpDirPath();
@@ -21,7 +21,7 @@ describe('renameService', () => {
     fse.mkdirsSync(tmpDir);
     process.chdir(tmpDir);
 
-    servicePath = tmpDir;
+    serviceDir = tmpDir;
 
     serverless = new Serverless();
     return serverless.init();
@@ -41,15 +41,15 @@ describe('renameService', () => {
     const defaultServiceName = 'service-name';
     const newServiceName = 'new-service-name';
 
-    const packageFile = path.join(servicePath, 'package.json');
-    const packageLockFile = path.join(servicePath, 'package-lock.json');
-    const serviceFile = path.join(servicePath, 'serverless.yml');
+    const packageFile = path.join(serviceDir, 'package.json');
+    const packageLockFile = path.join(serviceDir, 'package-lock.json');
+    const serviceFile = path.join(serviceDir, 'serverless.yml');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
     serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
-    renameService(newServiceName, servicePath);
+    renameService(newServiceName, serviceDir);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
     const packageLockJson = serverless.utils.readFileSync(packageLockFile);
@@ -67,15 +67,15 @@ describe('renameService', () => {
     const defaultServiceName = 'service-name';
     const newServiceName = 'new-service-name';
 
-    const packageFile = path.join(servicePath, 'package.json');
-    const packageLockFile = path.join(servicePath, 'package-lock.json');
-    const serviceFile = path.join(servicePath, 'serverless.ts');
+    const packageFile = path.join(serviceDir, 'package.json');
+    const packageLockFile = path.join(serviceDir, 'package-lock.json');
+    const serviceFile = path.join(serviceDir, 'serverless.ts');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
     serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceTs);
 
-    renameService(newServiceName, servicePath);
+    renameService(newServiceName, serviceDir);
     const serviceTs = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
     const packageLockJson = serverless.utils.readFileSync(packageLockFile);
@@ -92,15 +92,15 @@ describe('renameService', () => {
     const defaultServiceName = 'service-name';
     const newServiceName = 'new-service-name';
 
-    const packageFile = path.join(servicePath, 'package.json');
-    const packageLockFile = path.join(servicePath, 'package-lock.json');
-    const serviceFile = path.join(servicePath, 'serverless.yml');
+    const packageFile = path.join(serviceDir, 'package.json');
+    const packageLockFile = path.join(serviceDir, 'package-lock.json');
+    const serviceFile = path.join(serviceDir, 'serverless.yml');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
     serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
-    renameService(newServiceName, servicePath);
+    renameService(newServiceName, serviceDir);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
     const packageLockJson = serverless.utils.readFileSync(packageLockFile);
@@ -114,12 +114,12 @@ describe('renameService', () => {
       '# service: service-name #comment\n\nprovider:\n  name: aws\n# comment';
     const newServiceYml = '# service: new-service-name\n\nprovider:\n  name: aws\n# comment';
 
-    const serviceFile = path.join(servicePath, 'serverless.yml');
+    const serviceFile = path.join(serviceDir, 'serverless.yml');
 
     serverless.utils.writeFileDir(serviceFile);
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
-    renameService('new-service-name', servicePath);
+    renameService('new-service-name', serviceDir);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     expect(serviceYml).to.equal(newServiceYml);
   });
@@ -131,15 +131,15 @@ describe('renameService', () => {
     const defaultServiceName = 'service-name';
     const newServiceName = 'new-service-name';
 
-    const packageFile = path.join(servicePath, 'package.json');
-    const packageLockFile = path.join(servicePath, 'package-lock.json');
-    const serviceFile = path.join(servicePath, 'serverless.yml');
+    const packageFile = path.join(serviceDir, 'package.json');
+    const packageLockFile = path.join(serviceDir, 'package-lock.json');
+    const serviceFile = path.join(serviceDir, 'serverless.yml');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
     serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
-    renameService(newServiceName, servicePath);
+    renameService(newServiceName, serviceDir);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
     const packageLockJson = serverless.utils.readFileSync(packageLockFile);
@@ -157,15 +157,15 @@ describe('renameService', () => {
     const defaultServiceName = 'service-name';
     const newServiceName = 'new-service-name';
 
-    const packageFile = path.join(servicePath, 'package.json');
-    const packageLockFile = path.join(servicePath, 'package-lock.json');
-    const serviceFile = path.join(servicePath, 'serverless.ts');
+    const packageFile = path.join(serviceDir, 'package.json');
+    const packageLockFile = path.join(serviceDir, 'package-lock.json');
+    const serviceFile = path.join(serviceDir, 'serverless.ts');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
     serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceTs);
 
-    renameService(newServiceName, servicePath);
+    renameService(newServiceName, serviceDir);
     const serviceTs = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
     const packageLockJson = serverless.utils.readFileSync(packageLockFile);
@@ -183,15 +183,15 @@ describe('renameService', () => {
     const defaultServiceName = 'service-name';
     const newServiceName = 'new-service-name';
 
-    const packageFile = path.join(servicePath, 'package.json');
-    const packageLockFile = path.join(servicePath, 'package-lock.json');
-    const serviceFile = path.join(servicePath, 'serverless.yml');
+    const packageFile = path.join(serviceDir, 'package.json');
+    const packageLockFile = path.join(serviceDir, 'package-lock.json');
+    const serviceFile = path.join(serviceDir, 'serverless.yml');
 
     serverless.utils.writeFileSync(packageFile, { name: defaultServiceName });
     serverless.utils.writeFileSync(packageLockFile, { name: defaultServiceName });
     fse.writeFileSync(serviceFile, defaultServiceYml);
 
-    renameService(newServiceName, servicePath);
+    renameService(newServiceName, serviceDir);
     const serviceYml = fse.readFileSync(serviceFile, 'utf-8');
     const packageJson = serverless.utils.readFileSync(packageFile);
     const packageLockJson = serverless.utils.readFileSync(packageLockFile);
@@ -201,6 +201,6 @@ describe('renameService', () => {
   });
 
   it('should fail to set new service name in serverless.yml', () => {
-    expect(() => renameService('new-service-name', servicePath)).to.throw(Error);
+    expect(() => renameService('new-service-name', serviceDir)).to.throw(Error);
   });
 });

--- a/test/unit/lib/utils/telemetry/generatePayload.test.js
+++ b/test/unit/lib/utils/telemetry/generatePayload.test.js
@@ -17,7 +17,7 @@ const versions = {
 
 describe('lib/utils/telemetry/generatePayload', () => {
   it('Should resolve payload for AWS service', async () => {
-    const { servicePath } = await fixtures.setup('httpApi', {
+    const { servicePath: serviceDir } = await fixtures.setup('httpApi', {
       configExt: {
         functions: {
           withContainer: {
@@ -28,7 +28,7 @@ describe('lib/utils/telemetry/generatePayload', () => {
       },
     });
     await fs.promises.writeFile(
-      path.resolve(servicePath, 'package.json'),
+      path.resolve(serviceDir, 'package.json'),
       JSON.stringify({
         dependencies: {
           fooDep: '1',
@@ -46,7 +46,7 @@ describe('lib/utils/telemetry/generatePayload', () => {
     );
 
     const { serverless } = await runServerless({
-      cwd: servicePath,
+      cwd: serviceDir,
       command: '-v',
     });
     const payload = await generatePayload(serverless);

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -133,7 +133,7 @@ describe('test/unit/scripts/serverless.test.js', () => {
   });
 
   it('should load env variables from dotenv files', async () => {
-    const { servicePath } = await programmaticFixturesEngine.setup('aws', {
+    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('aws', {
       configExt: {
         useDotenv: true,
         custom: {
@@ -141,9 +141,9 @@ describe('test/unit/scripts/serverless.test.js', () => {
         },
       },
     });
-    await fs.writeFile(path.resolve(servicePath, '.env'), 'DEFAULT_ENV_VARIABLE=valuefromdefault');
+    await fs.writeFile(path.resolve(serviceDir, '.env'), 'DEFAULT_ENV_VARIABLE=valuefromdefault');
     expect(
-      String((await spawn('node', [serverlessPath, 'print'], { cwd: servicePath })).stdoutBuffer)
+      String((await spawn('node', [serverlessPath, 'print'], { cwd: serviceDir })).stdoutBuffer)
     ).to.include('fromDefaultEnv: valuefromdefault');
   });
 


### PR DESCRIPTION
`configurationPath` was introduced in first refactors as mid step, still more natural in programmatic usage is to refer to `serviceDir` and eventually `configurationFilename` (but not many use cases for that one)

In the end eventual service configuration to be passed to `Serverless` constructor will consist of following options:
- `configuration` - Service configuration object
- `serviceDir` - Base path for resolution of any paths that are configured in service configuration
- `configurationFilename` - Needed just in some cases (1) Error reporting (when we want to mention specifically configuration filename) (2) To update service configuration programmatically (e.g. to add plugin to `plugins` section with `plugin install` command). (As internals will become more and more modular, this property may appear at some point as optional)

_(Support for `configurationPath` in scope of v2, will be maintained to not break things)_

Settled on `serviceDir`, not `servicePath` (which was used so far in most places), to indicate that in all cases we deal with _directory_, also it'll match `baseDir` setting to be proposed as part of a solution for [mulitple service repo handling](https://github.com/serverless/serverless/issues/9095) and `sourceDir` which we plan to introduce with https://github.com/serverless/serverless/issues/7920

Additionally:
- Replace all internal `serverless.config.servicePath` occurences with `serverless.serviceDir` (this attributes to #8836)
- Rename all `servicePath` variables to `serviceDir` in codebase.
- Refactor packaging test to async/await (observed one issue, and switching from `execSync` to async `spawn` helped to see internally what's going on)

