### PR TITLE
Variables: Fix reporting of variable resolution errors

### DIFF
--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -126,6 +126,12 @@ module.exports = {
               return await result({ options, resolveConfigurationProperty, resolveVariable });
             } catch (error) {
               if (error.code === 'MISSING_VARIABLE_DEPENDENCY') throw error;
+              if (
+                error.constructor.name === 'ServerlessError' &&
+                error.message.startsWith('Cannot resolve variable at ')
+              ) {
+                throw error;
+              }
               throw new ServerlessError(
                 `Cannot resolve "${path.basename(filePath)}": Returned JS function errored with: ${
                   error && error.stack ? error.stack : error
@@ -173,6 +179,12 @@ module.exports = {
           result = await result({ options, resolveConfigurationProperty, resolveVariable });
         } catch (error) {
           if (error.code === 'MISSING_VARIABLE_DEPENDENCY') throw error;
+          if (
+            error.constructor.name === 'ServerlessError' &&
+            error.message.startsWith('Cannot resolve variable at ')
+          ) {
+            throw error;
+          }
           throw new ServerlessError(
             `Cannot resolve "${address}" out of "${path.basename(filePath)}": Received rejection: ${
               error && error.stack ? error.stack : error

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -24,7 +24,10 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       jsPropertyFunctionProperty: '${file(file-property-function.js):property.result}',
       addressSupport: '${file(file.json):result}',
       jsFunctionResolveVariable: '${file(file-function-variable.js)}',
+      jsFunctionResolveVariableMissingSource: '${file(file-function-variable-missing-source.js)}',
       jsPropertyFunctionResolveVariable: '${file(file-property-function-variable.js):property}',
+      jsPropertyFunctionResolveVariableMissingSource:
+        '${file(file-property-function-variable-missing-source.js):property}',
       nonExistingYaml: '${file(not-existing.yaml), null}',
       nonExistingJson: '${file(not-existing.json), null}',
       nonExistingJs: '${file(not-existing.js), null}',
@@ -184,6 +187,16 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     expect(variablesMeta.get('invalidJs').error.code).to.equal('VARIABLE_RESOLUTION_ERROR');
     expect(variablesMeta.get('invalidJs2').error.code).to.equal('VARIABLE_RESOLUTION_ERROR');
   });
+
+  it('should report with an error if JS function attempts to resolve missing source', () =>
+    expect(variablesMeta.get('jsFunctionResolveVariableMissingSource').error.code).to.equal(
+      'MISSING_VARIABLE_RESULT'
+    ));
+
+  it('should report with an error if JS function property attempts to resolve missing source', () =>
+    expect(variablesMeta.get('jsPropertyFunctionResolveVariableMissingSource').error.code).to.equal(
+      'MISSING_VARIABLE_RESULT'
+    ));
 
   it('should not support function resolvers in "js" file sources not confirmed to work with new resolver', async () => {
     configuration = {

--- a/test/unit/lib/configuration/variables/sources/fixture/file-function-variable-missing-source.js
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-function-variable-missing-source.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async ({ resolveVariable }) => ({
+  varResult: await resolveVariable('file(missing.yaml)'),
+});

--- a/test/unit/lib/configuration/variables/sources/fixture/file-property-function-variable-missing-source.js
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-property-function-variable-missing-source.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports.property = async ({ resolveVariable }) => ({
+  varResult: await resolveVariable('file(missing.json)'),
+});


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Addresses variable resolution error reporting issue showcased here: https://github.com/serverless/serverless/issues/9478

When in JS function variable resolver is used and it crashes with some resolution error, it ends with unfriendly error message as:

```
Cannot resolve variable at "custom.platformConfig": Cannot resolve "platformConfig.js": Returned JS function errored with: ServerlessError: Cannot resolve variable at "custom.platformConfig": Value not found at "s3" source
```

This patch ensures it's reduced to:

```
Cannot resolve variable at "custom.platformConfig": Value not found at "s3" source
```
