### PR TITLE
fix(Packaging): Fix support of the artifact S3 uri with region

### DIFF
--- a/lib/plugins/aws/utils/parse-s3-uri.js
+++ b/lib/plugins/aws/utils/parse-s3-uri.js
@@ -5,11 +5,17 @@ const patterns = [
   // S3 URI. Ex: s3://bucket/path/to/artifact.zip
   new RegExp('^s3://(?<bucket>[^/]+)/(?<key>.+)'),
 
-  // New style S3 URL. Ex: https://bucket.s3.REGION.amazonaws.com/path/to/artifact.zip
-  new RegExp('(?<bucket>[^/]+)\\.s3(\\.[\\w\\d-]+)?\\.amazonaws\\.com/(?<key>.+)'),
+  // New style S3 URL.
+  // Ex: https://bucket.s3.amazonaws.com/path/to/artifact.zip
+  // Ex: https://bucket.s3.region.amazonaws.com/path/to/artifact.zip
+  // Ex: https://bucket.s3-region.amazonaws.com/path/to/artifact.zip
+  new RegExp('(?<bucket>[^/]+)\\.s3([\\.-][\\w\\d-]+)?\\.amazonaws\\.com/(?<key>.+)'),
 
-  // Old style S3 URL. Ex: https://s3.REGION.amazonaws.com/bucket/path/to/artifact.zip
-  new RegExp('s3(\\.[\\w\\d-]+)?\\.amazonaws\\.com/(?<bucket>[^/]+)/(?<key>.+)'),
+  // Old style S3 URL.
+  // Ex: https://s3.amazonaws.com/bucket/path/to/artifact.zip
+  // Ex: https://s3.region.amazonaws.com/bucket/path/to/artifact.zip
+  // Ex: https://s3-region.amazonaws.com/bucket/path/to/artifact.zip
+  new RegExp('s3([\\.-][\\w\\d-]+)?\\.amazonaws\\.com/(?<bucket>[^/]+)/(?<key>.+)'),
 ];
 
 module.exports = (url) => {

--- a/lib/plugins/aws/utils/parse-s3-uri.js
+++ b/lib/plugins/aws/utils/parse-s3-uri.js
@@ -1,14 +1,15 @@
 'use strict';
 
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html
 const patterns = [
   // S3 URI. Ex: s3://bucket/path/to/artifact.zip
-  new RegExp('^s3://([^/]+)/(.+)'),
+  new RegExp('^s3://(?<bucket>[^/]+)/(?<key>.+)'),
 
-  // New style S3 URL. Ex: https://bucket.s3.amazonaws.com/path/to/artifact.zip
-  new RegExp('([^/]+)\\.s3\\.amazonaws\\.com/(.+)'),
+  // New style S3 URL. Ex: https://bucket.s3.REGION.amazonaws.com/path/to/artifact.zip
+  new RegExp('(?<bucket>[^/]+)\\.s3(\\.[\\w\\d-]+)?\\.amazonaws\\.com/(?<key>.+)'),
 
-  // Old style S3 URL. Ex: https://s3.amazonaws.com/bucket/path/to/artifact.zip
-  new RegExp('s3\\.amazonaws\\.com/([^/]+)/(.+)'),
+  // Old style S3 URL. Ex: https://s3.REGION.amazonaws.com/bucket/path/to/artifact.zip
+  new RegExp('s3(\\.[\\w\\d-]+)?\\.amazonaws\\.com/(?<bucket>[^/]+)/(?<key>.+)'),
 ];
 
 module.exports = (url) => {
@@ -16,8 +17,8 @@ module.exports = (url) => {
     const match = url.match(regex);
     if (match) {
       return {
-        Bucket: match[1],
-        Key: match[2],
+        Bucket: match.groups.bucket,
+        Key: match.groups.key,
       };
     }
   }

--- a/test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js
+++ b/test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js
@@ -27,6 +27,14 @@ describe('test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js', () => {
     const actual = parseS3URI('https://s3.us-west-1.amazonaws.com/test-bucket/path/to/artifact.zip');
     expect(actual).to.deep.equal(expected);
   });
+  it('should parse another old style S3 URL with region', () => {
+    const expected = {
+      Bucket: 'test-bucket',
+      Key: 'path/to/artifact.zip',
+    };
+    const actual = parseS3URI('https://s3-us-west-1.amazonaws.com/test-bucket/path/to/artifact.zip');
+    expect(actual).to.deep.equal(expected);
+  });
   it('should parse a new style S3 URL', () => {
     const expected = {
       Bucket: 'test-bucket',
@@ -41,6 +49,14 @@ describe('test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js', () => {
       Key: 'path/to/artifact.zip',
     };
     const actual = parseS3URI('https://test-bucket.s3.eu-west-1.amazonaws.com/path/to/artifact.zip');
+    expect(actual).to.deep.equal(expected);
+  });
+  it('should parse another new style S3 URL with region', () => {
+    const expected = {
+      Bucket: 'test-bucket',
+      Key: 'path/to/artifact.zip',
+    };
+    const actual = parseS3URI('https://test-bucket.s3-eu-west-1.amazonaws.com/path/to/artifact.zip');
     expect(actual).to.deep.equal(expected);
   });
   it('should reject non S3 URLs', () => {

--- a/test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js
+++ b/test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js
@@ -19,12 +19,28 @@ describe('test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js', () => {
     const actual = parseS3URI('https://s3.amazonaws.com/test-bucket/path/to/artifact.zip');
     expect(actual).to.deep.equal(expected);
   });
+  it('should parse an old style S3 URL with region', () => {
+    const expected = {
+      Bucket: 'test-bucket',
+      Key: 'path/to/artifact.zip',
+    };
+    const actual = parseS3URI('https://s3.us-west-1.amazonaws.com/test-bucket/path/to/artifact.zip');
+    expect(actual).to.deep.equal(expected);
+  });
   it('should parse a new style S3 URL', () => {
     const expected = {
       Bucket: 'test-bucket',
       Key: 'path/to/artifact.zip',
     };
     const actual = parseS3URI('https://test-bucket.s3.amazonaws.com/path/to/artifact.zip');
+    expect(actual).to.deep.equal(expected);
+  });
+  it('should parse a new style S3 URL with region', () => {
+    const expected = {
+      Bucket: 'test-bucket',
+      Key: 'path/to/artifact.zip',
+    };
+    const actual = parseS3URI('https://test-bucket.s3.eu-west-1.amazonaws.com/path/to/artifact.zip');
     expect(actual).to.deep.equal(expected);
   });
   it('should reject non S3 URLs', () => {

--- a/test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js
+++ b/test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js
@@ -24,7 +24,9 @@ describe('test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js', () => {
       Bucket: 'test-bucket',
       Key: 'path/to/artifact.zip',
     };
-    const actual = parseS3URI('https://s3.us-west-1.amazonaws.com/test-bucket/path/to/artifact.zip');
+    const actual = parseS3URI(
+      'https://s3.us-west-1.amazonaws.com/test-bucket/path/to/artifact.zip'
+    );
     expect(actual).to.deep.equal(expected);
   });
   it('should parse another old style S3 URL with region', () => {
@@ -32,7 +34,9 @@ describe('test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js', () => {
       Bucket: 'test-bucket',
       Key: 'path/to/artifact.zip',
     };
-    const actual = parseS3URI('https://s3-us-west-1.amazonaws.com/test-bucket/path/to/artifact.zip');
+    const actual = parseS3URI(
+      'https://s3-us-west-1.amazonaws.com/test-bucket/path/to/artifact.zip'
+    );
     expect(actual).to.deep.equal(expected);
   });
   it('should parse a new style S3 URL', () => {
@@ -48,7 +52,9 @@ describe('test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js', () => {
       Bucket: 'test-bucket',
       Key: 'path/to/artifact.zip',
     };
-    const actual = parseS3URI('https://test-bucket.s3.eu-west-1.amazonaws.com/path/to/artifact.zip');
+    const actual = parseS3URI(
+      'https://test-bucket.s3.eu-west-1.amazonaws.com/path/to/artifact.zip'
+    );
     expect(actual).to.deep.equal(expected);
   });
   it('should parse another new style S3 URL with region', () => {
@@ -56,7 +62,9 @@ describe('test/unit/lib/plugins/aws/utils/parse-s3-uri.test.js', () => {
       Bucket: 'test-bucket',
       Key: 'path/to/artifact.zip',
     };
-    const actual = parseS3URI('https://test-bucket.s3-eu-west-1.amazonaws.com/path/to/artifact.zip');
+    const actual = parseS3URI(
+      'https://test-bucket.s3-eu-west-1.amazonaws.com/path/to/artifact.zip'
+    );
     expect(actual).to.deep.equal(expected);
   });
   it('should reject non S3 URLs', () => {


### PR DESCRIPTION
#9380 Added support for most S3 bucket URIs, but not ones with region in their format, e.g. any bucket outside of us-east-1.

Closes: #9403
