### PR TITLE
Serverless incorrectly warns that TrustedKeyGroups as a CloudFront behavior is invalid 

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -163,6 +163,7 @@ class AwsCompileCloudFrontEvents {
         ViewerProtocolPolicy: {
           enum: ['allow-all', 'redirect-to-https', 'https-only'],
         },
+        TrustedKeyGroups:{type: 'array'}
       },
       additionalProperties: false,
     };

--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -163,7 +163,7 @@ class AwsCompileCloudFrontEvents {
         ViewerProtocolPolicy: {
           enum: ['allow-all', 'redirect-to-https', 'https-only'],
         },
-        TrustedKeyGroups:{type: 'array'}
+        TrustedKeyGroups:{type: 'array', items: {type: 'string'}}
       },
       additionalProperties: false,
     };


### PR DESCRIPTION
Fixes #9595
