### PR TITLE
Variables: Strip unrecognized legacy SSM instructions

### DIFF
--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -49,7 +49,8 @@ module.exports = {
     );
     if (!filePath.startsWith(`${projectDir}${path.sep}`)) {
       throw new ServerlessError(
-        'Cannot load file from outside of a project directory (with "projectDir" setting you may extend project boundary)',
+        'Cannot load file from outside of a project directory ' +
+          '(configure "projectDir" to extend project boundary)',
         'FILE_SOURCE_PATH_OUTSIDE_OF_PROJECT'
       );
     }

--- a/lib/configuration/variables/sources/instance-dependent/get-ssm.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-ssm.js
@@ -4,8 +4,6 @@ const ensureString = require('type/string/ensure');
 const ServerlessError = require('../../../../serverless-error');
 const logDeprecation = require('../../../../utils/logDeprecation');
 
-const legacyInstructions = new Set(['true', 'split']);
-
 module.exports = (serverlessInstance) => {
   return {
     resolve: async ({ address, params, resolveConfigurationProperty }) => {
@@ -33,22 +31,20 @@ module.exports = (serverlessInstance) => {
         const legacyInstructionSeparator = address.lastIndexOf('~');
         if (legacyInstructionSeparator !== -1) {
           const instruction = address.slice(legacyInstructionSeparator + 1);
-          if (legacyInstructions.has(instruction)) {
-            address = address.slice(0, legacyInstructionSeparator);
-            if (instruction === 'true') legacyShouldEnforceDecrypt = true;
-            else legacyShouldEnforceSplit = true;
-            logDeprecation(
-              'NEW_VARIABLES_RESOLVER',
-              'Syntax for referencing SSM parameters was upgraded with ' +
-                'automatic type detection ' +
-                'and there\'s no need to add "~true" or "~split" postfixes to variable references.\n' +
-                'Drop those postfixes and set "variablesResolutionMode: 20210326" in your ' +
-                'service config to adapt to a new behavior.\n' +
-                'Starting with next major release, ' +
-                'this will be communicated with a thrown error.\n',
-              { serviceConfig: serverlessInstance.configurationInput }
-            );
-          }
+          address = address.slice(0, legacyInstructionSeparator);
+          if (instruction === 'true') legacyShouldEnforceDecrypt = true;
+          else if (instruction === 'split') legacyShouldEnforceSplit = true;
+          logDeprecation(
+            'NEW_VARIABLES_RESOLVER',
+            'Syntax for referencing SSM parameters was upgraded with ' +
+              'automatic type detection ' +
+              'and there\'s no need to add "~true" or "~split" postfixes to variable references.\n' +
+              'Drop those postfixes and set "variablesResolutionMode: 20210326" in your ' +
+              'service config to adapt to a new behavior.\n' +
+              'Starting with next major release, ' +
+              'this will be communicated with a thrown error.\n',
+            { serviceConfig: serverlessInstance.configurationInput }
+          );
         }
       }
       const result = await (async () => {

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-ssm.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-ssm.test.js
@@ -147,6 +147,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
         custom: {
           existing: '${ssm:existing}',
           existingWithSplit: '${ssm:existing~split}',
+          existingWithUnrecognized: '${ssm:existing~other}',
           existingList: '${ssm:existingList}',
           existingListWithSplit: '${ssm:existingList~split}',
           secretManager: '${ssm:/aws/reference/secretsmanager/existing}',
@@ -211,6 +212,13 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
       expect(variablesMeta.get('custom\0existingList').error.code).to.equal(
         'VARIABLE_RESOLUTION_ERROR'
       );
+    });
+
+    it('should ignore unrecognized legacy instructions', () => {
+      if (variablesMeta.get('custom\0existingWithUnrecognized')) {
+        throw variablesMeta.get('custom\0existing').error;
+      }
+      expect(configuration.custom.existingWithUnrecognized).to.equal('value');
     });
 
     it('should resolve existing string list param', () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9597

Additionally I've improved error message related to `projectDir`
