### PR TITLE
fix(Telemetry): Ensure telemetry only matches js stacktrace paths

### DIFF
--- a/lib/utils/telemetry/resolve-error-location.js
+++ b/lib/utils/telemetry/resolve-error-location.js
@@ -8,7 +8,7 @@ const resolveErrorLocation = (exceptionTokens) => {
   const splittedStack = exceptionTokens.stack.split(/[\r\n]+/);
   if (splittedStack.length === 1 && exceptionTokens.code) return '<not available>';
 
-  const stacktraceLineRegex = /(?:\s*at.*\((.*)\).?|\s*at\s(.*))/;
+  const stacktraceLineRegex = /(?:\s*at.*\((.*:\d+:\d+)\).?|\s*at\s(.*:\d+:\d+))/;
   const stacktracePaths = [];
   for (const line of splittedStack) {
     const match = line.match(stacktraceLineRegex) || [];

--- a/test/unit/lib/utils/telemetry/resolve-error-location.test.js
+++ b/test/unit/lib/utils/telemetry/resolve-error-location.test.js
@@ -28,6 +28,14 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
     expect(result).to.equal('<not reflected in stack>');
   });
 
+  it('should not capture non-stacktrace paths', () => {
+    const err = new Error('test');
+    err.stack =
+      'Could not find a version that satisfies the requirement flask (from versions: none) No matching distribution found for flask.';
+    const result = resolveErrorLocation(tokenizeException(err));
+    expect(result).to.equal('<not reflected in stack>');
+  });
+
   if (process.platform !== 'win32') {
     it('should correctly handle paths not enclosed in parentheses', () => {
       const err = new Error('test');


### PR DESCRIPTION
Reported internally

It should resolve situations where the regex was not strict enough and was matching phrases as
- `from versions: none` (from Python requirements plugin)
- `unix:///var/run/docker.sock. Is the docker daemon running?.` (from Docker check) 
- `does not match the API schema.` (from webpack)

Additionally, it will not report the stacktrace lines coming from internals such as `node:child_process:573:9'` which are noise anyway. 