### PR TITLE
Fix stack errors processing

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -101,9 +101,12 @@ module.exports = {
                 this.serverless.cli.log(`View the full error output: ${stackUrl}`);
                 let errorMessage = 'An error occurred: ';
                 errorMessage += `${stackLatestError.LogicalResourceId} - `;
-                errorMessage += `${stackLatestError.ResourceStatusReason}.`;
+                errorMessage += `${
+                  stackLatestError.ResourceStatusReason || stackLatestError.ResourceStatus
+                }.`;
                 const errorCode = (() => {
                   if (
+                    stackLatestError.ResourceStatusReason &&
                     stackLatestError.ResourceStatusReason.startsWith('Properties validation failed')
                   ) {
                     return `AWS_STACK_${action.toUpperCase()}_VALIDATION_ERROR`;

--- a/lib/plugins/plugin/install.js
+++ b/lib/plugins/plugin/install.js
@@ -2,15 +2,26 @@
 
 const BbPromise = require('bluebird');
 const childProcess = BbPromise.promisifyAll(require('child_process'));
+const fsp = require('fs').promises;
 const fse = require('fs-extra');
 const path = require('path');
 const _ = require('lodash');
+const isPlainObject = require('type/plain-object/is');
+const yaml = require('js-yaml');
+const cloudformationSchema = require('@serverless/utils/cloudformation-schema');
+const log = require('@serverless/utils/log');
 const ServerlessError = require('../../serverless-error');
 const cliCommandsSchema = require('../../cli/commands-schema');
 const yamlAstParser = require('../../utils/yamlAstParser');
 const fileExists = require('../../utils/fs/fileExists');
 const pluginUtils = require('./lib/utils');
 const npmCommandDeferred = require('../../utils/npm-command-deferred');
+
+const requestManualUpdate = (serverlessFilePath) =>
+  log(`
+  Can't automatically add plugin into "${path.basename(serverlessFilePath)}" file.
+  Please make it manually.
+`);
 
 class PluginInstall {
   constructor(serverless, options) {
@@ -97,10 +108,7 @@ class PluginInstall {
     const serverlessFilePath = this.getServerlessFilePath();
     const fileExtension = path.extname(serverlessFilePath);
     if (fileExtension === '.js' || fileExtension === '.ts') {
-      this.serverless.cli.log(`
-          Can't automatically add plugin into "${path.basename(serverlessFilePath)}" file.
-          Please make it manually.
-        `);
+      requestManualUpdate(serverlessFilePath);
       return;
     }
 
@@ -136,7 +144,25 @@ class PluginInstall {
       return;
     }
 
-    const serverlessFileObj = await this.serverless.yamlParser.parse(serverlessFilePath);
+    const serverlessFileObj = yaml.load(await fsp.readFile(serverlessFilePath, 'utf8'), {
+      filename: serverlessFilePath,
+      schema: cloudformationSchema,
+    });
+    if (serverlessFileObj.plugins != null) {
+      // Plugins section can be behind veriables, opt-out in such case
+      if (isPlainObject(serverlessFileObj.plugins)) {
+        if (
+          serverlessFileObj.plugins.modules != null &&
+          !Array.isArray(serverlessFileObj.plugins.modules)
+        ) {
+          requestManualUpdate(serverlessFilePath);
+          return;
+        }
+      } else if (!Array.isArray(serverlessFileObj.plugins)) {
+        requestManualUpdate(serverlessFilePath);
+        return;
+      }
+    }
     await yamlAstParser.addNewArrayItem(
       serverlessFilePath,
       checkIsArrayPluginsObject(serverlessFileObj.plugins) ? 'plugins' : 'plugins.modules',

--- a/lib/plugins/plugin/uninstall.js
+++ b/lib/plugins/plugin/uninstall.js
@@ -2,12 +2,23 @@
 
 const BbPromise = require('bluebird');
 const childProcess = BbPromise.promisifyAll(require('child_process'));
+const fsp = require('fs').promises;
 const fse = require('fs-extra');
 const path = require('path');
 const _ = require('lodash');
+const isPlainObject = require('type/plain-object/is');
+const yaml = require('js-yaml');
+const cloudformationSchema = require('@serverless/utils/cloudformation-schema');
+const log = require('@serverless/utils/log');
 const cliCommandsSchema = require('../../cli/commands-schema');
 const yamlAstParser = require('../../utils/yamlAstParser');
 const pluginUtils = require('./lib/utils');
+
+const requestManualUpdate = (serverlessFilePath) =>
+  log(`
+  Can't automatically add plugin into "${path.basename(serverlessFilePath)}" file.
+  Please make it manually.
+`);
 
 class PluginUninstall {
   constructor(serverless, options) {
@@ -67,10 +78,7 @@ class PluginUninstall {
     const serverlessFilePath = this.getServerlessFilePath();
     const fileExtension = path.extname(serverlessFilePath);
     if (fileExtension === '.js' || fileExtension === '.ts') {
-      this.serverless.cli.log(`
-          Can't automatically remove plugin from "serverless.js" file.
-          Please make it manually.
-        `);
+      requestManualUpdate(serverlessFilePath);
       return;
     }
 
@@ -95,7 +103,25 @@ class PluginUninstall {
       return;
     }
 
-    const serverlessFileObj = await this.serverless.yamlParser.parse(serverlessFilePath);
+    const serverlessFileObj = yaml.load(await fsp.readFile(serverlessFilePath, 'utf8'), {
+      filename: serverlessFilePath,
+      schema: cloudformationSchema,
+    });
+    if (serverlessFileObj.plugins != null) {
+      // Plugins section can be behind veriables, opt-out in such case
+      if (isPlainObject(serverlessFileObj.plugins)) {
+        if (
+          serverlessFileObj.plugins.modules != null &&
+          !Array.isArray(serverlessFileObj.plugins.modules)
+        ) {
+          requestManualUpdate(serverlessFilePath);
+          return;
+        }
+      } else if (!Array.isArray(serverlessFileObj.plugins)) {
+        requestManualUpdate(serverlessFilePath);
+        return;
+      }
+    }
     await yamlAstParser.removeExistingArrayItem(
       serverlessFilePath,
       Array.isArray(serverlessFileObj.plugins) ? 'plugins' : 'plugins.modules',

--- a/lib/utils/tokenize-exception.js
+++ b/lib/utils/tokenize-exception.js
@@ -3,7 +3,7 @@
 const { inspect } = require('util');
 const isError = require('type/error/is');
 
-const userErrorNames = new Set(['ServerlessError', 'YAMLException']);
+const userErrorNames = new Set(['ServerlessError']);
 
 module.exports = (exception) => {
   if (isError(exception)) {

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -71,7 +71,8 @@ const processSpanPromise = (async () => {
     // Abort if command is not supported in this environment
     if (commandSchema && commandSchema.isHidden && commandSchema.noSupportNotice) {
       throw new ServerlessError(
-        `Cannot run \`${command}\` command: ${commandSchema.noSupportNotice}`
+        `Cannot run \`${command}\` command: ${commandSchema.noSupportNotice}`,
+        'NOT_SUPPORTED_COMMAND'
       );
     }
 
@@ -101,7 +102,8 @@ const processSpanPromise = (async () => {
           `Cannot resolve ${path.basename(
             configurationPath
           )}: "${humanizedPropertyPath}" property is not accessible ` +
-            '(configured behind variables which cannot be resolved at this stage)'
+            '(configured behind variables which cannot be resolved at this stage)',
+          'INACCESSIBLE_CONFIGURATION_PROPERTY'
         );
       }
       logDeprecation(
@@ -165,7 +167,8 @@ const processSpanPromise = (async () => {
                 `Cannot resolve ${path.basename(
                   configurationPath
                 )}: "variableSyntax" is not supported with new variables resolver. ` +
-                  'Please drop this setting'
+                  'Please drop this setting',
+                'UNSUPPORTED_VARIABLE_SYNTAX_CONFIGURATION'
               );
             }
             logDeprecation(
@@ -563,6 +566,7 @@ const processSpanPromise = (async () => {
                 'Invalid "configurationVariablesSources" ' +
                 `configuration on "${pluginName}", expected object, got: %v"`,
               Error: ServerlessError,
+              errorCode: 'INVALID_VARIABLE_SOURCES_CONFIGURATION',
             });
 
             for (const [sourceName, sourceConfig] of Object.entries(
@@ -572,7 +576,8 @@ const processSpanPromise = (async () => {
                 throw new ServerlessError(
                   `Cannot add "${sourceName}" configuration variable source ` +
                     `(through "${pluginName}" plugin) as resolution rules ` +
-                    'for this source name are already configured'
+                    'for this source name are already configured',
+                  'DUPLICATE_VARIABLE_SOURCE_CONFIGURATION'
                 );
               }
               ensurePlainFunction(
@@ -581,12 +586,14 @@ const processSpanPromise = (async () => {
                     `Invalid "configurationVariablesSources.${sourceName}" ` +
                     `configuration on "${pluginName}", expected object, got: %v"`,
                   Error: ServerlessError,
+                  errorCode: 'INVALID_VARIABLE_SOURCE_CONFIGURATION',
                 }).resolve,
                 {
                   errorMessage:
                     `Invalid "configurationVariablesSources.${sourceName}.resolve" ` +
                     `value on "${pluginName}", expected function, got: %v"`,
                   Error: ServerlessError,
+                  errorCode: 'INVALID_VARIABLE_SOURCE_RESOLVER_CONFIGURATION',
                 }
               );
 

--- a/test/unit/lib/plugins/aws/lib/monitorStack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitorStack.test.js
@@ -921,7 +921,6 @@ describe('monitorStack', () => {
             ResourceType: 'AWS::CloudFormation::Stack',
             Timestamp: new Date(),
             ResourceStatus: 'UPDATE_ROLLBACK_IN_PROGRESS',
-            ResourceStatusReason: 'Export is in use',
           },
         ],
       };
@@ -943,7 +942,7 @@ describe('monitorStack', () => {
 
       return awsPlugin.monitorStack('update', cfDataMock, { frequency: 10 }).catch((e) => {
         let errorMessage = 'An error occurred: ';
-        errorMessage += 'mocha - Export is in use.';
+        errorMessage += 'mocha - UPDATE_ROLLBACK_IN_PROGRESS.';
         expect(e.name).to.be.equal('ServerlessError');
         expect(e.message).to.be.equal(errorMessage);
         // callCount is 2 because Serverless will immediately exits and shows the error

--- a/test/unit/lib/plugins/plugin/install.test.js
+++ b/test/unit/lib/plugins/plugin/install.test.js
@@ -392,7 +392,7 @@ describe('PluginInstall', () => {
         });
     });
 
-    it('should not modify serverless .js file', () => {
+    it('should not modify serverless .js file', async () => {
       const serverlessJsFilePath = path.join(serviceDir, 'serverless.js');
       pluginInstall.serverless.configurationFilename = 'serverless.js';
       const serverlessJson = {
@@ -405,11 +405,10 @@ describe('PluginInstall', () => {
         `module.exports = ${JSON.stringify(serverlessJson)};`
       );
       pluginInstall.options.pluginName = 'serverless-plugin-1';
-      return expect(pluginInstall.addPluginToServerlessFile()).to.be.fulfilled.then(() => {
-        // use require to load serverless.js
-        // eslint-disable-next-line global-require
-        expect(require(serverlessJsFilePath).plugins).to.be.deep.equal([]);
-      });
+      await pluginInstall.addPluginToServerlessFile();
+      // use require to load serverless.js
+      // eslint-disable-next-line global-require
+      expect(require(serverlessJsFilePath).plugins).to.be.deep.equal([]);
     });
 
     it('should not modify serverless .ts file', () => {


### PR DESCRIPTION
Noticed 30+ error reports in mixpanel, pointing fact it's possibe that `ResourceStatusReason` is not provided on event we mark as _error event_.

This patch ensures we do not dirty crash in such case.

Additionally:
- Added missing error codes to `ServerlessError`'s in `scripts/serverless.js`
- Remove internal `YamlParser` dependency (it introduced alternative YAML parsing approach, which was used just in `plugin install/uninstall` command
- Improve `plugin install/uninstall` commands so they're safe in user used variables to define `plugins` (so far such configuration dirty crashed)
- Remove recognition of `YAMLParser` as user error. In new configuration read logic all YAML parse errors are already communicated with `ServerlessError` and same should be in all other cases