### PR TITLE
CLI: Recognize `--aws-profile` option by schema

### DIFF
--- a/lib/cli/commands-schema/common-options/aws-service.js
+++ b/lib/cli/commands-schema/common-options/aws-service.js
@@ -5,6 +5,9 @@ module.exports = {
     usage: 'Region of the service',
     shortcut: 'r',
   },
+  'aws-profile': {
+    usage: 'AWS profile to use with the command',
+  },
   'app': { usage: 'Dashboard app' },
   'org': { usage: 'Dashboard org' },
   'use-local-credentials': {

--- a/test/unit/lib/cli/filter-supported-options.test.js
+++ b/test/unit/lib/cli/filter-supported-options.test.js
@@ -49,6 +49,7 @@ describe('test/unit/lib/cli/filter-supported-options.test.js', () => {
       )
     ).to.deep.equal({
       'region': 'elo',
+      'aws-profile': null,
       'help': null,
       'version': null,
       'config': null,


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Address issue pointed here: https://github.com/serverless/serverless/issues/8356#issuecomment-821948879

During CLI options refactor, it was lost that internally we also support `--aws-profile` option (this option was never listed in any commands `options` and did not also appeared in help documentation)