### PR TITLE
fix(AWS API Gateway): Ensure unique name for request validator

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
@@ -177,7 +177,9 @@ module.exports = {
 
   createRequestValidator() {
     const validatorLogicalId = this.provider.naming.getValidatorLogicalId();
-    const validatorName = 'Validate request body and querystring parameters';
+    const validatorName = `${
+      this.serverless.service.service
+    }-${this.provider.getStage()} | Validate request body and querystring parameters`;
     this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
       validatorLogicalId
     ] = {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.test.js
@@ -9,14 +9,18 @@ chai.use(require('chai-as-promised'));
 describe('#compileRequestValidators()', () => {
   let cfResources;
   let naming;
+  let serviceName;
+  let stage;
 
   before(async () => {
-    const { cfTemplate, awsNaming } = await runServerless({
+    const { cfTemplate, awsNaming, serverless } = await runServerless({
       fixture: 'requestSchema',
       command: 'package',
     });
     cfResources = cfTemplate.Resources;
     naming = awsNaming;
+    serviceName = serverless.service.service;
+    stage = serverless.getProvider('aws').getStage();
   });
 
   describe(' reusable schemas ', () => {
@@ -329,6 +333,15 @@ describe('#compileRequestValidators()', () => {
           },
         },
       });
+    });
+
+    it('should create validator with that includes `service` and `stage`', () => {
+      const validatorLogicalId = naming.getValidatorLogicalId();
+      const validatorResource = cfResources[validatorLogicalId];
+
+      expect(validatorResource.Properties.Name).to.equal(
+        `${serviceName}-${stage} | Validate request body and querystring parameters`
+      );
     });
 
     it('should support multiple request:schema property for regression', () => {


### PR DESCRIPTION
Closes: #9369 