### PR TITLE
Ensure proper resolution in case of errors for AWS-related variables

### DIFF
--- a/lib/configuration/variables/sources/instance-dependent/get-cf.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-cf.js
@@ -41,7 +41,10 @@ module.exports = (serverlessInstance) => {
               { useCache: true, region: params && params[0] }
             );
         } catch (error) {
-          if (error.code === 'ValidationError' && error.message.includes('does not exist')) {
+          if (
+            error.code === 'AWS_CLOUD_FORMATION_DESCRIBE_STACKS_VALIDATION_ERROR' &&
+            error.message.includes('does not exist')
+          ) {
             return null;
           }
           throw error;

--- a/lib/configuration/variables/sources/instance-dependent/get-s3.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-s3.js
@@ -35,7 +35,8 @@ module.exports = (serverlessInstance) => {
             .getProvider('aws')
             .request('S3', 'getObject', { Bucket: bucketName, Key: key }, { useCache: true });
         } catch (error) {
-          if (error.code === 'NoSuchKey') return null;
+          // Check for normalized error code instead of native one
+          if (error.code === 'AWS_S3_GET_OBJECT_NO_SUCH_KEY') return null;
           throw error;
         }
       })();

--- a/lib/configuration/variables/sources/instance-dependent/get-ssm.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-ssm.js
@@ -63,7 +63,8 @@ module.exports = (serverlessInstance) => {
             { useCache: true, region }
           );
         } catch (error) {
-          if (error.code === 'ParameterNotFound') return null;
+          // Check for normalized error code instead of native one
+          if (error.code === 'AWS_S_S_M_GET_PARAMETER_PARAMETER_NOT_FOUND') return null;
           throw error;
         }
       })();

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-cf.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-cf.test.js
@@ -41,7 +41,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-c
           }
           if (StackName === 'notExisting') {
             throw Object.assign(new Error('Stack with id not-existing does not exist'), {
-              code: 'ValidationError',
+              code: 'AWS_CLOUD_FORMATION_DESCRIBE_STACKS_VALIDATION_ERROR',
             });
           }
           throw new Error('Unexpected call');

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-s3.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-s3.test.js
@@ -34,7 +34,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
           if (Bucket === 'existing') {
             if (Key === 'someKey') return { Body: 'foo' };
             throw Object.assign(new Error('The specified key does not exist.'), {
-              code: 'NoSuchKey',
+              code: 'AWS_S3_GET_OBJECT_NO_SUCH_KEY',
             });
           }
           throw Object.assign(new Error('The specified bucket does not exist.'), {

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-ssm.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-ssm.test.js
@@ -56,7 +56,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
                     '(ParameterNotFound) when referencing Secrets Manager'
                 ),
                 {
-                  code: 'ParameterNotFound',
+                  code: 'AWS_S_S_M_GET_PARAMETER_PARAMETER_NOT_FOUND',
                 }
               );
             }


### PR DESCRIPTION
Fixes a regression introduced with more granular error codes from AWS calls

Closes: https://github.com/serverless/serverless/issues/9516