### PR TITLE
Dont depend on default execution role when custom role provided with `!Sub`

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1625,9 +1625,10 @@ class AwsProvider {
         return customRole['Fn::GetAtt'][0];
       }
       if (
-        // otherwise, check if we have an import or parameters ref
+        // otherwise, check if we have an import, parameters ref or sub
         customRole['Fn::ImportValue'] ||
-        customRole.Ref
+        customRole.Ref ||
+        customRole['Fn::Sub']
       ) {
         return null;
       }


### PR DESCRIPTION
Closes: #8150 

I've decided to implement the test for `sqs`, because it's not really possible to implement different test with `runServerless` for this. Other affected devents are `stream`, `msk` and `kafka`. 