### PR TITLE
fix: Packaging - exclude documentation

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -58,7 +58,7 @@ Exclude all node_modules but then re-include a specific modules (in this case no
 
 ```yml
 package:
-  patterns:
+  exclude:
     - '!node_modules/**'
     - 'node_modules/node-fetch/**'
 ```


### PR DESCRIPTION
Seems the documentation is not uniform, it mentions exclude but it's not in the code block

Like done in https://github.com/serverless/serverless/blob/master/docs/providers/google/guide/packaging.md