### PR TITLE
Adapt the CloudFormation region syntax examples to reality

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -219,17 +219,17 @@ resources:
         Name: memorySize
 ```
 
-You can also reference CloudFormation stack in another regions with the `cf(REGION):stackName.outputKey` syntax. For example:
+You can also reference CloudFormation stack in another regions with the `cf.REGION:stackName.outputKey` syntax. For example:
 
 ```yml
 service: new-service
 provider: aws
 functions:
   hello:
-    name: ${cf(us-west-2):another-service-dev.functionPrefix}-hello
+    name: ${cf.us-west-2:another-service-dev.functionPrefix}-hello
     handler: handler.hello
   world:
-    name: ${cf(ap-northeast-1):another-stack.functionPrefix}-world
+    name: ${cf.ap-northeast-1:another-stack.functionPrefix}-world
     handler: handler.world
 ```
 


### PR DESCRIPTION
<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

The syntax for CloudFormation variable references with regions is `cf.REGION`, not `cf(REGION)`. 

See the [initial commit](https://github.com/serverless/serverless/commit/e90e293c716378b1d3f947651bb07701bb248cac) and a [later update](https://github.com/serverless/serverless/commit/7d3636f9682c7c9929a9061f105ed232d139aa56).

