### PR TITLE
Test: Ensure no deprecations in tests

### DIFF
--- a/test/fixtures/programmatic/apiGateway/serverless.yml
+++ b/test/fixtures/programmatic/apiGateway/serverless.yml
@@ -6,6 +6,7 @@ frameworkVersion: '*'
 provider:
   name: aws
   lambdaHashingVersion: 20201221
+  runtime: nodejs12.x
   apiGateway:
     shouldStartNameWithService: true
 

--- a/test/fixtures/programmatic/checkForChanges/serverless.yml
+++ b/test/fixtures/programmatic/checkForChanges/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 functions:

--- a/test/fixtures/programmatic/configSchemaExtensionsError/serverless.yml
+++ b/test/fixtures/programmatic/configSchemaExtensionsError/serverless.yml
@@ -2,6 +2,7 @@ service: configSchemaExtensionsError
 
 provider:
   name: someProvider
+  runtime: nodejs12.x
 
 configValidationMode: error
 frameworkVersion: '*'

--- a/test/fixtures/programmatic/ecr/serverless.yml
+++ b/test/fixtures/programmatic/ecr/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   ecr:
     images:
       baseimage:

--- a/test/fixtures/programmatic/function/serverless.yml
+++ b/test/fixtures/programmatic/function/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 functions:

--- a/test/fixtures/programmatic/functionCloudFront/serverless.yml
+++ b/test/fixtures/programmatic/functionCloudFront/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 functions:

--- a/test/fixtures/programmatic/functionDestinations/serverless.yml
+++ b/test/fixtures/programmatic/functionDestinations/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 functions:

--- a/test/fixtures/programmatic/functionLayers/serverless.yml
+++ b/test/fixtures/programmatic/functionLayers/serverless.yml
@@ -1,6 +1,7 @@
 service: service
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 layers:

--- a/test/fixtures/programmatic/httpApi/serverless.yml
+++ b/test/fixtures/programmatic/httpApi/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   logRetentionInDays: 14
   lambdaHashingVersion: 20201221
 

--- a/test/fixtures/programmatic/httpApiCatchAll/serverless.yml
+++ b/test/fixtures/programmatic/httpApiCatchAll/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 functions:

--- a/test/fixtures/programmatic/httpApiExport/serverless.yml
+++ b/test/fixtures/programmatic/httpApiExport/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 resources:

--- a/test/fixtures/programmatic/invocation/serverless.yml
+++ b/test/fixtures/programmatic/invocation/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 functions:

--- a/test/fixtures/programmatic/layer/serverless.yml
+++ b/test/fixtures/programmatic/layer/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 functions:

--- a/test/fixtures/programmatic/packageArtifact/serverless.yml
+++ b/test/fixtures/programmatic/packageArtifact/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 package:

--- a/test/fixtures/programmatic/packageArtifactInServerlessDir/serverless.yml
+++ b/test/fixtures/programmatic/packageArtifactInServerlessDir/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 plugins:

--- a/test/fixtures/programmatic/packaging/serverless.yml
+++ b/test/fixtures/programmatic/packaging/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 functions:

--- a/test/fixtures/programmatic/plugin/serverless.yml
+++ b/test/fixtures/programmatic/plugin/serverless.yml
@@ -5,6 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
 
 plugins:

--- a/test/fixtures/programmatic/requestSchema/serverless.yml
+++ b/test/fixtures/programmatic/requestSchema/serverless.yml
@@ -2,6 +2,7 @@ service: service
 
 provider:
   name: aws
+  runtime: nodejs12.x
   lambdaHashingVersion: 20201221
   apiGateway:
     request:

--- a/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
+++ b/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
@@ -8,7 +8,7 @@ chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 const FUNCTION_NAME_PATTERN = '^[a-zA-Z0-9-_]+$';
 
-describe('ConfigSchemaHandler', () => {
+describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
   describe('#constructor', () => {
     it('should freeze parts of schema for service', () => {
       return runServerless({


### PR DESCRIPTION
When working on CLI refactor, suddenly some tests started to fail for me, because of introduced deprecation logs.

This patch ensures our fixtures do not generate deprecation logs when not expected.

Complements https://github.com/serverless/serverless/pull/9416

Note: Such issues won't happen once we have https://github.com/serverless/serverless/issues/9024 addressed
