### PR TITLE
fix(AWS API Gateway): Dont create logGroup if logs disabled

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/stage.js
@@ -59,7 +59,7 @@ module.exports = {
       // --------------------------------------------------------------------------------
 
       // create log-specific resources
-      if (logs) {
+      if (logs && (logs.accessLogging == null || logs.accessLogging)) {
         // --- currently commented out since this is done via the SDK in updateStage.js ---
         // _.merge(stageResource.Properties, {
         //   AccessLogSetting: {


### PR DESCRIPTION
The issue in corresponding ticket was happening due to the fact that the `LogGroup` for API Gateway was referenced, while it was being removed via SDK calls due to disabled access logging. It resulted in CloudFormation resource existing, but actual LogGroup was missing. That change ensures that we're not creating LogGroup in CF if it's not needed.

Closes: https://github.com/serverless/serverless/issues/9552