### PR TITLE
Ensure to pass proper config for local fallback during error reporting

### DIFF
--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -74,6 +74,11 @@ module.exports = async (exception, options = {}) => {
           serverless,
           isLocallyInstalled,
           isUncaughtException,
+          command,
+          options: cliOptions,
+          commandSchema,
+          serviceDir,
+          configuration,
           hasTelemetryBeenReported,
         });
         return;


### PR DESCRIPTION
Not all needed properties were passed during local fallback for error handler which caused crashes. 

Closes: #9512