### PR TITLE
fix(AWS API Gateway): Support `Fn::Split` for `vpcEndpointIds` schema

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -307,6 +307,15 @@ class AwsProvider {
             type: 'string',
             pattern: '^arn:',
           },
+          awsCfArrayInstruction: {
+            anyOf: [
+              {
+                type: 'array',
+                items: { $ref: '#/definitions/awsCfInstruction' },
+              },
+              { $ref: '#/definitions/awsCfSplit' },
+            ],
+          },
           awsCfFunction: {
             anyOf: [
               { $ref: '#/definitions/awsCfImport' },
@@ -1105,10 +1114,7 @@ class AwsProvider {
               ],
             },
             vpc: { $ref: '#/definitions/awsLambdaVpcConfig' },
-            vpcEndpointIds: {
-              type: 'array',
-              items: { $ref: '#/definitions/awsCfInstruction' },
-            },
+            vpcEndpointIds: { $ref: '#/definitions/awsCfArrayInstruction' },
             versionFunctions: { $ref: '#/definitions/awsLambdaVersioning' },
             websocketsApiName: { type: 'string' },
             websocketsApiRouteSelectionExpression: { type: 'string' },


### PR DESCRIPTION
Closes: #9453 