### PR TITLE
CLI: Fix local fallback handling

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -249,6 +249,7 @@ class Serverless {
       configuration: this.configurationInput,
       isConfigurationResolved: this.isConfigurationInputResolved,
       hasResolvedCommandsExternally: this.hasResolvedCommandsExternally,
+      isTelemetryReportedExternally: this.isTelemetryReportedExternally,
       commands: this.processedInput.commands,
       options: this.processedInput.options,
       _isInvokedByGlobalInstallation: true,

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -270,9 +270,8 @@ class Serverless {
   }
 
   async run() {
-    if (!this.hasResolvedCommandsExternally) {
-      // Invoked by older global version. Ensure to have command schema saturated
-      // which is needed for complete help output
+    if (this._isInvokedByGlobalInstallation) {
+      // Ensure to have resolve-input populated with right result
       // TODO: Remove with next major
       const commandsSchema = require('./cli/commands-schema/resolve-final')(
         this.pluginManager.externalPlugins,

--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -59,7 +59,9 @@ module.exports = async (exception, options = {}) => {
     ? serverless.isInvokedByGlobalInstallation
     : passedIsInvokedByGlobalInstallation;
 
-  if (isInvokedByGlobalInstallation) {
+  // If provided serverless instance is a local fallback, and we're not in context of it
+  // Pass error handling to this local fallback implementation
+  if (isInvokedByGlobalInstallation && !(await resolveIsLocallyInstalled())) {
     const localServerlessPath = await resolveLocalServerlessPath();
 
     try {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9468

It appears we had a few quite critical issues when local fallback is concerned. 

1. Errors happening with local fallback triggered infinite loop, as global handler, invoked local hander, which again was invoking same local handler and so on, so on. Due to this issue it was observed that `serverless` process hangs.
Error in logic was that, in error handler we were unconditionally falling back to local handler if `serverless` installation in question was invoked by global. Still we didn't check wether we're not already in its context. Adding that check fixed the issue
2. Fixing above, exposed an actual error that happens in local fallback case. Error was caused by incomplete command schema provided to `lib/cli/resolve-input` util, which resolves final command schema and options for the invoked command. In result command as introduced by plugins (as `sls create_domain`) were not recognized, and that triggered a crash in telemetry payload generator, which depends on result as coming from `lib/cli/resolve-input`.
Fixed that that by ensuring that in case we're in local fallback, we're unconditionally resolve input with `lib/cli/resolve-input`, whith fully resolved commands schema map that includes schemas as introduced by plugins
3. Observing above, I found unexpected that telemetry is send internally (before command is processed) in case of latest version when it's fallback from latest version. This scenario was most likely not deeply explored when adding support for success/failure reporting. Ideally in case when both top level and local fallback are configured to report command outcome, it's always that top level installation reports the error (with slight exception that in case of an error, we will fallback to error handler of local version, which will send the telemetry, but that's totally fine IMO) - Ensured that's the case.

_Summarizing: Current local fallback behavior is very problematic, and raises tons of issues for us, which are very hard to predict when enhancing involved functionalities. Again I can't wait v3, where local fallback will be solved right way, without leaking into implementation internals._