### PR TITLE
docs: Fix quotation marks on serverless hooks

### DIFF
--- a/docs/guides/cicd/custom-scripts.md
+++ b/docs/guides/cicd/custom-scripts.md
@@ -85,7 +85,7 @@ plugins:
 custom:
   scripts:
     hooks:
-      ‘before:deploy:deploy': <your script>
+      'before:deploy:deploy': <your script>
 ```
 
 **After serverless deploy**
@@ -98,7 +98,7 @@ plugins:
 custom:
   scripts:
     hooks:
-      ‘deploy:finalize’: <your script>
+      'deploy:finalize': <your script>
 ```
 
 ## Additional lifecycle hooks


### PR DESCRIPTION
People copy pasting the config for hooks will copy invalid quotation marks and spend a while debugging it.

It doesn't close an issue.
