### PR TITLE
test: Adjust interactive CLI test after plugin changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@serverless/cli": "^1.5.2",
     "@serverless/components": "^3.9.2",
-    "@serverless/dashboard-plugin": "^5.0.0",
+    "@serverless/dashboard-plugin": "^5.1.0",
     "@serverless/utils": "^4.1.0",
     "ajv": "^6.12.6",
     "ajv-keywords": "^3.5.2",

--- a/test/unit/lib/cli/interactive-setup/index.test.js
+++ b/test/unit/lib/cli/interactive-setup/index.test.js
@@ -34,12 +34,7 @@ describe('test/unit/lib/cli/interactive-setup/index.test.js', () => {
 
       // dashboard-login
       {
-        instructionString: 'Would you like to enable this?',
-        input: 'Y',
-      },
-      {
-        instructionString: 'login or register?',
-        input: 'j',
+        instructionString: 'Do you want to login/register to Serverless Dashboard?',
       },
 
       // dashboard-set-org


### PR DESCRIPTION
Adjust interactive CLI test after changes in `dashboard-plugin`'s `5.1.0` release