### PR TITLE
refactor(Telemetry): Improve AWS stack error codes

### DIFF
--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -109,11 +109,14 @@ module.exports = {
                     stackLatestError.ResourceStatusReason &&
                     stackLatestError.ResourceStatusReason.startsWith('Properties validation failed')
                   ) {
-                    return `AWS_STACK_${action.toUpperCase()}_VALIDATION_ERROR`;
+                    return `AWS_CLOUD_FORMATION_${action.toUpperCase()}_STACK_INTERNAL_VALIDATION_ERROR`;
                   }
-                  return `AWS_STACK_${action.toUpperCase()}${resourceTypeToErrorCodePostfix(
-                    stackLatestError.ResourceType
-                  )}_${stackLatestError.ResourceStatus}`;
+                  return (
+                    `AWS_CLOUD_FORMATION_${action.toUpperCase()}_STACK_INTERNAL` +
+                    `${resourceTypeToErrorCodePostfix(stackLatestError.ResourceType)}_${
+                      stackLatestError.ResourceStatus
+                    }`
+                  );
                 })();
                 throw new ServerlessError(errorMessage, errorCode);
               }

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -105,11 +105,19 @@ module.exports = {
                   stackLatestError.ResourceStatusReason || stackLatestError.ResourceStatus
                 }.`;
                 const errorCode = (() => {
-                  if (
-                    stackLatestError.ResourceStatusReason &&
-                    stackLatestError.ResourceStatusReason.startsWith('Properties validation failed')
-                  ) {
-                    return `AWS_CLOUD_FORMATION_${action.toUpperCase()}_STACK_INTERNAL_VALIDATION_ERROR`;
+                  if (stackLatestError.ResourceStatusReason) {
+                    if (
+                      stackLatestError.ResourceStatusReason.startsWith(
+                        'Properties validation failed'
+                      )
+                    ) {
+                      return `AWS_CLOUD_FORMATION_${action.toUpperCase()}_STACK_INTERNAL_VALIDATION_ERROR`;
+                    }
+                    if (
+                      stackLatestError.ResourceStatusReason.includes('is not authorized to perform')
+                    ) {
+                      return `AWS_CLOUD_FORMATION_${action.toUpperCase()}_STACK_INTERNAL_INSUFFICIENT_PERMISSIONS`;
+                    }
                   }
                   return (
                     `AWS_CLOUD_FORMATION_${action.toUpperCase()}_STACK_INTERNAL` +


### PR DESCRIPTION
- Improve code naming consistency (so all cloudformation service errors start with `AWS_CLOUD_FORMATION_`
- Recognize permission errors and report them with `AWS_CLOUD_FORMATION_<action>_INSUFFICIENT_PERMISSIONS`