### PR TITLE
Dont update `vpc` during `deploy function` if uses CF intrinsic functions

### DIFF
--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -284,17 +284,11 @@ class AwsDeployFunction {
       const vpc = functionObj.vpc || providerObj.vpc;
       params.VpcConfig = {};
 
-      if (
-        _.isObject(vpc.securityGroupIds['Fn::Split']) ||
-        (Array.isArray(vpc.securityGroupIds) && !vpc.securityGroupIds.some(_.isObject))
-      ) {
+      if (Array.isArray(vpc.securityGroupIds) && !vpc.securityGroupIds.some(_.isObject)) {
         params.VpcConfig.SecurityGroupIds = vpc.securityGroupIds;
       }
 
-      if (
-        _.isObject(vpc.subnetIds['Fn::Split']) ||
-        (Array.isArray(vpc.subnetIds) && !vpc.subnetIds.some(_.isObject))
-      ) {
+      if (Array.isArray(vpc.subnetIds) && !vpc.subnetIds.some(_.isObject)) {
         params.VpcConfig.SubnetIds = vpc.subnetIds;
       }
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -376,8 +376,9 @@ class AwsProvider {
                 type: 'array',
                 minItems: 2,
                 maxItems: 2,
-                items: [{ type: 'string' }, { $ref: '#/definitions/awsCfFunction' }],
-                additionalItems: false,
+                items: {
+                  oneOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfFunction' }],
+                },
               },
             },
             required: ['Fn::Split'],


### PR DESCRIPTION
We should not attempt to update `VpcConfig` during `deploy function` if `vpc` uses CF intrinsic functions as they cannot be properly resolved during an update. 

Closes: #9423 