### PR TITLE
Telemetry: Optimise error location paths

### DIFF
--- a/lib/utils/telemetry/anonymize-stacktrace-paths.js
+++ b/lib/utils/telemetry/anonymize-stacktrace-paths.js
@@ -3,30 +3,32 @@
 const path = require('path');
 const commonPath = require('path2/common');
 
-const anonymizeStacktracePaths = (stacktracePaths) => {
-  const absoluteStacktracePaths = stacktracePaths.filter((p) => path.isAbsolute(p));
+const anonymizeStacktracePaths = (stackFrames) => {
+  const stackFramesWithAbsolutePaths = stackFrames.filter((p) => path.isAbsolute(p));
   let commonPathPrefix = '';
 
-  if (absoluteStacktracePaths.length) {
-    commonPathPrefix = commonPath(...absoluteStacktracePaths);
+  if (stackFramesWithAbsolutePaths.length) {
+    commonPathPrefix = commonPath(...stackFramesWithAbsolutePaths);
 
-    const lastServerlessIndex = commonPathPrefix.lastIndexOf(`${path.sep}serverless${path.sep}`);
+    const lastServerlessPathIndex = commonPathPrefix.lastIndexOf(
+      `${path.sep}serverless${path.sep}`
+    );
 
-    if (lastServerlessIndex !== -1) {
-      commonPathPrefix = commonPathPrefix.slice(0, lastServerlessIndex);
+    if (lastServerlessPathIndex !== -1) {
+      commonPathPrefix = commonPathPrefix.slice(0, lastServerlessPathIndex);
     } else {
       const nodeModulesPathPart = `${path.sep}node_modules${path.sep}`;
-      const lastNodeModulesIndex = commonPathPrefix.lastIndexOf(nodeModulesPathPart);
-      if (lastNodeModulesIndex !== -1) {
+      const lastNodeModulesPathIndex = commonPathPrefix.lastIndexOf(nodeModulesPathPart);
+      if (lastNodeModulesPathIndex !== -1) {
         commonPathPrefix = commonPathPrefix.slice(
           0,
-          lastNodeModulesIndex + nodeModulesPathPart.length - 1
+          lastNodeModulesPathIndex + nodeModulesPathPart.length - 1
         );
       }
     }
   }
 
-  return stacktracePaths.map((s) => s.replace(commonPathPrefix, ''));
+  return stackFrames.map((stackFrame) => stackFrame.replace(commonPathPrefix, ''));
 };
 
 module.exports = anonymizeStacktracePaths;

--- a/lib/utils/telemetry/anonymize-stacktrace-paths.js
+++ b/lib/utils/telemetry/anonymize-stacktrace-paths.js
@@ -15,11 +15,13 @@ const anonymizeStacktracePaths = (stacktracePaths) => {
     if (lastServerlessIndex !== -1) {
       commonPathPrefix = commonPathPrefix.slice(0, lastServerlessIndex);
     } else {
-      const lastNodeModulesIndex = commonPathPrefix.lastIndexOf(
-        `${path.sep}node_modules${path.sep}`
-      );
+      const nodeModulesPathPart = `${path.sep}node_modules${path.sep}`;
+      const lastNodeModulesIndex = commonPathPrefix.lastIndexOf(nodeModulesPathPart);
       if (lastNodeModulesIndex !== -1) {
-        commonPathPrefix = commonPathPrefix.slice(0, lastNodeModulesIndex);
+        commonPathPrefix = commonPathPrefix.slice(
+          0,
+          lastNodeModulesIndex + nodeModulesPathPart.length - 1
+        );
       }
     }
   }

--- a/lib/utils/telemetry/anonymize-stacktrace-paths.js
+++ b/lib/utils/telemetry/anonymize-stacktrace-paths.js
@@ -28,7 +28,21 @@ const anonymizeStacktracePaths = (stackFrames) => {
     }
   }
 
-  return stackFrames.map((stackFrame) => stackFrame.replace(commonPathPrefix, ''));
+  let previousStackFramePath = null;
+  return stackFrames.map((stackFrame) => {
+    stackFrame = stackFrame.replace(commonPathPrefix, '');
+    const locationIndex = stackFrame.search(/:\d+:/);
+    if (locationIndex === -1) {
+      previousStackFramePath = null;
+      return stackFrame;
+    }
+    const currentStackFramePath = stackFrame.slice(0, locationIndex);
+    if (currentStackFramePath === previousStackFramePath) {
+      return `^${stackFrame.slice(currentStackFramePath.length)}`;
+    }
+    previousStackFramePath = currentStackFramePath;
+    return stackFrame;
+  });
 };
 
 module.exports = anonymizeStacktracePaths;

--- a/test/unit/lib/utils/telemetry/anonymize-stacktrace-paths.test.js
+++ b/test/unit/lib/utils/telemetry/anonymize-stacktrace-paths.test.js
@@ -61,9 +61,9 @@ describe('test/unit/lib/utils/anonymize-stacktrace-paths.test.js', () => {
 
       const result = anonymizeStacktracePaths(stacktracePaths);
       expect(result).to.deep.equal([
-        '/node_modules/lib/plugins/aws/package/lib/getHashForFilePath.js:23:13',
-        '/node_modules/lib/plugins/otherfile.js:100:10',
-        '/node_modules/lib/plugins/another.js:100:10',
+        '/lib/plugins/aws/package/lib/getHashForFilePath.js:23:13',
+        '/lib/plugins/otherfile.js:100:10',
+        '/lib/plugins/another.js:100:10',
       ]);
     });
   }
@@ -130,9 +130,9 @@ describe('test/unit/lib/utils/anonymize-stacktrace-paths.test.js', () => {
 
       const result = anonymizeStacktracePaths(stacktracePaths);
       expect(result).to.deep.equal([
-        '\\node_modules\\lib\\plugins\\aws\\package\\lib\\getHashForFilePath.js:23:13',
-        '\\node_modules\\lib\\plugins\\otherfile.js:100:10',
-        '\\node_modules\\lib\\plugins\\another.js:100:10',
+        '\\lib\\plugins\\aws\\package\\lib\\getHashForFilePath.js:23:13',
+        '\\lib\\plugins\\otherfile.js:100:10',
+        '\\lib\\plugins\\another.js:100:10',
       ]);
     });
   }

--- a/test/unit/lib/utils/telemetry/anonymize-stacktrace-paths.test.js
+++ b/test/unit/lib/utils/telemetry/anonymize-stacktrace-paths.test.js
@@ -66,6 +66,25 @@ describe('test/unit/lib/utils/anonymize-stacktrace-paths.test.js', () => {
         '/lib/plugins/another.js:100:10',
       ]);
     });
+
+    it('Should strip same following file paths', () => {
+      const stacktracePaths = [
+        '/home/xxx/yyy/zzz-serverless/node_modules/lib/plugins/aws/package/lib/getHashForFilePath.js:23:13',
+        '/home/xxx/yyy/zzz-serverless/node_modules/lib/plugins/aws/package/lib/getHashForFilePath.js:3:3',
+        '/home/xxx/yyy/zzz-serverless/node_modules/lib/plugins/otherfile.js:100:10',
+        '/home/xxx/yyy/zzz-serverless/node_modules/lib/plugins/another.js:100:10',
+        '/home/xxx/yyy/zzz-serverless/node_modules/lib/plugins/another.js:4:12',
+      ];
+
+      const result = anonymizeStacktracePaths(stacktracePaths);
+      expect(result).to.deep.equal([
+        '/lib/plugins/aws/package/lib/getHashForFilePath.js:23:13',
+        '^:3:3',
+        '/lib/plugins/otherfile.js:100:10',
+        '/lib/plugins/another.js:100:10',
+        '^:4:12',
+      ]);
+    });
   }
 
   it('Should handle stacktrace with only relative paths', () => {
@@ -133,6 +152,25 @@ describe('test/unit/lib/utils/anonymize-stacktrace-paths.test.js', () => {
         '\\lib\\plugins\\aws\\package\\lib\\getHashForFilePath.js:23:13',
         '\\lib\\plugins\\otherfile.js:100:10',
         '\\lib\\plugins\\another.js:100:10',
+      ]);
+    });
+
+    it('Should strip same following file paths', () => {
+      const stacktracePaths = [
+        'C:\\home\\xxx\\yyy\\zzz-serverless\\node_modules\\lib\\plugins\\aws\\package\\lib\\getHashForFilePath.js:23:13',
+        'C:\\home\\xxx\\yyy\\zzz-serverless\\node_modules\\lib\\plugins\\aws\\package\\lib\\getHashForFilePath.js:3:3',
+        'C:\\home\\xxx\\yyy\\zzz-serverless\\node_modules\\lib\\plugins\\otherfile.js:100:10',
+        'C:\\home\\xxx\\yyy\\zzz-serverless\\node_modules\\lib\\plugins\\another.js:100:10',
+        'C:\\home\\xxx\\yyy\\zzz-serverless\\node_modules\\lib\\plugins\\another.js:4:12',
+      ];
+
+      const result = anonymizeStacktracePaths(stacktracePaths);
+      expect(result).to.deep.equal([
+        '\\lib\\plugins\\aws\\package\\lib\\getHashForFilePath.js:23:13',
+        '^:3:3',
+        '\\lib\\plugins\\otherfile.js:100:10',
+        '\\lib\\plugins\\another.js:100:10',
+        '^:4:12',
       ]);
     });
   }

--- a/test/unit/lib/utils/telemetry/resolve-error-location.test.js
+++ b/test/unit/lib/utils/telemetry/resolve-error-location.test.js
@@ -72,9 +72,9 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
         [
           '/test/unit/lib/utils/resolve-error-location.test.js:10:17',
           '/node_modules/mocha/lib/runnable.js:366:21',
-          '/node_modules/mocha/lib/runnable.js:354:5',
+          '^:354:5',
           '/node_modules/mocha/lib/runner.js:677:10',
-          '/node_modules/mocha/lib/runner.js:801:12',
+          '^:801:12',
         ].join('\n')
       );
     });
@@ -116,9 +116,9 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
         [
           '/test/unit/lib/utils/resolve-error-location.test.js:10:17',
           '/node_modules/mocha/lib/runnable.js:366:21',
-          '/node_modules/mocha/lib/runnable.js:354:5',
+          '^:354:5',
           '/node_modules/mocha/lib/runner.js:677:10',
-          '/node_modules/mocha/lib/runner.js:801:12',
+          '^:801:12',
         ].join('\n')
       );
     });


### PR DESCRIPTION
It appears that in mixpanel there's a constraint of maximum 255 characters length for any string value.

In result some of our generated error location paths are stored partially, and we miss some valuable information.

This patch introduces two optimizations:

1. Truncate `/node_modules/` path prefix to `/`
2. If given file path is repeated, in following path it's replaced by `^` character