### PR TITLE
Send telemetry after command is processed in `scripts/serverless.js`

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -95,6 +95,7 @@ class Serverless {
       this.processedInput = { commands, options };
     }
     this.hasResolvedCommandsExternally = Boolean(configObject.hasResolvedCommandsExternally);
+    this.isTelemetryReportedExternally = Boolean(configObject.isTelemetryReportedExternally);
 
     // Due to design flaw properties of configObject (which is to be merged onto `this.config`)
     // also are subject to variables resolution.

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -108,6 +108,7 @@ class Serverless {
     delete configObject.commands;
     delete configObject.isConfigurationResolved;
     delete configObject.hasResolvedCommandsExternally;
+    delete configObject.isTelemetryReportedExternally;
     delete configObject.options;
 
     this.providers = {};

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -598,12 +598,15 @@ class PluginManager {
       await hook();
     }
 
-    await storeTelemetryLocally(await generateTelemetryPayload(this.serverless));
     let deferredBackendNotificationRequest;
-    if (commandsArray.join(' ') === 'deploy') {
-      deferredBackendNotificationRequest = sendTelemetry({
-        serverlessExecutionSpan: this.serverless.onExitPromise,
-      });
+
+    if (!this.serverless.isTelemetryReportedExternally) {
+      await storeTelemetryLocally(await generateTelemetryPayload(this.serverless));
+      if (commandsArray.join(' ') === 'deploy') {
+        deferredBackendNotificationRequest = sendTelemetry({
+          serverlessExecutionSpan: this.serverless.onExitPromise,
+        });
+      }
     }
 
     try {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -15,6 +15,7 @@ const renderCommandHelp = require('../cli/render-help/command');
 const { storeLocally: storeTelemetryLocally, send: sendTelemetry } = require('../utils/telemetry');
 const generateTelemetryPayload = require('../utils/telemetry/generatePayload');
 const processBackendNotificationRequest = require('../utils/processBackendNotificationRequest');
+const isTelemetryDisabled = require('../utils/telemetry/areDisabled');
 
 const requireServicePlugin = (serviceDir, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
@@ -600,7 +601,9 @@ class PluginManager {
 
     let deferredBackendNotificationRequest;
 
-    if (!this.serverless.isTelemetryReportedExternally) {
+    // TODO: Remove this logic with `v3.0.0` along with removal of `isTelemetryReportedExternally`
+    // After we are ensured that local fallback from `v3` will always fall back to `v3` local installation
+    if (!this.serverless.isTelemetryReportedExternally && !isTelemetryDisabled) {
       await storeTelemetryLocally(await generateTelemetryPayload(this.serverless));
       if (commandsArray.join(' ') === 'deploy') {
         deferredBackendNotificationRequest = sendTelemetry({

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -384,6 +384,11 @@ const processSpanPromise = (async () => {
     try {
       serverless.onExitPromise = processSpanPromise;
       serverless.invocationId = uuid.v4();
+      // TODO: REMOVE WITH NEXT MAJOR
+      // The purpose of below logic is to ensure that locally resolved `serverless` instance
+      // that might be in lower version will not attempt to handle telemetry on its own
+      require('../lib/utils/telemetry/areDisabled'); // Ensure value is resolved
+      process.env.SLS_TRACKING_DISABLED = '1';
       await serverless.init();
       if (serverless.invokedInstance) {
         // Local (in service) installation was found and initialized internally,

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -369,6 +369,7 @@ const processSpanPromise = (async () => {
       isConfigurationResolved:
         commands[0] === 'plugin' || Boolean(variablesMeta && !variablesMeta.size),
       hasResolvedCommandsExternally: true,
+      isTelemetryReportedExternally: true,
       commands,
       options,
     });


### PR DESCRIPTION
Addresses: #9346 

I'm still not sure about potentially refactoring the implementation that currently lives in `PluginManager`, do you feel like we should also change it to report after the command executes? What about further changes to it when we will detect if command failed with error? 