### PR TITLE
fix: prevent crash when packaging in parallel

### DIFF
--- a/lib/plugins/aws/customResources/generateZip.js
+++ b/lib/plugins/aws/customResources/generateZip.js
@@ -9,7 +9,9 @@ const safeMoveFile = require('../../../utils/fs/safeMoveFile');
 
 const srcDirPath = path.join(__dirname, 'resources');
 
-module.exports = async (artifactName) => {
+const artifactName = 'custom-resources.zip';
+
+module.exports = async () => {
   const resultPath = await ensureArtifact(artifactName, async (cachePath) => {
     const tmpDirPath = getTmpDirPath();
     const tmpInstalledLambdaPath = path.resolve(tmpDirPath, 'resource-lambda');

--- a/lib/plugins/aws/customResources/generateZip.js
+++ b/lib/plugins/aws/customResources/generateZip.js
@@ -5,12 +5,11 @@ const fse = require('fs-extra');
 const getTmpDirPath = require('../../../utils/fs/getTmpDirPath');
 const createZipFile = require('../../../utils/fs/createZipFile');
 const ensureArtifact = require('../../../utils/ensureArtifact');
+const safeMoveFile = require('../../../utils/fs/safeMoveFile');
 
 const srcDirPath = path.join(__dirname, 'resources');
 
-const artifactName = 'custom-resources.zip';
-
-module.exports = async () => {
+module.exports = async (artifactName) => {
   const resultPath = await ensureArtifact(artifactName, async (cachePath) => {
     const tmpDirPath = getTmpDirPath();
     const tmpInstalledLambdaPath = path.resolve(tmpDirPath, 'resource-lambda');
@@ -18,7 +17,7 @@ module.exports = async () => {
     const cachedZipFilePath = path.resolve(cachePath, artifactName);
     await fse.copy(srcDirPath, tmpInstalledLambdaPath);
     await createZipFile(tmpInstalledLambdaPath, tmpZipFilePath);
-    await fse.move(tmpZipFilePath, cachedZipFilePath);
+    await safeMoveFile(tmpZipFilePath, cachedZipFilePath);
   });
   return path.resolve(resultPath, artifactName);
 };

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -9,7 +9,7 @@ const generateZip = require('./generateZip');
 const ServerlessError = require('../../../serverless-error');
 
 const prepareCustomResourcePackage = _.memoize(async (zipFilePath) =>
-  BbPromise.all([generateZip('custom-resources.zip'), fse.mkdirs(path.dirname(zipFilePath))])
+  BbPromise.all([generateZip(), fse.mkdirs(path.dirname(zipFilePath))])
     .then(([cachedZipFilePath]) => fse.copy(cachedZipFilePath, zipFilePath))
     .then(() => path.basename(zipFilePath))
 );

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -9,7 +9,7 @@ const generateZip = require('./generateZip');
 const ServerlessError = require('../../../serverless-error');
 
 const prepareCustomResourcePackage = _.memoize(async (zipFilePath) =>
-  BbPromise.all([generateZip(), fse.mkdirs(path.dirname(zipFilePath))])
+  BbPromise.all([generateZip('custom-resources.zip'), fse.mkdirs(path.dirname(zipFilePath))])
     .then(([cachedZipFilePath]) => fse.copy(cachedZipFilePath, zipFilePath))
     .then(() => path.basename(zipFilePath))
 );

--- a/lib/utils/fs/safeMoveFile.js
+++ b/lib/utils/fs/safeMoveFile.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const fsp = require('fs').promises;
+const crypto = require('crypto');
+const path = require('path');
+
+/**
+ * Given a path that designates a location of a file on another device,
+ * will return a path to file in the same folder, but with a unique name
+ * to avoid collisions.
+ *
+ * @param {*} destPath the path to the final location of the file being moved
+ * @returns a unique path to a file on the same device as the file being moved
+ */
+const generateTemporaryPathOnDestinationDevice = (destPath) => {
+  const dirName = path.dirname(destPath);
+  // Generate a unique destination file name to get the file onto the destination filesystem
+  const tempName = path.basename(destPath) + crypto.randomBytes(8).toString('hex');
+  return path.join(dirName, tempName);
+};
+
+/**
+ * Allows a file to be moved (renamed) even across filesystem boundaries.
+ *
+ * If the rename fails because the file is getting renamed across file system boundaries,
+ * the file is first copied to the destination file system under a temporary name,
+ * and then renamed from there.
+ *
+ * This is done because rename is atomic but copy is not, and can leave partially copied files.
+ *
+ * @param {*} oldPath the original file that should be moved
+ * @param {*} newPath the path to move the file to
+ */
+async function safeMoveFile(oldPath, newPath) {
+  try {
+    // Golden path, we simply rename the file in an atomic operation
+    await fsp.rename(oldPath, newPath);
+  } catch (err) {
+    // The EXDEV error indicates that the rename failed because the rename was across filesystem boundaries
+    // This might occur if a distro uses tmpfs for temporary directories
+    if (err.code === 'EXDEV') {
+      // Generate a unique destination file name to get the file onto the destination filesystem
+      const tempPath = generateTemporaryPathOnDestinationDevice(newPath);
+
+      // Copy onto the destination filesystem (not guaranteed to be atomic)
+      await fsp.copyFile(oldPath, tempPath);
+      // Atomically move the file onto the destination path, overwriting it
+      await fsp.rename(tempPath, newPath);
+      // Delete the old file once both the above operations succeed
+      await fsp.unlink(oldPath);
+    } else {
+      throw err;
+    }
+  }
+}
+
+module.exports = safeMoveFile;

--- a/test/unit/lib/plugins/aws/customResources/generateZip.test.js
+++ b/test/unit/lib/plugins/aws/customResources/generateZip.test.js
@@ -4,45 +4,20 @@ const proxyquire = require('proxyquire').noCallThru();
 const fse = require('fs-extra');
 const sinon = require('sinon');
 const chai = require('chai');
-const fs = require('fs');
 const { getTmpDirPath, listZipFiles } = require('../../../../../utils/fs');
 const { join } = require('path');
 const { expect } = require('chai');
-const fsp = require('fs').promises;
 const sinonChai = require('sinon-chai');
 
 chai.use(sinonChai);
 
-// Stub out functions that generateZip calls to force error conditions
+// Stub out functions that generateZip calls to override hardcoded paths
 const ensureArtifactStub = sinon.stub();
 const getTmpDirPathStub = sinon.stub();
 const generateZip = proxyquire('../../../../../../lib/plugins/aws/customResources/generateZip.js', {
   '../../../utils/ensureArtifact': ensureArtifactStub,
   '../../../utils/fs/getTmpDirPath': getTmpDirPathStub,
 });
-
-/**
- * Returns and Error object that resembles the EXDEV errors that are thrown
- * when you try to rename across device boundaries.
- *
- * @returns an Error object that resembles the EXDEV errors are thrown
- */
-const createFakeExDevError = () => {
-  // Properties captured by using fs.renameSync in the Node v12.20.1 REPL
-  const fakeCrossDeviceError = new Error(
-    "Error: EXDEV: cross-device link not permitted, rename '/foo/bar' -> '/bar/baz'"
-  );
-  // This is the important property that safeMoveFile looks for
-  // to fallback to copy then rename behaviour
-  fakeCrossDeviceError.code = 'EXDEV';
-
-  // These other properties aren't used but it doesn't hurt to have an accurate error object
-  fakeCrossDeviceError.errno = -18;
-  fakeCrossDeviceError.syscall = 'rename';
-  fakeCrossDeviceError.path = '/foo/bar';
-  fakeCrossDeviceError.dest = '/bar/baz';
-  return fakeCrossDeviceError;
-};
 
 /**
  * The name of the artefact that generateZip generates
@@ -69,8 +44,6 @@ const sourcePath = getTmpDirPath();
 const cachedFile = join(cachePath, artefactName);
 
 describe('#generateZip()', () => {
-  let renameStub;
-
   beforeEach(() => {
     // Set up differently by different tests
     ensureArtifactStub.reset();
@@ -78,12 +51,6 @@ describe('#generateZip()', () => {
     // This always returns the same value
     getTmpDirPathStub.reset();
     getTmpDirPathStub.returns(sourcePath);
-
-    // Normally we just want this to work like usual
-    // The source and cache path are on the same device (/tmp) for these tests
-    // so there should not be any cross device renaming during unit tests
-    renameStub = sinon.stub(fsp, 'rename');
-    renameStub.callThrough();
 
     // Ensure the cache directory exists so that the rename doesn't fail
     fse.ensureDirSync(cachePath);
@@ -93,183 +60,65 @@ describe('#generateZip()', () => {
     // Clean up test directories after each test so they don't interfere with each other
     fse.removeSync(cachePath);
     fse.removeSync(sourcePath);
-    fsp.rename.restore();
   });
 
-  describe('when the temporary directory is not on a different device to the cache directory', () => {
-    describe('when the file does not exist by the time the zip is generated', () => {
-      beforeEach(async () => {
-        // Override the ensureArtifact function to set the cache path to the test one
-        ensureArtifactStub.callsFake(async (_, generate) => {
-          await generate(cachePath);
-          return cachePath;
-        });
-      });
-
-      it('should write a file', async () => {
-        await generateZip(artefactName);
-
-        const exists = fse.existsSync(cachedFile);
-        expect(exists).to.be.true;
-        expect(renameStub).to.have.been.calledOnce;
-      });
-    });
-
-    describe('when the file already exists by the time the zip is generated', () => {
-      beforeEach(async () => {
-        // Override the ensureArtifact function so that it always calls the 'generate' function
-        // even if the file already exists
-        // This will simulate the scenario when multiple serverless instances are packaging at once
-        // and one of the instances writes to the cache path while the others are still generating the zip file
-        ensureArtifactStub.callsFake(async (_, generate) => {
-          await generate(cachePath);
-          return cachePath;
-        });
-
-        // Create an existing file that should conflict with the generated artefact
-        fse.ensureFileSync(cachedFile);
-        fse.writeFileSync(cachedFile, 'cached data');
-      });
-
-      describe('when the cached file is open for writing', () => {
-        it('should overwrite the cached file', async () => {
-          const fd = fs.openSync(cachedFile, 'r+');
-
-          try {
-            await generateZip(artefactName);
-
-            const cachedData = fse.readFileSync(cachedFile).toString();
-            expect(cachedData).not.to.eq('cached data');
-            expect(renameStub).to.have.been.calledOnce;
-          } finally {
-            fs.closeSync(fd);
-          }
-        });
-      });
-
-      describe('when the cached file is not open', () => {
-        it('should overwrite the cached file with a valid zip file', async () => {
-          await generateZip(artefactName);
-
-          // Check that the file was actually overwritten
-          const cachedData = fse.readFileSync(cachedFile).toString();
-          expect(cachedData).not.to.eq('cached data');
-
-          expect(renameStub).to.have.been.calledOnce;
-
-          // List the files in the zip to make sure it is valid
-          const filesInZip = await listZipFiles(cachedFile);
-          expect(filesInZip).to.have.all.members([
-            'README.md',
-            'apiGatewayCloudWatchRole/handler.js',
-            'cognitoUserPool/handler.js',
-            'cognitoUserPool/lib/permissions.js',
-            'cognitoUserPool/lib/userPool.js',
-            'eventBridge/handler.js',
-            'eventBridge/lib/eventBridge.js',
-            'eventBridge/lib/permissions.js',
-            'eventBridge/lib/utils.js',
-            's3/handler.js',
-            's3/lib/bucket.js',
-            's3/lib/permissions.js',
-            'utils.js',
-          ]);
-        });
-      });
-    });
-  });
-
-  describe('when the temporary directory is on a different device to the cache directory', () => {
+  describe('when the file does not exist by the time the zip is generated', () => {
     beforeEach(async () => {
       // Override the ensureArtifact function to set the cache path to the test one
       ensureArtifactStub.callsFake(async (_, generate) => {
         await generate(cachePath);
         return cachePath;
       });
-
-      const error = createFakeExDevError();
-      renameStub.onFirstCall().rejects(error);
     });
 
-    describe('when the file does not exist by the time the zip is generated', () => {
-      beforeEach(async () => {
-        // Override the ensureArtifact function to set the cache path to the test one
-        ensureArtifactStub.callsFake(async (_, generate) => {
-          await generate(cachePath);
-          return cachePath;
-        });
+    it('should write a file', async () => {
+      await generateZip(artefactName);
+
+      const exists = fse.existsSync(cachedFile);
+      expect(exists).to.be.true;
+    });
+  });
+
+  describe('when the file already exists by the time the zip is generated', () => {
+    beforeEach(async () => {
+      // Override the ensureArtifact function so that it always calls the 'generate' function
+      // even if the file already exists
+      // This will simulate the scenario when multiple serverless instances are packaging at once
+      // and one of the instances writes to the cache path while the others are still generating the zip file
+      ensureArtifactStub.callsFake(async (_, generate) => {
+        await generate(cachePath);
+        return cachePath;
       });
 
-      it('should write a file', async () => {
-        await generateZip(artefactName);
-
-        const exists = fse.existsSync(cachedFile);
-        expect(exists).to.be.true;
-        expect(renameStub).to.have.been.calledTwice;
-      });
+      // Create an existing file that should conflict with the generated artefact
+      fse.ensureFileSync(cachedFile);
+      fse.writeFileSync(cachedFile, 'cached data');
     });
 
-    describe('when the file already exists by the time the zip is generated', () => {
-      beforeEach(async () => {
-        // Override the ensureArtifact function so that it always calls the 'generate' function
-        // even if the file already exists
-        // This will simulate the scenario when multiple serverless instances are packaging at once
-        // and one of the instances writes to the cache path while the others are still generating the zip file
-        ensureArtifactStub.callsFake(async (_, generate) => {
-          await generate(cachePath);
-          return cachePath;
-        });
+    it('should overwrite the cached file with a valid zip file', async () => {
+      await generateZip(artefactName);
 
-        // Create an existing file that should conflict with the generated artefact
-        fse.ensureFileSync(cachedFile);
-        fse.writeFileSync(cachedFile, 'cached data');
-      });
+      // Check that the file was actually overwritten
+      const cachedData = fse.readFileSync(cachedFile).toString();
+      expect(cachedData).not.to.eq('cached data');
 
-      describe('when the cached file is open for writing', () => {
-        it('should overwrite the cached file', async () => {
-          const fd = fs.openSync(cachedFile, 'r+');
-
-          try {
-            await generateZip(artefactName);
-
-            const cachedData = fse.readFileSync(cachedFile).toString();
-            expect(cachedData).not.to.eq('cached data');
-            expect(renameStub).to.have.been.calledTwice;
-          } finally {
-            fs.closeSync(fd);
-          }
-        });
-      });
-
-      describe('when the cached file is not open', () => {
-        it('should overwrite the cached file with a valid zip file', async () => {
-          await generateZip(artefactName);
-
-          // Check that the file was actually overwritten
-          const cachedData = fse.readFileSync(cachedFile).toString();
-          expect(cachedData).not.to.eq('cached data');
-
-          expect(renameStub).to.have.been.calledTwice;
-
-          // List the files in the zip to make sure it is valid
-          const filesInZip = await listZipFiles(cachedFile);
-          expect(filesInZip).to.have.all.members([
-            'README.md',
-            'apiGatewayCloudWatchRole/handler.js',
-            'cognitoUserPool/handler.js',
-            'cognitoUserPool/lib/permissions.js',
-            'cognitoUserPool/lib/userPool.js',
-            'eventBridge/handler.js',
-            'eventBridge/lib/eventBridge.js',
-            'eventBridge/lib/permissions.js',
-            'eventBridge/lib/utils.js',
-            's3/handler.js',
-            's3/lib/bucket.js',
-            's3/lib/permissions.js',
-            'utils.js',
-          ]);
-        });
-      });
+      // List the files in the zip to make sure it is valid
+      const filesInZip = await listZipFiles(cachedFile);
+      expect(filesInZip).to.have.all.members([
+        'README.md',
+        'apiGatewayCloudWatchRole/handler.js',
+        'cognitoUserPool/handler.js',
+        'cognitoUserPool/lib/permissions.js',
+        'cognitoUserPool/lib/userPool.js',
+        'eventBridge/handler.js',
+        'eventBridge/lib/eventBridge.js',
+        'eventBridge/lib/permissions.js',
+        'eventBridge/lib/utils.js',
+        's3/handler.js',
+        's3/lib/bucket.js',
+        's3/lib/permissions.js',
+        'utils.js',
+      ]);
     });
   });
 });

--- a/test/unit/lib/plugins/aws/customResources/generateZip.test.js
+++ b/test/unit/lib/plugins/aws/customResources/generateZip.test.js
@@ -1,0 +1,279 @@
+'use strict';
+
+const proxyquire = require('proxyquire').noCallThru();
+const fse = require('fs-extra');
+const sinon = require('sinon');
+const chai = require('chai');
+const fs = require('fs');
+const { getTmpDirPath, listZipFiles } = require('../../../../../utils/fs');
+const { join } = require('path');
+const { expect } = require('chai');
+const fsp = require('fs').promises;
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
+// Stub out functions that generateZip calls to force error conditions
+const ensureArtifactStub = sinon.stub();
+const getTmpDirPathStub = sinon.stub();
+const renameStub = sinon.stub(fsp, 'rename');
+const safeMoveFile = proxyquire('../../../../../../lib/utils/fs/safeMoveFile', {
+  fs: {
+    promises: fsp,
+  },
+});
+const generateZip = proxyquire('../../../../../../lib/plugins/aws/customResources/generateZip.js', {
+  '../../../utils/ensureArtifact': ensureArtifactStub,
+  '../../../utils/fs/getTmpDirPath': getTmpDirPathStub,
+  '../../../utils/fs/safeMoveFile': safeMoveFile,
+});
+
+/**
+ * Returns and Error object that resembles the EXDEV errors that are thrown
+ * when you try to rename across device boundaries.
+ *
+ * @returns an Error object that resembles the EXDEV errors are thrown
+ */
+const createFakeExDevError = () => {
+  // Properties captured by using fs.renameSync in the Node v12.20.1 REPL
+  const fakeCrossDeviceError = new Error(
+    "Error: EXDEV: cross-device link not permitted, rename '/foo/bar' -> '/bar/baz'"
+  );
+  // This is the important property that safeMoveFile looks for
+  // to fallback to copy then rename behaviour
+  fakeCrossDeviceError.code = 'EXDEV';
+
+  // These other properties aren't used but it doesn't hurt to have an accurate error object
+  fakeCrossDeviceError.errno = -18;
+  fakeCrossDeviceError.syscall = 'rename';
+  fakeCrossDeviceError.path = '/foo/bar';
+  fakeCrossDeviceError.dest = '/bar/baz';
+  return fakeCrossDeviceError;
+};
+
+/**
+ * The name of the artefact that generateZip generates
+ */
+const artefactName = 'resource-lambda.zip';
+
+// Generate temporary directories once per test run
+// They will be cleaned up when the tests are done
+
+/**
+ * The path to the mock cache directory
+ */
+const cachePath = getTmpDirPath();
+/**
+ * The path to the directory when the zip file is generated in
+ * before it is copied to the cache path
+ */
+const sourcePath = getTmpDirPath();
+
+/**
+ * The full path to the generated artefact after is has been
+ * copied to the cache directory
+ */
+const cachedFile = join(cachePath, artefactName);
+
+describe('#generateZip()', () => {
+  beforeEach(() => {
+    // Set up differently by different tests
+    ensureArtifactStub.reset();
+
+    // This always returns the same value
+    getTmpDirPathStub.reset();
+    getTmpDirPathStub.returns(sourcePath);
+
+    // Normally we just want this to work like usual
+    // The source and cache path are on the same device (/tmp) for these tests
+    // so there should not be any cross device renaming during unit tests
+    renameStub.reset();
+    renameStub.callThrough();
+
+    // Ensure the cache directory exists so that the rename doesn't fail
+    fse.ensureDirSync(cachePath);
+  });
+
+  afterEach(() => {
+    // Clean up test directories after each test so they don't interfere with each other
+    fse.removeSync(cachePath);
+    fse.removeSync(sourcePath);
+  });
+
+  describe('when the temporary directory is not on a different device to the cache directory', () => {
+    describe('when the file does not exist by the time the zip is generated', () => {
+      beforeEach(async () => {
+        // Override the ensureArtifact function to set the cache path to the test one
+        ensureArtifactStub.callsFake(async (_, generate) => {
+          await generate(cachePath);
+          return cachePath;
+        });
+      });
+
+      it('should write a file', async () => {
+        await generateZip(artefactName);
+
+        const exists = fse.existsSync(cachedFile);
+        expect(exists).to.be.true;
+        expect(renameStub).to.have.been.calledOnce;
+      });
+    });
+
+    describe('when the file already exists by the time the zip is generated', () => {
+      beforeEach(async () => {
+        // Override the ensureArtifact function so that it always calls the 'generate' function
+        // even if the file already exists
+        // This will simulate the scenario when multiple serverless instances are packaging at once
+        // and one of the instances writes to the cache path while the others are still generating the zip file
+        ensureArtifactStub.callsFake(async (_, generate) => {
+          await generate(cachePath);
+          return cachePath;
+        });
+
+        // Create an existing file that should conflict with the generated artefact
+        fse.ensureFileSync(cachedFile);
+        fse.writeFileSync(cachedFile, 'cached data');
+      });
+
+      describe('when the cached file is open for writing', () => {
+        it('should overwrite the cached file', async () => {
+          const fd = fs.openSync(cachedFile, 'r+');
+
+          try {
+            await generateZip(artefactName);
+
+            const cachedData = fse.readFileSync(cachedFile).toString();
+            expect(cachedData).not.to.eq('cached data');
+            expect(renameStub).to.have.been.calledOnce;
+          } finally {
+            fs.closeSync(fd);
+          }
+        });
+      });
+
+      describe('when the cached file is not open', () => {
+        it('should overwrite the cached file with a valid zip file', async () => {
+          await generateZip(artefactName);
+
+          // Check that the file was actually overwritten
+          const cachedData = fse.readFileSync(cachedFile).toString();
+          expect(cachedData).not.to.eq('cached data');
+
+          expect(renameStub).to.have.been.calledOnce;
+
+          // List the files in the zip to make sure it is valid
+          const filesInZip = await listZipFiles(cachedFile);
+          expect(filesInZip).to.have.all.members([
+            'README.md',
+            'apiGatewayCloudWatchRole/handler.js',
+            'cognitoUserPool/handler.js',
+            'cognitoUserPool/lib/permissions.js',
+            'cognitoUserPool/lib/userPool.js',
+            'eventBridge/handler.js',
+            'eventBridge/lib/eventBridge.js',
+            'eventBridge/lib/permissions.js',
+            'eventBridge/lib/utils.js',
+            's3/handler.js',
+            's3/lib/bucket.js',
+            's3/lib/permissions.js',
+            'utils.js',
+          ]);
+        });
+      });
+    });
+  });
+
+  describe('when the temporary directory is on a different device to the cache directory', () => {
+    beforeEach(async () => {
+      // Override the ensureArtifact function to set the cache path to the test one
+      ensureArtifactStub.callsFake(async (_, generate) => {
+        await generate(cachePath);
+        return cachePath;
+      });
+
+      const error = createFakeExDevError();
+      renameStub.onFirstCall().rejects(error);
+    });
+
+    describe('when the file does not exist by the time the zip is generated', () => {
+      beforeEach(async () => {
+        // Override the ensureArtifact function to set the cache path to the test one
+        ensureArtifactStub.callsFake(async (_, generate) => {
+          await generate(cachePath);
+          return cachePath;
+        });
+      });
+
+      it('should write a file', async () => {
+        await generateZip(artefactName);
+
+        const exists = fse.existsSync(cachedFile);
+        expect(exists).to.be.true;
+        expect(renameStub).to.have.been.calledTwice;
+      });
+    });
+
+    describe('when the file already exists by the time the zip is generated', () => {
+      beforeEach(async () => {
+        // Override the ensureArtifact function so that it always calls the 'generate' function
+        // even if the file already exists
+        // This will simulate the scenario when multiple serverless instances are packaging at once
+        // and one of the instances writes to the cache path while the others are still generating the zip file
+        ensureArtifactStub.callsFake(async (_, generate) => {
+          await generate(cachePath);
+          return cachePath;
+        });
+
+        // Create an existing file that should conflict with the generated artefact
+        fse.ensureFileSync(cachedFile);
+        fse.writeFileSync(cachedFile, 'cached data');
+      });
+
+      describe('when the cached file is open for writing', () => {
+        it('should overwrite the cached file', async () => {
+          const fd = fs.openSync(cachedFile, 'r+');
+
+          try {
+            await generateZip(artefactName);
+
+            const cachedData = fse.readFileSync(cachedFile).toString();
+            expect(cachedData).not.to.eq('cached data');
+            expect(renameStub).to.have.been.calledTwice;
+          } finally {
+            fs.closeSync(fd);
+          }
+        });
+      });
+
+      describe('when the cached file is not open', () => {
+        it('should overwrite the cached file with a valid zip file', async () => {
+          await generateZip(artefactName);
+
+          // Check that the file was actually overwritten
+          const cachedData = fse.readFileSync(cachedFile).toString();
+          expect(cachedData).not.to.eq('cached data');
+
+          expect(renameStub).to.have.been.calledTwice;
+
+          // List the files in the zip to make sure it is valid
+          const filesInZip = await listZipFiles(cachedFile);
+          expect(filesInZip).to.have.all.members([
+            'README.md',
+            'apiGatewayCloudWatchRole/handler.js',
+            'cognitoUserPool/handler.js',
+            'cognitoUserPool/lib/permissions.js',
+            'cognitoUserPool/lib/userPool.js',
+            'eventBridge/handler.js',
+            'eventBridge/lib/eventBridge.js',
+            'eventBridge/lib/permissions.js',
+            'eventBridge/lib/utils.js',
+            's3/handler.js',
+            's3/lib/bucket.js',
+            's3/lib/permissions.js',
+            'utils.js',
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/test/unit/lib/plugins/aws/customResources/generateZip.test.js
+++ b/test/unit/lib/plugins/aws/customResources/generateZip.test.js
@@ -1,124 +1,31 @@
 'use strict';
 
-const proxyquire = require('proxyquire').noCallThru();
-const fse = require('fs-extra');
-const sinon = require('sinon');
-const chai = require('chai');
-const { getTmpDirPath, listZipFiles } = require('../../../../../utils/fs');
-const { join } = require('path');
+const path = require('path');
+const globby = require('globby');
+const { listZipFiles } = require('../../../../../utils/fs');
 const { expect } = require('chai');
-const sinonChai = require('sinon-chai');
+const generateZip = require('../../../../../../lib/plugins/aws/customResources/generateZip');
 
-chai.use(sinonChai);
+// The directory that holds the files that generateZip zips up
+const resourcesDir = path.resolve(
+  __dirname,
+  '../../../../../../lib/plugins/aws/customResources/resources/'
+);
 
-// Stub out functions that generateZip calls to override hardcoded paths
-const ensureArtifactStub = sinon.stub();
-const getTmpDirPathStub = sinon.stub();
-const generateZip = proxyquire('../../../../../../lib/plugins/aws/customResources/generateZip.js', {
-  '../../../utils/ensureArtifact': ensureArtifactStub,
-  '../../../utils/fs/getTmpDirPath': getTmpDirPathStub,
-});
-
-/**
- * The name of the artefact that generateZip generates
- */
-const artefactName = 'resource-lambda.zip';
-
-// Generate temporary directories once per test run
-// They will be cleaned up when the tests are done
-
-/**
- * The path to the mock cache directory
- */
-const cachePath = getTmpDirPath();
-/**
- * The path to the directory when the zip file is generated in
- * before it is copied to the cache path
- */
-const sourcePath = getTmpDirPath();
-
-/**
- * The full path to the generated artefact after is has been
- * copied to the cache directory
- */
-const cachedFile = join(cachePath, artefactName);
-
-describe('#generateZip()', () => {
-  beforeEach(() => {
-    // Set up differently by different tests
-    ensureArtifactStub.reset();
-
-    // This always returns the same value
-    getTmpDirPathStub.reset();
-    getTmpDirPathStub.returns(sourcePath);
-
-    // Ensure the cache directory exists so that the rename doesn't fail
-    fse.ensureDirSync(cachePath);
-  });
-
-  afterEach(() => {
-    // Clean up test directories after each test so they don't interfere with each other
-    fse.removeSync(cachePath);
-    fse.removeSync(sourcePath);
-  });
-
-  describe('when the file does not exist by the time the zip is generated', () => {
-    beforeEach(async () => {
-      // Override the ensureArtifact function to set the cache path to the test one
-      ensureArtifactStub.callsFake(async (_, generate) => {
-        await generate(cachePath);
-        return cachePath;
-      });
-    });
-
-    it('should write a file', async () => {
-      await generateZip(artefactName);
-
-      const exists = fse.existsSync(cachedFile);
-      expect(exists).to.be.true;
-    });
-  });
-
-  describe('when the file already exists by the time the zip is generated', () => {
-    beforeEach(async () => {
-      // Override the ensureArtifact function so that it always calls the 'generate' function
-      // even if the file already exists
-      // This will simulate the scenario when multiple serverless instances are packaging at once
-      // and one of the instances writes to the cache path while the others are still generating the zip file
-      ensureArtifactStub.callsFake(async (_, generate) => {
-        await generate(cachePath);
-        return cachePath;
-      });
-
-      // Create an existing file that should conflict with the generated artefact
-      fse.ensureFileSync(cachedFile);
-      fse.writeFileSync(cachedFile, 'cached data');
-    });
-
-    it('should overwrite the cached file with a valid zip file', async () => {
-      await generateZip(artefactName);
-
-      // Check that the file was actually overwritten
-      const cachedData = fse.readFileSync(cachedFile).toString();
-      expect(cachedData).not.to.eq('cached data');
+describe('test/unit/lib/plugins/aws/customResources/generateZip.test.js', () => {
+  describe('when generating a zip file', () => {
+    it('should generate a zip file with the contents of the resources directory', async () => {
+      const zipFilePath = await generateZip();
 
       // List the files in the zip to make sure it is valid
-      const filesInZip = await listZipFiles(cachedFile);
-      expect(filesInZip).to.have.all.members([
-        'README.md',
-        'apiGatewayCloudWatchRole/handler.js',
-        'cognitoUserPool/handler.js',
-        'cognitoUserPool/lib/permissions.js',
-        'cognitoUserPool/lib/userPool.js',
-        'eventBridge/handler.js',
-        'eventBridge/lib/eventBridge.js',
-        'eventBridge/lib/permissions.js',
-        'eventBridge/lib/utils.js',
-        's3/handler.js',
-        's3/lib/bucket.js',
-        's3/lib/permissions.js',
-        'utils.js',
-      ]);
+      const filesInZip = await listZipFiles(zipFilePath);
+
+      const filesInResourceDirAbsolute = await globby(path.join(resourcesDir, '**'));
+      // Globby returns absolute paths to CWD so we need to convert them to relative to compare with the zip file
+      const filesInResourceDirRelative = filesInResourceDirAbsolute.map((p) =>
+        path.relative(resourcesDir, p)
+      );
+      expect(filesInZip).to.have.all.members(filesInResourceDirRelative);
     });
   });
 });

--- a/test/unit/lib/plugins/aws/customResources/generateZip.test.js
+++ b/test/unit/lib/plugins/aws/customResources/generateZip.test.js
@@ -20,12 +20,8 @@ describe('test/unit/lib/plugins/aws/customResources/generateZip.test.js', () => 
       // List the files in the zip to make sure it is valid
       const filesInZip = await listZipFiles(zipFilePath);
 
-      const filesInResourceDirAbsolute = await globby(path.join(resourcesDir, '**'));
-      // Globby returns absolute paths to CWD so we need to convert them to relative to compare with the zip file
-      const filesInResourceDirRelative = filesInResourceDirAbsolute.map((p) =>
-        path.relative(resourcesDir, p)
-      );
-      expect(filesInZip).to.have.all.members(filesInResourceDirRelative);
+      const filesInResourceDir = await globby('**', { cwd: resourcesDir });
+      expect(filesInZip).to.have.all.members(filesInResourceDir);
     });
   });
 });

--- a/test/unit/lib/utils/fs/safeMoveFile.test.js
+++ b/test/unit/lib/utils/fs/safeMoveFile.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const fse = require('fs-extra');
+const sinon = require('sinon');
+const chai = require('chai');
+const fs = require('fs');
+const { getTmpDirPath } = require('../../../../utils/fs');
+const { join } = require('path');
+const { expect } = require('chai');
+const fsp = require('fs').promises;
+const sinonChai = require('sinon-chai');
+const safeMoveFile = require('../../../../../lib/utils/fs/safeMoveFile');
+
+chai.use(sinonChai);
+
+/**
+ * Returns and Error object that resembles the EXDEV errors that are thrown
+ * when you try to rename across device boundaries.
+ *
+ * @returns an Error object that resembles the EXDEV errors are thrown
+ */
+const createFakeExDevError = () => {
+  // Properties captured by using fs.renameSync in the Node v12.20.1 REPL
+  const fakeCrossDeviceError = new Error(
+    "Error: EXDEV: cross-device link not permitted, rename '/foo/bar' -> '/bar/baz'"
+  );
+  // This is the important property that safeMoveFile looks for
+  // to fallback to copy then rename behaviour
+  fakeCrossDeviceError.code = 'EXDEV';
+
+  // These other properties aren't used but it doesn't hurt to have an accurate error object
+  fakeCrossDeviceError.errno = -18;
+  fakeCrossDeviceError.syscall = 'rename';
+  fakeCrossDeviceError.path = '/foo/bar';
+  fakeCrossDeviceError.dest = '/bar/baz';
+  return fakeCrossDeviceError;
+};
+
+/**
+ * The name of the file that will be moved
+ */
+const artefactName = 'foo-bar.zip';
+
+// Generate temporary directories once per test run
+// They will be cleaned up when the tests are done
+
+/**
+ * The folder that the test file will be moved to
+ */
+const destinationPath = getTmpDirPath();
+
+/**
+ * The folder that the test file will come from
+ */
+const sourcePath = getTmpDirPath();
+
+/**
+ * The full path to destination where the file is being moved to
+ */
+const destinationFile = join(destinationPath, artefactName);
+
+/**
+ * The full path to the file that is being moved
+ */
+const sourceFile = join(sourcePath, artefactName);
+
+describe('#safeMoveFile()', () => {
+  let renameStub;
+  let copyFileStub;
+  let unlinkStub;
+
+  beforeEach(async () => {
+    renameStub = sinon.stub(fsp, 'rename');
+    copyFileStub = sinon.stub(fsp, 'copyFile');
+    unlinkStub = sinon.stub(fsp, 'unlink');
+    // Allow the fs calls to act as normal until we want to force the rename to fail
+    renameStub.callThrough();
+    copyFileStub.callThrough();
+    unlinkStub.callThrough();
+
+    // Ensure the cache directory exists so that the rename doesn't fail
+    fse.ensureDirSync(sourcePath);
+    fse.ensureDirSync(destinationPath);
+
+    // Write a test file to rename
+    await fse.writeFile(sourceFile, 'source data');
+  });
+
+  afterEach(() => {
+    // Clean up test directories after each test so they don't interfere with each other
+    fse.removeSync(destinationPath);
+    fse.removeSync(sourcePath);
+    // Reset stubbed methods
+    fsp.rename.restore();
+    fsp.copyFile.restore();
+    fsp.unlink.restore();
+  });
+
+  /**
+   * Run the test suite with the provided post assertion function.
+   * The post assertion function will be called after each test scenario is executed
+   * so that the test scenarios can be reused.
+   *
+   * @param {*} postAssertion the function that is called after every test scenario
+   */
+  const runTestScenariosWithPostAssertion = (postAssertion) => {
+    describe('when the file does not exist by the time the zip is generated', () => {
+      it('should write a file', async () => {
+        await safeMoveFile(sourceFile, destinationFile);
+
+        const exists = fse.existsSync(destinationFile);
+        expect(exists).to.be.true;
+        postAssertion();
+      });
+    });
+
+    describe('when the file already exists by the time the zip is generated', () => {
+      beforeEach(async () => {
+        // Create an existing file that is at the destination
+        fse.ensureFileSync(destinationFile);
+        fse.writeFileSync(destinationFile, 'existing destination data');
+      });
+
+      describe('when the cached file is open for writing', () => {
+        it('should overwrite the cached file', async () => {
+          const fd = fs.openSync(destinationFile, 'r+');
+
+          try {
+            await safeMoveFile(sourceFile, destinationFile);
+
+            const cachedData = fse.readFileSync(destinationFile).toString();
+            expect(cachedData).not.to.eq('existing destination data');
+            postAssertion();
+          } finally {
+            fs.closeSync(fd);
+          }
+        });
+      });
+
+      describe('when the cached file is not open', () => {
+        it('should overwrite the cached file with a valid zip file', async () => {
+          await safeMoveFile(sourceFile, destinationFile);
+
+          // Check that the file was actually overwritten
+          const cachedData = fse.readFileSync(destinationFile).toString();
+          expect(cachedData).not.to.eq('existing destination data');
+
+          postAssertion();
+        });
+      });
+    });
+  };
+
+  describe('when the temporary directory is not on a different device to the cache directory', () => {
+    runTestScenariosWithPostAssertion(() => {
+      // Happy path: Only rename is called
+      expect(renameStub).to.have.be.calledOnce;
+      expect(copyFileStub).to.not.have.been.called;
+      expect(unlinkStub).to.not.have.been.called;
+    });
+  });
+
+  describe('when the temporary directory is on a different device to the cache directory', () => {
+    beforeEach(async () => {
+      const error = createFakeExDevError();
+      renameStub.onFirstCall().rejects(error);
+    });
+
+    runTestScenariosWithPostAssertion(() => {
+      // Rename is called twice because the first call will fail due to the cross device rename
+      // The second call is across the same device
+      expect(renameStub).to.have.been.calledTwice;
+      expect(copyFileStub).to.have.been.calledOnce;
+      expect(unlinkStub).to.have.been.calledOnce;
+    });
+  });
+});

--- a/test/unit/lib/utils/fs/safeMoveFile.test.js
+++ b/test/unit/lib/utils/fs/safeMoveFile.test.js
@@ -3,7 +3,6 @@
 const fse = require('fs-extra');
 const sinon = require('sinon');
 const chai = require('chai');
-const fs = require('fs');
 const { getTmpDirPath } = require('../../../../utils/fs');
 const { join } = require('path');
 const { expect } = require('chai');
@@ -119,22 +118,6 @@ describe('#safeMoveFile()', () => {
         // Create an existing file that is at the destination
         fse.ensureFileSync(destinationFile);
         fse.writeFileSync(destinationFile, 'existing destination data');
-      });
-
-      describe('when the cached file is open for writing', () => {
-        it('should overwrite the cached file', async () => {
-          const fd = fs.openSync(destinationFile, 'r+');
-
-          try {
-            await safeMoveFile(sourceFile, destinationFile);
-
-            const cachedData = fse.readFileSync(destinationFile).toString();
-            expect(cachedData).not.to.eq('existing destination data');
-            postAssertion();
-          } finally {
-            fs.closeSync(fd);
-          }
-        });
       });
 
       describe('when the cached file is not open', () => {


### PR DESCRIPTION
- Previously there was a race condition in ensureArtifact where if you were running multiple 'sls package' in parallel, two or more instances of serverless could notice that the custom resources package was missing and try and create it
- This meant that one of the serverless instances would 'win' the race and create it first. Then the other instances would crash because the file already existed
- Now each project gets its own cache folder and they can't conflict with each other, even if they are packaging in parallel
- Also implemented a safe move function that allows files to be renamed across filesystem boundaries

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9565 
