### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "process-utils": "^4.0.0",
     "proxyquire": "^2.1.3",
     "semver-regex": "^3.1.2",
-    "sinon": "^10.0.0",
+    "sinon": "^11.1.1",
     "sinon-chai": "^3.7.0",
     "standard-version": "^9.3.0",
     "strip-ansi": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "d": "^1.0.1",
     "dayjs": "^1.10.5",
     "decompress": "^4.2.1",
-    "dotenv": "^9.0.2",
+    "dotenv": "^10.0.0",
     "essentials": "^1.1.1",
     "fastest-levenshtein": "^1.0.12",
     "filesize": "^6.3.0",


### PR DESCRIPTION
Upgrade 
- `dotenv` to v10. It's confirmed to not have breaking changes: https://github.com/motdotla/dotenv/issues/541
- `sinon` to v11. Breaking change seems only related to timers, which we do not use: https://github.com/sinonjs/sinon/blob/master/CHANGELOG.md#1100--2021-05-24

