### PR TITLE
Present default project name if possible

### DIFF
--- a/lib/cli/interactive-setup/service.js
+++ b/lib/cli/interactive-setup/service.js
@@ -8,7 +8,6 @@ const inquirer = require('@serverless/utils/inquirer');
 const resolveConfigurationPath = require('../resolve-configuration-path');
 const readConfiguration = require('../../configuration/read');
 const resolveVariables = require('../../configuration/variables');
-const { confirm } = require('./utils');
 const createFromLocalTemplate = require('../../utils/create-from-local-template');
 const npmCommandDeferred = require('../../utils/npm-command-deferred');
 const ServerlessError = require('../../serverless-error');
@@ -50,12 +49,13 @@ const INVALID_PROJECT_NAME_MESSAGE =
   '   - It should start with an alphabetic character.\n' +
   "   - Shouldn't exceed 128 characters";
 
-const projectNameInput = async (workingDir) =>
+const projectNameInput = async (workingDir, projectType) =>
   (
     await inquirer.prompt({
       message: 'What do you want to call this project?',
       type: 'input',
       name: 'projectName',
+      default: projectType ? `${projectType}-project` : null,
       validate: async (input) => {
         input = input.trim();
         if (!isValidServiceName(input)) {
@@ -72,7 +72,7 @@ const projectNameInput = async (workingDir) =>
     })
   ).projectName.trim();
 
-const resolveProjectNameInput = async (options, workingDir) => {
+const resolveProjectNameInput = async (options, workingDir, projectType = null) => {
   if (options.name) {
     if (!isValidServiceName(options.name)) {
       throw new ServerlessError(INVALID_PROJECT_NAME_MESSAGE, 'INVALID_PROJECT_NAME');
@@ -96,7 +96,7 @@ const resolveProjectNameInput = async (options, workingDir) => {
     return options.name;
   }
 
-  return projectNameInput(workingDir);
+  return projectNameInput(workingDir, projectType);
 };
 
 module.exports = {
@@ -135,10 +135,15 @@ module.exports = {
       !context.options.template &&
       !context.options['template-url']
     ) {
-      const isConfirmed = await confirm('No project detected. Do you want to create a new one?', {
-        name: 'shouldCreateNewProject',
-      });
-      if (!isConfirmed) return;
+      const isConfirmed = (
+        await inquirer.prompt({
+          message: 'No project detected. Do you want to create a new one?',
+          type: 'list',
+          name: 'shouldCreateNewProject',
+          choices: ['Yes', 'No'],
+        })
+      ).shouldCreateNewProject;
+      if (isConfirmed !== 'Yes') return;
     }
 
     let projectDir;
@@ -180,7 +185,7 @@ module.exports = {
           return;
         }
       }
-      projectName = await resolveProjectNameInput(context.options, workingDir);
+      projectName = await resolveProjectNameInput(context.options, workingDir, projectType);
       projectDir = join(workingDir, projectName);
       const templateUrl = `https://github.com/serverless/examples/tree/master/${projectType}`;
       process.stdout.write(`\nDownloading "${projectType}" template...\n`);

--- a/test/unit/lib/cli/interactive-setup/service.test.js
+++ b/test/unit/lib/cli/interactive-setup/service.test.js
@@ -54,7 +54,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
 
   it("Should abort if user doesn't want setup", async () => {
     configureInquirerStub(inquirer, {
-      confirm: { shouldCreateNewProject: false },
+      list: { shouldCreateNewProject: 'No' },
     });
     await step.run({ options: {} });
     return confirmEmptyWorkingDir();
@@ -62,8 +62,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
 
   it("Should abort if user choses 'other' template", async () => {
     configureInquirerStub(inquirer, {
-      confirm: { shouldCreateNewProject: true },
-      list: { projectType: 'other' },
+      list: { projectType: 'other', shouldCreateNewProject: 'Yes' },
     });
     await step.run({ options: {} });
     return confirmEmptyWorkingDir();
@@ -90,8 +89,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       });
 
       configureInquirerStub(inquirer, {
-        confirm: { shouldCreateNewProject: true },
-        list: { projectType: 'aws-nodejs' },
+        list: { projectType: 'aws-nodejs', shouldCreateNewProject: 'Yes' },
         input: { projectName: 'test-project' },
       });
       await mockedStep.run({ options: {} });
@@ -125,8 +123,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       });
 
       configureInquirerStub(inquirer, {
-        confirm: { shouldCreateNewProject: true },
-        list: { projectType: 'aws-nodejs' },
+        list: { projectType: 'aws-nodejs', shouldCreateNewProject: 'Yes' },
         input: { projectName: 'test-project-template' },
       });
       await mockedStep.run({ options: {} });
@@ -165,8 +162,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       });
 
       configureInquirerStub(inquirer, {
-        confirm: { shouldCreateNewProject: true },
-        list: { projectType: 'aws-nodejs' },
+        list: { shouldCreateNewProject: 'Yes', projectType: 'aws-nodejs' },
         input: { projectName: 'test-project-package-json' },
       });
       await mockedStep.run({ options: {} });
@@ -204,8 +200,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       });
 
       configureInquirerStub(inquirer, {
-        confirm: { shouldCreateNewProject: true },
-        list: { projectType: 'aws-nodejs' },
+        list: { projectType: 'aws-nodejs', shouldCreateNewProject: 'Yes' },
         input: { projectName: 'test-project-missing-npm' },
       });
 
@@ -242,8 +237,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       });
 
       configureInquirerStub(inquirer, {
-        confirm: { shouldCreateNewProject: true },
-        list: { projectType: 'aws-nodejs' },
+        list: { projectType: 'aws-nodejs', shouldCreateNewProject: 'Yes' },
         input: { projectName: 'test-project-failed-install' },
       });
 
@@ -360,8 +354,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
         },
       });
       configureInquirerStub(inquirer, {
-        confirm: { shouldCreateNewProject: true },
-        list: { projectType: 'aws-nodejs' },
+        list: { projectType: 'aws-nodejs', shouldCreateNewProject: 'Yes' },
         input: { projectName: 'test-error-during-download' },
       });
       await expect(mockedStep.run({ options: {} })).to.be.eventually.rejected.and.have.property(
@@ -403,8 +396,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
 
   it('Should not allow project creation in a directory in which already service is configured', async () => {
     configureInquirerStub(inquirer, {
-      confirm: { shouldCreateNewProject: true },
-      list: { projectType: 'aws-nodejs' },
+      list: { projectType: 'aws-nodejs', shouldCreateNewProject: 'Yes' },
       input: { projectName: 'existing' },
     });
 
@@ -430,8 +422,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
 
   it('Should not allow project creation using an invalid project name', async () => {
     configureInquirerStub(inquirer, {
-      confirm: { shouldCreateNewProject: true },
-      list: { projectType: 'aws-nodejs' },
+      list: { projectType: 'aws-nodejs', shouldCreateNewProject: 'Yes' },
       input: { projectName: 'elo grzegżółka' },
     });
     await expect(step.run({ options: {} })).to.eventually.be.rejected.and.have.property(


### PR DESCRIPTION
Addresses: #9367 

I've decided to NOT provide the default project name in situations where `template-url` or `template-path` is used as it requires parsing/normalization of template names and introduces additional complexity. Please let me know if you feel otherwise. 