### PR TITLE
Variables: Ensure resolution with new resolver in a local fallback

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -5,6 +5,7 @@ const os = require('os');
 const ensureString = require('type/string/ensure');
 const ensureArray = require('type/array/ensure');
 const ensurePlainObject = require('type/plain-object/ensure');
+const _ = require('lodash');
 const CLI = require('./classes/CLI');
 const Config = require('./classes/Config');
 const YamlParser = require('./classes/YamlParser');
@@ -272,8 +273,8 @@ class Serverless {
 
   async run() {
     if (this._isInvokedByGlobalInstallation) {
-      // Ensure to have resolve-input populated with right result
       // TODO: Remove with next major
+      // Ensure to have resolve-input populated with right result
       const commandsSchema = require('./cli/commands-schema/resolve-final')(
         this.pluginManager.externalPlugins,
         {
@@ -283,7 +284,106 @@ class Serverless {
       );
       const resolveInput = require('./cli/resolve-input');
       resolveInput.clear();
-      resolveInput(commandsSchema);
+      const { options, isHelpRequest } = resolveInput(commandsSchema);
+      if (
+        !this.isConfigurationInputResolved &&
+        this.serviceDir &&
+        !_.get(this.configurationInput, 'provider.variableSyntax')
+      ) {
+        // We're in a local fallback from other version which may not have a new variables engine
+        // (or have it incomplete). Therefore resolve variables with a new resolver
+        const resolveVariablesMeta = require('./configuration/variables/resolve-meta');
+        const isPropertyResolved = require('./configuration/variables/is-property-resolved');
+        const resolveVariables = require('./configuration/variables/resolve');
+        const eventuallyReportVariableResolutionErrors = require('./configuration/variables/eventually-report-resolution-errors');
+        const resolveProviderName = require('./configuration/resolve-provider-name');
+        const filterSupportedOptions = require('./cli/filter-supported-options');
+
+        const variablesMeta = resolveVariablesMeta(this.configurationInput);
+        // IIFE for maintanance convinience
+        await (async () => {
+          if (!variablesMeta.size) return;
+          const configurationPath = path.resolve(this.serviceDir, this.configurationFilename);
+          if (
+            eventuallyReportVariableResolutionErrors(
+              configurationPath,
+              this.configurationInput,
+              variablesMeta
+            )
+          ) {
+            return;
+          }
+
+          for (const coreProperty of [
+            'app',
+            'disabledDeprecations',
+            'org',
+            'provider\0name',
+            'useDotenv',
+            'variablesResolutionMode',
+          ]) {
+            if (!isPropertyResolved(variablesMeta, coreProperty)) return;
+          }
+          const providerName = resolveProviderName(this.configurationInput);
+          const resolverConfiguration = {
+            serviceDir: this.serviceDir,
+            configuration: this.configurationInput,
+            variablesMeta,
+            sources: {
+              env: require('./configuration/variables/sources/env'),
+              file: require('./configuration/variables/sources/file'),
+              opt: require('./configuration/variables/sources/opt'),
+              self: require('./configuration/variables/sources/self'),
+              strToBool: require('./configuration/variables/sources/str-to-bool'),
+              sls: require('./configuration/variables/sources/instance-dependent/get-sls')(this),
+            },
+            options: filterSupportedOptions(options, {
+              commandSchema: resolveInput.commandSchema,
+              providerName,
+            }),
+            propertyPathsToResolve: isHelpRequest ? new Set(['plugins']) : null,
+          };
+          if (providerName === 'aws') {
+            Object.assign(resolverConfiguration.sources, {
+              cf: require('./configuration/variables/sources/instance-dependent/get-cf')(this),
+              s3: require('./configuration/variables/sources/instance-dependent/get-s3')(this),
+              ssm: require('./configuration/variables/sources/instance-dependent/get-ssm')(this),
+            });
+          }
+          if (this.configurationInput.org && this.pluginManager.dashboardPlugin) {
+            for (const [sourceName, sourceConfig] of Object.entries(
+              this.pluginManager.dashboardPlugin.configurationVariablesSources
+            )) {
+              resolverConfiguration.sources[sourceName] = sourceConfig;
+            }
+          }
+          resolverConfiguration.fulfilledSources = new Set(
+            Object.keys(resolverConfiguration.sources)
+          );
+          if (!(this.configurationInput.variablesResolutionMode >= 20210326)) {
+            // New resolver, resolves just recognized CLI options. Therefore we cannot assume
+            // we have full "opt" source data if user didn't explicitly switch to new resolver
+            resolverConfiguration.fulfilledSources.delete('opt');
+          }
+
+          const resolverExternalPluginSources = require('../lib/configuration/variables/sources/resolve-external-plugin-sources');
+          resolverExternalPluginSources(
+            this.configurationInput,
+            resolverConfiguration,
+            this.pluginManager.externalPlugins
+          );
+          await resolveVariables(resolverConfiguration);
+          if (!variablesMeta.size) {
+            this.isConfigurationInputResolved = true;
+            return;
+          }
+          eventuallyReportVariableResolutionErrors(
+            configurationPath,
+            this.configurationInput,
+            variablesMeta
+          );
+        })();
+      }
     }
     if (this.cli.displayHelp(this.processedInput)) {
       return;

--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -224,11 +224,6 @@ class ConfigSchemaHandler {
         properties: { stage: { type: 'string' } },
       });
     }
-    if (!this.schema.properties.provider.properties.variableSyntax) {
-      addPropertiesToSchema(this.schema.properties.provider, {
-        properties: { variableSyntax: { type: 'string' } },
-      });
-    }
   }
 
   defineCustomProperties(configSchemaParts) {

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -19,7 +19,6 @@ class Service {
     this.serviceObject = null;
     this.provider = {
       stage: 'dev',
-      variableSyntax: '\\${([^{}:]+?(?:\\(|:)(?:[^:{}][^{}]*?)?)}',
     };
     this.custom = {};
     this.plugins = [];
@@ -148,9 +147,6 @@ class Service {
     if (serverlessFile.provider) {
       if (serverlessFile.provider.stage == null) {
         serverlessFile.provider.stage = this.provider.stage;
-      }
-      if (serverlessFile.provider.variableSyntax == null) {
-        serverlessFile.provider.variableSyntax = this.provider.variableSyntax;
       }
       this.provider = serverlessFile.provider;
     }

--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -103,7 +103,10 @@ class Variables {
   }
 
   loadVariableSyntax() {
-    this.variableSyntax = RegExp(this.service.provider.variableSyntax, 'g');
+    this.variableSyntax = RegExp(
+      this.service.provider.variableSyntax || '\\${([^{}:]+?(?:\\(|:)(?:[^:{}][^{}]*?)?)}',
+      'g'
+    );
   }
 
   initialCall(func) {

--- a/lib/configuration/variables/sources/resolve-external-plugin-sources.js
+++ b/lib/configuration/variables/sources/resolve-external-plugin-sources.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const ensurePlainObject = require('type/plain-object/ensure');
+const ensurePlainFunction = require('type/plain-function/ensure');
+const ServerlessError = require('../../../serverless-error');
+const logDeprecation = require('../../../utils/logDeprecation');
+
+module.exports = (configuration, resolverConfiguration, externalPlugins) => {
+  for (const externalPlugin of externalPlugins) {
+    const pluginName = externalPlugin.constructor.name;
+    if (externalPlugin.configurationVariablesSources != null) {
+      ensurePlainObject(externalPlugin.configurationVariablesSources, {
+        errorMessage:
+          'Invalid "configurationVariablesSources" ' +
+          `configuration on "${pluginName}", expected object, got: %v"`,
+        Error: ServerlessError,
+        errorCode: 'INVALID_VARIABLE_SOURCES_CONFIGURATION',
+      });
+
+      for (const [sourceName, sourceConfig] of Object.entries(
+        externalPlugin.configurationVariablesSources
+      )) {
+        if (resolverConfiguration.sources[sourceName]) {
+          throw new ServerlessError(
+            `Cannot add "${sourceName}" configuration variable source ` +
+              `(through "${pluginName}" plugin) as resolution rules ` +
+              'for this source name are already configured',
+            'DUPLICATE_VARIABLE_SOURCE_CONFIGURATION'
+          );
+        }
+        ensurePlainFunction(
+          ensurePlainObject(sourceConfig, {
+            errorMessage:
+              `Invalid "configurationVariablesSources.${sourceName}" ` +
+              `configuration on "${pluginName}", expected object, got: %v"`,
+            Error: ServerlessError,
+            errorCode: 'INVALID_VARIABLE_SOURCE_CONFIGURATION',
+          }).resolve,
+          {
+            errorMessage:
+              `Invalid "configurationVariablesSources.${sourceName}.resolve" ` +
+              `value on "${pluginName}", expected function, got: %v"`,
+            Error: ServerlessError,
+            errorCode: 'INVALID_VARIABLE_SOURCE_RESOLVER_CONFIGURATION',
+          }
+        );
+
+        resolverConfiguration.sources[sourceName] = sourceConfig;
+        resolverConfiguration.fulfilledSources.add(sourceName);
+      }
+    } else if (
+      externalPlugin.variableResolvers &&
+      configuration.variablesResolutionMode < 20210326
+    ) {
+      logDeprecation(
+        'NEW_VARIABLES_RESOLVER',
+        `Plugin "${pluginName}" attempts to extend old variables resolver. ` +
+          'Ensure to rely on latest version of a plugin and if this warning is ' +
+          'still displayed please report the problem at plugin issue tracker' +
+          'Starting with next major release, ' +
+          'old variables resolver will not be supported.\n',
+        { serviceConfig: configuration }
+      );
+    }
+  }
+};

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -554,67 +554,13 @@ const processSpanPromise = (async () => {
           }
         }
 
-        const ensurePlainFunction = require('type/plain-function/ensure');
-        const ensurePlainObject = require('type/plain-object/ensure');
-
         // Register variable source resolvers provided by external plugins
-        for (const externalPlugin of serverless.pluginManager.externalPlugins) {
-          const pluginName = externalPlugin.constructor.name;
-          if (externalPlugin.configurationVariablesSources != null) {
-            ensurePlainObject(externalPlugin.configurationVariablesSources, {
-              errorMessage:
-                'Invalid "configurationVariablesSources" ' +
-                `configuration on "${pluginName}", expected object, got: %v"`,
-              Error: ServerlessError,
-              errorCode: 'INVALID_VARIABLE_SOURCES_CONFIGURATION',
-            });
-
-            for (const [sourceName, sourceConfig] of Object.entries(
-              externalPlugin.configurationVariablesSources
-            )) {
-              if (resolverConfiguration.sources[sourceName]) {
-                throw new ServerlessError(
-                  `Cannot add "${sourceName}" configuration variable source ` +
-                    `(through "${pluginName}" plugin) as resolution rules ` +
-                    'for this source name are already configured',
-                  'DUPLICATE_VARIABLE_SOURCE_CONFIGURATION'
-                );
-              }
-              ensurePlainFunction(
-                ensurePlainObject(sourceConfig, {
-                  errorMessage:
-                    `Invalid "configurationVariablesSources.${sourceName}" ` +
-                    `configuration on "${pluginName}", expected object, got: %v"`,
-                  Error: ServerlessError,
-                  errorCode: 'INVALID_VARIABLE_SOURCE_CONFIGURATION',
-                }).resolve,
-                {
-                  errorMessage:
-                    `Invalid "configurationVariablesSources.${sourceName}.resolve" ` +
-                    `value on "${pluginName}", expected function, got: %v"`,
-                  Error: ServerlessError,
-                  errorCode: 'INVALID_VARIABLE_SOURCE_RESOLVER_CONFIGURATION',
-                }
-              );
-
-              resolverConfiguration.sources[sourceName] = sourceConfig;
-              resolverConfiguration.fulfilledSources.add(sourceName);
-            }
-          } else if (
-            externalPlugin.variableResolvers &&
-            configuration.variablesResolutionMode < 20210326
-          ) {
-            logDeprecation(
-              'NEW_VARIABLES_RESOLVER',
-              `Plugin "${pluginName}" attempts to extend old variables resolver. ` +
-                'Ensure to rely on latest version of a plugin and if this warning is ' +
-                'still displayed please report the problem at plugin issue tracker' +
-                'Starting with next major release, ' +
-                'old variables resolver will not be supported.\n',
-              { serviceConfig: configuration }
-            );
-          }
-        }
+        const resolverExternalPluginSources = require('../lib/configuration/variables/sources/resolve-external-plugin-sources');
+        resolverExternalPluginSources(
+          configuration,
+          resolverConfiguration,
+          serverless.pluginManager.externalPlugins
+        );
 
         // Having all source resolvers configured, resolve variables
         await resolveVariables(resolverConfiguration);

--- a/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
+++ b/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
@@ -318,7 +318,6 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
           properties: {
             name: { const: 'someProvider' },
             stage: { type: 'string' },
-            variableSyntax: { type: 'string' },
           },
           required: ['name'],
           additionalProperties: false,

--- a/test/unit/lib/configuration/variables/sources/resolve-external-plugin-resources.test.js
+++ b/test/unit/lib/configuration/variables/sources/resolve-external-plugin-resources.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const ServerlessError = require('../../../../../../lib/serverless-error');
+const resolveExternalPluginSources = require('../../../../../../lib/configuration/variables/sources/resolve-external-plugin-sources');
+
+describe('test/unit/lib/configuration/variables/sources/resolve-external-plugin-resources.test.js', () => {
+  it('should resolve external plugin sources', () => {
+    const sources = {};
+    const fulfilledSources = new Set();
+    const externalPlugins = [
+      {
+        configurationVariablesSources: {
+          ext1: { resolve: () => {} },
+          ext2: { resolve: () => {} },
+        },
+      },
+      {
+        configurationVariablesSources: {
+          ext3: { resolve: () => {} },
+        },
+      },
+    ];
+    resolveExternalPluginSources({}, { sources, fulfilledSources }, new Set(externalPlugins));
+    expect(sources).to.deep.equal({
+      ...externalPlugins[0].configurationVariablesSources,
+      ...externalPlugins[1].configurationVariablesSources,
+    });
+    expect(fulfilledSources).to.deep.equal(new Set(Object.keys(sources)));
+  });
+
+  it('should reject meaningfully invalid sources configuration', () => {
+    expect(() =>
+      resolveExternalPluginSources(
+        {},
+        { sources: {}, fulfilledSources: new Set() },
+        new Set([
+          {
+            configurationVariablesSources: 'foo',
+          },
+        ])
+      )
+    )
+      .to.throw(ServerlessError)
+      .with.property('code', 'INVALID_VARIABLE_SOURCES_CONFIGURATION');
+
+    expect(() =>
+      resolveExternalPluginSources(
+        {},
+        { sources: { existing: { resolve: () => {} } }, fulfilledSources: new Set(['existing']) },
+        new Set([
+          {
+            configurationVariablesSources: { existing: { resolve: () => {} } },
+          },
+        ])
+      )
+    )
+      .to.throw(ServerlessError)
+      .with.property('code', 'DUPLICATE_VARIABLE_SOURCE_CONFIGURATION');
+
+    expect(() =>
+      resolveExternalPluginSources(
+        {},
+        { sources: {}, fulfilledSources: new Set() },
+        new Set([
+          {
+            configurationVariablesSources: { source: 'foo' },
+          },
+        ])
+      )
+    )
+      .to.throw(ServerlessError)
+      .with.property('code', 'INVALID_VARIABLE_SOURCE_CONFIGURATION');
+
+    expect(() =>
+      resolveExternalPluginSources(
+        {},
+        { sources: {}, fulfilledSources: new Set() },
+        new Set([
+          {
+            configurationVariablesSources: { source: { resolve: 'foo ' } },
+          },
+        ])
+      )
+    )
+      .to.throw(ServerlessError)
+      .with.property('code', 'INVALID_VARIABLE_SOURCE_RESOLVER_CONFIGURATION');
+  });
+});


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9523

Proposed solution doesn't map 1:1 in what global does, but it's just few edge cases that are left out, and it should ensure proper variables resolution where there's properly constructed service configuration and there's a local version fallback from older global version.

Additionally:
- Hardcoded assignment of `variableSyntax` default stood in a way here, so I've refactored it a bit
- Secluded `resolveExternalPluginSources` from main script, to have it reusable for this patch

Tested locally (no automated tests unfortunately, as it's a not trivial to emulate local fallback, and this is a temporary patch that will move away with v3)
