### PR TITLE
Telemetry: Ensure that container commands do not trigger telemetry

### DIFF
--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -73,6 +73,10 @@ module.exports = memoizee((commandsSchema = require('./commands-schema')) => {
     result.isContainerCommand = Array.from(commandsSchema.keys()).some((commandName) =>
       commandName.startsWith(`${command} `)
     );
+    if (result.isContainerCommand) {
+      result.isHelpRequest = true;
+      return result;
+    }
   }
 
   if (
@@ -82,18 +86,17 @@ module.exports = memoizee((commandsSchema = require('./commands-schema')) => {
     command === 'help'
   ) {
     result.isHelpRequest = true;
+    return result;
   }
 
-  if (!result.isHelpRequest) {
-    const argsString = args.join(' ');
-    if (command && argsString !== command && !argsString.startsWith(`${command} `)) {
-      // Some options were passed before command name (e.g. "sls -v deploy"), deprecate such usage
-      require('../utils/logDeprecation')(
-        'CLI_OPTIONS_BEFORE_COMMAND',
-        '"serverless" command options are expected to follow command and not be put before the command.\n' +
-          'Starting from next major Serverless will no longer support the latter form.'
-      );
-    }
+  const argsString = args.join(' ');
+  if (command && argsString !== command && !argsString.startsWith(`${command} `)) {
+    // Some options were passed before command name (e.g. "sls -v deploy"), deprecate such usage
+    require('../utils/logDeprecation')(
+      'CLI_OPTIONS_BEFORE_COMMAND',
+      '"serverless" command options are expected to follow command and not be put before the command.\n' +
+        'Starting from next major Serverless will no longer support the latter form.'
+    );
   }
 
   return result;


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

There's an internal concept of _container_ command, which is a no-op command name in middle, which if invoked we show help showing sub commands, e.g. it's the case for `config tabcompletion`.

Those commands were not marked as _help_ commands, so they're destined for telemetry. Still they also do not have command schema, and that crashes telemetry payload generation here: https://github.com/serverless/serverless/blob/95e063d904443044b73d61e73d04447b298d22ed/lib/utils/telemetry/generatePayload.js#L125

Marking telemetry command as _help_ command fixes the issue

