### PR TITLE
refactor(AWS Deploy): Deprecate `function` option in `deploy` command

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -32,6 +32,14 @@ Note:
 - Configuration setting is ineffective for deprecations reported before service configuration is read.
 - `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
 
+<a name="CLI_DEPLOY_FUNCTION_OPTION"><div>&nbsp;</div></a>
+
+## CLI `--function`/`-f` option for `deploy` command
+
+Deprecation code: `CLI_DEPLOY_FUNCTION_OPTION'`
+
+Starting with v3.0.0, `--function` or `-f` option for `deploy` command will be removed. In order to deploy a single function, please use `deploy function` command instead.
+
 <a name="CHANGE_OF_DEFAULT_RUNTIME_TO_NODEJS14X"><div>&nbsp;</div></a>
 
 ## Change of default runtime to `nodejs14.x`

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -420,3 +420,12 @@ Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be re
 Deprecation code: `BIN_SERVERLESS`
 
 Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0
+
+<a name="CLI_DEPLOY_FUNCTION_OPTION"><div>&nbsp;</div></a>
+
+## CLI deploy command function option deprecated
+
+Deprecation code: `CLI_DEPLOY_FUNCTION_OPTION'`
+
+The `--function` or `-f` option in `deploy` command has been deprecated and will be removed in the next major release (3.0.0). Please use
+`sls deploy function` command instead.

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -420,12 +420,3 @@ Please use `onUnauthenticatedRequest` instead. `allowUnauthenticated` will be re
 Deprecation code: `BIN_SERVERLESS`
 
 Please use `bin/serverless.js` instead. `bin/serverless` will be removed with v2.0.0
-
-<a name="CLI_DEPLOY_FUNCTION_OPTION"><div>&nbsp;</div></a>
-
-## CLI deploy command function option deprecated
-
-Deprecation code: `CLI_DEPLOY_FUNCTION_OPTION'`
-
-The `--function` or `-f` option in `deploy` command has been deprecated and will be removed in the next major release (3.0.0). Please use
-`sls deploy function` command instead.

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -26,7 +26,7 @@ commands.set('deploy', {
       type: 'boolean',
     },
     'function': {
-      usage: "Function name. Deploys a single function (see 'deploy function')",
+      usage: "Function name. Deploys a single function. DEPRECATED: use 'deploy function' instead.",
       shortcut: 'f',
     },
     'aws-s3-accelerate': {

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -38,8 +38,7 @@ class Deploy {
         if (this.options.function) {
           this.serverless.logDeprecation(
             'CLI_DEPLOY_FUNCTION_OPTION',
-            'The `--function` or `-f` option for `deploy` command has been' +
-              ' deprecated and will be removed in the next major release (3.0.0). Please use `sls deploy function` command instead.'
+            'Starting with v3.0.0, `--function` or `-f` option for `deploy` command will be removed. In order to deploy a single function, please use `deploy function` command instead.'
           );
           // If the user has given a function parameter, spawn a function deploy
           // and terminate execution right afterwards. We did not enter the

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -29,6 +29,17 @@ class Deploy {
     };
 
     this.hooks = {
+      'initialize': () => {
+        const isDeployCommand =
+          this.serverless.processedInput.commands.length === 1 &&
+          this.serverless.processedInput.commands[0] === 'deploy';
+        if (isDeployCommand && this.options.function) {
+          this.serverless.logDeprecation(
+            'CLI_DEPLOY_FUNCTION_OPTION',
+            'Starting with v3.0.0, `--function` or `-f` option for `deploy` command will be removed. In order to deploy a single function, please use `deploy function` command instead.'
+          );
+        }
+      },
       'before:deploy:deploy': async () => {
         const provider = this.serverless.service.provider.name;
         if (!this.serverless.getProvider(provider)) {
@@ -36,10 +47,6 @@ class Deploy {
           throw new ServerlessError(errorMessage, 'INVALID_PROVIDER');
         }
         if (this.options.function) {
-          this.serverless.logDeprecation(
-            'CLI_DEPLOY_FUNCTION_OPTION',
-            'Starting with v3.0.0, `--function` or `-f` option for `deploy` command will be removed. In order to deploy a single function, please use `deploy function` command instead.'
-          );
           // If the user has given a function parameter, spawn a function deploy
           // and terminate execution right afterwards. We did not enter the
           // deploy lifecycle yet, so nothing has to be cleaned up.

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -36,6 +36,11 @@ class Deploy {
           throw new ServerlessError(errorMessage, 'INVALID_PROVIDER');
         }
         if (this.options.function) {
+          this.serverless.logDeprecation(
+            'CLI_DEPLOY_FUNCTION_OPTION',
+            'The `--function` or `-f` option for `deploy` command has been' +
+              ' deprecated and will be removed in the next major release (3.0.0). Please use `sls deploy function` command instead.'
+          );
           // If the user has given a function parameter, spawn a function deploy
           // and terminate execution right afterwards. We did not enter the
           // deploy lifecycle yet, so nothing has to be cleaned up.


### PR DESCRIPTION
closes #9312 