### PR TITLE
9347 - Support for custom IAM Role path

### DIFF
--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -24,6 +24,8 @@ All IAM-related properties of provider are grouped under `iam` property:
 provider:
   iam:
     role:
+      name: custom-role-name
+      path: /custom-role-path/
       statements:
         - Effect: 'Allow',
           Resource: '*',
@@ -118,6 +120,21 @@ provider:
   iam:
     role:
       name: your-custom-name-${sls:stage}-role
+```
+
+### Path for the Default IAM Role
+
+By default, it will use a path of: `/`
+
+This can be overridden by setting `provider.iam.role.path`:
+
+```yml
+service: new-service
+
+provider:
+  iam:
+    role:
+      path: /your-custom-path/
 ```
 
 ## Custom IAM Roles

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -208,6 +208,7 @@ provider:
     # .. OR configure logical role
     role:
       name: your-custom-name-role # Optional custom name for default IAM role
+      path: /your-custom-path/ # Optional custom path for default IAM role
       managedPolicies: # Optional IAM Managed Policies, which allows to include the policies into IAM Role
         - arn:aws:iam:*****:policy/some-managed-policy
       permissionsBoundary: arn:aws:iam::XXXXXX:policy/policy # ARN of an Permissions Boundary for the role.

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -88,7 +88,8 @@ module.exports = {
 
   // Role
   getRolePath() {
-    return '/';
+    const customRolePath = _.get(this.provider, 'serverless.service.provider.iam.role.path');
+    return customRolePath || '/';
   },
   getRoleName() {
     const customRoleName = _.get(this.provider, 'serverless.service.provider.iam.role.name');

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -886,6 +886,10 @@ class AwsProvider {
                           type: 'string',
                           pattern: '^[A-Za-z0-9/_+=,.@-]{1,64}$',
                         },
+                        path: {
+                          type: 'string',
+                          pattern: '(^\\/$)|(^\\/[\u0021-\u007f]+\\/$)',
+                        },
                         managedPolicies: {
                           type: 'array',
                           items: { $ref: '#/definitions/awsArn' },

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -106,6 +106,12 @@ describe('#naming()', () => {
     it('should return `/`', () => {
       expect(sdk.naming.getRolePath()).to.equal('/');
     });
+
+    it('uses custom role path', () => {
+      const customRolePath = '/custom-role-path/';
+      _.set(sdk.naming.provider, 'serverless.service.provider.iam.role.path', customRolePath);
+      expect(sdk.naming.getRolePath()).to.eql(customRolePath);
+    });
   });
 
   describe('#getRoleName()', () => {

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -278,6 +278,8 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
             provider: {
               iam: {
                 role: {
+                  name: 'custom-default-role',
+                  path: '/custom-role-path/',
                   statements: [
                     {
                       Effect: 'Allow',
@@ -311,43 +313,13 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
       });
 
       it('should support `provider.iam.role.name`', async () => {
-        const customRoleName = 'custom-default-role';
-        const { cfTemplate, awsNaming } = await runServerless({
-          fixture: 'function',
-          command: 'package',
-          configExt: {
-            provider: {
-              iam: {
-                role: {
-                  name: customRoleName,
-                },
-              },
-            },
-          },
-        });
-
-        const iamRoleLambdaResource = cfTemplate.Resources[awsNaming.getRoleLogicalId()];
-        expect(iamRoleLambdaResource.Properties.RoleName).to.be.eq(customRoleName);
+        const iamRoleLambdaResource = cfResources[naming.getRoleLogicalId()];
+        expect(iamRoleLambdaResource.Properties.RoleName).to.be.eq('custom-default-role');
       });
 
       it('should support `provider.iam.role.path`', async () => {
-        const customRolePath = '/custom-role-path/';
-        const { cfTemplate, awsNaming } = await runServerless({
-          fixture: 'function',
-          command: 'package',
-          configExt: {
-            provider: {
-              iam: {
-                role: {
-                  path: customRolePath,
-                },
-              },
-            },
-          },
-        });
-
-        const iamRoleLambdaResource = cfTemplate.Resources[awsNaming.getRoleLogicalId()];
-        expect(iamRoleLambdaResource.Properties.Path).to.be.eq(customRolePath);
+        const iamRoleLambdaResource = cfResources[naming.getRoleLogicalId()];
+        expect(iamRoleLambdaResource.Properties.Path).to.be.eq('/custom-role-path/');
       });
 
       it('should reject an invalid `provider.iam.role.path`', async () => {


### PR DESCRIPTION
feat: Added support for custom IAM Role path via property `provider.iam.role.path`.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9347
