### PR TITLE
chore: Fix typo in `resolve-input.js`

### DIFF
--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -62,7 +62,7 @@ module.exports = memoizee((commandsSchema = require('./commands-schema')) => {
     }
     // Unlikely scenario, where after applying the command schema different command resolves
     // It can happen only in cases where e.g. for "sls deploy --force  function -f foo"
-    // we intially assume "deploy" command, while after applying "deploy" command schema it's
+    // we initially assume "deploy" command, while after applying "deploy" command schema it's
     // actually a "deploy function" command that resolves
     command = resolvedCommand;
     commandSchema = commandsSchema.get(resolvedCommand);


### PR DESCRIPTION
intially -> initially
