### PR TITLE
Fix handling of numeric error codes coming from AWS SDK requests

### DIFF
--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -203,7 +203,11 @@ async function awsRequest(service, method, ...args) {
             providerError: Object.assign({}, err, { retryable: false }),
           });
         }
-        const providerErrorCodeExtension = err.code ? normalizeErrorCodePostfix(err.code) : 'ERROR';
+        const providerErrorCodeExtension = (() => {
+          if (!err.code) return 'ERROR';
+          if (typeof err.code === 'number') return `HTTP_${err.code}_ERROR`;
+          return normalizeErrorCodePostfix(err.code);
+        })();
         throw Object.assign(
           new ServerlessError(
             process.env.SLS_DEBUG && err.stack ? `${err.stack}\n${'-'.repeat(100)}` : message,

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -252,6 +252,30 @@ describe('#request', () => {
         'AWS_S3_TEST_SOME_ERROR'
       );
     });
+
+    it('should handle numeric error codes', () => {
+      const error = {
+        statusCode: 500,
+        message: 'Some error message',
+        code: 500,
+      };
+      class FakeS3 {
+        test() {
+          return {
+            promise: async () => {
+              throw error;
+            },
+          };
+        }
+      }
+      const awsRequest = proxyquire('../../../../lib/aws/request', {
+        'aws-sdk': { S3: FakeS3 },
+      });
+      return expect(awsRequest({ name: 'S3' }, 'test')).to.eventually.be.rejected.and.have.property(
+        'code',
+        'AWS_S3_TEST_HTTP_500_ERROR'
+      );
+    });
   });
 
   it('should expose original error message in thrown error message', () => {

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -233,9 +233,10 @@ describe('#request', () => {
       const error = {
         statusCode: 500,
         message: 'Some error message',
+        code: 'SomeError',
       };
       class FakeS3 {
-        error() {
+        test() {
           return {
             promise: async () => {
               throw error;
@@ -246,7 +247,10 @@ describe('#request', () => {
       const awsRequest = proxyquire('../../../../lib/aws/request', {
         'aws-sdk': { S3: FakeS3 },
       });
-      return expect(awsRequest({ name: 'S3' }, 'error')).to.be.rejected;
+      return expect(awsRequest({ name: 'S3' }, 'test')).to.eventually.be.rejected.and.have.property(
+        'code',
+        'AWS_S3_TEST_SOME_ERROR'
+      );
     });
   });
 

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -229,7 +229,7 @@ describe('#request', () => {
       return expect(sendFake.promise).to.have.been.calledOnce;
     });
 
-    it('should expose non-retryable errors', () => {
+    it('should expose non-retryable errors', async () => {
       const error = {
         statusCode: 500,
         message: 'Some error message',
@@ -247,13 +247,13 @@ describe('#request', () => {
       const awsRequest = proxyquire('../../../../lib/aws/request', {
         'aws-sdk': { S3: FakeS3 },
       });
-      return expect(awsRequest({ name: 'S3' }, 'test')).to.eventually.be.rejected.and.have.property(
+      await expect(awsRequest({ name: 'S3' }, 'test')).to.eventually.be.rejected.and.have.property(
         'code',
         'AWS_S3_TEST_SOME_ERROR'
       );
     });
 
-    it('should handle numeric error codes', () => {
+    it('should handle numeric error codes', async () => {
       const error = {
         statusCode: 500,
         message: 'Some error message',
@@ -271,7 +271,7 @@ describe('#request', () => {
       const awsRequest = proxyquire('../../../../lib/aws/request', {
         'aws-sdk': { S3: FakeS3 },
       });
-      return expect(awsRequest({ name: 'S3' }, 'test')).to.eventually.be.rejected.and.have.property(
+      await expect(awsRequest({ name: 'S3' }, 'test')).to.eventually.be.rejected.and.have.property(
         'code',
         'AWS_S3_TEST_HTTP_500_ERROR'
       );


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9511