### PR TITLE
Variables: Expose variable resolver function to variable source resolvers

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -476,17 +476,17 @@ With a new variables resolver (_which will be the only used resolver in v3 of a 
 
 - `options` - An object referencing resolved CLI params as passed to the command
 - `resolveConfigurationProperty([key1, key2, ...keyN])` - Async function which resolves specific service configuration property. It returns a fully resolved value of configuration property. If circular reference is detected resolution will be rejected.
+- `resolveVariable(variableString)` - Async function which resolves provided variable string. String should be passed without wrapping (`${` and `}`) braces. Example valid values:
+  - `file(./config.js):SOME_VALUE`
+  - `env:SOME_ENV_VAR, null` (end with `, null`, if missing value at the variable source should be resolved with `null`, and not with a thrown error)
 
-Example, of how to obtain a value of AWS region that will be used by Serverless Framework:
+Example on how to obtain some Serverless Framework configuration values:
 
 ```js
 // config.js (when relying on new variables resolver)
-module.exports = async ({ options, resolveConfigurationProperty }) => {
-  let region = options.region;
-  if (!region) {
-    region = await resolveConfigurationProperty(['provider', 'region']);
-    if (!region) region = 'us-east-1'; // Framework default
-  }
+module.exports = async ({ options, resolveVariable }) => {
+  const stage = await resolveVariable('sls:stage');
+  const region = await resolveVariable('opt:region, self:provider.region, "us-east-1"');
   ...
 }
 ```

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -483,6 +483,30 @@ Object.defineProperties(
               propertyPath,
               ensureArray(dependencyPropertyPathKeys, { ensureItem: ensureString })
             ),
+          resolveVariable: async (variableString) => {
+            variableString = `\${${ensureString(variableString, {
+              Error: ServerlessError,
+              name: 'variableString',
+              errorCode: 'INVALID_VARIABLE_INPUT_TYPE',
+            })}}`;
+            const variableData = parse(variableString);
+            if (!variableData) {
+              throw new ServerlessError(
+                `Invalid variable value: "${variableString}"`,
+                'INVALID_VARIABLE_INPUT'
+              );
+            }
+            const meta = {
+              value: variableString,
+              variables: variableData,
+            };
+            await this.resolveVariables(resolutionBatchId, propertyPath, meta);
+            if (meta.error) throw meta.error;
+            if (meta.variables) {
+              throw new ServerlessError('Cannot resolve variable', 'MISSING_VARIABLE_DEPENDENCY');
+            }
+            return meta.value;
+          },
         });
         ensurePlainObject(result, {
           errorMessage: `Unexpected "${sourceData.type}" source result: %v`,

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -48,7 +48,7 @@ class VariablesResolver {
 
     // Resolve all variables simultaneously
     // Resolution batches are identified to ensure source resolution cache is not shared among them.
-    // (each new resolutioon batch has access to extended configuration structure
+    // (each new resolution batch has access to extended configuration structure
     // and cached source resolver may block access to already resolved structure)
     const resolutionBatchId = ++lastResolutionBatchId;
 

--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -21,7 +21,14 @@ const readFile = async (filePath, serviceDir) => {
 };
 
 module.exports = {
-  resolve: async ({ serviceDir, params, address, resolveConfigurationProperty, options }) => {
+  resolve: async ({
+    serviceDir,
+    params,
+    address,
+    resolveConfigurationProperty,
+    resolveVariable,
+    options,
+  }) => {
     if (!params || !params[0]) {
       throw new ServerlessError(
         'Missing path argument in variable "file" source',
@@ -116,7 +123,7 @@ module.exports = {
             }
             try {
               isResolvedByFunction = true;
-              return await result({ options, resolveConfigurationProperty });
+              return await result({ options, resolveConfigurationProperty, resolveVariable });
             } catch (error) {
               if (error.code === 'MISSING_VARIABLE_DEPENDENCY') throw error;
               throw new ServerlessError(
@@ -163,7 +170,7 @@ module.exports = {
         }
         isResolvedByFunction = true;
         try {
-          result = await result({ options, resolveConfigurationProperty });
+          result = await result({ options, resolveConfigurationProperty, resolveVariable });
         } catch (error) {
           if (error.code === 'MISSING_VARIABLE_DEPENDENCY') throw error;
           throw new ServerlessError(

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -34,10 +34,10 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       propertyDeepCircularC: '${sourceProperty(propertyDeepCircularA)}',
       propertyRoot: '${sourceProperty:}',
       withString: 'foo${sourceDirect:}',
-      resolvesVariablesObject: '${sourceVariables(object)}',
-      resolvesVariablesArray: '${sourceVariables(array)}',
-      resolvesVariablesString: '${sourceVariables(string)}',
-      resolvesVariablesStringInvalid: '${sourceVariables(stringInvalid)}',
+      resolvesResultVariablesObject: '${sourceResultVariables(object)}',
+      resolvesResultVariablesArray: '${sourceResultVariables(array)}',
+      resolvesResultVariablesString: '${sourceResultVariables(string)}',
+      resolvesResultVariablesStringInvalid: '${sourceResultVariables(stringInvalid)}',
       incomplete: '${sourceDirect:}elo${sourceIncomplete:}',
       missing: '${sourceDirect:}elo${sourceMissing:}other${sourceMissing:}',
       missingFallback: '${sourceDirect:}elo${sourceMissing:, "foo"}',
@@ -83,7 +83,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
           return { value: result == null ? null : result };
         },
       },
-      sourceVariables: {
+      sourceResultVariables: {
         resolve: ({ params: [type] }) => {
           switch (type) {
             case 'object':
@@ -229,9 +229,9 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     });
 
     it('should resolve variables in returned results', () => {
-      expect(configuration.resolvesVariablesObject).to.deep.equal({ foo: 234 });
-      expect(configuration.resolvesVariablesArray).to.deep.equal([1, 234]);
-      expect(configuration.resolvesVariablesString).to.equal(234);
+      expect(configuration.resolvesResultVariablesObject).to.deep.equal({ foo: 234 });
+      expect(configuration.resolvesResultVariablesArray).to.deep.equal([1, 234]);
+      expect(configuration.resolvesResultVariablesString).to.equal(234);
     });
 
     // https://github.com/serverless/serverless/issues/9016
@@ -340,7 +340,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     });
 
     it('should error on invalid variable notation in returned result', () => {
-      const valueMeta = variablesMeta.get('resolvesVariablesStringInvalid');
+      const valueMeta = variablesMeta.get('resolvesResultVariablesStringInvalid');
       expect(valueMeta).to.not.have.property('variables');
       expect(valueMeta.error.code).to.equal('UNTERMINATED_VARIABLE');
     });
@@ -375,7 +375,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
         'propertyDeepCircularB',
         'propertyDeepCircularC',
         'propertyRoot',
-        'resolvesVariablesStringInvalid',
+        'resolvesResultVariablesStringInvalid',
         'missing',
         'nonStringStringPart',
         'nestUnrecognized\0unrecognized',

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -23,6 +23,8 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       jsPropertyFunction: '${file(file-property-function.js):property}',
       jsPropertyFunctionProperty: '${file(file-property-function.js):property.result}',
       addressSupport: '${file(file.json):result}',
+      jsFunctionResolveVariable: '${file(file-function-variable.js)}',
+      jsPropertyFunctionResolveVariable: '${file(file-property-function-variable.js):property}',
       nonExistingYaml: '${file(not-existing.yaml), null}',
       nonExistingJson: '${file(not-existing.json), null}',
       nonExistingJs: '${file(not-existing.js), null}',
@@ -88,6 +90,15 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
 
   it('should support "address" argument', () =>
     expect(configuration.addressSupport).to.equal('json'));
+
+  it('should support internal variable resolution', () => {
+    expect(configuration.jsFunctionResolveVariable).to.deep.equal({
+      varResult: { result: 'yaml' },
+    });
+    expect(configuration.jsPropertyFunctionResolveVariable).to.deep.equal({
+      varResult: { result: 'json' },
+    });
+  });
 
   it('should uncoditionally split "address" property keys by "."', () =>
     expect(configuration.ambiguousAddress).to.equal('object'));

--- a/test/unit/lib/configuration/variables/sources/fixture/file-function-variable.js
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-function-variable.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async ({ resolveVariable }) => ({
+  varResult: await resolveVariable('file(file.yaml)'),
+});

--- a/test/unit/lib/configuration/variables/sources/fixture/file-property-function-variable.js
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-property-function-variable.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.property = async ({ resolveVariable }) => ({
+  varResult: await resolveVariable('file(file.json)'),
+});


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9112 

After all, instead of introducing `resolveSource(name, { params, address })`, I decided to introduce `resolveVariable(variableString)` as that feels way more convenient, and I believe more simple to use (it's also a bit more powerful, as supports fallback sources in same manner as when variables are configured into properties).

