### PR TITLE
9215 update permission boundary naming

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -166,6 +166,9 @@ Staring with v3.0.0, all IAM-related settings of _provider_ including `iamRoleSt
 - `provider.iamManagedPolicies` -> `provider.iam.role.managedPolicies`
 - `provider.cfnRole` -> `provider.iam.deploymentRole`
 
+In addition, a prior update had documented the new Permissions Boundary property as `iam.role.permissionBoundary`. This
+has now been deprecated in favor of `iam.role.permissionsBoundary` to match the CloudFormation property.
+
 <a name="AWS_API_GATEWAY_SPECIFIC_KEYS"><div>&nbsp;</div></a>
 
 ## API Gateway specific configuration

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -161,7 +161,7 @@ Deprecation code: `PROVIDER_IAM_SETTINGS`
 Staring with v3.0.0, all IAM-related settings of _provider_ including `iamRoleStatements`, `iamManagedPolicies`, `role` and `cfnRole` will be grouped under `iam` property. Refer to the[IAM Guide](/framework/docs/providers/aws/guide/iam.md).
 
 - `provider.role` -> `provider.iam.role`
-- `provider.rolePermissionsBoundary` -> `provider.iam.role.permissionBoundary`
+- `provider.rolePermissionsBoundary` -> `provider.iam.role.permissionsBoundary`
 - `provider.iamRoleStatements` -> `provider.iam.role.statements`
 - `provider.iamManagedPolicies` -> `provider.iam.role.managedPolicies`
 - `provider.cfnRole` -> `provider.iam.deploymentRole`

--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -30,7 +30,7 @@ provider:
           NotAction: 'iam:DeleteUser',
       managedPolicies:
         - 'arn:aws:iam::123456789012:user/*',
-      permissionBoundary: arn:aws:iam::123456789012:policy/boundaries
+      permissionsBoundary: arn:aws:iam::123456789012:policy/boundaries
       tags:
         key: value
     deploymentRole: arn:aws:iam::123456789012:role/deploy-role

--- a/lib/plugins/aws/package/lib/mergeIamTemplates.js
+++ b/lib/plugins/aws/package/lib/mergeIamTemplates.js
@@ -81,7 +81,9 @@ module.exports = {
     }
 
     // set permission boundary
-    if (iamRole.permissionBoundary) {
+    if (iamRole.permissionsBoundary) {
+      iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = iamRole.permissionsBoundary;
+    } else if (iamRole.permissionBoundary) {
       iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = iamRole.permissionBoundary;
     } else if (this.serverless.service.provider.rolePermissionsBoundary) {
       iamRoleLambdaExecutionTemplate.Properties.PermissionsBoundary = this.serverless.service.provider.rolePermissionsBoundary;

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -233,7 +233,8 @@ class AwsProvider {
           'PROVIDER_IAM_SETTINGS',
           {
             'provider.role': 'provider.iam.role',
-            'provider.rolePermissionsBoundary': 'provider.iam.role.permissionBoundary',
+            'provider.rolePermissionsBoundary': 'provider.iam.role.permissionsBoundary',
+            'provider.iam.role.permissionBoundary': 'provider.iam.role.permissionsBoundary',
             'provider.iamManagedPolicies': 'provider.iam.role.managedPolicies',
             'provider.iamRoleStatements': 'provider.iam.role.statements',
             'provider.cfnRole': 'provider.iam.deploymentRole',
@@ -867,6 +868,7 @@ class AwsProvider {
                         },
                         statements: { $ref: '#/definitions/awsIamPolicyStatements' },
                         permissionBoundary: { $ref: '#/definitions/awsArnString' },
+                        permissionsBoundary: { $ref: '#/definitions/awsArnString' },
                         tags: { $ref: '#/definitions/awsResourceTags' },
                       },
                       additionalProperties: false,

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -235,6 +235,30 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           'arn:aws:iam::123456789012:policy/XCompanyBoundaries'
         );
       });
+
+      it('should support `provider.iam.role.permissionBoundary`', async () => {
+        const { cfTemplate, awsNaming } = await runServerless({
+          fixture: 'function',
+          cliArgs: ['package'],
+          configExt: {
+            provider: {
+              iam: {
+                role: {
+                  permissionBoundary: ['arn:aws:iam::123456789012:policy/XCompanyBoundaries'],
+                },
+              },
+            },
+          },
+        });
+
+        const IamRoleLambdaExecution = awsNaming.getRoleLogicalId();
+        const {
+          Properties: { PermissionsBoundary },
+        } = cfTemplate.Resources[IamRoleLambdaExecution];
+        expect(PermissionsBoundary).to.be.equal(
+          'arn:aws:iam::123456789012:policy/XCompanyBoundaries'
+        );
+      });
     });
 
     describe('Provider properties', () => {
@@ -262,7 +286,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
                     'arn:aws:s3:::my_corporate_bucket/Development/*',
                     'arn:aws:iam::123456789012:u*',
                   ],
-                  permissionBoundary: ['arn:aws:iam::123456789012:policy/XCompanyBoundaries'],
+                  permissionsBoundary: ['arn:aws:iam::123456789012:policy/XCompanyBoundaries'],
                   tags: {
                     sweet: 'potato',
                   },


### PR DESCRIPTION
fix: Deprecated IAM Role 'permissionBoundary' property in favor of
'permissionsBoundary' to match CloudFormation. The previous property
name will still be supported at present.

I wasn't sure if this should be called out in a completely standalone deprecations section / deprecation key. As it is more of a correction, I opted to include it as an addendum to the existing IAM Role deprecation callout. If anyone feels like this should live in its own section altogether, I could update this to include its own deprecation section and key.

Closes: 9215
