### PR TITLE
#9291 fix: Create a single request validator instead of a request validator per request schema

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -284,8 +284,8 @@ module.exports = {
   getMethodLogicalId(resourceId, methodName) {
     return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}`;
   },
-  getValidatorLogicalId(modelLogicalId) {
-    return `${modelLogicalId}Validator`;
+  getValidatorLogicalId() {
+    return `${this.provider.serverless.service.service}RequestValidator`;
   },
   getModelLogicalId(schemaId) {
     return `ApiGateway${_.upperFirst(_.camelCase(schemaId))}Model`;

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -285,7 +285,14 @@ module.exports = {
     return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}`;
   },
   getValidatorLogicalId() {
-    return `${this.provider.serverless.service.service}RequestValidator`;
+    return `ApiGateway${_.upperFirst(
+      this.normalizeNameToAlphaNumericOnly(
+        _.camelCase(
+          // Service name trimmed to 150 chars to avoid going over 255 character limit
+          this.provider.serverless.service.service.slice(0, 150)
+        )
+      )
+    )}RequestValidator`;
   },
   getModelLogicalId(schemaId) {
     return `ApiGateway${_.upperFirst(_.camelCase(schemaId))}Model`;

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -285,8 +285,8 @@ module.exports = {
     return `ApiGatewayMethod${resourceId}${this.normalizeMethodName(methodName)}`;
   },
   getValidatorLogicalId() {
-    return `ApiGateway${_.upperFirst(
-      this.normalizeNameToAlphaNumericOnly(this.provider.serverless.service.service)
+    return `ApiGateway${this.normalizeNameToAlphaNumericOnly(
+      this.provider.serverless.service.service
     )}RequestValidator`;
   },
   getModelLogicalId(schemaId) {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -286,12 +286,7 @@ module.exports = {
   },
   getValidatorLogicalId() {
     return `ApiGateway${_.upperFirst(
-      this.normalizeNameToAlphaNumericOnly(
-        _.camelCase(
-          // Service name trimmed to 150 chars to avoid going over 255 character limit
-          this.provider.serverless.service.service.slice(0, 150)
-        )
-      )
+      this.normalizeNameToAlphaNumericOnly(this.provider.serverless.service.service)
     )}RequestValidator`;
   },
   getModelLogicalId(schemaId) {

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
@@ -13,36 +13,42 @@ module.exports = {
         event.http.method
       );
 
+      let validatorLogicalId;
+      let validatorName;
+
       if (event.http.request && event.http.request.schemas) {
         const template = this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
           methodLogicalId
         ];
         for (const [contentType, schemaConfig] of _.entries(event.http.request.schemas)) {
           let modelLogicalId;
-          let validatorLogicalId;
 
           const referencedDefinitionFromProvider =
             !_.isObject(schemaConfig) && _.get(apiGatewayConfig, `request.schemas.${schemaConfig}`);
 
+          if (!validatorLogicalId) {
+            const requestValidator = this.createRequestValidator();
+            validatorLogicalId = requestValidator.validatorLogicalId;
+            validatorName = requestValidator.validatorName;
+          }
+
           if (referencedDefinitionFromProvider) {
-            const models = this.createProviderModel(
+            modelLogicalId = this.createProviderModel(
               schemaConfig,
-              apiGatewayConfig.request.schemas[schemaConfig]
+              apiGatewayConfig.request.schemas[schemaConfig],
+              validatorLogicalId,
+              validatorName
             );
-            modelLogicalId = models.modelLogicalId;
-            validatorLogicalId = models.validatorLogicalId;
           } else {
             // In this situation, we have two options - schema is defined as string that does not reference model from provider or as an object
             let modelName;
             let description;
             let definition;
-            let validatorName;
 
             if (_.isObject(schemaConfig)) {
               if (schemaConfig.schema) {
                 // In this case, schema is defined as an object with explicit properties
                 modelName = schemaConfig.name;
-                validatorName = modelName ? `${modelName}Validator` : null;
                 description = schemaConfig.description;
                 definition = schemaConfig.schema;
               } else {
@@ -60,10 +66,6 @@ module.exports = {
               contentType
             );
 
-            validatorLogicalId = this.provider.naming.getValidatorLogicalId(
-              this.provider.naming.getModelLogicalId(resourceName)
-            );
-
             Object.assign(
               this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
               {
@@ -75,16 +77,6 @@ module.exports = {
                     Schema: definition,
                     Name: modelName,
                     Description: description,
-                  },
-                },
-
-                [validatorLogicalId]: {
-                  Type: 'AWS::ApiGateway::RequestValidator',
-                  Properties: {
-                    RestApiId: this.provider.getApiGatewayRestApiId(),
-                    ValidateRequestBody: true,
-                    ValidateRequestParameters: true,
-                    Name: validatorName,
                   },
                 },
               }
@@ -107,9 +99,11 @@ module.exports = {
             contentType
           );
 
-          const validatorLogicalId = this.provider.naming.getValidatorLogicalId(
-            this.provider.naming.getModelLogicalId(resourceName)
-          );
+          if (!validatorLogicalId) {
+            const requestValidator = this.createRequestValidator();
+            validatorLogicalId = requestValidator.validatorLogicalId;
+            validatorName = requestValidator.validatorName;
+          }
 
           template.Properties.RequestValidatorId = { Ref: validatorLogicalId };
           template.Properties.RequestModels = template.Properties.RequestModels || {};
@@ -124,23 +118,14 @@ module.exports = {
                 Schema: schema,
               },
             },
-            [validatorLogicalId]: {
-              Type: 'AWS::ApiGateway::RequestValidator',
-              Properties: {
-                RestApiId: this.provider.getApiGatewayRestApiId(),
-                ValidateRequestBody: true,
-                ValidateRequestParameters: true,
-              },
-            },
           });
         }
       }
     });
   },
 
-  createProviderModel(schemaId, schemaConfig) {
+  createProviderModel(schemaId, schemaConfig, validatorLogicalId, validatorName) {
     let modelName;
-    let validatorName;
     let description;
     let definition;
 
@@ -152,8 +137,6 @@ module.exports = {
     }
 
     const modelLogicalId = this.provider.naming.getModelLogicalId(schemaId);
-
-    const validatorLogicalId = this.provider.naming.getValidatorLogicalId(modelLogicalId);
 
     if (schemaConfig.name) {
       modelName = schemaConfig.name;
@@ -173,14 +156,6 @@ module.exports = {
           ContentType: 'application/json',
         },
       },
-      [validatorLogicalId]: {
-        Type: 'AWS::ApiGateway::RequestValidator',
-        Properties: {
-          RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
-          ValidateRequestBody: true,
-          ValidateRequestParameters: true,
-        },
-      },
     });
 
     if (modelName) {
@@ -197,9 +172,26 @@ module.exports = {
         modelLogicalId
       ].Properties.Description = description;
     }
+    return modelLogicalId;
+  },
+
+  createRequestValidator() {
+    const validatorLogicalId = this.provider.naming.getValidatorLogicalId();
+    const validatorName = 'Validate request body and querystring parameters';
+    Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+      [validatorLogicalId]: {
+        Type: 'AWS::ApiGateway::RequestValidator',
+        Properties: {
+          RestApiId: this.provider.getApiGatewayRestApiId(),
+          ValidateRequestBody: true,
+          ValidateRequestParameters: true,
+          Name: validatorName,
+        },
+      },
+    });
     return {
-      modelLogicalId,
       validatorLogicalId,
+      validatorName,
     };
   },
 };

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
@@ -178,17 +178,17 @@ module.exports = {
   createRequestValidator() {
     const validatorLogicalId = this.provider.naming.getValidatorLogicalId();
     const validatorName = 'Validate request body and querystring parameters';
-    Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
-      [validatorLogicalId]: {
-        Type: 'AWS::ApiGateway::RequestValidator',
-        Properties: {
-          RestApiId: this.provider.getApiGatewayRestApiId(),
-          ValidateRequestBody: true,
-          ValidateRequestParameters: true,
-          Name: validatorName,
-        },
+    this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
+      validatorLogicalId
+    ] = {
+      Type: 'AWS::ApiGateway::RequestValidator',
+      Properties: {
+        RestApiId: this.provider.getApiGatewayRestApiId(),
+        ValidateRequestBody: true,
+        ValidateRequestParameters: true,
+        Name: validatorName,
       },
-    });
+    };
     return {
       validatorLogicalId,
       validatorName,

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -416,8 +416,8 @@ describe('#naming()', () => {
 
   describe('#getValidatorLogicalId()', () => {
     it('', () => {
-      expect(sdk.naming.getValidatorLogicalId('ApiGatewayMethodResourceId')).to.equal(
-        'ApiGatewayMethodResourceIdValidator'
+      expect(sdk.naming.getValidatorLogicalId()).to.equal(
+        `${this.provider.serverless.service.service}RequestValidator`
       );
     });
   });

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -416,8 +416,9 @@ describe('#naming()', () => {
 
   describe('#getValidatorLogicalId()', () => {
     it('', () => {
+      serverless.service.service = 'myService';
       expect(sdk.naming.getValidatorLogicalId()).to.equal(
-        `${this.provider.serverless.service.service}RequestValidator`
+        `${serverless.service.service}RequestValidator`
       );
     });
   });

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -416,10 +416,8 @@ describe('#naming()', () => {
 
   describe('#getValidatorLogicalId()', () => {
     it('', () => {
-      serverless.service.service = 'myService';
-      expect(sdk.naming.getValidatorLogicalId()).to.equal(
-        `${serverless.service.service}RequestValidator`
-      );
+      serverless.service.service = 'my-Service';
+      expect(sdk.naming.getValidatorLogicalId()).to.equal('ApiGatewayMyServiceRequestValidator');
     });
   });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.test.js
@@ -94,7 +94,7 @@ describe('#compileRequestValidators()', () => {
      **/
     it('should reference model from provider:apiGateway:requestSchemas', () => {
       const modelLogicalId = naming.getModelLogicalId('test-model');
-      const validatorLogicalId = naming.getValidatorLogicalId(modelLogicalId);
+      const validatorLogicalId = naming.getValidatorLogicalId();
       const methodLogicalId = naming.getMethodLogicalId('TestDashmodelDashfull', 'get');
       const methodResource = cfResources[methodLogicalId];
 
@@ -116,9 +116,7 @@ describe('#compileRequestValidators()', () => {
         'get',
         'application/json'
       );
-      const validatorLogicalId = naming.getValidatorLogicalId(
-        naming.getModelLogicalId('TestDashdirectDashsimple')
-      );
+      const validatorLogicalId = naming.getValidatorLogicalId();
       const methodLogicalId = naming.getMethodLogicalId('TestDashdirectDashsimple', 'get');
       const methodResource = cfResources[methodLogicalId];
 
@@ -168,9 +166,7 @@ describe('#compileRequestValidators()', () => {
         'get',
         'application/json'
       );
-      const validatorLogicalId = naming.getValidatorLogicalId(
-        naming.getModelLogicalId('TestDashdirectDashfull')
-      );
+      const validatorLogicalId = naming.getValidatorLogicalId();
       const methodLogicalId = naming.getMethodLogicalId('TestDashdirectDashfull', 'get');
       const methodResource = cfResources[methodLogicalId];
 
@@ -225,9 +221,7 @@ describe('#compileRequestValidators()', () => {
         'get',
         'text/plain'
       );
-      const validatorLogicalId = naming.getValidatorLogicalId(
-        naming.getModelLogicalId('TestDashmultiple')
-      );
+      const validatorLogicalId = naming.getValidatorLogicalId();
       const methodLogicalId = naming.getMethodLogicalId('TestDashmultiple', 'get');
       const methodResource = cfResources[methodLogicalId];
 
@@ -295,9 +289,7 @@ describe('#compileRequestValidators()', () => {
         'get',
         'application/json'
       );
-      const validatorLogicalId = naming.getValidatorLogicalId(
-        naming.getModelLogicalId('TestDashdeprecatedDashsimple')
-      );
+      const validatorLogicalId = naming.getValidatorLogicalId();
       const methodLogicalId = naming.getMethodLogicalId('TestDashdeprecatedDashsimple', 'get');
       const methodResource = cfResources[methodLogicalId];
 
@@ -350,9 +342,7 @@ describe('#compileRequestValidators()', () => {
         'get',
         'text/plain'
       );
-      const validatorLogicalId = naming.getValidatorLogicalId(
-        naming.getModelLogicalId('TestDashdeprecatedDashmultiple')
-      );
+      const validatorLogicalId = naming.getValidatorLogicalId();
       const methodLogicalId = naming.getMethodLogicalId('TestDashdeprecatedDashmultiple', 'get');
       const methodResource = cfResources[methodLogicalId];
 


### PR DESCRIPTION
fix: Create a single request validator for all API Gateway request schemas instead of creating a new request validator per request schema. This resolves the issue of hitting the 20 request validator hard limit imposed by API Gateway.

Closes: #9291
