### PR TITLE
fix(Templates): Allow usage of `google-nodejs-typescript` template

### DIFF
--- a/lib/templates/recommended-list/index.js
+++ b/lib/templates/recommended-list/index.js
@@ -40,6 +40,7 @@ module.exports = [
   'fn-nodejs',
   'fn-go',
   'google-nodejs',
+  'google-nodejs-typescript',
   'google-python',
   'google-go',
   'kubeless-python',


### PR DESCRIPTION
https://github.com/serverless/serverless/pull/9445 adds `google-nodejs-typescript` template but it can't be used because it is not in the `recommended-list`. 
![Screenshot from 2021-06-07 10-41-34](https://user-images.githubusercontent.com/31917261/120986507-fa0d9b80-c77c-11eb-916f-02ff4a5e0a5a.png)

This PR allow the usage of the template by adding its name in the `recommended-list`. 
![Screenshot from 2021-06-07 10-43-20](https://user-images.githubusercontent.com/31917261/120986752-36d99280-c77d-11eb-8bdc-f760083cb783.png)
