### PR TITLE
Variables: Fix top level properties resolution handling

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -385,6 +385,10 @@ class Serverless {
         })();
       }
     }
+
+    // Ensure to pick eventual variable resolution that happens after all plugins are loaded
+    if (this.configurationInput) this.service.reloadServiceFileParam();
+
     if (this.cli.displayHelp(this.processedInput)) {
       return;
     }

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -103,14 +103,6 @@ class Service {
       );
     }
 
-    // #######################################################################
-    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/plugins/print/print.js ##
-    // #######################################################################
-    // #####################################################################
-    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/classes/Variables.js ##
-    // ##   there, see `getValueFromSelf`                                 ##
-    // ##   here, see below                                               ##
-    // #####################################################################
     if (!_.isObject(serverlessFile.provider)) {
       const providerName = serverlessFile.provider;
       serverlessFile.provider = {

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -51,17 +51,16 @@ class Service {
   }
 
   loadServiceFileParam() {
-    const serverlessFileParam = this.serverless.configurationInput;
     // Not used internally, left set to not break plugins which depend on it
     // TOOD: Remove with next major
     this.serviceFilename = this.serverless.configurationFilename;
 
-    const serverlessFile = serverlessFileParam;
+    const configurationInput = this.serverless.configurationInput;
     // basic service level validation
     const version = this.serverless.utils.getVersion();
-    let ymlVersion = serverlessFile.frameworkVersion;
+    let ymlVersion = configurationInput.frameworkVersion;
     if (ymlVersion && !semver.validRange(ymlVersion)) {
-      if (serverlessFile.configValidationMode === 'error') {
+      if (configurationInput.configValidationMode === 'error') {
         throw new ServerlessError(
           'Configured "frameworkVersion" does not represent a valid semver version range.',
           'INVALID_FRAMEWORK_VERSION'
@@ -90,20 +89,20 @@ class Service {
       ].join('');
       throw new ServerlessError(errorMessage, 'FRAMEWORK_VERSION_MISMATCH');
     }
-    if (!serverlessFile.service) {
+    if (!configurationInput.service) {
       throw new ServerlessError(
         `"service" property is missing in ${this.serverless.configurationFilename}`,
         'SERVICE_NAME_MISSING'
       );
     }
-    if (!serverlessFile.provider) {
+    if (!configurationInput.provider) {
       throw new ServerlessError(
         `"provider" property is missing in ${this.serverless.configurationFilename}`,
         'PROVIDER_NAME_MISSING'
       );
     }
 
-    this.initialServerlessConfig = serverlessFile;
+    this.initialServerlessConfig = configurationInput;
 
     // TODO: Ideally below approach should be replaced at some point with:
     // 1. In "initialization" phase: Minimize reliance on service configuration
@@ -119,54 +118,55 @@ class Service {
     //
     // `provider` (`provder.name` by many plugin constructs, and few other core properties as
     //              `provider.stage` are read by dashboard plugin)
-    if (!_.isObject(serverlessFile.provider)) {
-      const providerName = serverlessFile.provider;
-      serverlessFile.provider = {
+    if (!_.isObject(configurationInput.provider)) {
+      const providerName = configurationInput.provider;
+      configurationInput.provider = {
         name: providerName,
       };
     }
-    if (serverlessFile.provider.stage == null) {
-      serverlessFile.provider.stage = 'dev';
+    if (configurationInput.provider.stage == null) {
+      configurationInput.provider.stage = 'dev';
     }
-    this.provider = serverlessFile.provider;
+    this.provider = configurationInput.provider;
 
     // `service` (read by dashboard plugin)
-    if (_.isObject(serverlessFile.service)) {
+    if (_.isObject(configurationInput.service)) {
       this.serverless._logDeprecation(
         'SERVICE_OBJECT_NOTATION',
         'Starting from next major object notation for "service" property will no longer be ' +
           'recognized. Set "service" property directly with service name.'
       );
-      this.serviceObject = serverlessFile.service;
-      this.service = serverlessFile.service.name;
+      this.serviceObject = configurationInput.service;
+      this.service = configurationInput.service.name;
     } else {
-      this.serviceObject = { name: serverlessFile.service };
-      this.service = serverlessFile.service;
+      this.serviceObject = { name: configurationInput.service };
+      this.service = configurationInput.service;
     }
 
     // (dashboard plugin)
-    this.app = serverlessFile.app;
-    this.tenant = serverlessFile.tenant;
-    this.org = serverlessFile.org;
+    this.app = configurationInput.app;
+    this.tenant = configurationInput.tenant;
+    this.org = configurationInput.org;
 
-    this.plugins = serverlessFile.plugins;
-    this.disabledDeprecations = serverlessFile.disabledDeprecations;
+    this.plugins = configurationInput.plugins;
+    this.disabledDeprecations = configurationInput.disabledDeprecations;
 
     // `package.path` is read by few core plugins at initialization
-    if (serverlessFile.package) {
-      this.package = serverlessFile.package;
+    if (configurationInput.package) {
+      this.package = configurationInput.package;
     }
 
     // ## Properties accessed at "run" phase
-    this.custom = serverlessFile.custom; // (dashboard plugin)
-    this.resources = serverlessFile.resources;
-    this.functions = serverlessFile.functions || {};
-    this.configValidationMode = serverlessFile.configValidationMode || 'warn';
-    this.unresolvedVariablesNotificationMode = serverlessFile.unresolvedVariablesNotificationMode;
+    this.custom = configurationInput.custom; // (dashboard plugin)
+    this.resources = configurationInput.resources;
+    this.functions = configurationInput.functions || {};
+    this.configValidationMode = configurationInput.configValidationMode || 'warn';
+    this.unresolvedVariablesNotificationMode =
+      configurationInput.unresolvedVariablesNotificationMode;
     if (this.provider.name === 'aws') {
-      this.layers = serverlessFile.layers || {};
+      this.layers = configurationInput.layers || {};
     }
-    this.outputs = serverlessFile.outputs;
+    this.outputs = configurationInput.outputs;
 
     return this;
   }

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -171,6 +171,27 @@ class Service {
     return this;
   }
 
+  reloadServiceFileParam() {
+    const configurationInput = this.initialServerlessConfig;
+    if (_.isObject(configurationInput.provider)) {
+      this.provider = configurationInput.provider;
+      if (this.provider.stage == null) this.provider.stage = 'dev';
+    }
+    if (configurationInput.package) {
+      this.package = configurationInput.package;
+    }
+    this.custom = configurationInput.custom;
+    this.resources = configurationInput.resources;
+    this.functions = configurationInput.functions || {};
+    this.configValidationMode = configurationInput.configValidationMode || 'warn';
+    this.unresolvedVariablesNotificationMode =
+      configurationInput.unresolvedVariablesNotificationMode;
+    if (this.provider.name === 'aws') {
+      this.layers = configurationInput.layers || {};
+    }
+    this.outputs = configurationInput.outputs;
+  }
+
   setFunctionNames(rawOptions) {
     const options = rawOptions || {};
     options.stage = options.stage || options.s;

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -103,13 +103,34 @@ class Service {
       );
     }
 
+    this.initialServerlessConfig = serverlessFile;
+
+    // TODO: Ideally below approach should be replaced at some point with:
+    // 1. In "initialization" phase: Minimize reliance on service configuration
+    //    to few core properties
+    // 2. Before "run" phase: Validate and normalize (via AJV) `serverless.configurationInput`
+    //    into `serverless.configuration`
+    // 3. In "run" phase: Instead of relying on `serverless.service` rely on
+    //    `serverless.configuration` internally
+
+    // Below comments provide usage feedback helfpul for future refactor process.
+
+    // ## Properties currently accessed at "initialization" phase
+    //
+    // `provider` (`provder.name` by many plugin constructs, and few other core properties as
+    //              `provider.stage` are read by dashboard plugin)
     if (!_.isObject(serverlessFile.provider)) {
       const providerName = serverlessFile.provider;
       serverlessFile.provider = {
         name: providerName,
       };
     }
+    if (serverlessFile.provider.stage == null) {
+      serverlessFile.provider.stage = 'dev';
+    }
+    this.provider = serverlessFile.provider;
 
+    // `service` (read by dashboard plugin)
     if (_.isObject(serverlessFile.service)) {
       this.serverless._logDeprecation(
         'SERVICE_OBJECT_NOTATION',
@@ -123,37 +144,29 @@ class Service {
       this.service = serverlessFile.service;
     }
 
+    // (dashboard plugin)
     this.app = serverlessFile.app;
     this.tenant = serverlessFile.tenant;
     this.org = serverlessFile.org;
-    this.custom = serverlessFile.custom;
+
     this.plugins = serverlessFile.plugins;
-    this.resources = serverlessFile.resources;
-    this.functions = serverlessFile.functions || {};
-    this.configValidationMode = serverlessFile.configValidationMode || 'warn';
     this.disabledDeprecations = serverlessFile.disabledDeprecations;
-    this.unresolvedVariablesNotificationMode = serverlessFile.unresolvedVariablesNotificationMode;
 
-    // merge so that the default settings are still in place and
-    // won't be overwritten
-    if (serverlessFile.provider) {
-      if (serverlessFile.provider.stage == null) {
-        serverlessFile.provider.stage = this.provider.stage;
-      }
-      this.provider = serverlessFile.provider;
-    }
-
+    // `package.path` is read by few core plugins at initialization
     if (serverlessFile.package) {
       this.package = serverlessFile.package;
     }
 
+    // ## Properties accessed at "run" phase
+    this.custom = serverlessFile.custom; // (dashboard plugin)
+    this.resources = serverlessFile.resources;
+    this.functions = serverlessFile.functions || {};
+    this.configValidationMode = serverlessFile.configValidationMode || 'warn';
+    this.unresolvedVariablesNotificationMode = serverlessFile.unresolvedVariablesNotificationMode;
     if (this.provider.name === 'aws') {
       this.layers = serverlessFile.layers || {};
     }
-
     this.outputs = serverlessFile.outputs;
-
-    this.initialServerlessConfig = serverlessFile;
 
     return this;
   }

--- a/lib/plugins/print.js
+++ b/lib/plugins/print.js
@@ -66,22 +66,6 @@ class Print {
     }
   }
   async print() {
-    // #####################################################################
-    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/classes/Variables.js ##
-    // ##   there, see `populateService`                                  ##
-    // ##   here, see below                                               ##
-    // #####################################################################
-    // ###################################################################
-    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/classes/Service.js ##
-    // ##   there, see `constructor` and `loadServiceFileParam`         ##
-    // ##   here, see `strip` and `adorn`                               ##
-    // ###################################################################
-    // The *already loaded* Service (i.e. serverless.yml) is adorned with extras for use by the
-    // framework and throughout its codebase.  We could try using the populated service but that
-    // would require playing whack-a-mole on issues as changes are made to the service anywhere in
-    // the codebase.  Avoiding that, this method must read the serverless.yml file itself, adorn it
-    // as the Service class would and then populate it, reversing the adornments thereafter in
-    // preparation for printing the service for the user.
     const svc = this.serverless.configurationInput;
     const service = svc;
     this.adorn(service);

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -598,6 +598,17 @@ const processSpanPromise = (async () => {
               for (const propertyPath of propertyPaths) legacySsmVarPropertyPaths.add(propertyPath);
               unresolvedSources.delete(sourceType);
             }
+            if (sourceType === 'param' || sourceType === 'output') {
+              logDeprecation(
+                'NEW_VARIABLES_RESOLVER',
+                '"param" and "output" variable sources can be resolved only in context of ' +
+                  'services deployed to Serverless Dashboard (with "org" setting configured).\n' +
+                  'Starting with next major release, ' +
+                  'this will be communicated with a thrown error.\n',
+                { serviceConfig: configuration }
+              );
+              unresolvedSources.delete(sourceType);
+            }
           }
           if (legacyCfVarPropertyPaths.size) {
             logDeprecation(
@@ -645,6 +656,18 @@ const processSpanPromise = (async () => {
           const unrecognizedSourceNames = Array.from(unresolvedSources.keys()).filter(
             (sourceName) => !recognizedSourceNames.has(sourceName)
           );
+
+          if (
+            unrecognizedSourceNames.includes('param') ||
+            unrecognizedSourceNames.includes('output')
+          ) {
+            throw new ServerlessError(
+              '"Cannot resolve configuration: ' +
+                '"param" and "output" variable sources can be resolved only in context of ' +
+                'services deployed to Serverless Dashboard (with "org" setting configured)',
+              'DASHBOARD_VARIABLE_SOURCES_MISUSE'
+            );
+          }
           throw new ServerlessError(
             `Approached unrecognized configuration variable sources: "${unrecognizedSourceNames.join(
               '", "'

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -546,7 +546,11 @@ const processSpanPromise = (async () => {
         }
 
         // Register dashboard specific variable source resolvers
-        if (configuration.org && serverless.pluginManager.dashboardPlugin) {
+        if (
+          // TODO: Remove "tenant" support with next major
+          (configuration.org || configuration.tenant) &&
+          serverless.pluginManager.dashboardPlugin
+        ) {
           for (const [sourceName, sourceConfig] of Object.entries(
             serverless.pluginManager.dashboardPlugin.configurationVariablesSources
           )) {

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -364,11 +364,12 @@ const processSpanPromise = (async () => {
           if (!variablesMeta.size) return; // All properties successuflly resolved
 
           if (!ensureResolvedProperty('plugins')) return;
+          if (!ensureResolvedProperty('package\0path')) return;
 
           if (!ensureResolvedProperty('frameworkVersion')) return;
-          if (!ensureResolvedProperty('configValidationMode')) return;
           if (!ensureResolvedProperty('app')) return;
           if (!ensureResolvedProperty('org')) return;
+          if (!ensureResolvedProperty('tenant')) return;
           if (!ensureResolvedProperty('service', { shouldSilentlyReturnIfLegacyMode: true })) {
             return;
           }


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9589 

Issue happened when top level property was configured behind variable, and used variable sources where provided by plugins, so variable resolution happened after _initialization_ phase.

It was due fact that, at _initialization_ phase in [`Service`](https://github.com/serverless/serverless/blob/8ac249b1eadf3173359e02886e71bb89234ebd51/lib/classes/Service.js#L114-L164) class we copy those properties onto `service` class instance, and in all internal logic they're accessed from there.

This was ok, for objects where deeper properties were behind variables (as objects are passed by reference, without creating a new copy), but didn't work if at first stage property was _string_ and after it was resolved into _object_ (and that's the case reported in #9242)

I've cleaned up `Service` logic, and introduced `reloadServiceFileParam` function, which we invoke at begin of _run_ phase, which ensures that eventual top level properties which were converted are also updated on `service` object.

--- 

Additionally improve handling of dashboard plugin variable sources, as so far logic imposed a scenarios where `param` and `output` could have been reported as _unrecognized_ sources, which is misleading.

First problem was that we didn't load those sources where `tenant` was used instead of `org`, and when dashboard plugin still respects `tenant` that was inconsistent (so until dashboard plugin respects them, we need to also recognize them - we will clean this up with next major)
Second problem was usage of `param` or `output` variables, without `org` configured. This is now reported with meaningful message.

