### PR TITLE
fix(Telemetry): Do not report invalid commands

### DIFF
--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -15,6 +15,7 @@ const isTelemetryDisabled = require('../utils/telemetry/areDisabled');
 const { storeLocally: storeTelemetryLocally, send: sendTelemetry } = require('../utils/telemetry');
 const generateTelemetryPayload = require('../utils/telemetry/generatePayload');
 const resolveErrorLocation = require('../utils/telemetry/resolve-error-location');
+const resolveInput = require('./resolve-input');
 
 const consoleLog = (message) => process.stdout.write(`${message}\n`);
 
@@ -140,8 +141,9 @@ module.exports = async (exception, options = {}) => {
   consoleLog(chalk.yellow(`     Components Version:        ${componentsVersion}`));
   consoleLog(' ');
 
-  // If `hasTelemetryBeenReported` is not defined, we don't want to publish telemetry
-  if (!isTelemetryDisabled && hasTelemetryBeenReported === false) {
+  // If `hasTelemetryBeenReported` is not defined, we don't want to publish telemetry, similarily for when `commandSchema` is not available
+  const { commandSchema } = resolveInput();
+  if (commandSchema && !isTelemetryDisabled && hasTelemetryBeenReported === false) {
     const telemetryPayload = await generateTelemetryPayload(serverless);
     const failureReason = {
       kind: isUserError ? 'user' : 'programmer',


### PR DESCRIPTION
As was discovered in #9426, we should not report errors related to invalid commands as they are usually caused by a typo or missing plugin installation. 