### PR TITLE
CLI: Fix issues related to local version fallback

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -276,6 +276,7 @@ class Serverless {
         this.pluginManager.externalPlugins,
         {
           providerName: this.service.provider.name,
+          configuration: this.configurationInput,
         }
       );
       const resolveInput = require('./cli/resolve-input');

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -275,7 +275,7 @@ class Serverless {
       const commandsSchema = require('./cli/commands-schema/resolve-final')(
         this.pluginManager.externalPlugins,
         {
-          providerName: this.service.providerName,
+          providerName: this.service.provider.name,
         }
       );
       const resolveInput = require('./cli/resolve-input');

--- a/lib/utils/telemetry/cache-path.js
+++ b/lib/utils/telemetry/cache-path.js
@@ -6,5 +6,5 @@ const os = require('os');
 module.exports = (() => {
   const resolvedHomeDir = os.homedir();
   if (!resolvedHomeDir) return null;
-  return path.resolve(resolvedHomeDir, '.serverless', 'analytics-cache');
+  return path.resolve(resolvedHomeDir, '.serverless', 'telemetry-cache');
 })();


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9428

Additionally changed the name of the cache folder for telemetry payload. This may introduce slight friction where after upgrade some stored payload will no longer be send (as new version will look into new version).

Still I assume that loss will be negligible, and renaming of a folder is the only way to fix the issue, where old _global_ sends all cached payload on any command and _local_ fallback send same with `sls deploy`


