### PR TITLE
Documentation: Remove reference to not supported `--noDeploy`

### DIFF
--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -23,7 +23,6 @@ serverless deploy
 ## Options
 
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
-- `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.

--- a/docs/providers/azure/cli-reference/deploy.md
+++ b/docs/providers/azure/cli-reference/deploy.md
@@ -29,7 +29,6 @@ The `sls deploy apim` command will deploy API management as configured within `s
 - `--region` or `-r` - Specify region name
 - `--subscriptionId` or `-i` - Specify subscription ID
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
-- `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 
 ## Artifacts

--- a/docs/providers/kubeless/cli-reference/deploy.md
+++ b/docs/providers/kubeless/cli-reference/deploy.md
@@ -27,7 +27,6 @@ This is the simplest deployment usage possible. With this command Serverless wil
 ## Options
 
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
-- `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory.
 - `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
 - `--package` or `-p` The path of a previously packaged deployment to get deployed (skips packaging step).
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.


### PR DESCRIPTION
As a follow up to https://github.com/serverless/serverless/discussions/9389, complements https://github.com/serverless/serverless/commit/688d09b1f7f28f8b1656d3f7f31c6c2765a01b9d

In Azure and Kubeless this option was never supported, so it was simply listed there by mistake.

It is actually supported in Openwhisk so I left it documented there (and it's the only place in our docs where this option remains listed)

#### Additional clarification note:

Technically removing this option (which was done and published already) can be considered breaking. When I did that, I mistakenly assumed it was added just for internal testing purpose, while it appeared that it was added in early stage of v1 for v0.5 resemblance (where such option was supported)

However:
- This option was not listed in options list internally (so never appeared in `sls deploy --help` output), and in Framework website documentation appeared just for a 2 last months (was introduced this February with https://github.com/serverless/serverless/pull/8922)
- It reflects different naming convention (it's `--noDeploy` not `--no-deploy`, as if it's with other option names)
- Use case is controversial, as about same can be achieved with `sls package`. Technically it's after _dry run_ functionality, which ideally should work a bit different, and which we may consider introducing in a future (possibly with better named option as `--dry-run`)

In light of above, and that we didn't see many reports that removing it broke things (aside of single https://github.com/serverless/serverless/discussions/9389), I'll keep it removed
