### PR TITLE
feat(Templates): Update dependencies for `cloudflare` template

### DIFF
--- a/lib/plugins/create/templates/cloudflare-workers-enterprise/package.json
+++ b/lib/plugins/create/templates/cloudflare-workers-enterprise/package.json
@@ -9,6 +9,6 @@
   "author": "cloudflare",
   "license": "MIT",
   "devDependencies": {
-    "serverless-cloudflare-workers": "1.0.5"
+    "serverless-cloudflare-workers": "1.2.0"
   }
 }

--- a/lib/plugins/create/templates/cloudflare-workers/package.json
+++ b/lib/plugins/create/templates/cloudflare-workers/package.json
@@ -9,6 +9,6 @@
   "author": "cloudflare",
   "license": "MIT",
   "devDependencies": {
-    "serverless-cloudflare-workers": "1.0.5"
+    "serverless-cloudflare-workers": "1.2.0"
   }
 }


### PR DESCRIPTION
serverless-cloudflare-workers's old version in template not support to config worker's environment variable through `serverless deploy`. Update it in the cli generated template to support this feature.

related issue: https://github.com/serverless/serverless/issues/9372