### PR TITLE
CLI: Ensure no general help is listed under interactive setup help

### DIFF
--- a/lib/cli/render-help/index.js
+++ b/lib/cli/render-help/index.js
@@ -8,7 +8,10 @@ const renderCommandHelp = require('./command');
 module.exports = (loadedPlugins) => {
   const { command, options } = resolveInput();
   if (!command) {
-    if (options['help-interactive']) renderInteractiveSetupHelp();
+    if (options['help-interactive']) {
+      renderInteractiveSetupHelp();
+      return;
+    }
     renderGeneralHelp(loadedPlugins);
   } else if (command === 'help') {
     renderGeneralHelp(loadedPlugins);

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -185,6 +185,14 @@ describe('test/unit/scripts/serverless.test.js', () => {
     expect(output).to.include('stage');
   });
 
+  it('should print interactive setup help to stdout', async () => {
+    const output = String(
+      (await spawn('node', [serverlessPath, '--help-interactive'])).stdoutBuffer
+    );
+    expect(output).to.include('Interactive CLI');
+    expect(output).to.not.include('General Commands');
+  });
+
   it('should show help when running container command', async () => {
     // Note: Arbitrarily picked "plugin" command for testing
     const output = stripAnsi(


### PR DESCRIPTION
Discovered that general help is listed under interactive CLI help, that's not expected. This PR fixes that

<img width="1171" alt="Screenshot 2021-04-30 at 12 35 26" src="https://user-images.githubusercontent.com/122434/116683977-a1debf00-a9b0-11eb-8858-605918c582c9.png">
