### PR TITLE
CLI: Do not validate command when falling back to old version

### DIFF
--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -402,7 +402,7 @@ const processSpanPromise = (async () => {
       // IIFE for maintanance convenience
       await (async () => {
         if (!configuration) return;
-        let hasFinalCommandSchema = false;
+        let hasFinalCommandSchema = null;
         if (configuration.plugins) {
           // After plugins are loaded, re-resolve CLI command and options schema as plugin
           // might have defined extra commands and options
@@ -423,9 +423,12 @@ const processSpanPromise = (async () => {
               hasFinalCommandSchema = true;
             }
           } else {
-            // Invocation fallen back to old Framework version. As we do not have easily
-            // accessible info on loaded plugins, skip further variables resolution
+            // Invocation fallen back to old Framework version, where we do not have easily
+            // accessible info on loaded plugins
+            // 1. Skip further variables resolution
             variablesMeta = null;
+            // 2. Avoid command validation
+            hasFinalCommandSchema = false;
           }
         }
         if (!providerName && !hasFinalCommandSchema) {
@@ -435,9 +438,10 @@ const processSpanPromise = (async () => {
             require('../lib/cli/commands-schema/aws-service')
           ));
         }
+        if (hasFinalCommandSchema == null) hasFinalCommandSchema = true;
 
         // Validate result command and options
-        require('../lib/cli/ensure-supported-command')(configuration);
+        if (hasFinalCommandSchema) require('../lib/cli/ensure-supported-command')(configuration);
         if (isHelpRequest) return;
         if (!_.get(variablesMeta, 'size')) return;
 


### PR DESCRIPTION
Old versions may not provide information on external plugins, and in such case we do not have a full picture supported commands and options.
We should avoid any validation in such case

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Issue reported internally.

When latest global version falls back to older local version (one that doesn't expose `pluginManager.externalPlugins` which was introduced with https://github.com/serverless/serverless/pull/8532 and first published with v2.13.0), then we don't have information on commands and options as exposed by plugins, yet we were attempting on command validation.
With this PR we fix this issue
