### PR TITLE
API: Ensure `config.servicePath` works as an alias for `config.s…

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -33,7 +33,7 @@ class Serverless {
 
     if (configObject.serviceDir != null) {
       // Modern intialization way, to be the only supported way with v3
-      configObject.servicePath = this.serviceDir = path.resolve(
+      this.serviceDir = path.resolve(
         ensureString(configObject.serviceDir, {
           name: 'config.serviceDir',
           Error: ServerlessError,
@@ -61,7 +61,7 @@ class Serverless {
           Error: ServerlessError,
         })
       );
-      this.serviceDir = configObject.servicePath = process.cwd();
+      this.serviceDir = process.cwd();
       this.configurationFilename = configurationPath.slice(this.serviceDir.length + 1);
       this.configurationInput = ensurePlainObject(configObject.configuration, {
         isOptional: true,
@@ -156,7 +156,7 @@ class Serverless {
     if (this._shouldResolveConfigurationInternally) {
       const configurationPath = await resolveConfigurationPath();
       if (configurationPath) {
-        this.serviceDir = this.config.servicePath = process.cwd();
+        this.serviceDir = process.cwd();
         this.configurationFilename = configurationPath.slice(this.serviceDir.length + 1);
       }
     }

--- a/lib/classes/Config.js
+++ b/lib/classes/Config.js
@@ -14,6 +14,14 @@ class Config {
   update(config) {
     return _.merge(this, config);
   }
+
+  get servicePath() {
+    return this.serverless.serviceDir;
+  }
+
+  set servicePath(value) {
+    this.serverless.serviceDir = value;
+  }
 }
 
 module.exports = Config;

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -163,7 +163,6 @@ class Create {
     }
 
     this.serverless.serviceDir = process.cwd();
-    this.serverless.config.servicePath = process.cwd();
 
     return createFromTemplate(this.options.template, process.cwd(), { name: serviceName }).then(
       () => {


### PR DESCRIPTION
Some plugins override `config.servicePath`, and after recent changes this property is not read in Framework internalls.

This patch ensures that `config.servicePath` serves as _live_ alias of `serviceDir`