### PR TITLE
Telemetry: Report resource types as configured explicitly by user

### DIFF
--- a/lib/utils/telemetry/generatePayload.js
+++ b/lib/utils/telemetry/generatePayload.js
@@ -5,6 +5,7 @@ const os = require('os');
 const fs = require('fs').promises;
 const resolve = require('ncjsm/resolve');
 const _ = require('lodash');
+const isPlainObject = require('type/plain-object/is');
 const isObject = require('type/object/is');
 const userConfig = require('@serverless/utils/config');
 const isStandalone = require('../isStandaloneExecutable');
@@ -43,6 +44,29 @@ const getServiceConfig = ({ configuration, options }) => {
     return result;
   })();
 
+  const resolveResourceTypes = (resources) => {
+    if (!isPlainObject(resources)) return [];
+    return [
+      ...new Set(
+        Object.values(resources)
+          .map((resource) => {
+            const type = _.get(resource, 'Type');
+            if (typeof type !== 'string' || !type.includes('::')) return null;
+            const domain = type.slice(0, type.indexOf(':'));
+            return domain === 'AWS' ? type : domain;
+          })
+          .filter(Boolean)
+      ),
+    ];
+  };
+
+  const resources = (() => {
+    if (!isAwsProvider) return undefined;
+    return {
+      general: resolveResourceTypes(_.get(configuration.resources, 'Resources')),
+    };
+  })();
+
   return {
     provider: {
       name: providerName,
@@ -70,6 +94,7 @@ const getServiceConfig = ({ configuration, options }) => {
         };
       })
       .filter(Boolean),
+    resources,
   };
 };
 

--- a/test/unit/lib/utils/telemetry/generatePayload.test.js
+++ b/test/unit/lib/utils/telemetry/generatePayload.test.js
@@ -40,6 +40,35 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
               '000000000000.dkr.ecr.sa-east-1.amazonaws.com/test-lambda-docker@sha256:6bb600b4d6e1d7cf521097177dd0c4e9ea373edb91984a505333be8ac9455d38',
           },
         },
+        resources: {
+          Resources: {
+            ExtraLogGroup: {
+              Type: 'AWS::Logs::LogGroup',
+              Properties: {
+                LogGroupName: '/aws/lambda/extra-log',
+              },
+            },
+            AnotherExtraLogGroup: {
+              Type: 'AWS::Logs::LogGroup',
+              Properties: {
+                LogGroupName: '/aws/lambda/extra-log-2',
+              },
+            },
+            ExtraBucket: {
+              Type: 'AWS::S3::Bucket',
+            },
+            ExtraCustom: {
+              Type: 'Custom::Matthieu',
+            },
+          },
+          extensions: {
+            FunctionLambdaFunction: {
+              Properties: {
+                Runtime: 'nodejs14.x',
+              },
+            },
+          },
+        },
       },
     });
     await fs.promises.writeFile(
@@ -105,6 +134,9 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
           { runtime: 'nodejs14.x', events: [] },
           { runtime: '$containerimage', events: [] },
         ],
+        resources: {
+          general: ['AWS::Logs::LogGroup', 'AWS::S3::Bucket', 'Custom'],
+        },
       },
       isAutoUpdateEnabled: false,
       isTabAutocompletionInstalled: false,
@@ -159,6 +191,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
           { runtime: 'foo', events: [{ type: 'someEvent' }] },
           { runtime: 'bar', events: [] },
         ],
+        resources: undefined,
       },
       isAutoUpdateEnabled: false,
       isTabAutocompletionInstalled: false,
@@ -216,6 +249,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
         },
         plugins: [],
         functions: [],
+        resources: { general: [] },
       },
       isAutoUpdateEnabled: false,
       isTabAutocompletionInstalled: false,
@@ -314,6 +348,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
           { runtime: 'nodejs12.x', events: [] },
           { runtime: 'nodejs12.x', events: [] },
         ],
+        resources: { general: [] },
       },
       isAutoUpdateEnabled: false,
       isTabAutocompletionInstalled: false,


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

_Originally proposed by @mnapoli_

This should give good idea of what missing functionalities in a Framework are in demand

Currently in Framework, user can extend the generated template by defining resources in:
- `resources.Resources` - to introduce new resources, but also extensions to resources already generated by the Framework. This property is scheduled to be deprecated as it performs blind merge, and unexpected merge side effects can happen (we had reports of that)
- `resources.extensions` - dedicated and recommended property to extend resources as generated by the Framework. It guarantees no surprises and each extension property is treated invididualy.

Above is to be extended with `resource.additions` and having that `resources.Resources` will be deprecated (handled at https://github.com/serverless/serverless/issues/6575)

Having above state, at the time-being I propose to report with telemetry just resources configured at `resources.Resources`, with `config.resources.general` property (note that in `resources.extensions` `Type` is not supported, so even if we find this data also valuable, reporting of it in anonymous way will require some more sophisticated handling).

After support for `resources.additions` is added, these resource types will be reported with `config.resources.additions` property

_To be followed with PR's in our internal packages that provide support for new property_

