### PR TITLE
fix(AWS API Gateway): Fix schema for `apiKeys` and `permissionsBoundary`

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -276,26 +276,33 @@ class AwsProvider {
               anyOf: [
                 { type: 'string' },
                 {
-                  type: 'object',
-                  properties: {
-                    name: { type: 'string' },
-                    value: { type: 'string' },
-                    description: { type: 'string' },
-                    customerId: { type: 'string' },
-                  },
-                  anyOf: [{ required: ['name'] }, { required: ['value'] }],
-                  additionalProperties: false,
+                  $ref: '#/definitions/awsApiGatewayApiKeysProperties',
                 },
                 {
                   type: 'object',
                   maxProperties: 1,
                   additionalProperties: {
                     type: 'array',
-                    items: { type: 'string' },
+                    items: {
+                      oneOf: [
+                        { type: 'string' },
+                        { $ref: '#/definitions/awsApiGatewayApiKeysProperties' },
+                      ],
+                    },
                   },
                 },
               ],
             },
+          },
+          awsApiGatewayApiKeysProperties: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              value: { type: 'string' },
+              description: { type: 'string' },
+              customerId: { type: 'string' },
+            },
+            additionalProperties: false,
           },
           awsArn: {
             anyOf: [
@@ -907,8 +914,8 @@ class AwsProvider {
                           items: { $ref: '#/definitions/awsArn' },
                         },
                         statements: { $ref: '#/definitions/awsIamPolicyStatements' },
-                        permissionBoundary: { $ref: '#/definitions/awsArnString' },
-                        permissionsBoundary: { $ref: '#/definitions/awsArnString' },
+                        permissionBoundary: { $ref: '#/definitions/awsArn' },
+                        permissionsBoundary: { $ref: '#/definitions/awsArn' },
                         tags: { $ref: '#/definitions/awsResourceTags' },
                       },
                       additionalProperties: false,

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -376,6 +376,32 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         );
       });
 
+      it('should support `provider.iam.role.permissionBoundary` defined with CF intrinsic functions', async () => {
+        const { cfTemplate, awsNaming } = await runServerless({
+          fixture: 'function',
+          command: 'package',
+          configExt: {
+            provider: {
+              iam: {
+                role: {
+                  permissionsBoundary: {
+                    'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:policy/XCompanyBoundaries',
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        const IamRoleLambdaExecution = awsNaming.getRoleLogicalId();
+        const {
+          Properties: { PermissionsBoundary },
+        } = cfTemplate.Resources[IamRoleLambdaExecution];
+        expect(PermissionsBoundary).to.deep.includes({
+          'Fn::Sub': 'arn:aws:iam::${AWS::AccountId}:policy/XCompanyBoundaries',
+        });
+      });
+
       it('should ensure needed IAM configuration when `provider.vpc` is configured', () => {
         const IamRoleLambdaExecution = naming.getRoleLogicalId();
         const iamResource = cfResources[IamRoleLambdaExecution];

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -376,7 +376,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         );
       });
 
-      it('should support `provider.iam.role.permissionBoundary` defined with CF intrinsic functions', async () => {
+      it('should support `provider.iam.role.permissionsBoundary` defined with CF intrinsic functions', async () => {
         const { cfTemplate, awsNaming } = await runServerless({
           fixture: 'function',
           command: 'package',


### PR DESCRIPTION
Updates schema to match existing implementation.
There was an existing test that already covered the apiKeys implementation which I refactored to use runServerless so that the schema is checked as well. I also added an extra test case to this for the case where neither name or value is provided, which were previously required fields in the schema (but not in the implementation).

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9080
