### PR TITLE
feat: add ${merge(...)} pseudo-variable support

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -50,6 +50,7 @@ You can define your own variable syntax (regex) if it conflicts with CloudFormat
 - [Properties exported from Javascript files (sync or async)](#reference-variables-in-javascript-files)
 - [Pseudo Parameters Reference](#pseudo-parameters-reference)
 - [Read String Variable Values as Boolean Values](#read-string-variable-values-as-boolean-values)
+- [Merge multiple object/array sources](#merge-multiple-objectarray-sources)
 
 ## Casting string variables to boolean values
 
@@ -691,3 +692,42 @@ can be used in values which are passed through as is to CloudFormation template 
 Otherwise Serverless Framework has no implied understanding of them and does not try to resolve them on its own.
 
 Same handling applies to [CloudFormation Intrinsic functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
+
+## Merge multiple object/array sources
+
+The `${merge(...)}` pseudo-variable merges the provided values. The provided values can be a list of objects or a list of arrays.
+
+### Merging objects
+
+For example:
+
+```yml
+custom:
+  environment:
+    FOO: value
+
+provider:
+  environment: ${merge(${self:custom.environment}, ${file(common-env.json)}})}
+```
+
+will do a shallow merge of the objects obtained by resolving `${self:custom.environment}` and `${file(common-env.json)}`.
+
+If there is a key collision (the same key exists in more than one of the objects), the merge will raise an error.
+
+### Merging arrays
+
+Arrays are "merged" by concatenation.
+
+For example:
+
+```yml
+custom:
+  list1: ['a', 'b']
+  list2: ['c', 'd']
+
+  example: ${merge(${self:custom.list1}), ${self:custom.list2})}
+```
+
+In this case `example` will have the value `["a", "b", "c", "d"]`.
+
+There is no check for duplicate items in the provided arrays.

--- a/lib/configuration/variables/index.js
+++ b/lib/configuration/variables/index.js
@@ -1,5 +1,5 @@
-// Resolves all non instance dependent variables in a provided configuraton
-// This util is not used in Serveless process flow, but is handy for side resolution of variables
+// Resolves all non instance dependent variables in a provided configuration
+// This util is not used in Serverless process flow, but is handy for side resolution of variables
 
 'use strict';
 
@@ -11,6 +11,7 @@ const resolve = require('./resolve');
 const sources = {
   env: require('./sources/env'),
   file: require('./sources/file'),
+  merge: require('./sources/merge'),
   opt: require('./sources/opt'),
   self: require('./sources/self'),
   strToBool: require('./sources/str-to-bool'),
@@ -47,7 +48,7 @@ module.exports = async ({ serviceDir, servicePath, configuration, options }) => 
     variablesMeta,
     sources,
     options,
-    fulfilledSources: new Set(['env', 'file', 'opt', 'self', 'strToBool']),
+    fulfilledSources: new Set(['env', 'file', 'merge', 'opt', 'self', 'strToBool']),
   });
 
   reportEventualErrors(variablesMeta);

--- a/lib/configuration/variables/sources/merge.js
+++ b/lib/configuration/variables/sources/merge.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const ServerlessError = require('../../../serverless-error');
+const isPlainObject = require('type/plain-object/is');
+
+module.exports = {
+  resolve: ({ params }) => {
+    if (!params || params.length < 2) {
+      throw new ServerlessError(
+        'Missing arguments for variable "merge" source (at least two arguments are expected)',
+        'MISSING_VARIABLE_MERGE_PARAMS'
+      );
+    }
+
+    if (params.every((item) => Array.isArray(item))) {
+      const result = [];
+      for (const param of params) result.push(...param);
+      return { value: result };
+    }
+
+    if (params.every((item) => isPlainObject(item))) {
+      const keys = {};
+
+      params.forEach((item, index) => {
+        Object.keys(item).forEach((key) => {
+          if (keys[key] !== undefined) {
+            throw new ServerlessError(
+              `Unsafe arguments for variable "merge" source: Duplicate key "${key}" in [${index}] (first seen in [${keys[key]}])`,
+              'UNSAFE_VARIABLE_MERGE_PARAMS'
+            );
+          }
+          keys[key] = index;
+        });
+      });
+
+      return { value: Object.assign({}, ...params) };
+    }
+
+    throw new ServerlessError(
+      'Invalid arguments for variable "merge" (expected exclusive list of arrays or plain objects)',
+      'INVALID_VARIABLE_MERGE_PARAMS'
+    );
+  },
+};

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -206,12 +206,13 @@ const processSpanPromise = (async () => {
               sources: {
                 env: require('../lib/configuration/variables/sources/env'),
                 file: require('../lib/configuration/variables/sources/file'),
+                merge: require('../lib/configuration/variables/sources/merge'),
                 opt: require('../lib/configuration/variables/sources/opt'),
                 self: require('../lib/configuration/variables/sources/self'),
                 strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
               },
               options: filterSupportedOptions(options, { commandSchema, providerName }),
-              fulfilledSources: new Set(['file', 'self', 'strToBool']),
+              fulfilledSources: new Set(['file', 'merge', 'self', 'strToBool']),
               propertyPathsToResolve: new Set(['provider\0name', 'provider\0stage', 'useDotenv']),
             };
             await resolveVariables(resolverConfiguration);

--- a/test/unit/lib/configuration/variables/sources/merge.test.js
+++ b/test/unit/lib/configuration/variables/sources/merge.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const path = require('path');
+const resolve = require('../../../../../../lib/configuration/variables/resolve');
+const resolveMeta = require('../../../../../../lib/configuration/variables/resolve-meta');
+
+const selfSource = require('../../../../../../lib/configuration/variables/sources/self');
+const mergeSource = require('../../../../../../lib/configuration/variables/sources/merge');
+
+describe('test/unit/lib/configuraiton/variables/sources/merge.test.js', () => {
+  const serviceDir = path.resolve(__dirname, 'fixture');
+  let configuration;
+  let variablesMeta;
+
+  before(async () => {
+    configuration = {
+      list1: ['a', 'b'],
+      list2: [{ c: 'd' }, ['e']],
+      listTest: '${merge(${self:list1}, ${self:list2})}',
+
+      obj1: { a: 'b' },
+      obj2: { c: 'd' },
+      objTest: '${merge(${self:obj1}, ${self:obj2})}',
+
+      duplicate: '${merge(${self:obj1}, ${self:obj1})}',
+
+      empty: '${merge()}',
+
+      notObjects: '${merge(1,2)}',
+    };
+
+    variablesMeta = resolveMeta(configuration);
+    await resolve({
+      serviceDir,
+      configuration,
+      variablesMeta,
+      sources: { self: selfSource, merge: mergeSource },
+      options: {},
+      fulfilledSources: new Set(['self', 'merge']),
+    });
+  });
+
+  it('should merge lists by concatenation', () => {
+    expect(configuration.listTest).to.deep.equal(['a', 'b', { c: 'd' }, ['e']]);
+  });
+
+  it('should merge objects', () => {
+    expect(configuration.objTest).to.deep.equal({ a: 'b', c: 'd' });
+  });
+
+  it('should raise an error for duplicate object keys', () => {
+    expect(variablesMeta.get('duplicate').error.code).to.equal('VARIABLE_RESOLUTION_ERROR');
+  });
+
+  it('should raise an error for empty merge', () => {
+    expect(variablesMeta.get('empty').error.code).to.equal('VARIABLE_RESOLUTION_ERROR');
+  });
+
+  it('should raise an error when merged items are not objects or arrays', () => {
+    expect(variablesMeta.get('notObjects').error.code).to.equal('VARIABLE_RESOLUTION_ERROR');
+  });
+});


### PR DESCRIPTION
Introduces a `merge` variable source, so a single object or array can be constructed from multiple sources as follows:

```yml
custom:
  environment:
    FOO: value

provider:
  environment: ${merge(${self:custom.environment}, ${file(common-env.json)}})}
```

Important constraints met:
* Supports constructing objects and arrays exclusively
* Imply a top level merge. In object case it should work similarly to `Object.assign({}, param1, param2, ..)`. In case of arrays: `[].push(...param1, ...param2)`
* In case of object construction throw an exception if two input objects share same key (does not silently override them)
* Ensure that all input params are either exclusively objects, or exclusively arrays (throw otherwise)

_Note: the original issue specified "plain objects" compared to this implementation which is "objects"... I didn't want to preclude merging objects with functions in case someone comes up with an interesting idea for using that capability._

Addresses: #8037 

Related: serverless/utils#79, #9299.