### PR TITLE
fix(Telemetry): Handle error locations not enclosed in parens

### DIFF
--- a/lib/utils/telemetry/resolve-error-location.js
+++ b/lib/utils/telemetry/resolve-error-location.js
@@ -8,11 +8,11 @@ const resolveErrorLocation = (exceptionTokens) => {
   const splittedStack = exceptionTokens.stack.split('\n');
   if (splittedStack.length === 1 && exceptionTokens.code) return '<not available>';
 
-  const stacktraceLineRegex = /\s*at.*\((.*)\).?/;
+  const stacktraceLineRegex = /(?:\s*at.*\((.*)\).?|\s*at\s(.*))/;
   const stacktracePaths = [];
   for (const line of splittedStack) {
     const match = line.match(stacktraceLineRegex) || [];
-    const matchedPath = match[1];
+    const matchedPath = match[1] || match[2];
     if (matchedPath) {
       // Limited to maximum 5 lines in location
       if (stacktracePaths.push(matchedPath) === 5) break;

--- a/lib/utils/telemetry/resolve-error-location.js
+++ b/lib/utils/telemetry/resolve-error-location.js
@@ -5,7 +5,7 @@ const anonymizeStacktracePaths = require('./anonymize-stacktrace-paths');
 const resolveErrorLocation = (exceptionTokens) => {
   if (!exceptionTokens.stack) return '<not accessible due to non-error exception>';
 
-  const splittedStack = exceptionTokens.stack.split('\n');
+  const splittedStack = exceptionTokens.stack.split(/[\r\n]+/);
   if (splittedStack.length === 1 && exceptionTokens.code) return '<not available>';
 
   const stacktraceLineRegex = /(?:\s*at.*\((.*)\).?|\s*at\s(.*))/;

--- a/test/unit/lib/utils/telemetry/resolve-error-location.test.js
+++ b/test/unit/lib/utils/telemetry/resolve-error-location.test.js
@@ -76,11 +76,11 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
     it('should correctly handle paths not enclosed in parentheses', () => {
       const err = new Error('test');
       err.stack =
-        'Error: spawn E2BIG\n' +
-        '    at ChildProcess.spawn (node:internal/child_process:403:11)\n' +
-        '    at Object.spawn (node:child_process:573:9)\n' +
-        '    at C:\\home\\xxx\\api\\node_modules\\bestzip\\lib\\bestzip.js:75:29\n' +
-        '    at C:\\home\\xxx\\api\\node_modules\\async\\dist\\async.js:1802:20\n';
+        'Error: spawn E2BIG\r\n' +
+        '    at ChildProcess.spawn (node:internal/child_process:403:11)\r\n' +
+        '    at Object.spawn (node:child_process:573:9)\r\n' +
+        '    at C:\\home\\xxx\\api\\node_modules\\bestzip\\lib\\bestzip.js:75:29\r\n' +
+        '    at C:\\home\\xxx\\api\\node_modules\\async\\dist\\async.js:1802:20\r\n';
 
       const result = resolveErrorLocation(tokenizeException(err));
       expect(result).to.equal(
@@ -97,12 +97,12 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
       const err = new Error('test');
       err.stack =
         'Error:\n' +
-        '    at Context.it (C:\\home\\xxx\\serverless\\test\\unit\\lib\\utils\\resolve-error-location.test.js:10:17)\n' +
-        '    at callFn (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runnable.js:366:21)\n' +
-        '    at Test.Runnable.run (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runnable.js:354:5)\n' +
-        '    at Runner.runTest (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:677:10)\n' +
-        '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:801:12)\n' +
-        '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:594:14)\n';
+        '    at Context.it (C:\\home\\xxx\\serverless\\test\\unit\\lib\\utils\\resolve-error-location.test.js:10:17)\r\n' +
+        '    at callFn (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runnable.js:366:21)\r\n' +
+        '    at Test.Runnable.run (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runnable.js:354:5)\r\n' +
+        '    at Runner.runTest (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:677:10)\r\n' +
+        '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:801:12)\r\n' +
+        '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:594:14)\r\n';
       const result = resolveErrorLocation(tokenizeException(err));
       expect(result).to.equal(
         [

--- a/test/unit/lib/utils/telemetry/resolve-error-location.test.js
+++ b/test/unit/lib/utils/telemetry/resolve-error-location.test.js
@@ -29,6 +29,26 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
   });
 
   if (process.platform !== 'win32') {
+    it('should correctly handle paths not enclosed in parentheses', () => {
+      const err = new Error('test');
+      err.stack =
+        'Error: spawn E2BIG\n' +
+        '    at ChildProcess.spawn (node:internal/child_process:403:11)\n' +
+        '    at Object.spawn (node:child_process:573:9)\n' +
+        '    at /home/xxx/api/node_modules/bestzip/lib/bestzip.js:75:29\n' +
+        '    at /home/xxx/api/node_modules/async/dist/async.js:1802:20\n';
+
+      const result = resolveErrorLocation(tokenizeException(err));
+      expect(result).to.equal(
+        [
+          'node:internal/child_process:403:11',
+          'node:child_process:573:9',
+          '/bestzip/lib/bestzip.js:75:29',
+          '/async/dist/async.js:1802:20',
+        ].join('\n')
+      );
+    });
+
     it('should return at most 5 lines', () => {
       const err = new Error('test');
       err.stack =
@@ -53,6 +73,26 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
   }
 
   if (process.platform === 'win32') {
+    it('should correctly handle paths not enclosed in parentheses', () => {
+      const err = new Error('test');
+      err.stack =
+        'Error: spawn E2BIG\n' +
+        '    at ChildProcess.spawn (node:internal/child_process:403:11)\n' +
+        '    at Object.spawn (node:child_process:573:9)\n' +
+        '    at C:\\home\\xxx\\api\\node_modules\\bestzip\\lib\\bestzip.js:75:29\n' +
+        '    at C:\\home\\xxx\\api\\node_modules\\async\\dist\\async.js:1802:20\n';
+
+      const result = resolveErrorLocation(tokenizeException(err));
+      expect(result).to.equal(
+        [
+          'node:internal/child_process:403:11',
+          'node:child_process:573:9',
+          '/bestzip/lib/bestzip.js:75:29',
+          '/async/dist/async.js:1802:20',
+        ].join('\n')
+      );
+    });
+
     it('should return at most 5 lines and use `/` path separator', () => {
       const err = new Error('test');
       err.stack =


### PR DESCRIPTION
I've noticed that the previous version didn't correcly handle situations where the location in stack trace was not enclosed in parentheses, e.g. as reported here: 
```
Error ---------------------------------------------------
 
  Error: spawn E2BIG
      at ChildProcess.spawn (node:internal/child_process:403:11)
      at Object.spawn (node:child_process:573:9)
      at /Users/chris/Projects/Nebula/api/node_modules/bestzip/lib/bestzip.js:75:29
      at /Users/chris/Projects/Nebula/api/node_modules/async/dist/async.js:1802:20
      at /Users/chris/Projects/Nebula/api/node_modules/async/dist/async.js:248:13
      at wrapper (/Users/chris/Projects/Nebula/api/node_modules/async/dist/async.js:268:20)
      at iterateeCallback (/Users/chris/Projects/Nebula/api/node_modules/async/dist/async.js:421:28)
      at /Users/chris/Projects/Nebula/api/node_modules/async/dist/async.js:321:20
      at /Users/chris/Projects/Nebula/api/node_modules/async/dist/async.js:245:17
      at /Users/chris/Projects/Nebula/api/node_modules/async/dist/async.js:1792:24
      at /Users/chris/Projects/Nebula/api/node_modules/bestzip/lib/bestzip.js:49:7
      at processTicksAndRejections (node:internal/process/task_queues:75:11)
```

This should fix it and additionally it ensures to split on OS-agnostic new line characters.