### PR TITLE
Remove BlueBird form zipService

### DIFF
--- a/lib/plugins/package/lib/zipService.js
+++ b/lib/plugins/package/lib/zipService.js
@@ -1,33 +1,36 @@
 'use strict';
 
-const BbPromise = require('bluebird');
 const archiver = require('archiver');
 const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
-const fs = BbPromise.promisifyAll(require('fs'));
-const childProcess = BbPromise.promisifyAll(require('child_process'));
+const util = require('util');
+const fs = require('fs');
+const childProcess = require('child_process');
 const globby = require('globby');
 const _ = require('lodash');
+
+const mapPromiseSeries = require('../../../utils/promise/mapPromiseSeries');
 
 const excludeNodeDevDependenciesMemoized = _.memoize(excludeNodeDevDependencies);
 
 module.exports = {
-  zipService(exclude, include, zipFileName) {
+  async zipService(exclude, include, zipFileName) {
     const params = {
       exclude,
       include,
       zipFileName,
     };
 
-    return BbPromise.bind(this)
-      .then(() => BbPromise.resolve(params))
-      .then(this.excludeDevDependencies)
-      .then(this.zip);
+    return await this.excludeDevDependencies(params).then(this.zip);
   },
 
-  excludeDevDependencies(params) {
+  async excludeDevDependencies(params) {
     const servicePath = this.serverless.config.servicePath;
+
+    mapPromiseSeries(['test'], item => {
+      return Promise.resolve();
+    });
 
     let excludeDevDependencies = this.serverless.service.package.excludeDevDependencies;
     if (excludeDevDependencies === undefined || excludeDevDependencies === null) {
@@ -37,8 +40,7 @@ module.exports = {
     if (excludeDevDependencies) {
       this.serverless.cli.log('Excluding development dependencies...');
 
-      return BbPromise.bind(this)
-        .then(() => excludeNodeDevDependenciesMemoized(servicePath))
+      return excludeNodeDevDependenciesMemoized(servicePath)
         .then(exAndInNode => {
           params.exclude = _.union(params.exclude, exAndInNode.exclude); //eslint-disable-line
           params.include = _.union(params.include, exAndInNode.include); //eslint-disable-line
@@ -47,10 +49,10 @@ module.exports = {
         .catch(() => params);
     }
 
-    return BbPromise.resolve(params);
+    return Promise.resolve(params);
   },
 
-  zip(params) {
+  async zip(params) {
     return this.resolveFilePathsFromPatterns(params).then(filePaths =>
       this.zipFiles(filePaths, params.zipFileName)
     );
@@ -64,10 +66,10 @@ module.exports = {
    * @param filesToChmodPlusX - an array of files to add the execute bit to.
    *                            used for golang support on windows.
    */
-  zipFiles(files, zipFileName, prefix, filesToChmodPlusX) {
+  async zipFiles(files, zipFileName, prefix, filesToChmodPlusX) {
     if (files.length === 0) {
       const error = new this.serverless.classes.Error('No files to package');
-      return BbPromise.reject(error);
+      return Promise.reject(error);
     }
 
     const zip = archiver.create('zip');
@@ -81,7 +83,7 @@ module.exports = {
 
     const output = fs.createWriteStream(artifactFilePath);
 
-    return new BbPromise((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       output.on('close', () => resolve(artifactFilePath));
       output.on('error', err => reject(err));
       zip.on('error', err => reject(err));
@@ -94,7 +96,7 @@ module.exports = {
         const normalizedFilesToChmodPlusX =
           filesToChmodPlusX && _.uniq(filesToChmodPlusX.map(file => path.normalize(file)));
 
-        return BbPromise.all(normalizedFiles.map(this.getFileContentAndStat.bind(this)))
+        return Promise.all(normalizedFiles.map(this.getFileContentAndStat.bind(this)))
           .then(contents => {
             contents
               .sort((content1, content2) => content1.filePath.localeCompare(content2.filePath))
@@ -121,13 +123,14 @@ module.exports = {
     });
   },
 
-  getFileContentAndStat(filePath) {
+  async getFileContentAndStat(filePath) {
     const fullPath = path.resolve(this.serverless.config.servicePath, filePath);
+    const statAsync = util.promisify(fs.stat);
 
-    return BbPromise.all([
+    return Promise.all([
       // Get file contents and stat in parallel
       this.getFileContent(fullPath),
-      fs.statAsync(fullPath),
+      statAsync(fullPath),
     ]).then(result => ({
       data: result[0],
       stat: result[1],
@@ -136,12 +139,14 @@ module.exports = {
   },
 
   // Useful point of entry for e.g. transpilation plugins
-  getFileContent(fullPath) {
-    return fs.readFileAsync(fullPath);
+  async getFileContent(fullPath) {
+    const readFileAsync = util.promisify(fs.readFile);
+
+    return readFileAsync(fullPath);
   },
 };
 
-function excludeNodeDevDependencies(servicePath) {
+async function excludeNodeDevDependencies(servicePath) {
   const exAndIn = {
     include: [],
     exclude: [],
@@ -175,54 +180,59 @@ function excludeNodeDevDependencies(servicePath) {
     });
 
     if (!packageJsonPaths.length) {
-      return BbPromise.resolve(exAndIn);
+      return Promise.resolve(exAndIn);
     }
 
     // NOTE: using mapSeries here for a sequential computation (w/o race conditions)
-    return (
-      BbPromise.mapSeries(packageJsonPaths, packageJsonPath => {
-        // the path where the package.json file lives
-        const fullPath = path.join(servicePath, packageJsonPath);
-        const dirWithPackageJson = fullPath.replace(path.join(path.sep, 'package.json'), '');
+    return await mapPromiseSeries(packageJsonPaths, async packageJsonPath => {
+      // the path where the package.json file lives
+      const fullPath = path.join(servicePath, packageJsonPath);
 
-        // we added a catch which resolves so that npm commands with an exit code of 1
-        // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
-        return BbPromise.map(['dev', 'prod'], env => {
+      const dirWithPackageJson = fullPath.replace(path.join(path.sep, 'package.json'), '');
+
+      // we added a catch which resolves so that npm commands with an exit code of 1
+      // (e.g. if the package.json is invalid) won't crash the dev dependency exclusion process
+      return Promise.allSettled(
+        ['dev', 'prod'].map(async env => {
           const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
-          return childProcess
-            .execAsync(
-              `npm ls --${env}=true --parseable=true --long=false --silent >> ${depFile}`,
-              { cwd: dirWithPackageJson }
-            )
-            .catch(() => BbPromise.resolve());
-        });
-      })
-        // NOTE: using mapSeries here for a sequential computation (w/o race conditions)
-        .then(() =>
-          BbPromise.mapSeries(['dev', 'prod'], env => {
-            const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
-            return fs
-              .readFileAsync(depFile)
-              .then(fileContent => _.uniq(fileContent.toString('utf8').split('\n')).filter(Boolean))
-              .catch(() => BbPromise.resolve());
-          })
-        )
-        .then(devAndProDependencies => {
-          const devDependencies = devAndProDependencies[0];
-          const prodDependencies = devAndProDependencies[1];
+          const execAsync = util.promisify(childProcess.exec);
 
-          // NOTE: the order for _.difference is important
-          const dependencies = _.difference(devDependencies, prodDependencies);
-          const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
+          return await execAsync(
+            `npm ls --${env}=true --parseable=true --long=false --silent >> ${depFile}`,
+            { cwd: dirWithPackageJson }
+          ).catch(() => Promise.resolve());
+        })
+      );
+    })
+      // NOTE: using mapSeries here for a sequential computation (w/o race conditions)
+      .then(() =>
+        mapPromiseSeries(['dev', 'prod'], async env => {
+          const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile;
+          const readFileAsync = util.promisify(fs.readFile);
 
-          if (dependencies.length) {
-            return BbPromise.map(dependencies, item =>
-              item.replace(path.join(servicePath, path.sep), '')
-            )
+          return readFileAsync(depFile)
+            .then(fileContent => _.uniq(fileContent.toString('utf8').split('\n')).filter(Boolean))
+            .catch(() => Promise.resolve());
+        })
+      )
+      .then(devAndProDependencies => {
+        const devDependencies = devAndProDependencies[0];
+        const prodDependencies = devAndProDependencies[1];
+
+        // NOTE: the order for _.difference is important
+        const dependencies = _.difference(devDependencies, prodDependencies);
+        const nodeModulesRegex = new RegExp(`${path.join('node_modules', path.sep)}.*`, 'g');
+
+        if (dependencies.length) {
+          return Promise.allSettled(
+            dependencies
+              .map(item => item.replace(path.join(servicePath, path.sep), ''))
               .filter(item => item.length > 0 && item.match(nodeModulesRegex))
-              .reduce((globs, item) => {
+              .map(async item => {
                 const packagePath = path.join(servicePath, item, 'package.json');
-                return fs.readFileAsync(packagePath, 'utf-8').then(
+                const readFileAsync = util.promisify(fs.readFile);
+
+                return await readFileAsync(packagePath, 'utf-8').then(
                   packageJsonFile => {
                     const lastIndex = item.lastIndexOf(path.sep) + 1;
                     const moduleName = item.substr(lastIndex);
@@ -243,29 +253,32 @@ function excludeNodeDevDependencies(servicePath) {
                       baseGlobs.push(path.join(modulePath, '.bin', moduleName));
                     }
 
-                    return globs.concat(baseGlobs);
+                    return baseGlobs;
                   },
-                  () => globs
+                  () => []
                 );
-              }, [])
-              .then(globs => {
-                exAndIn.exclude = exAndIn.exclude.concat(globs);
-                return exAndIn;
-              });
-          }
+              })
+          )
+            .then(results => {
+              return results.reduce((arr, result) => [...arr, ...result.value], []);
+            })
+            .then(globs => {
+              exAndIn.exclude = exAndIn.exclude.concat(globs);
+              return exAndIn;
+            });
+        }
 
-          return exAndIn;
-        })
-        .then(() => {
-          // cleanup
-          fs.unlinkSync(nodeDevDepFile);
-          fs.unlinkSync(nodeProdDepFile);
-          return exAndIn;
-        })
-        .catch(() => exAndIn)
-    );
+        return exAndIn;
+      })
+      .then(() => {
+        // cleanup
+        fs.unlinkSync(nodeDevDepFile);
+        fs.unlinkSync(nodeProdDepFile);
+        return exAndIn;
+      })
+      .catch(() => exAndIn);
   } catch (e) {
     // fail silently
-    return BbPromise.resolve(exAndIn);
+    return Promise.resolve(exAndIn);
   }
 }

--- a/lib/plugins/package/lib/zipService.test.js
+++ b/lib/plugins/package/lib/zipService.test.js
@@ -8,9 +8,8 @@ const path = require('path');
 const JsZip = require('jszip');
 const globby = require('globby');
 const _ = require('lodash');
-const BbPromise = require('bluebird');
-const fs = BbPromise.promisifyAll(require('fs'));
-const childProcess = BbPromise.promisifyAll(require('child_process'));
+const fs = require('fs');
+const childProcess = require('child_process');
 const sinon = require('sinon');
 const Package = require('../package');
 const Serverless = require('../../../Serverless');
@@ -122,21 +121,21 @@ describe('zipService', () => {
 
     describe('when dealing with Node.js runtimes', () => {
       let globbySyncStub;
-      let execAsyncStub;
-      let readFileAsyncStub;
+      let execStub;
+      let readFileStub;
       let servicePath;
 
       beforeEach(() => {
         servicePath = packagePlugin.serverless.config.servicePath;
         globbySyncStub = sinon.stub(globby, 'sync');
-        execAsyncStub = sinon.stub(childProcess, 'execAsync');
-        readFileAsyncStub = sinon.stub(fs, 'readFileAsync');
+        execStub = sinon.stub(childProcess, 'exec');
+        readFileStub = sinon.stub(fs, 'readFile');
       });
 
       afterEach(() => {
         globby.sync.restore();
-        childProcess.execAsync.restore();
-        fs.readFileAsync.restore();
+        childProcess.exec.restore();
+        fs.readFile.restore();
       });
 
       it('should do nothing if no packages are used', () => {
@@ -147,8 +146,8 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.not.have.been.called;
-            expect(readFileAsyncStub).to.not.have.been.called;
+            expect(execStub).to.not.have.been.called;
+            expect(readFileStub).to.not.have.been.called;
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.config.servicePath,
               dot: true,
@@ -167,15 +166,15 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.resolves();
+        execStub.yields();
         const depPaths = '';
-        readFileAsyncStub.resolves(depPaths);
+        readFileStub.yields(null, depPaths);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
-            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(execStub).to.have.been.calledTwice;
+            expect(readFileStub).to.have.been.calledTwice;
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.config.servicePath,
               dot: true,
@@ -183,14 +182,14 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
+            expect(execStub.args[0][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
+            expect(execStub.args[0][1].cwd).to.match(/.+/);
+            expect(execStub.args[1][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
+            expect(execStub.args[1][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -204,8 +203,8 @@ describe('zipService', () => {
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.not.have.been.called;
-            expect(readFileAsyncStub).to.not.have.been.called;
+            expect(execStub).to.not.have.been.called;
+            expect(readFileStub).to.not.have.been.called;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -217,15 +216,15 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.onCall(0).resolves();
-        execAsyncStub.onCall(1).rejects();
-        readFileAsyncStub.resolves();
+        execStub.onCall(0).yields();
+        execStub.onCall(1).yields('Failure');
+        readFileStub.yields();
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
-            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(execStub).to.have.been.calledTwice;
+            expect(readFileStub).to.have.been.calledTwice;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -237,16 +236,16 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.resolves();
+        execStub.yields();
 
-        readFileAsyncStub.onCall(0).resolves();
-        readFileAsyncStub.onCall(1).rejects();
+        readFileStub.onCall(0).yields();
+        readFileStub.onCall(1).yields('Failure');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
-            expect(readFileAsyncStub).to.have.been.calledTwice;
+            expect(execStub).to.have.been.calledTwice;
+            expect(readFileStub).to.have.been.calledTwice;
             expect(updatedParams.exclude).to.deep.equal(['user-defined-exclude-me']);
             expect(updatedParams.include).to.deep.equal(['user-defined-include-me']);
             expect(updatedParams.zipFileName).to.equal(params.zipFileName);
@@ -269,40 +268,40 @@ describe('zipService', () => {
         ];
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.onCall(0).resolves();
-        execAsyncStub.onCall(1).resolves();
-        execAsyncStub.onCall(2).rejects();
-        execAsyncStub.onCall(3).rejects();
-        execAsyncStub.onCall(4).resolves();
-        execAsyncStub.onCall(5).resolves();
+        execStub.onCall(0).yields();
+        execStub.onCall(1).yields();
+        execStub.onCall(2).yields('Failure');
+        execStub.onCall(3).yields('Failure');
+        execStub.onCall(4).yields();
+        execStub.onCall(5).yields();
         const depPaths = [
           path.join(servicePath, 'node_modules', 'module-1'),
           path.join(servicePath, 'node_modules', 'module-2'),
           path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1'),
           path.join(servicePath, '1st', '2nd', 'node_modules', 'module-2'),
         ].join('\n');
-        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
-        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
-        readFileAsyncStub.onCall(2).resolves('{}');
-        readFileAsyncStub.onCall(3).resolves('{}');
-        readFileAsyncStub.onCall(4).resolves('{}');
-        readFileAsyncStub.onCall(5).resolves('{}');
+        readFileStub.withArgs(sinon.match(/dev$/)).yields(null, depPaths);
+        readFileStub.withArgs(sinon.match(/prod$/)).yields(null, []);
+        readFileStub.onCall(2).yields(null, '{}');
+        readFileStub.onCall(3).yields(null, '{}');
+        readFileStub.onCall(4).yields(null, '{}');
+        readFileStub.onCall(5).yields(null, '{}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub.callCount).to.equal(6);
-            expect(readFileAsyncStub).to.have.callCount(6);
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(execStub.callCount).to.equal(6);
+            expect(readFileStub).to.have.callCount(6);
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, 'node_modules', 'module-1', 'package.json')
             );
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, 'node_modules', 'module-2', 'package.json')
             );
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json')
             );
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
@@ -312,30 +311,30 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
+            expect(execStub.args[0][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
+            expect(execStub.args[0][1].cwd).to.match(/.+/);
+            expect(execStub.args[1][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[2][0]).to.match(
+            expect(execStub.args[1][1].cwd).to.match(/.+/);
+            expect(execStub.args[2][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[2][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[3][0]).to.match(
+            expect(execStub.args[2][1].cwd).to.match(/.+/);
+            expect(execStub.args[3][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[3][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[4][0]).to.match(
+            expect(execStub.args[3][1].cwd).to.match(/.+/);
+            expect(execStub.args[4][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[4][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[5][0]).to.match(
+            expect(execStub.args[4][1].cwd).to.match(/.+/);
+            expect(execStub.args[5][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[5][1].cwd).to.match(/.+/);
+            expect(execStub.args[5][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               path.join('node_modules', 'module-1', '**'),
@@ -353,25 +352,25 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.resolves();
+        execStub.yields();
         const depPaths = [
           path.join(servicePath, 'node_modules', 'module-1'),
           path.join(servicePath, 'node_modules', 'module-2'),
         ].join('\n');
-        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
-        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
-        readFileAsyncStub.onCall(2).resolves('{}');
-        readFileAsyncStub.onCall(3).resolves('{}');
+        readFileStub.withArgs(sinon.match(/dev$/)).yields(null, depPaths);
+        readFileStub.withArgs(sinon.match(/prod$/)).yields(null, []);
+        readFileStub.onCall(2).yields(null, '{}');
+        readFileStub.onCall(3).yields(null, '{}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
-            expect(readFileAsyncStub).to.have.callCount(4);
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(execStub).to.have.been.calledTwice;
+            expect(readFileStub).to.have.callCount(4);
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, 'node_modules', 'module-1', 'package.json')
             );
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, 'node_modules', 'module-2', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
@@ -381,14 +380,14 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
+            expect(execStub.args[0][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
+            expect(execStub.args[0][1].cwd).to.match(/.+/);
+            expect(execStub.args[1][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
+            expect(execStub.args[1][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               path.join('node_modules', 'module-1', '**'),
@@ -414,7 +413,7 @@ describe('zipService', () => {
         ];
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.resolves();
+        execStub.yields();
         const depPaths = [
           path.join(servicePath, 'node_modules', 'module-1'),
           path.join(servicePath, 'node_modules', 'module-2'),
@@ -423,20 +422,20 @@ describe('zipService', () => {
           path.join(servicePath, '1st', '2nd', 'node_modules', 'module-1'),
           path.join(servicePath, '1st', '2nd', 'node_modules', 'module-2'),
         ].join('\n');
-        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths);
-        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
-        readFileAsyncStub.onCall(2).resolves('{}');
-        readFileAsyncStub.onCall(3).resolves('{}');
-        readFileAsyncStub.onCall(4).resolves('{}');
-        readFileAsyncStub.onCall(5).resolves('{}');
-        readFileAsyncStub.onCall(6).resolves('{}');
-        readFileAsyncStub.onCall(7).resolves('{}');
+        readFileStub.withArgs(sinon.match(/dev$/)).yields(null, depPaths);
+        readFileStub.withArgs(sinon.match(/prod$/)).yields(null, []);
+        readFileStub.onCall(2).yields(null, '{}');
+        readFileStub.onCall(3).yields(null, '{}');
+        readFileStub.onCall(4).yields(null, '{}');
+        readFileStub.onCall(5).yields(null, '{}');
+        readFileStub.onCall(6).yields(null, '{}');
+        readFileStub.onCall(7).yields(null, '{}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub.callCount).to.equal(6);
-            expect(readFileAsyncStub).to.have.callCount(8);
+            expect(execStub.callCount).to.equal(6);
+            expect(readFileStub).to.have.callCount(8);
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
               cwd: packagePlugin.serverless.config.servicePath,
               dot: true,
@@ -444,30 +443,30 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
+            expect(execStub.args[0][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
+            expect(execStub.args[0][1].cwd).to.match(/.+/);
+            expect(execStub.args[1][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[2][0]).to.match(
+            expect(execStub.args[1][1].cwd).to.match(/.+/);
+            expect(execStub.args[2][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[2][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[3][0]).to.match(
+            expect(execStub.args[2][1].cwd).to.match(/.+/);
+            expect(execStub.args[3][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[3][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[4][0]).to.match(
+            expect(execStub.args[3][1].cwd).to.match(/.+/);
+            expect(execStub.args[4][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[4][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[5][0]).to.match(
+            expect(execStub.args[4][1].cwd).to.match(/.+/);
+            expect(execStub.args[5][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[5][1].cwd).to.match(/.+/);
+            expect(execStub.args[5][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               path.join('node_modules', 'module-1', '**'),
@@ -487,24 +486,24 @@ describe('zipService', () => {
         const filePaths = ['package.json', 'node_modules'];
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.resolves();
+        execStub.yields();
 
         const devDepPaths = [
           path.join(servicePath, 'node_modules', 'module-1'),
           path.join(servicePath, 'node_modules', 'module-2'),
         ].join('\n');
-        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
+        readFileStub.withArgs(sinon.match(/dev$/)).yields(null, devDepPaths);
 
         const prodDepPaths = [path.join(servicePath, 'node_modules', 'module-2')];
-        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves(prodDepPaths);
-        readFileAsyncStub.onCall(2).resolves('{}');
+        readFileStub.withArgs(sinon.match(/prod$/)).yields(null, prodDepPaths);
+        readFileStub.onCall(2).yields(null, '{}');
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
-            expect(readFileAsyncStub).to.have.been.calledThrice;
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(execStub).to.have.been.calledTwice;
+            expect(readFileStub).to.have.been.calledThrice;
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, 'node_modules', 'module-1', 'package.json')
             );
             expect(globbySyncStub).to.have.been.calledWithExactly(['**/package.json'], {
@@ -514,14 +513,14 @@ describe('zipService', () => {
               follow: true,
               nosort: true,
             });
-            expect(execAsyncStub.args[0][0]).to.match(
+            expect(execStub.args[0][0]).to.match(
               /npm ls --dev=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[0][1].cwd).to.match(/.+/);
-            expect(execAsyncStub.args[1][0]).to.match(
+            expect(execStub.args[0][1].cwd).to.match(/.+/);
+            expect(execStub.args[1][0]).to.match(
               /npm ls --prod=true --parseable=true --long=false --silent >> .+/
             );
-            expect(execAsyncStub.args[1][1].cwd).to.match(/.+/);
+            expect(execStub.args[1][1].cwd).to.match(/.+/);
             expect(updatedParams.exclude).to.deep.equal([
               'user-defined-exclude-me',
               path.join('node_modules', 'module-1', '**'),
@@ -545,38 +544,41 @@ describe('zipService', () => {
         const filePaths = ['node_modules/', 'package.json'].concat(devPaths).concat(prodPaths);
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.resolves();
+        execStub.yields();
 
         const mapper = depPath => path.join(`${servicePath}`, depPath);
 
         const devDepPaths = devPaths.map(mapper).join('\n');
-        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(devDepPaths);
+        readFileStub.withArgs(sinon.match(/dev$/)).yields(null, devDepPaths);
 
         const prodDepPaths = prodPaths.map(mapper).join('\n');
-        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves(prodDepPaths);
+        readFileStub.withArgs(sinon.match(/prod$/)).yields(null, prodDepPaths);
 
-        readFileAsyncStub.onCall(2).resolves('{"name": "bro-module", "bin": "main.js"}');
-        readFileAsyncStub
+        readFileStub.onCall(2).yields(null, '{"name": "bro-module", "bin": "main.js"}');
+        readFileStub
           .onCall(3)
-          .resolves('{"name": "lumo-clj", "bin": {"lumo": "./bin/lumo.js"}}');
-        readFileAsyncStub
+          .yields(null, '{"name": "lumo-clj", "bin": {"lumo": "./bin/lumo.js"}}');
+        readFileStub
           .onCall(4)
           // need to handle possibility of multiple executables provided by the lib
-          .resolves('{"name": "meowmix", "bin": {"meow": "./bin/meow.js", "mix": "./bin/mix.js"}}');
+          .yields(
+            null,
+            '{"name": "meowmix", "bin": {"meow": "./bin/meow.js", "mix": "./bin/mix.js"}}'
+          );
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.been.calledOnce;
-            expect(execAsyncStub).to.have.been.calledTwice;
+            expect(execStub).to.have.been.calledTwice;
 
-            expect(readFileAsyncStub).to.have.callCount(5);
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(readFileStub).to.have.callCount(5);
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, 'node_modules', 'bro-module', 'package.json')
             );
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, 'node_modules', 'lumo-clj', 'package.json')
             );
-            expect(readFileAsyncStub).to.have.been.calledWith(
+            expect(readFileStub).to.have.been.calledWith(
               path.join(servicePath, 'node_modules', 'meowmix', 'package.json')
             );
 
@@ -607,7 +609,7 @@ describe('zipService', () => {
         ];
 
         globbySyncStub.returns(filePaths);
-        execAsyncStub.resolves();
+        execStub.yields();
         const deps = [
           'node_modules/module-1',
           'node_modules/module-2',
@@ -617,8 +619,8 @@ describe('zipService', () => {
           '1st/2nd/node_modules/module-2',
         ];
         const depPaths = deps.map(depPath => path.join(`${servicePath}`, depPath));
-        readFileAsyncStub.withArgs(sinon.match(/dev$/)).resolves(depPaths.join('\n'));
-        readFileAsyncStub.withArgs(sinon.match(/prod$/)).resolves([]);
+        readFileStub.withArgs(sinon.match(/dev$/)).yields(null, depPaths.join('\n'));
+        readFileStub.withArgs(sinon.match(/prod$/)).yields(null, []);
 
         const module1PackageJson = JSON.stringify({
           name: 'module-1',
@@ -631,20 +633,20 @@ describe('zipService', () => {
           bin: './main.js',
         });
 
-        readFileAsyncStub.onCall(2).resolves(module1PackageJson);
-        readFileAsyncStub.onCall(3).resolves(module2PackageJson);
-        readFileAsyncStub.onCall(4).resolves(module1PackageJson);
-        readFileAsyncStub.onCall(5).resolves(module2PackageJson);
-        readFileAsyncStub.onCall(6).resolves(module1PackageJson);
-        readFileAsyncStub.onCall(7).resolves(module2PackageJson);
+        readFileStub.onCall(2).yields(null, module1PackageJson);
+        readFileStub.onCall(3).yields(null, module2PackageJson);
+        readFileStub.onCall(4).yields(null, module1PackageJson);
+        readFileStub.onCall(5).yields(null, module2PackageJson);
+        readFileStub.onCall(6).yields(null, module1PackageJson);
+        readFileStub.onCall(7).yields(null, module2PackageJson);
 
         return expect(packagePlugin.excludeDevDependencies(params)).to.be.fulfilled.then(
           updatedParams => {
             expect(globbySyncStub).to.have.been.calledOnce;
-            expect(execAsyncStub.callCount).to.equal(6);
-            expect(readFileAsyncStub).to.have.callCount(8);
+            expect(execStub.callCount).to.equal(6);
+            expect(readFileStub).to.have.callCount(8);
             for (const depPath of deps) {
-              expect(readFileAsyncStub).to.have.been.calledWith(
+              expect(readFileStub).to.have.been.calledWith(
                 path.join(servicePath, depPath, 'package.json')
               );
             }

--- a/lib/utils/promise/mapPromiseSeries.js
+++ b/lib/utils/promise/mapPromiseSeries.js
@@ -1,0 +1,9 @@
+// native promise based drop-in replacement for BlueBird Promise.mapSeries
+'use strict';
+
+module.exports = (items, func) => {
+  return items.reduce(
+    (promise, item) => promise.then(result => func(item).then(mapped => [...result, mapped])),
+    Promise.resolve([])
+  );
+};


### PR DESCRIPTION
Based on discussion in https://github.com/serverless/serverless/pull/9542, adding a PR to refactor out blubbird from zipService

Note: I get a linting failure, but there's no other way to use async/await.