### PR TITLE
fix(Telemetry): Properly resolve location when for only relative paths

### DIFF
--- a/lib/utils/telemetry/anonymize-stacktrace-paths.js
+++ b/lib/utils/telemetry/anonymize-stacktrace-paths.js
@@ -4,16 +4,23 @@ const path = require('path');
 const commonPath = require('path2/common');
 
 const anonymizeStacktracePaths = (stacktracePaths) => {
-  let commonPathPrefix = commonPath(...stacktracePaths.filter((p) => path.isAbsolute(p)));
+  const absoluteStacktracePaths = stacktracePaths.filter((p) => path.isAbsolute(p));
+  let commonPathPrefix = '';
 
-  const lastServerlessIndex = commonPathPrefix.lastIndexOf(`${path.sep}serverless${path.sep}`);
+  if (absoluteStacktracePaths.length) {
+    commonPathPrefix = commonPath(...absoluteStacktracePaths);
 
-  if (lastServerlessIndex !== -1) {
-    commonPathPrefix = commonPathPrefix.slice(0, lastServerlessIndex);
-  } else {
-    const lastNodeModulesIndex = commonPathPrefix.lastIndexOf(`${path.sep}node_modules${path.sep}`);
-    if (lastNodeModulesIndex !== -1) {
-      commonPathPrefix = commonPathPrefix.slice(0, lastNodeModulesIndex);
+    const lastServerlessIndex = commonPathPrefix.lastIndexOf(`${path.sep}serverless${path.sep}`);
+
+    if (lastServerlessIndex !== -1) {
+      commonPathPrefix = commonPathPrefix.slice(0, lastServerlessIndex);
+    } else {
+      const lastNodeModulesIndex = commonPathPrefix.lastIndexOf(
+        `${path.sep}node_modules${path.sep}`
+      );
+      if (lastNodeModulesIndex !== -1) {
+        commonPathPrefix = commonPathPrefix.slice(0, lastNodeModulesIndex);
+      }
     }
   }
 

--- a/test/unit/lib/utils/telemetry/anonymize-stacktrace-paths.test.js
+++ b/test/unit/lib/utils/telemetry/anonymize-stacktrace-paths.test.js
@@ -68,6 +68,13 @@ describe('test/unit/lib/utils/anonymize-stacktrace-paths.test.js', () => {
     });
   }
 
+  it('Should handle stacktrace with only relative paths', () => {
+    const stacktracePaths = ['somefile.js:100:10', 'another.js:100:10'];
+
+    const result = anonymizeStacktracePaths(stacktracePaths);
+    expect(result).to.deep.equal(['somefile.js:100:10', 'another.js:100:10']);
+  });
+
   if (process.platform === 'win32') {
     it('Should remove common prefix up to last `serverless` occurence for windows-style paths', () => {
       const stacktracePaths = [


### PR DESCRIPTION
Fixes situation where `commonPrefixPath` was invoked with empty list of paths (all were filtered out because there were all relative)