### PR TITLE
API: Bring back legacy `service.serviceFilename` to not break plugins

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -53,6 +53,9 @@ class Service {
 
   loadServiceFileParam() {
     const serverlessFileParam = this.serverless.configurationInput;
+    // Not used internally, left set to not break plugins which depend on it
+    // TOOD: Remove with next major
+    this.serviceFilename = this.serverless.configurationFilename;
 
     const serverlessFile = serverlessFileParam;
     // basic service level validation


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9351

Brings back `service.serviceFilename` removed with https://github.com/serverless/serverless/commit/fc3a4391b5411f77a51a84f93a166903c51cb80f