### PR TITLE
Ensure `ServerlessError` instances have `code` set

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -37,20 +37,24 @@ class Serverless {
         ensureString(configObject.serviceDir, {
           name: 'config.serviceDir',
           Error: ServerlessError,
+          errorCode: 'INVALID_NON_STRING_SERVICE_DIR',
         })
       );
       this.configurationFilename = ensureString(configObject.configurationFilename, {
         name: 'config.configurationFilename',
         Error: ServerlessError,
+        errorCode: 'INVALID_NON_STRING_CONFIGURATION_FILENAME',
       });
       if (path.isAbsolute(this.configurationFilename)) {
         throw new ServerlessError(
-          `"config.configurationFilename" cannot be absolute path. Received: ${configObject.configurationFilename}`
+          `"config.configurationFilename" cannot be absolute path. Received: ${configObject.configurationFilename}`,
+          'INVALID_ABSOLUTE_PATH_CONFIGURATION_FILENAME'
         );
       }
       this.configurationInput = ensurePlainObject(configObject.configuration, {
         name: 'config.configuration',
         Error: ServerlessError,
+        errorCode: 'INVALID_NON_OBJECT_CONFIGURATION',
       });
       this.isConfigurationInputResolved = Boolean(configObject.isConfigurationResolved);
     } else if (configObject.configurationPath != null) {
@@ -59,6 +63,7 @@ class Serverless {
         ensureString(configObject.configurationPath, {
           name: 'config.configurationPath',
           Error: ServerlessError,
+          errorCode: 'INVALID_NON_STRING_CONFIGURATION_PATH',
         })
       );
       this.serviceDir = process.cwd();
@@ -67,6 +72,7 @@ class Serverless {
         isOptional: true,
         name: 'config.configuration',
         Error: ServerlessError,
+        errorCode: 'INVALID_NON_OBJECT_CONFIGURATION',
       });
       if (this.configurationInput) {
         this.isConfigurationInputResolved = Boolean(configObject.isConfigurationResolved);

--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -194,7 +194,7 @@ async function awsRequest(service, method, ...args) {
             : bottomError.message;
           message = errorMessage;
           // We do not want to trigger the retry mechanism for credential errors
-          throw Object.assign(new ServerlessError(errorMessage), {
+          throw Object.assign(new ServerlessError(errorMessage, 'AWS_CREDENTIALS_NOT_FOUND'), {
             providerError: Object.assign({}, err, { retryable: false }),
           });
         }

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -122,7 +122,7 @@ class ConfigSchemaHandler {
             ? `${ERROR_PREFIX}: \n     ${messages.join('\n     ')}`
             : `${ERROR_PREFIX} ${messages[0]}`;
 
-        throw new ServerlessError(errorMessage, 'SCHEMA_VALIDATION');
+        throw new ServerlessError(errorMessage, 'INVALID_NON_SCHEMA_COMPLIANT_CONFIGURATION');
       } else {
         if (messages.length === 1) {
           this.serverless.cli.log(`${WARNING_PREFIX} ${messages[0]}`, 'Serverless', {

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -122,7 +122,7 @@ class ConfigSchemaHandler {
             ? `${ERROR_PREFIX}: \n     ${messages.join('\n     ')}`
             : `${ERROR_PREFIX} ${messages[0]}`;
 
-        throw new ServerlessError(errorMessage);
+        throw new ServerlessError(errorMessage, 'SCHEMA_VALIDATION');
       } else {
         if (messages.length === 1) {
           this.serverless.cli.log(`${WARNING_PREFIX} ${messages[0]}`, 'Serverless', {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -188,12 +188,14 @@ class PluginManager {
               `Serverless plugin "${name}" not found.`,
               ' Make sure it\'s installed and listed in the "plugins" section',
               ' of your serverless config file.',
-            ].join('')
+            ].join(''),
+            'PLUGIN_NOT_FOUND'
           );
         }
         if (!Plugin) {
           throw new ServerlessError(
-            `Serverless plugin "${name}", didn't export Plugin constructor.`
+            `Serverless plugin "${name}", didn't export Plugin constructor.`,
+            'MISSING_PLUGIN_NAME'
           );
         }
         return Plugin;
@@ -231,7 +233,10 @@ class PluginManager {
   createCommandAlias(alias, command) {
     // Deny self overrides
     if (command.startsWith(alias)) {
-      throw new ServerlessError(`Command "${alias}" cannot be overriden by an alias`);
+      throw new ServerlessError(
+        `Command "${alias}" cannot be overriden by an alias`,
+        'INVALID_COMMAND_ALIAS'
+      );
     }
 
     const splitAlias = alias.split(':');
@@ -245,7 +250,8 @@ class PluginManager {
     // Check if the alias is already defined
     if (aliasTarget.command) {
       throw new ServerlessError(
-        `Alias "${alias}" is already defined for command ${aliasTarget.command}`
+        `Alias "${alias}" is already defined for command ${aliasTarget.command}`,
+        'COMMAND_ALIAS_ALREADY_DEFINED'
       );
     }
     // Check if the alias would overwrite an exiting command
@@ -257,7 +263,10 @@ class PluginManager {
         return __.commands[aliasPath];
       }, this)
     ) {
-      throw new ServerlessError(`Command "${alias}" cannot be overriden by an alias`);
+      throw new ServerlessError(
+        `Command "${alias}" cannot be overriden by an alias`,
+        'INVALID_COMMAND_ALIAS'
+      );
     }
     aliasTarget.command = command;
   }
@@ -270,7 +279,10 @@ class PluginManager {
     // Check if there is already an alias for the same path as the command
     const aliasCommand = this.getAliasCommandTarget(key.split(':'));
     if (aliasCommand) {
-      throw new ServerlessError(`Command "${key}" cannot override an existing alias`);
+      throw new ServerlessError(
+        `Command "${key}" cannot override an existing alias`,
+        'INVALID_COMMAND_OVERRIDE_EXISTING_ALIAS'
+      );
     }
     // Load the command
     const commands = _.mapValues(details.commands, (subDetails, subKey) =>
@@ -488,7 +500,7 @@ class PluginManager {
             }
           }
           errorMessage.push('" to see a more helpful error message for this command.');
-          throw new ServerlessError(errorMessage.join(''));
+          throw new ServerlessError(errorMessage.join(''), 'SUBCOMMAND_NOT_FOUND');
         }
 
         // top level command isn't valid. give a suggestion
@@ -502,7 +514,7 @@ class PluginManager {
           `Serverless command "${commandName}" not found. Did you mean "${suggestedCommand}"?`,
           ' Run "serverless help" for a list of all available commands.',
         ].join('');
-        throw new ServerlessError(errorMessage);
+        throw new ServerlessError(errorMessage, 'COMMAND_NOT_FOUND');
       },
       { commands: this.commands }
     );
@@ -622,7 +634,7 @@ class PluginManager {
           'This command can only be run in a Serverless service directory. ',
           "Make sure to reference a valid config file in the current working directory if you're using a custom config file",
         ].join('');
-        throw new ServerlessError(msg);
+        throw new ServerlessError(msg, 'INVALID_COMMAND_MISSING_SERVICE_DIRECTORY');
       }
     }
   }
@@ -652,7 +664,7 @@ class PluginManager {
           typeof value.customValidation.errorMessage === 'string' &&
           !value.customValidation.regularExpression.test(this.cliOptions[key])
         ) {
-          throw new ServerlessError(value.customValidation.errorMessage);
+          throw new ServerlessError(value.customValidation.errorMessage, 'INVALID_CLI_OPTION');
         }
       });
     }

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -256,14 +256,20 @@ class Service {
     if (functionName in this.functions) {
       return this.functions[functionName];
     }
-    throw new ServerlessError(`Function "${functionName}" doesn't exist in this Service`);
+    throw new ServerlessError(
+      `Function "${functionName}" doesn't exist in this Service`,
+      'FUNCTION_MISSING_IN_SERVICE'
+    );
   }
 
   getLayer(layerName) {
     if (layerName in this.layers) {
       return this.layers[layerName];
     }
-    throw new ServerlessError(`Layer "${layerName}" doesn't exist in this Service`);
+    throw new ServerlessError(
+      `Layer "${layerName}" doesn't exist in this Service`,
+      'LAYER_MISSING_IN_SERVICE'
+    );
   }
 
   getEventInFunction(eventName, functionName) {
@@ -273,7 +279,10 @@ class Service {
     if (event) {
       return event;
     }
-    throw new ServerlessError(`Event "${eventName}" doesn't exist in function "${functionName}"`);
+    throw new ServerlessError(
+      `Event "${eventName}" doesn't exist in function "${functionName}"`,
+      'EVENT_MISSING_FOR_FUNCTION'
+    );
   }
 
   getAllEventsInFunction(functionName) {

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -451,7 +451,7 @@ class Variables {
         ` a string for variable ${matchedString}.`,
         ' Please make sure the value of the property is a string.',
       ].join('');
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'INVALID_NON_STRING_PROPERTY');
     }
     return property;
   }
@@ -565,7 +565,9 @@ class Variables {
           ' You can only reference env vars, options, & files.',
           ' You can check our docs for more info.',
         ].join('');
-        ret = BbPromise.reject(new ServerlessError(errorMessage));
+        ret = BbPromise.reject(
+          new ServerlessError(errorMessage, 'INVALID_VARIABLE_REFERENCE_SYNTAX')
+        );
       }
       ret = this.tracker.add(variableString, ret, propertyString);
     }
@@ -708,7 +710,9 @@ class Variables {
                 ` file "${referencedFileRelativePath}".`,
                 ' Check if your javascript is returning the correct data.',
               ].join('');
-              return BbPromise.reject(new ServerlessError(errorMessage));
+              return BbPromise.reject(
+                new ServerlessError(errorMessage, 'INVALID_FILE_VARIABLE_SYNTAX')
+              );
             }
             return BbPromise.resolve(deepValueToPopulateResolved);
           }
@@ -727,7 +731,9 @@ class Variables {
             ` file "${referencedFileRelativePath}" sub properties`,
             ' Please use ":" to reference sub properties.',
           ].join('');
-          return BbPromise.reject(new ServerlessError(errorMessage));
+          return BbPromise.reject(
+            new ServerlessError(errorMessage, 'INVALID_FILE_VARIABLE_SYNTAX')
+          );
         }
         deepProperties = deepProperties.slice(1).split('.');
         return this.getDeeperValue(deepProperties, valueToPopulate);
@@ -767,7 +773,7 @@ class Variables {
             ` Stack name: "${stackName}"`,
             ` Requested variable: "${outputLogicalId}".`,
           ].join('');
-          return BbPromise.reject(new ServerlessError(errorMessage));
+          return BbPromise.reject(new ServerlessError(errorMessage, 'INVALID_CF_VARIABLE'));
         }
         return BbPromise.resolve(output.OutputValue);
       });
@@ -791,7 +797,7 @@ class Variables {
       .then((response) => BbPromise.resolve(response.Body.toString()))
       .catch((err) => {
         const errorMessage = `Error getting value for ${variableString}. ${err.message}`;
-        return BbPromise.reject(new ServerlessError(errorMessage));
+        return BbPromise.reject(new ServerlessError(errorMessage, 'INVALID_S3_VARIABLE'));
       });
   }
 
@@ -836,7 +842,7 @@ class Variables {
         },
         (err) => {
           if (!err.providerError || err.providerError.statusCode !== 400) {
-            throw new ServerlessError(err.message);
+            throw new ServerlessError(err.message, 'INVALID_SSM_VARIABLE');
           }
         }
       );
@@ -855,7 +861,8 @@ class Variables {
           return true;
         }
         throw new ServerlessError(
-          'Unexpected strToBool input; expected either "true", "false", "0", or "1".'
+          'Unexpected strToBool input; expected either "true", "false", "0", or "1".',
+          'INVALID_STR_TO_BOOL_SOURCE_VALUE'
         );
       }
       // Cast non-string inputs

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -451,7 +451,7 @@ class Variables {
         ` a string for variable ${matchedString}.`,
         ' Please make sure the value of the property is a string.',
       ].join('');
-      throw new ServerlessError(errorMessage, 'INVALID_NON_STRING_PROPERTY');
+      throw new ServerlessError(errorMessage, 'INVALID_NON_STRING_VARIABLE_RESOLUTION_RESULT');
     }
     return property;
   }

--- a/lib/configuration/read.js
+++ b/lib/configuration/read.js
@@ -37,7 +37,7 @@ const resolveTsNode = async (serviceDir) => {
         return require.resolve(`${String(stdoutBuffer).trim()}/ts-node`);
       } catch (globalDepError) {
         if (globalDepError.code !== 'MODULE_NOT_FOUND') throw globalDepError;
-        throw new ServerlessError('"ts-node" not found');
+        throw new ServerlessError('"ts-node" not found', 'TS_NODE_NOT_FOUND');
       }
     }
   }

--- a/lib/configuration/resolve-provider-name.js
+++ b/lib/configuration/resolve-provider-name.js
@@ -12,6 +12,7 @@ module.exports = (configuration) => {
       {
         Error: ServerlessError,
         errorMessage: 'Invalid service configuration: "provider.name" property is missing',
+        errorCode: 'INVALID_CONFIGURATION_PROVIDER_NAME_MISSING',
       }
     );
   } catch (error) {

--- a/lib/configuration/variables/sources/env.js
+++ b/lib/configuration/variables/sources/env.js
@@ -14,7 +14,7 @@ module.exports = {
     address = ensureString(address, {
       Error: ServerlessError,
       errorMessage: 'Non-string address argument in variable "env" source: %v',
-      errorCode: 'INVALID_ENV_SOURCE_ADDRESS_ARGUMENT',
+      errorCode: 'INVALID_ENV_SOURCE_ADDRESS',
     });
 
     return { value: process.env[address] || null, isPending: !isSourceFulfilled };

--- a/lib/configuration/variables/sources/env.js
+++ b/lib/configuration/variables/sources/env.js
@@ -14,6 +14,7 @@ module.exports = {
     address = ensureString(address, {
       Error: ServerlessError,
       errorMessage: 'Non-string address argument in variable "env" source: %v',
+      errorCode: 'INVALID_ENV_SOURCE_ADDRESS_ARGUMENT',
     });
 
     return { value: process.env[address] || null, isPending: !isSourceFulfilled };

--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -33,6 +33,7 @@ module.exports = {
       ensureString(params[0], {
         Error: ServerlessError,
         errorMessage: 'Non-string path argument in variable "file" source: %v',
+        errorCode: 'INVALID_FILE_SOURCE_PATH_ARGUMENT',
       })
     );
     if (!filePath.startsWith(`${serviceDir}${path.sep}`)) {
@@ -45,6 +46,7 @@ module.exports = {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument for variable "file" source: %v',
+        errorCode: 'INVALID_FILE_SOURCE_ADDRESS_ARGUMENT',
       });
     }
 

--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -46,7 +46,7 @@ module.exports = {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument for variable "file" source: %v',
-        errorCode: 'INVALID_FILE_SOURCE_ADDRESS_ARGUMENT',
+        errorCode: 'INVALID_FILE_SOURCE_ADDRESS',
       });
     }
 

--- a/lib/configuration/variables/sources/instance-dependent/get-cf.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-cf.js
@@ -17,6 +17,7 @@ module.exports = (serverlessInstance) => {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument in variable "cf" source: %v',
+        errorCode: 'INVALID_CF_SOURCE_ADDRESS_ARGUMENT',
       });
       const separatorIndex = address.indexOf('.');
       if (separatorIndex === -1) {

--- a/lib/configuration/variables/sources/instance-dependent/get-cf.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-cf.js
@@ -17,7 +17,7 @@ module.exports = (serverlessInstance) => {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument in variable "cf" source: %v',
-        errorCode: 'INVALID_CF_SOURCE_ADDRESS_ARGUMENT',
+        errorCode: 'INVALID_CF_SOURCE_ADDRESS',
       });
       const separatorIndex = address.indexOf('.');
       if (separatorIndex === -1) {

--- a/lib/configuration/variables/sources/instance-dependent/get-s3.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-s3.js
@@ -16,7 +16,7 @@ module.exports = (serverlessInstance) => {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument in variable "s3" source: %v',
-        errorCode: 'INVALID_S3_SOURCE_ADDRESS_ARGUMENT',
+        errorCode: 'INVALID_S3_SOURCE_ADDRESS',
       });
       const separatorIndex = address.indexOf('/');
       if (separatorIndex === -1) {

--- a/lib/configuration/variables/sources/instance-dependent/get-s3.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-s3.js
@@ -16,6 +16,7 @@ module.exports = (serverlessInstance) => {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument in variable "s3" source: %v',
+        errorCode: 'INVALID_S3_SOURCE_ADDRESS_ARGUMENT',
       });
       const separatorIndex = address.indexOf('/');
       if (separatorIndex === -1) {

--- a/lib/configuration/variables/sources/instance-dependent/get-sls.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-sls.js
@@ -15,6 +15,7 @@ module.exports = (serverlessInstance) => {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument in variable "sls" source: %v',
+        errorCode: 'INVALID_SLS_SOURCE_ADDRESS_ARGUMENT',
       });
 
       switch (address) {

--- a/lib/configuration/variables/sources/instance-dependent/get-sls.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-sls.js
@@ -15,7 +15,7 @@ module.exports = (serverlessInstance) => {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument in variable "sls" source: %v',
-        errorCode: 'INVALID_SLS_SOURCE_ADDRESS_ARGUMENT',
+        errorCode: 'INVALID_SLS_SOURCE_ADDRESS',
       });
 
       switch (address) {

--- a/lib/configuration/variables/sources/instance-dependent/get-ssm.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-ssm.js
@@ -19,7 +19,7 @@ module.exports = (serverlessInstance) => {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument in variable "ssm" source: %v',
-        errorCode: 'INVALID_SSM_SOURCE_ADDRESS_ARGUMENT',
+        errorCode: 'INVALID_SSM_SOURCE_ADDRESS',
       });
       const region = !params || !params[0] || params[0] === 'raw' ? undefined : params[0];
       const shouldReturnRawValue = params && (params[0] === 'raw' || params[1] === 'raw');

--- a/lib/configuration/variables/sources/instance-dependent/get-ssm.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-ssm.js
@@ -19,6 +19,7 @@ module.exports = (serverlessInstance) => {
       address = ensureString(address, {
         Error: ServerlessError,
         errorMessage: 'Non-string address argument in variable "ssm" source: %v',
+        errorCode: 'INVALID_SSM_SOURCE_ADDRESS_ARGUMENT',
       });
       const region = !params || !params[0] || params[0] === 'raw' ? undefined : params[0];
       const shouldReturnRawValue = params && (params[0] === 'raw' || params[1] === 'raw');

--- a/lib/configuration/variables/sources/opt.js
+++ b/lib/configuration/variables/sources/opt.js
@@ -9,7 +9,7 @@ module.exports = {
       isOptional: true,
       Error: ServerlessError,
       errorMessage: 'Non-string address argument in variable "opt" source: %v',
-      errorCode: 'INVALID_OPT_SOURCE_ADDRESS_ARGUMENT',
+      errorCode: 'INVALID_OPT_SOURCE_ADDRESS',
     });
     if (!isSourceFulfilled) {
       if (address == null) return { value: null, isPending: true };

--- a/lib/configuration/variables/sources/opt.js
+++ b/lib/configuration/variables/sources/opt.js
@@ -9,6 +9,7 @@ module.exports = {
       isOptional: true,
       Error: ServerlessError,
       errorMessage: 'Non-string address argument in variable "opt" source: %v',
+      errorCode: 'INVALID_OPT_SOURCE_ADDRESS_ARGUMENT',
     });
     if (!isSourceFulfilled) {
       if (address == null) return { value: null, isPending: true };

--- a/lib/configuration/variables/sources/str-to-bool.js
+++ b/lib/configuration/variables/sources/str-to-bool.js
@@ -15,6 +15,7 @@ module.exports = {
     const stringValue = ensureString(params[0], {
       Error: ServerlessError,
       errorMessage: 'Non-string "strToBool" input:. Received: %v',
+      errorCode: 'INVALID_STR_TO_BOOL_SOURCE_VALUE',
     }).trim();
 
     if (trueStrings.has(stringValue)) return { value: true };

--- a/lib/plugins/aws/configCredentials.js
+++ b/lib/plugins/aws/configCredentials.js
@@ -24,7 +24,10 @@ class AwsConfigCredentials {
     };
 
     if (!os.homedir()) {
-      throw new ServerlessError("Can't find home directory on your local file system.");
+      throw new ServerlessError(
+        "Can't find home directory on your local file system.",
+        'MISSING_HOME_DIRECTORY'
+      );
     }
 
     this.hooks = {
@@ -42,7 +45,10 @@ class AwsConfigCredentials {
 
     // validate
     if (!this.options.key || !this.options.secret) {
-      throw new ServerlessError('Please include --key and --secret options for AWS.');
+      throw new ServerlessError(
+        'Please include --key and --secret options for AWS.',
+        'MISSING_KEY_AND_SECRET_CLI_OPTIONS'
+      );
     }
 
     this.serverless.cli.log('Setting up AWS...');

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -50,7 +50,10 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
     Handler = 'apiGatewayCloudWatchRole/handler.handler';
     customResourceFunctionLogicalId = awsProvider.naming.getCustomResourceApiGatewayAccountCloudWatchRoleHandlerFunctionLogicalId();
   } else {
-    throw new ServerlessError(`No implementation found for Custom Resource "${resourceName}"`);
+    throw new ServerlessError(
+      `No implementation found for Custom Resource "${resourceName}"`,
+      'MISSING_CUSTOM_RESOURCE_IMPLEMENTATION'
+    );
   }
   absoluteFunctionName = `${funcPrefix}-${functionName}`;
   if (absoluteFunctionName.length > 64) {

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -59,7 +59,8 @@ module.exports = {
               `The serverless deployment bucket "${params.Bucket}" does not exist.`,
               `Create it manually if you want to reuse the CloudFormation stack "${stackName}",`,
               'or delete the stack if it is no longer required.',
-            ].join(' ')
+            ].join(' '),
+            'DEPLOYMENT_BUCKET_DOES_NOT_EXIST'
           )
         );
       })

--- a/lib/plugins/aws/deploy/lib/existsDeploymentBucket.js
+++ b/lib/plugins/aws/deploy/lib/existsDeploymentBucket.js
@@ -17,13 +17,17 @@ module.exports = {
         if (result.LocationConstraint === 'EU') result.LocationConstraint = 'eu-west-1';
         if (result.LocationConstraint !== this.provider.getRegion()) {
           throw new ServerlessError(
-            'Deployment bucket is not in the same region as the lambda function'
+            'Deployment bucket is not in the same region as the lambda function',
+            'DEPLOYMENT_BUCKET_INVALID_REGION'
           );
         }
         return BbPromise.resolve();
       })
       .catch((err) => {
-        throw new ServerlessError(`Could not locate deployment bucket. Error: ${err.message}`);
+        throw new ServerlessError(
+          `Could not locate deployment bucket. Error: ${err.message}`,
+          'DEPLOYMENT_BUCKET_NOT_FOUND'
+        );
       });
   },
 };

--- a/lib/plugins/aws/deploy/lib/extendedValidate.js
+++ b/lib/plugins/aws/deploy/lib/extendedValidate.js
@@ -16,7 +16,8 @@ module.exports = {
     );
     if (!this.serverless.utils.fileExistsSync(serviceStateFilePath)) {
       throw new ServerlessError(
-        `No ${serviceStateFileName} file found in the package path you provided.`
+        `No ${serviceStateFileName} file found in the package path you provided.`,
+        'MISSING_SERVICE_STATE_FILE'
       );
     }
     const state = this.serverless.utils.readFileSync(serviceStateFilePath);
@@ -86,7 +87,8 @@ module.exports = {
 
         if (!this.serverless.utils.fileExistsSync(artifactFilePath)) {
           throw new ServerlessError(
-            `No ${artifactFileName} file found in the package path you provided.`
+            `No ${artifactFileName} file found in the package path you provided.`,
+            'MISSING_ARTIFACT_FILE'
           );
         }
       });

--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -78,7 +78,7 @@ class AwsDeployFunction {
             ' After that you can redeploy your services functions with the',
             ' "serverless deploy function" command.',
           ].join('');
-          throw new ServerlessError(errorMessage);
+          throw new ServerlessError(errorMessage, 'FUNCTION_NOT_YET_DEPLOYED');
         }
         throw error;
       }
@@ -120,7 +120,10 @@ class AwsDeployFunction {
       }
       const roleProperties = roleResource.Properties;
       if (!roleProperties.RoleName) {
-        throw new ServerlessError('Role resource missing RoleName property');
+        throw new ServerlessError(
+          'Role resource missing RoleName property',
+          'MISSING_ROLENAME_FOR_ROLE'
+        );
       }
       const compiledFullRoleName = `${roleProperties.Path || '/'}${roleProperties.RoleName}`;
 
@@ -146,7 +149,8 @@ class AwsDeployFunction {
         if (err.providerError && err.providerError.code === 'ResourceConflictException') {
           if (didOneMinutePass) {
             throw new ServerlessError(
-              'Retry timed out. Please try to deploy your function once again.'
+              'Retry timed out. Please try to deploy your function once again.',
+              'DEPLOY_FUNCTION_CONFIGURATION_UPDATE_TIMED_OUT'
             );
           }
           this.serverless.cli.log(
@@ -258,7 +262,7 @@ class AwsDeployFunction {
           // taken from the bash man pages
           if (!key.match(/^[A-Za-z_][a-zA-Z0-9_]*$/)) {
             const errorMessage = 'Invalid characters in environment variable';
-            throw new ServerlessError(errorMessage);
+            throw new ServerlessError(errorMessage, 'DEPLOY_FUNCTION_INVALID_ENV_VARIABLE');
           }
 
           if (params.Environment.Variables[key] != null) {

--- a/lib/plugins/aws/info/getStackInfo.js
+++ b/lib/plugins/aws/info/getStackInfo.js
@@ -47,7 +47,8 @@ module.exports = {
             },
             (error) => {
               throw new ServerlessError(
-                `Could not resolve provider.httpApi.id parameter. ${error.message}`
+                `Could not resolve provider.httpApi.id parameter. ${error.message}`,
+                'UNABLE_TO_RESOLVE_HTTP_API_ID'
               );
             }
           )

--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -67,7 +67,10 @@ class AwsInvokeLocal {
     const exists = await fileExists(absolutePath);
 
     if (!exists) {
-      throw new ServerlessError(`The file you provided does not exist: ${absolutePath}`);
+      throw new ServerlessError(
+        `The file you provided does not exist: ${absolutePath}`,
+        'INVOKE_LOCAL_MISSING_FILE'
+      );
     }
     if (absolutePath.endsWith('.js')) {
       // to support js - export as an input data
@@ -86,7 +89,8 @@ class AwsInvokeLocal {
 
     if (this.options.functionObj.image) {
       throw new ServerlessError(
-        'Local invocation of lambdas pointing AWS ECR images is not supported'
+        'Local invocation of lambdas pointing AWS ECR images is not supported',
+        'INVOKE_LOCAL_IMAGE_BACKED_FUNCTIONS_NOT_SUPPORTED'
       );
     }
     if (this.options.contextPath) {
@@ -198,7 +202,8 @@ class AwsInvokeLocal {
           }
         } catch (error) {
           throw new ServerlessError(
-            `Could not resolve "${name}" environment variable: ${error.message}`
+            `Could not resolve "${name}" environment variable: ${error.message}`,
+            'INVOKE_LOCAL_INVALID_ENV_VARIABLE'
           );
         }
       })

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -91,7 +91,7 @@ module.exports = {
                 let errorMessage = 'An error occurred: ';
                 errorMessage += `${stackLatestError.LogicalResourceId} - `;
                 errorMessage += `${stackLatestError.ResourceStatusReason}.`;
-                throw new ServerlessError(errorMessage);
+                throw new ServerlessError(errorMessage, 'STACK_MONITORING_FAILURE');
               }
             },
             (e) => {
@@ -102,7 +102,7 @@ module.exports = {
                 stackStatus = 'DELETE_COMPLETE';
                 return;
               }
-              throw new ServerlessError(e.message);
+              throw new ServerlessError(e.message, 'STACK_MONITORING_FAILURE');
             }
           )
       )

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -91,7 +91,7 @@ module.exports = {
                 let errorMessage = 'An error occurred: ';
                 errorMessage += `${stackLatestError.LogicalResourceId} - `;
                 errorMessage += `${stackLatestError.ResourceStatusReason}.`;
-                throw new ServerlessError(errorMessage, 'STACK_MONITORING_FAILURE');
+                throw new ServerlessError(errorMessage, 'STACK_OPERATION_FAILURE');
               }
             },
             (e) => {
@@ -102,7 +102,7 @@ module.exports = {
                 stackStatus = 'DELETE_COMPLETE';
                 return;
               }
-              throw new ServerlessError(e.message, 'STACK_MONITORING_FAILURE');
+              throw new ServerlessError(e.message, 'STACK_OPERATION_FAILURE');
             }
           )
       )

--- a/lib/plugins/aws/lib/validate.js
+++ b/lib/plugins/aws/lib/validate.js
@@ -5,7 +5,10 @@ const ServerlessError = require('../../../serverless-error');
 module.exports = {
   validate() {
     if (!this.serverless.serviceDir) {
-      throw new ServerlessError('This command can only be run inside a service directory');
+      throw new ServerlessError(
+        'This command can only be run inside a service directory',
+        'MISSING_SERVICE_DIRECTORY'
+      );
     }
 
     this.options.stage = this.provider.getStage();

--- a/lib/plugins/aws/logs.js
+++ b/lib/plugins/aws/logs.js
@@ -47,7 +47,7 @@ class AwsLogs {
 
     const reply = await this.provider.request('CloudWatchLogs', 'describeLogStreams', params);
     if (!reply || reply.logStreams.length === 0) {
-      throw new ServerlessError('No existing streams for the function');
+      throw new ServerlessError('No existing streams for the function', 'NO_EXISTING_LOG_STREAMS');
     }
 
     return reply.logStreams.map((logStream) => logStream.logStreamName);

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -115,7 +115,10 @@ module.exports = {
     }
     const matches = listenerArn.match(this.ALB_LISTENER_REGEXP);
     if (!matches) {
-      throw new ServerlessError(`Invalid ALB listenerArn in function "${functionName}".`);
+      throw new ServerlessError(
+        `Invalid ALB listenerArn in function "${functionName}".`,
+        'ALB_INVALID_LISTENER_ARN'
+      );
     }
     return { albId: matches[1], listenerId: matches[2] };
   },
@@ -138,7 +141,7 @@ module.exports = {
         '  Events in the same function cannot use the same priority even if they have a different listenerArn.\n',
         '  This is a Serverless limitation that will be fixed in the next major release.',
       ].join('');
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'ALB_PRIORITY_ALREADY_IN_USE');
     }
 
     comparator = (e1, e2) => samePriority(e1, e2) && sameListener(e1, e2) && !sameFunction(e1, e2);
@@ -148,7 +151,7 @@ module.exports = {
         `ALB event in function "${duplicates[0].functionName}"`,
         ` cannot use priority "${duplicates[0].priority}" because it is already in use.`,
       ].join('');
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'ALB_PRIORITY_ALREADY_IN_USE');
     }
   },
 
@@ -159,7 +162,8 @@ module.exports = {
     for (const auth of eventAuthorizers) {
       if (!authorizers[auth]) {
         throw new ServerlessError(
-          `No match for "${auth}" in function "${functionName}" found in registered ALB authorizers`
+          `No match for "${auth}" in function "${functionName}" found in registered ALB authorizers`,
+          'ALB_MISSING_AUTHORIZER'
         );
       }
     }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -81,7 +81,7 @@ module.exports = {
               "that there's a way to support your setup).",
             ].join('');
 
-            throw new ServerlessError(errorMessage);
+            throw new ServerlessError(errorMessage, 'API_GATEWAY_REST_API_ID_NOT_RESOLVED');
           }
           return resolveStage
             .call(this)

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -28,7 +28,10 @@ module.exports = {
         vpcEndpointIds = this.serverless.service.provider.vpcEndpointIds;
 
         if (endpointType !== 'PRIVATE') {
-          throw new ServerlessError('VPC endpoint IDs are only available for private APIs');
+          throw new ServerlessError(
+            'VPC endpoint IDs are only available for private APIs',
+            'API_GATEWAY_INVALID_VPC_ENDPOINT_IDS_CONFIG'
+          );
         }
       }
     }

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.js
@@ -42,7 +42,10 @@ module.exports = {
           !usagePlansIncludeName &&
           _.isObject(value)
         ) {
-          throw new ServerlessError(`API key "${name}" has no usage plan defined`);
+          throw new ServerlessError(
+            `API key "${name}" has no usage plan defined`,
+            'API_GATEWAY_KEY_WITHOUT_USAGE_PLAN'
+          );
         }
         if (_.isObject(apiKeyDefinition) && usagePlansIncludeName) {
           keyNumber = 0;

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -83,7 +83,7 @@ module.exports = {
               const errorMessage = [
                 `You need to set the request uri when using the ${http.integration} integration.`,
               ];
-              throw new ServerlessError(errorMessage);
+              throw new ServerlessError(errorMessage, 'API_GATEWAY_MISSING_REQUEST_URI');
             }
 
             http.connectionType = this.getConnectionType(http);
@@ -92,7 +92,7 @@ module.exports = {
               const errorMessage = [
                 `You need to set connectionId when using ${http.connectionType} connectionType.`,
               ];
-              throw new ServerlessError(errorMessage);
+              throw new ServerlessError(errorMessage, 'API_GATEWAY_MISSING_CONNECTION_ID');
             }
           }
 
@@ -158,7 +158,8 @@ module.exports = {
                 `Invalid stage name ${stage}:`,
                 'it should contains only [-_a-zA-Z0-9] for AWS provider if http event are present',
                 'according to API Gateway limitation.',
-              ].join(' ')
+              ].join(' '),
+              'API_GATEWAY_INVALID_STAGE_NAME'
             );
           }
 
@@ -235,7 +236,8 @@ module.exports = {
           _.isObject(authorizer.arn)
         ) {
           throw new ServerlessError(
-            'Please provide an authorizer name for authorizers of type COGNITO_USER_POOLS'
+            'Please provide an authorizer name for authorizers of type COGNITO_USER_POOLS',
+            'API_GATEWAY_MISSING_AUTHORIZER_NAME'
           );
         } else {
           name = this.provider.naming.extractAuthorizerNameFromArn(arn);
@@ -243,7 +245,10 @@ module.exports = {
       } else if (authorizer.name) {
         authorizerFunctionName = name = authorizer.name;
       } else {
-        throw new ServerlessError('Please provide either an authorizer name or ARN');
+        throw new ServerlessError(
+          'Please provide either an authorizer name or ARN',
+          'API_GATEWAY_MISSING_AUTHORIZER_NAME_OR_ARN'
+        );
       }
 
       if (!type) {
@@ -289,7 +294,7 @@ module.exports = {
       const errorMessage = [
         'Cognito claims can only be filtered when using the lambda integration type',
       ];
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'API_GATEWAY_INVALID_COGNITO_CLAIMS');
     }
 
     return {

--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -416,7 +416,8 @@ class AwsCompileCloudFrontEvents {
             if (event.cloudFront.isDefaultOrigin) {
               if (defaultOrigin && defaultOrigin !== origin) {
                 throw new ServerlessError(
-                  'Found more than one cloudfront event with "isDefaultOrigin" defined'
+                  'Found more than one cloudfront event with "isDefaultOrigin" defined',
+                  'CLOUDFRONT_MULTIPLE_DEFAULT_ORIGIN_EVENTS'
                 );
               }
               defaultOrigin = origin;
@@ -534,13 +535,17 @@ class AwsCompileCloudFrontEvents {
     if (lambdaAtEdgeFunctions.length) {
       if (this.provider.getRegion() !== 'us-east-1') {
         throw new ServerlessError(
-          'CloudFront associated functions have to be deployed to the us-east-1 region.'
+          'CloudFront associated functions have to be deployed to the us-east-1 region.',
+          'CLOUDFRONT_INVALID_REGION'
         );
       }
 
       // Check if all behaviors got unique pathPatterns
       if (behaviors.length !== _.uniqBy(behaviors, 'PathPattern').length) {
-        throw new ServerlessError('Found more than one behavior with the same PathPattern');
+        throw new ServerlessError(
+          'Found more than one behavior with the same PathPattern',
+          'CLOUDFRONT_MULTIPLE_BEHAVIORS_FOR_SINGLE_PATH_PATTERN'
+        );
       }
 
       // Check if all event types in every behavior is unique
@@ -553,7 +558,8 @@ class AwsCompileCloudFrontEvents {
         })
       ) {
         throw new ServerlessError(
-          'The event type of a function association must be unique in the cache behavior'
+          'The event type of a function association must be unique in the cache behavior',
+          'CLOUDFRONT_EVENT_TYPE_NON_UNIQUE_CACHE_BEHAVIOR'
         );
       }
 
@@ -563,7 +569,8 @@ class AwsCompileCloudFrontEvents {
         if (!origin) {
           if (origins.length > 1) {
             throw new ServerlessError(
-              'Found more than one origin but none of the cloudfront event has "isDefaultOrigin" defined'
+              'Found more than one origin but none of the cloudfront event has "isDefaultOrigin" defined',
+              'CLOUDFRONT_MULTIPLE_DEFAULT_ORIGIN_EVENTS'
             );
           }
           origin = origins[0];

--- a/lib/plugins/aws/package/compile/events/cloudWatchEvent.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchEvent.js
@@ -70,7 +70,8 @@ class AwsCompileCloudWatchEventEvents {
                   'You can only set one of input, inputPath, or inputTransformer ',
                   'properties at the same time for cloudwatch events. ',
                   'Please check the AWS docs for more info',
-                ].join('')
+                ].join(''),
+                'CLOUDWATCH_MULTIPLE_INPUT_PROPERTIES'
               );
             }
 

--- a/lib/plugins/aws/package/compile/events/cloudWatchLog.js
+++ b/lib/plugins/aws/package/compile/events/cloudWatchLog.js
@@ -59,7 +59,7 @@ class AwsCompileCloudWatchLogEvents {
                 `"${LogGroupName}" logGroup for cloudwatchLog event is duplicated.`,
                 ' This property can only be set once per CloudFormation stack.',
               ].join('');
-              throw new ServerlessError(errorMessage);
+              throw new ServerlessError(errorMessage, 'CLOUDWATCHLOG_DUPLICATED_LOG_GROUP_EVENT');
             }
             logGroupNames.push(LogGroupName);
             logGroupNamesThisFunction.push(LogGroupName);

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool.js
@@ -151,7 +151,7 @@ class AwsCompileCognitoUserPoolEvents {
                 'Only one Cognito User Pool can be configured per function.',
                 ` In "${FunctionName}" you're attempting to configure "${currentPoolName}" and "${pool}" at the same time.`,
               ].join('');
-              throw new ServerlessError(errorMessage);
+              throw new ServerlessError(errorMessage, 'COGNITO_MULTIPLE_USER_POOLS_PER_FUNCTION');
             }
 
             const eventFunctionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -126,7 +126,8 @@ class AwsCompileEventBridgeEvents {
                 [
                   'You can only set one of input, inputPath, or inputTransformer ',
                   'properties for eventBridge events.',
-                ].join('')
+                ].join(''),
+                'EVENTBRIDGE_MULTIPLE_INPUT_PROPERTIES'
               );
             }
 

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -102,7 +102,7 @@ class AwsCompileS3Events {
                 `${bucketName} - Bucket name must conform to pattern ${this.serverless.configSchemaHandler.schema.definitions.awsS3BucketName.pattern}.`,
                 `Please check provider.s3.${bucketRef} and/or s3 events of function "${functionName}".`,
               ].join(' ');
-              throw new ServerlessError(errorMessage);
+              throw new ServerlessError(errorMessage, 'S3_INVALID_BUCKET_PATTERN');
             }
 
             if (bucketsLambdaConfigurations[bucketName]) {
@@ -282,7 +282,7 @@ class AwsCompileS3Events {
                 'Only one S3 Bucket can be configured per function.',
                 ` In "${FunctionName}" you're attempting to configure "${currentBucketName}" and "${bucket}" at the same time.`,
               ].join('');
-              throw new ServerlessError(errorMessage);
+              throw new ServerlessError(errorMessage, 'S3_MULTIPLE_BUCKETS_PER_FUNCTION');
             }
 
             rules = (event.s3.rules || []).map((rule) => {

--- a/lib/plugins/aws/package/compile/events/sns.js
+++ b/lib/plugins/aws/package/compile/events/sns.js
@@ -87,7 +87,8 @@ class AwsCompileSNSEvents {
                 // Only true when providing CFN intrinsic function (not string) to arn property without topicName property
                 if (!topicName) {
                   throw new ServerlessError(
-                    'Missing "sns.topicName" setting (it needs to be provided if "sns.arn" is not provided as plain ARN string)'
+                    'Missing "sns.topicName" setting (it needs to be provided if "sns.arn" is not provided as plain ARN string)',
+                    'SNS_MISSING_TOPIC_NAME'
                   );
                 }
               } else {

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -46,7 +46,8 @@ module.exports = {
           throw new ServerlessError(
             `provider.logs.websocket.level is set to an invalid value. Support values are ${Array.from(
               validLogLevels
-            ).join(', ')}, got ${level}.`
+            ).join(', ')}, got ${level}.`,
+            'WEBSOCKETS_INVALID_LOGS_LEVEL'
           );
         }
       }

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
@@ -82,7 +82,8 @@ module.exports = {
                 if (_.isObject(event.websocket.authorizer.arn)) {
                   if (!event.websocket.authorizer.name) {
                     throw new ServerlessError(
-                      'Websocket Authorizer: Non-string "arn" needs to be accompanied with "name"'
+                      'Websocket Authorizer: Non-string "arn" needs to be accompanied with "name"',
+                      'WEBSOCKETS_MISSING_AUTHORIZER_NAME'
                     );
                   }
                   websocketObj.authorizer.name = event.websocket.authorizer.name;

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -148,12 +148,14 @@ class AwsCompileFunctions {
 
     if (!functionObject.handler && !functionObject.image) {
       throw new ServerlessError(
-        `Either "handler" or "image" property needs to be set on function "${functionName}"`
+        `Either "handler" or "image" property needs to be set on function "${functionName}"`,
+        'FUNCTION_NEITHER_HANDLER_NOR_IMAGE_DEFINED_ERROR'
       );
     }
     if (functionObject.handler && functionObject.image) {
       throw new ServerlessError(
-        `Either "handler" or "image" property (not both) needs to be set on function "${functionName}".`
+        `Either "handler" or "image" property (not both) needs to be set on function "${functionName}".`,
+        'FUNCTION_BOTH_HANDLER_AND_IMAGE_DEFINED_ERROR'
       );
     }
 
@@ -634,7 +636,10 @@ class AwsCompileFunctions {
       if (functionAddress.includes(':sqs:')) return 'sqs:SendMessage';
       if (functionAddress.includes(':sns:')) return 'sns:Publish';
       if (functionAddress.includes(':event-bus/')) return 'events:PutEvents';
-      throw new ServerlessError(`Unsupported destination target ${functionAddress}`);
+      throw new ServerlessError(
+        `Unsupported destination target ${functionAddress}`,
+        'UNSUPPORTED_DESTINATION_TARGET'
+      );
     })();
     iamPolicyStatements.push({
       Effect: 'Allow',

--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -75,7 +75,7 @@ module.exports = {
       const errorMessage = [
         'You cannot enable and disable S3 Transfer Acceleration at the same time',
       ].join('');
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'S3_ACCELERATION_ENABLED_AND_DISABLED');
     }
 
     if (bucketName) {

--- a/lib/plugins/aws/utils/resolveCfImportValue.js
+++ b/lib/plugins/aws/utils/resolveCfImportValue.js
@@ -11,7 +11,8 @@ function resolveCfImportValue(provider, name, sdkParams = {}) {
     }
 
     throw new ServerlessError(
-      `Could not resolve Fn::ImportValue with name ${name}. Are you sure this value is exported ?`
+      `Could not resolve Fn::ImportValue with name ${name}. Are you sure this value is exported ?`,
+      'CF_IMPORT_RESOLUTION'
     );
   });
 }

--- a/lib/plugins/aws/utils/resolveCfRefValue.js
+++ b/lib/plugins/aws/utils/resolveCfRefValue.js
@@ -19,7 +19,8 @@ function resolveCfRefValue(provider, resourceLogicalId, sdkParams = {}) {
       }
 
       throw new ServerlessError(
-        `Could not resolve Ref with name ${resourceLogicalId}. Are you sure this value matches one resource logical ID ?`
+        `Could not resolve Ref with name ${resourceLogicalId}. Are you sure this value matches one resource logical ID ?`,
+        'CF_REF_RESOLUTION'
       );
     });
 }

--- a/lib/plugins/config.js
+++ b/lib/plugins/config.js
@@ -69,7 +69,7 @@ class Config {
         `Provider "${provider}" is not supported.`,
         ` Supported providers are: ${humanReadableProvidersList}.`,
       ].join('');
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'INVALID_PROVIDER');
     }
   }
 
@@ -84,19 +84,20 @@ class Config {
         return;
       }
       if (this.serverless.isLocallyInstalled) {
-        throw new ServerlessError(noSupportErrorMessage);
+        throw new ServerlessError(noSupportErrorMessage, 'AUTO_UPDATE_NOT_SUPPORTED');
       }
       if (this.serverless.isStandaloneExecutable) {
         if (process.platform === 'win32') {
-          throw new ServerlessError(noSupportErrorMessage);
+          throw new ServerlessError(noSupportErrorMessage, 'AUTO_UPDATE_NOT_SUPPORTED');
         }
       } else {
         if (!(await isNpmGlobalPackage())) {
-          throw new ServerlessError(noSupportErrorMessage);
+          throw new ServerlessError(noSupportErrorMessage, 'AUTO_UPDATE_NOT_SUPPORTED');
         }
         if (!(await isNpmPackageWritable(this.serverless))) {
           throw new ServerlessError(
-            'Auto update cannot be set, due to missing write access to npm global installation'
+            'Auto update cannot be set, due to missing write access to npm global installation',
+            'AUTO_UPDATE_NOT_SET_MISSING_WRITE_ACCESS'
           );
         }
       }
@@ -123,7 +124,8 @@ class Config {
 
       if (!validShells.has(shell)) {
         throw new ServerlessError(
-          `Shell "${shell}" is not supported. Supported shells: ${Array.from(validShells)}.`
+          `Shell "${shell}" is not supported. Supported shells: ${Array.from(validShells)}.`,
+          'TABCOMPLETION_INVALID_SHELL_ARGUMENT'
         );
       }
       const location = (() => {

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -22,7 +22,7 @@ const handleServiceCreationError = (error) => {
     'Please check that you have the required permissions to write to the directory',
   ].join('');
 
-  throw new ServerlessError(errorMessage);
+  throw new ServerlessError(errorMessage, 'UNABLE_TO_CREATE_SERVICE');
 };
 
 class Create {
@@ -66,7 +66,7 @@ class Create {
           this.serverless.cli.log(message);
         })
         .catch((err) => {
-          throw new ServerlessError(err);
+          throw new ServerlessError(err, 'BOILERPLATE_GENERATION_ERROR');
         });
     } else if ('template-path' in this.options) {
       // Copying template from a local directory
@@ -75,7 +75,7 @@ class Create {
         : path.join(process.cwd(), this.options.name);
       if (dirExistsSync(serviceDir)) {
         const errorMessage = `A folder named "${serviceDir}" already exists.`;
-        throw new ServerlessError(errorMessage);
+        throw new ServerlessError(errorMessage, 'TARGET_FOLDER_ALREADY_EXISTS');
       }
       copyDirContentsSync(untildify(this.options['template-path']), serviceDir, {
         noLinks: true,
@@ -88,7 +88,7 @@ class Create {
         'You must either pass a template name (--template), ',
         'a URL (--template-url) or a local path (--template-path).',
       ].join('');
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'MISSING_TEMPLATE_CLI_PARAM');
     }
     return BbPromise.resolve();
   }
@@ -101,7 +101,7 @@ class Create {
         `Template "${this.options.template}" is not supported.`,
         ` Supported templates are: ${humanReadableTemplatesList}.`,
       ].join('');
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'NOT_SUPPORTED_TEMPLATE');
     }
 
     // store the custom options for the service if given
@@ -125,7 +125,7 @@ class Create {
           'Rename or move the directory and try again if you want serverless to create it"',
         ].join('');
 
-        throw new ServerlessError(errorMessage);
+        throw new ServerlessError(errorMessage, 'TARGET_FOLDER_ALREADY_EXISTS');
       }
 
       this.serverless.cli.log(`Generating boilerplate in "${newPath}"`);
@@ -144,7 +144,7 @@ class Create {
             `Move the file and try again if you want serverless to write a new "${filename}"`,
           ].join('');
 
-          throw new ServerlessError(errorMessage);
+          throw new ServerlessError(errorMessage, 'TEMPLATE_FILE_ALREADY_EXISTS');
         }
       });
     }

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -33,7 +33,7 @@ class Deploy {
         const provider = this.serverless.service.provider.name;
         if (!this.serverless.getProvider(provider)) {
           const errorMessage = `The specified provider "${provider}" does not exist.`;
-          throw new ServerlessError(errorMessage);
+          throw new ServerlessError(errorMessage, 'INVALID_PROVIDER');
         }
         if (this.options.function) {
           // If the user has given a function parameter, spawn a function deploy

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -260,7 +260,7 @@ module.exports = {
         .filter((r) => r[1] === true)
         .map((r) => r[0]);
       if (filePaths.length !== 0) return filePaths;
-      throw new ServerlessError('No file matches include / exclude patterns');
+      throw new ServerlessError('No file matches include / exclude patterns', 'NO_MATCHED_FILES');
     });
   },
 };

--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -58,7 +58,7 @@ module.exports = {
    */
   zipFiles(files, zipFileName, prefix) {
     if (files.length === 0) {
-      const error = new ServerlessError('No files to package');
+      const error = new ServerlessError('No files to package', 'NO_FILES_TO_PACKAGE');
       return BbPromise.reject(error);
     }
 
@@ -117,7 +117,10 @@ module.exports = {
         filePath,
       }),
       (error) => {
-        throw new ServerlessError(`Cannot read file ${filePath} due to: ${error.message}`);
+        throw new ServerlessError(
+          `Cannot read file ${filePath} due to: ${error.message}`,
+          'CANNOT_READ_FILE'
+        );
       }
     );
   },

--- a/lib/plugins/plugin/lib/utils.js
+++ b/lib/plugins/plugin/lib/utils.js
@@ -12,7 +12,10 @@ const ServerlessError = require('../../../serverless-error');
 module.exports = {
   validate() {
     if (!this.serverless.serviceDir) {
-      throw new ServerlessError('This command can only be run inside a service directory');
+      throw new ServerlessError(
+        'This command can only be run inside a service directory',
+        'MISSING_SERVICE_DIRECTORY'
+      );
     }
 
     return BbPromise.resolve();
@@ -22,7 +25,10 @@ module.exports = {
     if (this.serverless.configurationFilename) {
       return path.resolve(this.serverless.serviceDir, this.serverless.configurationFilename);
     }
-    throw new ServerlessError('Could not find any serverless service definition file.');
+    throw new ServerlessError(
+      'Could not find any serverless service definition file.',
+      'MISSING_SERVICE_CONFIGURATION_FILE'
+    );
   },
 
   getPlugins() {

--- a/lib/plugins/print.js
+++ b/lib/plugins/print.js
@@ -100,7 +100,10 @@ class Print {
         conf = conf[step];
 
         if (!conf) {
-          throw new ServerlessError(`Path "${this.options.path}" not found`);
+          throw new ServerlessError(
+            `Path "${this.options.path}" not found`,
+            'INVALID_PATH_ARGUMENT'
+          );
         }
       }
     }
@@ -110,7 +113,7 @@ class Print {
       if (this.options.transform === 'keys') {
         conf = Object.keys(conf);
       } else {
-        throw new ServerlessError('Transform can only be "keys"');
+        throw new ServerlessError('Transform can only be "keys"', 'INVALID_TRANSFORM');
       }
     }
 
@@ -123,7 +126,10 @@ class Print {
         out = conf.join(os.EOL);
       } else {
         if (_.isObject(conf)) {
-          throw new ServerlessError('Cannot print an object as "text"');
+          throw new ServerlessError(
+            'Cannot print an object as "text"',
+            'PRINT_INVALID_OBJECT_AS_TEXT'
+          );
         }
 
         out = String(conf);
@@ -133,7 +139,7 @@ class Print {
     } else if (format === 'yaml') {
       out = yaml.dump(JSON.parse(jc.stringify(conf)), { noRefs: true });
     } else {
-      throw new ServerlessError('Format must be "yaml", "json" or "text"');
+      throw new ServerlessError('Format must be "yaml", "json" or "text"', 'PRINT_INVALID_FORMAT');
     }
 
     this.serverless.cli.consoleLog(out);

--- a/lib/plugins/standalone.js
+++ b/lib/plugins/standalone.js
@@ -57,7 +57,8 @@ module.exports = class Standalone {
           'Note: Service is safe to upgrade if no deprecations are logged during its deployment.',
           `      Check https://github.com/serverless/serverless/releases/tag/v${latestMajor}.0.0 ` +
             'for list of all breaking changes',
-        ].join('\n')
+        ].join('\n'),
+        'CANNOT_UPGRADE_MAJOR'
       );
     }
     this.serverless.cli.log('Downloading new version...');
@@ -66,7 +67,8 @@ module.exports = class Standalone {
     if (!standaloneResponse.ok) {
       throw new ServerlessError(
         'Sorry unable to `upgrade` at this point ' +
-          `(server rejected request with ${standaloneResponse.status})`
+          `(server rejected request with ${standaloneResponse.status})`,
+        'UPGRADE_ERROR'
       );
     }
     await fse.remove(BINARY_TMP_PATH);

--- a/lib/utils/downloadTemplateFromRepo.js
+++ b/lib/utils/downloadTemplateFromRepo.js
@@ -40,7 +40,7 @@ function validateUrl({ url, hostname, service, owner, repo }) {
   // validate if given url is a valid url
   if (url.hostname !== hostname || !owner || !repo) {
     const errorMessage = `The URL must be a valid ${service} URL in the following format: https://${hostname}/serverless/serverless`;
-    throw new ServerlessError(errorMessage);
+    throw new ServerlessError(errorMessage, 'INVALID_TEMPLATE_URL');
   }
 }
 
@@ -211,14 +211,14 @@ function parsePlainGitURL(url) {
 function parseRepoURL(inputUrl) {
   return new BbPromise((resolve, reject) => {
     if (!inputUrl) {
-      return reject(new ServerlessError('URL is required'));
+      return reject(new ServerlessError('URL is required', 'MISSING_TEMPLATE_URL'));
     }
 
     const url = URL.parse(inputUrl.replace(/\/$/, ''));
 
     // check if url parameter is a valid url
     if (!url.host && !url.href.startsWith('git@')) {
-      return reject(new ServerlessError('The URL you passed is not valid'));
+      return reject(new ServerlessError('The URL you passed is not valid', 'INVALID_TEMPLATE_URL'));
     }
 
     if (isPlainGitURL(url.href)) {
@@ -233,7 +233,7 @@ function parseRepoURL(inputUrl) {
 
     const msg =
       'The URL you passed is not one of the valid providers: "GitHub", "GitHub Entreprise", "Bitbucket", "Bitbucket Server" or "GitLab".';
-    const err = new ServerlessError(msg);
+    const err = new ServerlessError(msg, 'INVALID_TEMPLATE_PROVIDER');
     // test if it's a private bitbucket server
     return retrieveBitbucketServerInfo(url)
       .then((isBitbucket) => {
@@ -277,7 +277,7 @@ function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
 
     if (dirExistsSync(path.join(process.cwd(), dirName))) {
       const errorMessage = `A folder named "${dirName}" already exists.`;
-      throw new ServerlessError(errorMessage);
+      throw new ServerlessError(errorMessage, 'TARGET_FOLDER_ALREADY_EXISTS');
     }
 
     log(`Downloading and installing "${serviceName}"...`);

--- a/lib/utils/renameService.js
+++ b/lib/utils/renameService.js
@@ -57,7 +57,7 @@ function renameService(name, serviceDir) {
   }
 
   const errorMessage = ['serverless.yml or serverlss.ts not found in', ` ${serviceDir}`].join('');
-  throw new ServerlessError(errorMessage);
+  throw new ServerlessError(errorMessage, 'MISSING_SERVICE_FILE');
 }
 
 module.exports.renameService = renameService;

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -53,9 +53,7 @@ describe('#request', () => {
             Key: 'test-key',
           }
         )
-      ).to.be.rejectedWith(
-        'AWS provider credentials not found. Learn how to set up AWS provider credentials in our docs here: <\u001b[32mhttp://slss.io/aws-creds-setup\u001b[39m>.'
-      );
+      ).to.be.eventually.rejected.and.have.property('code', 'AWS_CREDENTIALS_NOT_FOUND');
     });
 
     it('should support passing params without credentials', async () => {

--- a/test/unit/lib/configuration/resolve-provider-name.test.js
+++ b/test/unit/lib/configuration/resolve-provider-name.test.js
@@ -3,8 +3,9 @@
 const { expect } = require('chai');
 
 const resolveProviderName = require('../../../../lib/configuration/resolve-provider-name');
+const ServerlessError = require('../../../../lib/serverless-error');
 
-describe('test/unit/lib/configuration/resolve-provider.name.test.js', () => {
+describe('test/unit/lib/configuration/resolve-provider-name.test.js', () => {
   it('should read name from "provider"', () => {
     expect(resolveProviderName({ provider: 'foo' })).to.equal('foo');
   });
@@ -12,14 +13,18 @@ describe('test/unit/lib/configuration/resolve-provider.name.test.js', () => {
     expect(resolveProviderName({ provider: { name: 'foo' } })).to.equal('foo');
   });
   it('should reject missing "provider.name"', () => {
-    expect(() => resolveProviderName({ provider: {} })).to.throw('Invalid service configuration');
+    expect(() => resolveProviderName({ provider: {} }))
+      .to.throw(ServerlessError)
+      .with.property('code', 'INVALID_CONFIGURATION_PROVIDER_NAME_MISSING');
   });
   it('should reject invalid "provider.name"', () => {
-    expect(() => resolveProviderName({ provider: { name: {} } })).to.throw(
-      'Invalid service configuration'
-    );
+    expect(() => resolveProviderName({ provider: { name: {} } }))
+      .to.throw(ServerlessError)
+      .with.property('code', 'INVALID_CONFIGURATION_PROVIDER_NAME_MISSING');
   });
   it('should reject missing "provider"', () => {
-    expect(() => resolveProviderName({})).to.throw('Invalid service configuration');
+    expect(() => resolveProviderName({}))
+      .to.throw(ServerlessError)
+      .with.property('code', 'INVALID_CONFIGURATION_PROVIDER_NAME_MISSING');
   });
 });

--- a/test/unit/lib/plugins/aws/deployFunction.test.js
+++ b/test/unit/lib/plugins/aws/deployFunction.test.js
@@ -968,6 +968,6 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
           },
         },
       })
-    ).to.be.eventually.rejectedWith('Please run "serverless deploy" to deploy your service');
+    ).to.be.eventually.rejected.and.have.property('code', 'FUNCTION_NOT_YET_DEPLOYED');
   });
 });

--- a/test/unit/lib/utils/downloadTemplateFromRepo.test.js
+++ b/test/unit/lib/utils/downloadTemplateFromRepo.test.js
@@ -73,13 +73,15 @@ describe('downloadTemplateFromRepo', () => {
 
   describe('downloadTemplateFromRepo', () => {
     it('should reject an error if the passed URL option is not a valid URL', () => {
-      return expect(downloadTemplateFromRepo('invalidUrl')).to.be.rejectedWith(Error);
+      return expect(
+        downloadTemplateFromRepo('invalidUrl')
+      ).to.be.eventually.rejected.and.have.property('code', 'INVALID_TEMPLATE_URL');
     });
 
     it('should reject an error if the passed URL is not a valid GitHub URL', () => {
       return expect(
         downloadTemplateFromRepo('http://no-git-hub-url.com/foo/bar')
-      ).to.be.rejectedWith(Error);
+      ).to.be.eventually.rejected.and.have.property('code', 'INVALID_TEMPLATE_PROVIDER');
     });
 
     it('should reject an error if a directory with the same service name is already present', () => {
@@ -88,7 +90,7 @@ describe('downloadTemplateFromRepo', () => {
 
       return expect(
         downloadTemplateFromRepo('https://github.com/johndoe/existing-service')
-      ).to.be.rejectedWith(Error);
+      ).to.be.eventually.rejected.and.have.property('code', 'TARGET_FOLDER_ALREADY_EXISTS');
     });
 
     it('should download the service based on a regular .git URL', () => {
@@ -223,23 +225,31 @@ describe('downloadTemplateFromRepo', () => {
       const serviceDirName = path.join(serviceDir, 'rest-api-with-dynamodb');
       fse.mkdirsSync(serviceDirName);
 
-      return expect(downloadTemplateFromRepo(null, url)).to.be.rejectedWith(Error);
+      return expect(
+        downloadTemplateFromRepo(null, url)
+      ).to.be.eventually.rejected.and.have.property('code', 'MISSING_TEMPLATE_URL');
     });
   });
 
   describe('parseRepoURL', () => {
     it('should reject an error if no URL is provided', () => {
-      return expect(parseRepoURL()).to.be.rejectedWith(Error);
+      return expect(parseRepoURL()).to.be.eventually.rejected.and.have.property(
+        'code',
+        'MISSING_TEMPLATE_URL'
+      );
     });
 
     it('should reject an error if URL is not valid', () => {
-      return expect(parseRepoURL('non_valid_url')).to.be.rejectedWith(Error);
+      return expect(parseRepoURL('non_valid_url')).to.be.eventually.rejected.and.have.property(
+        'code',
+        'INVALID_TEMPLATE_URL'
+      );
     });
 
     it('should throw an error if URL is not of valid provider', () => {
-      return expect(parseRepoURL('https://kostasbariotis.com/repo/owner')).to.be.rejectedWith(
-        Error
-      );
+      return expect(
+        parseRepoURL('https://kostasbariotis.com/repo/owner')
+      ).to.be.eventually.rejected.and.have.property('code', 'INVALID_TEMPLATE_PROVIDER');
     });
 
     it('should parse a valid GitHub URL', () => {

--- a/test/unit/lib/utils/renameService.test.js
+++ b/test/unit/lib/utils/renameService.test.js
@@ -201,6 +201,8 @@ describe('renameService', () => {
   });
 
   it('should fail to set new service name in serverless.yml', () => {
-    expect(() => renameService('new-service-name', serviceDir)).to.throw(Error);
+    expect(() => renameService('new-service-name', serviceDir))
+      .to.throw()
+      .and.have.property('code', 'MISSING_SERVICE_FILE');
   });
 });


### PR DESCRIPTION
Whenever it was fairly strainghforward, I've added tests for added codes, however, in a lot of places that would require modifying old-style test which means extensive test suite refactoring. I decided to skip that in such cases due to how time consuming that would be. If you feel otherwise and think we should first continue with refactoring of tests, please let me know

Addresses: #9346 