### PR TITLE
feat(AWS Streams): Allowing for consumerName to be configured. 

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -69,7 +69,12 @@ functions:
       - stream:
           type: kinesis
           arn: arn:aws:kinesis:region:XXXXXX:stream/foobar
-          consumer: preExistingName
+          consumer: arn:aws:kinesis:us-west-2:xxx:stream/my-kinesis-stream/consumer/my-consumer
+      - stream:
+        type: kinesis
+        arn: arn:aws:kinesis:region:XXXXXX:stream/foobar
+        consumer: true
+        consumerName: 'my-consumer'
 ```
 
 ## Setting the BatchSize and StartingPosition
@@ -291,7 +296,7 @@ This configuration controls the optional usage of Kinesis data streams enhanced 
 
 The `consumer` property can be used to put a [stream consumer](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kinesis-streamconsumer.html) between your function's [event source mapping](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html) and the stream it consumes.
 
-The configuration below creates a new stream consumer.
+The configuration below creates a new stream consumer. The default name of the consumer can be overridden with the optional `consumerName` property.
 
 ```yml
 functions:
@@ -301,6 +306,7 @@ functions:
       - stream:
           arn: arn:aws:kinesis:region:XXXXXX:stream/foo
           consumer: true
+          consumerName: optional-consumer-name
 ```
 
 The configuration below uses the pre-existing stream consumer with the given ARN.

--- a/lib/plugins/aws/package/compile/events/stream.js
+++ b/lib/plugins/aws/package/compile/events/stream.js
@@ -267,16 +267,13 @@ class AwsCompileStreamEvents {
               };
             }
 
-            const newStreamObject = {
-              [streamLogicalId]: streamResource,
-            };
-
             if (event.stream.consumer && streamType === 'kinesis') {
               if (event.stream.consumer === true) {
-                const consumerName = this.provider.naming.getStreamConsumerName(
-                  functionName,
-                  streamName
-                );
+                const consumerName = event.stream.consumerName
+                  ? event.stream.consumerName
+                  : this.provider.naming.getStreamConsumerName(functionName, streamName);
+                const consumerLogicalId =
+                  this.provider.naming.getStreamConsumerLogicalId(consumerName);
                 const consumerResource = {
                   Type: 'AWS::Kinesis::StreamConsumer',
                   Properties: {
@@ -284,30 +281,27 @@ class AwsCompileStreamEvents {
                     ConsumerName: consumerName,
                   },
                 };
-                const consumerLogicalId =
-                  this.provider.naming.getStreamConsumerLogicalId(consumerName);
-                newStreamObject[consumerLogicalId] = consumerResource;
-                if (Array.isArray(streamResource.DependsOn)) {
-                  streamResource.DependsOn.push(consumerLogicalId);
-                } else {
-                  streamResource.DependsOn = [streamResource.DependsOn, consumerLogicalId];
-                }
+                _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+                  [consumerLogicalId]: consumerResource,
+                });
+                streamResource.DependsOn = Array.isArray(streamResource.DependsOn)
+                  ? streamResource.DependsOn
+                  : [streamResource.DependsOn];
+                streamResource.DependsOn.push(consumerLogicalId);
                 const consumerArnRef = {
                   Ref: consumerLogicalId,
                 };
                 streamResource.Properties.EventSourceArn = consumerArnRef;
                 kinesisConsumerStatement.Resource.push(consumerArnRef);
               } else {
-                const consumerArn = event.stream.consumer;
-                streamResource.Properties.EventSourceArn = consumerArn;
-                kinesisConsumerStatement.Resource.push(consumerArn);
+                streamResource.Properties.EventSourceArn = event.stream.consumer;
+                kinesisConsumerStatement.Resource.push(event.stream.consumer);
               }
             }
 
-            _.merge(
-              this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-              newStreamObject
-            );
+            _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
+              [streamLogicalId]: streamResource,
+            });
           }
         });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
@@ -1159,6 +1159,13 @@ describe('AwsCompileStreamEvents', () => {
                   consumer: false,
                 },
               },
+              {
+                stream: {
+                  arn: 'arn:aws:kinesis:region:account:stream/ghi',
+                  consumer: true,
+                  consumerName: 'MyConsumerName',
+                },
+              },
             ],
           },
         };
@@ -1431,6 +1438,40 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.Properties.MaximumRecordAgeInSeconds
+        ).to.equal(undefined);
+
+        // event 9
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisGhi.Type
+        ).to.equal('AWS::Lambda::EventSourceMapping');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisGhi.DependsOn
+        ).to.include('IamRoleLambdaExecution');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisGhi.Properties.EventSourceArn
+        ).to.eql({ Ref: 'MyConsumerNameStreamConsumer' });
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisGhi.Properties.BatchSize
+        ).to.equal(10);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisGhi.Properties.StartingPosition
+        ).to.equal('TRIM_HORIZON');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisGhi.Properties.Enabled
+        ).to.equal(true);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisGhi.Properties.BisectBatchOnFunctionError
+        ).to.equal(undefined);
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisGhi.Properties.MaximumRecordAgeInSeconds
         ).to.equal(undefined);
       });
 


### PR DESCRIPTION
Fixes #9491

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->


This allows for specifying multiple kinesis fanout consumers  for the same stream and function. More detail in the [linked issue.](https://github.com/serverless/serverless/issues/9491).

Let me know if you have a better suggestion for naming. I went with `consumerName` for now, but could also see it being an object maybe? Let me know your thoughts, thanks!

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9491
