### PR TITLE
CLI: Ensure to report only unrecognized sources as unrecognized

### DIFF
--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -581,7 +581,6 @@ const processSpanPromise = (async () => {
         const unresolvedSources =
           require('../lib/configuration/variables/resolve-unresolved-source-types')(variablesMeta);
         if (!(configuration.variablesResolutionMode >= 20210326)) {
-          unresolvedSources.delete('opt');
           const legacyCfVarPropertyPaths = new Set();
           const legacySsmVarPropertyPaths = new Set();
           for (const [sourceType, propertyPaths] of unresolvedSources) {
@@ -620,12 +619,16 @@ const processSpanPromise = (async () => {
               { serviceConfig: configuration }
             );
           }
-          if (unresolvedSources.size) {
+          const recognizedSourceNames = new Set(Object.keys(resolverConfiguration.sources));
+          const unrecognizedSourceNames = Array.from(unresolvedSources.keys()).filter(
+            (sourceName) => !recognizedSourceNames.has(sourceName)
+          );
+          if (unrecognizedSourceNames.length) {
             logDeprecation(
               'NEW_VARIABLES_RESOLVER',
-              `Approached unrecognized configuration variable sources: "${Array.from(
-                unresolvedSources.keys()
-              ).join('", "')}".\n` +
+              `Approached unrecognized configuration variable sources: "${unrecognizedSourceNames.join(
+                '", "'
+              )}".\n` +
                 'From a next major this will be communicated with a thrown error.\n' +
                 'Set "variablesResolutionMode: 20210326" in your service config, ' +
                 'to adapt to new behavior now',


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Fixes invalid report, as showcased in #9442 

In this scenario `self` reveals as _unrecognized_, as it targets property to be resolved with _unrecognized_ source.

I've fixed the implementation to simply filter out all recognized sources from all reported _unresolved_ sources (technically any source may resolve with variable that points _unrecognized_ source, so be subject to this error)