### PR TITLE
fix(Telemetry): Do not send request when there are no events

### DIFF
--- a/lib/utils/telemetry/index.js
+++ b/lib/utils/telemetry/index.js
@@ -173,6 +173,8 @@ async function send(options = {}) {
     )
   ).filter(Boolean);
 
+  if (!payloadsWithIds.length) return null;
+
   return request(
     payloadsWithIds
       .map((item) => item.payload)

--- a/test/unit/lib/utils/telemetry/index.test.js
+++ b/test/unit/lib/utils/telemetry/index.test.js
@@ -52,6 +52,8 @@ describe('test/unit/lib/utils/telemetry/index.test.js', () => {
   });
 
   afterEach(async () => {
+    usedOptions = null;
+    usedUrl = null;
     const dirFilenames = await fse.readdir(cacheDirPath);
     await Promise.all(
       dirFilenames.map(async (filename) => fse.unlink(path.join(cacheDirPath, filename)))
@@ -103,5 +105,11 @@ describe('test/unit/lib/utils/telemetry/index.test.js', () => {
     await send();
     const dirFilenames = await fse.readdir(cacheDirPath);
     expect(dirFilenames.filter(isFilename).length).to.equal(0);
+  });
+
+  it('Should not send request when there are no events to send', async () => {
+    await send();
+    expect(usedUrl).to.be.null;
+    expect(usedOptions).to.be.null;
   });
 });


### PR DESCRIPTION
In situations when there was a problem with saving and/or reading telemetry events, we should not attempt to send an empty event list. 