### PR TITLE
Config Schema: Improve error messaging for same type variants

### DIFF
--- a/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
+++ b/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.js
@@ -190,9 +190,13 @@ const filterIrrelevantAnyOfErrors = (resultErrorsSet) => {
       }
       // 2.2.8 If more than one variant left, expose just "no matching variant" error
       for (const dataPathOneOfPathVariantErrors of dataPathOneOfPathVariants) {
+        const types = new Set();
         for (const dataPathOneOfPathVariantError of dataPathOneOfPathVariantErrors) {
+          const parentSchema = dataPathOneOfPathVariantError.parentSchema;
+          types.add(parentSchema.const ? 'const' : parentSchema.type);
           resultErrorsSet.delete(dataPathOneOfPathVariantError);
         }
+        if (types.size === 1) noMatchingVariantError.commonType = types.values().next().value;
       }
     });
   }
@@ -225,7 +229,12 @@ const improveMessages = (resultErrorsSet) => {
         }
       // fallthrough
       case 'oneOf':
-        error.message = 'unsupported configuration format';
+        if (error.commonType) {
+          if (error.commonType === 'const') error.message = 'unsupported value';
+          else error.message = `unsupported ${error.commonType} format`;
+        } else {
+          error.message = 'unsupported configuration format';
+        }
         break;
       case 'enum':
         if (error.params.allowedValues.every((value) => typeof value === 'string')) {

--- a/test/unit/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.test.js
+++ b/test/unit/lib/classes/ConfigSchemaHandler/normalizeAjvErrors.test.js
@@ -58,6 +58,19 @@ describe('#normalizeAjvErrors', () => {
               },
             ],
           },
+          someString: {
+            anyOf: [
+              {
+                type: 'string',
+                pattern: 'foo',
+              },
+              {
+                type: 'string',
+                pattern: 'bar',
+              },
+              { type: 'object' },
+            ],
+          },
         },
       },
       package: {
@@ -165,6 +178,7 @@ describe('#normalizeAjvErrors', () => {
       },
       custom: {
         someCustom: { name: 'third' },
+        someString: 'other',
       },
       package: { incclude: ['./folder'] },
       functions: {
@@ -336,6 +350,21 @@ describe('#normalizeAjvErrors', () => {
           })
         ).to.be.true
     );
+    it(
+      'should report in anyOf case, where two values of same (string) type are possible ' +
+        'and for all variants errors relate to paths of same depth',
+      () =>
+        expect(
+          errors.some((error) => {
+            if (error.dataPath !== '.custom.someString') {
+              return false;
+            }
+            if (error.keyword !== 'anyOf') return false;
+            error.isExpected = true;
+            return true;
+          })
+        ).to.be.true
+    );
     it('should report the duplicated erorr message if more than one dependency is missing only once', () => {
       const depsErrors = errors.filter((item) => item.keyword === 'dependencies');
       expect(depsErrors).to.have.lengthOf(1);
@@ -370,5 +399,21 @@ describe('#normalizeAjvErrors', () => {
           return true;
         }).message
       ).to.include('unsupported function event'));
+    it('should report value which do not match multiple constants with a meaningful message', () =>
+      expect(
+        errors.find((error) => {
+          if (error.dataPath !== '.custom.someCustom') return false;
+          if (error.keyword !== 'anyOf') return false;
+          return true;
+        }).message
+      ).to.include('unsupported value'));
+    it('should report value which do not match multiple string formats with a meaningful message', () =>
+      expect(
+        errors.find((error) => {
+          if (error.dataPath !== '.custom.someString') return false;
+          if (error.keyword !== 'anyOf') return false;
+          return true;
+        }).message
+      ).to.include('unsupported string format'));
   });
 });


### PR DESCRIPTION
When two different variants for string value are provided, and value doesn't match, we show message:

```
at 'xxx.xxx': unsupported configuration format
```

Which is vague, as it indicates that we may ve off largely (e.g. value of string type is not expected at all)

This patch improves the messaging to

```
at 'xxx.xxx': unsupported string format
```

Which gives better idea, as it should indicate that we support _string_ here, but not at provided format
