### PR TITLE
Introduce deprecation notification mode

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -17,6 +17,21 @@ disabledDeprecations:
   - '*' # To disable all deprecation messages
 ```
 
+## Notifications mode
+
+By default deprecations are logged as warnings. If there's an intention to work with _deprecation_ free service, reporting mode can be switched so approached deprecation is reported with a thrown error.
+
+Mode can be set via environment variable: `SLS_DEPRECATION_NOTIFICATION_MODE=error` or via top level service configuration setting:
+
+```yaml
+deprecationNotificationMode: error
+```
+
+Note:
+
+- Configuration setting is ineffective for deprecations reported before service configuration is read.
+- `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
+
 <a name="CHANGE_OF_DEFAULT_RUNTIME_TO_NODEJS14X"><div>&nbsp;</div></a>
 
 ## Change of default runtime to `nodejs14.x`

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -29,6 +29,7 @@ enableLocalInstallationFallback: false # If set to 'true', guarantees that it's 
 useDotenv: false # If set to 'true', environment variables will be automatically loaded from .env files
 variablesResolutionMode: null # To crash on variable resolution errors (as coming from new resolver), set this value to "20210326"
 unresolvedVariablesNotificationMode: warn # If set to 'error', references to variables that cannot be resolved will result in an error being thrown (applies to legacy resolver)
+deprecationNotificationMode: warn # If set to 'error' any reported deprection will result in an error being thrown
 
 disabledDeprecations: # Disable deprecation logs by their codes. Default is empty.
   - DEP_CODE_1 # Deprecation code to disable

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -445,7 +445,7 @@ class Serverless {
 
   // Only for internal use
   _logDeprecation(code, message) {
-    return logDeprecation(code, message, { serviceConfig: this.service });
+    return logDeprecation(code, message, { serviceConfig: this.configurationInput });
   }
 
   // To be used by external plugins

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -150,6 +150,7 @@ class Service {
 
     this.plugins = configurationInput.plugins;
     this.disabledDeprecations = configurationInput.disabledDeprecations;
+    this.deprecationNotificationMode = configurationInput.deprecationNotificationMode;
 
     // `package.path` is read by few core plugins at initialization
     if (configurationInput.package) {

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -115,7 +115,10 @@ class Service {
     // Below comments provide usage feedback helfpul for future refactor process.
 
     // ## Properties currently accessed at "initialization" phase
-    //
+
+    this.disabledDeprecations = configurationInput.disabledDeprecations;
+    this.deprecationNotificationMode = configurationInput.deprecationNotificationMode;
+
     // `provider` (`provder.name` by many plugin constructs, and few other core properties as
     //              `provider.stage` are read by dashboard plugin)
     if (!_.isObject(configurationInput.provider)) {
@@ -149,8 +152,6 @@ class Service {
     this.org = configurationInput.org;
 
     this.plugins = configurationInput.plugins;
-    this.disabledDeprecations = configurationInput.disabledDeprecations;
-    this.deprecationNotificationMode = configurationInput.deprecationNotificationMode;
 
     // `package.path` is read by few core plugins at initialization
     if (configurationInput.package) {

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -20,6 +20,9 @@ const schema = {
       required: [],
       // User is free to add any properties for its own purpose
     },
+    deprecationsNotificationMode: {
+      enum: ['error', 'warn'],
+    },
     disabledDeprecations: {
       anyOf: [
         { const: '*' },

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -50,6 +50,7 @@ class AwsCompileFunctions {
         if (
           !this.serverless.service.provider.lambdaHashingVersion &&
           Object.keys(this.serverless.service.functions).length &&
+          Object.values(this.serverless.service.functions).some(({ handler }) => handler) &&
           (this.serverless.service.provider.versionFunctions ||
             Object.values(this.serverless.service.functions).some(
               ({ versionFunction }) => versionFunction

--- a/lib/utils/logDeprecation.js
+++ b/lib/utils/logDeprecation.js
@@ -2,8 +2,12 @@
 
 const chalk = require('chalk');
 const weakMemoizee = require('memoizee/weak');
+const _ = require('lodash');
+const ServerlessError = require('../serverless-error');
 
 const disabledCodesByEnv = extractCodes(process.env.SLS_DEPRECATION_DISABLE);
+
+const notificationModeByEnv = process.env.SLS_DEPRECATION_NOTIFICATION_MODE;
 
 const triggeredDeprecations = new Set();
 
@@ -23,6 +27,11 @@ const resolveDeprecatedByService = weakMemoizee((serviceConfig) => {
   }
   return new Set(disabledDeprecations);
 });
+
+const isErrorNotificationMode = (serviceConfig) => {
+  if (notificationModeByEnv) return notificationModeByEnv === 'error';
+  return _.get(serviceConfig, 'deprecationNotificationMode') === 'error';
+};
 
 function writeDeprecation(code, message) {
   const prefix = 'Serverless: ';
@@ -53,11 +62,19 @@ module.exports = (code, message, { serviceConfig } = {}) => {
     ) {
       return;
     }
+
     if (serviceConfig) {
       const serviceDisabledCodes = resolveDeprecatedByService(serviceConfig);
       if (serviceDisabledCodes.has(code) || serviceDisabledCodes.has('*')) {
         return;
       }
+    }
+
+    if (isErrorNotificationMode(serviceConfig)) {
+      throw new ServerlessError(
+        `${message}\n  More Info: https://www.serverless.com/framework/docs/deprecations/#${code}`,
+        `REJECTED_DEPRECATION_${code}`
+      );
     }
 
     writeDeprecation(code, message);

--- a/lib/utils/logDeprecation.js
+++ b/lib/utils/logDeprecation.js
@@ -5,7 +5,7 @@ const weakMemoizee = require('memoizee/weak');
 const _ = require('lodash');
 const ServerlessError = require('../serverless-error');
 
-const disabledCodesByEnv = extractCodes(process.env.SLS_DEPRECATION_DISABLE);
+const disabledDeprecationCodesByEnv = extractCodes(process.env.SLS_DEPRECATION_DISABLE);
 
 const notificationModeByEnv = process.env.SLS_DEPRECATION_NOTIFICATION_MODE;
 
@@ -18,7 +18,7 @@ function extractCodes(codesStr) {
   return new Set(codesStr.split(','));
 }
 
-const resolveDeprecatedByService = weakMemoizee((serviceConfig) => {
+const resolveDisabledDeprecationsByService = weakMemoizee((serviceConfig) => {
   let disabledDeprecations = [];
   if (typeof serviceConfig.disabledDeprecations === 'string') {
     disabledDeprecations = [serviceConfig.disabledDeprecations];
@@ -57,14 +57,14 @@ module.exports = (code, message, { serviceConfig } = {}) => {
   try {
     if (
       triggeredDeprecations.has(code) ||
-      disabledCodesByEnv.has(code) ||
-      disabledCodesByEnv.has('*')
+      disabledDeprecationCodesByEnv.has(code) ||
+      disabledDeprecationCodesByEnv.has('*')
     ) {
       return;
     }
 
     if (serviceConfig) {
-      const serviceDisabledCodes = resolveDeprecatedByService(serviceConfig);
+      const serviceDisabledCodes = resolveDisabledDeprecationsByService(serviceConfig);
       if (serviceDisabledCodes.has(code) || serviceDisabledCodes.has('*')) {
         return;
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^8.1.1",
+    "@serverless/test": "^8.2.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "cos-nodejs-sdk-v5": "^2.9.20",

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -203,6 +203,7 @@ const processSpanPromise = (async () => {
           // variable resolution choices
           if (!ensureResolvedProperty('variablesResolutionMode')) return;
           if (!ensureResolvedProperty('disabledDeprecations')) return;
+          if (!ensureResolvedProperty('deprecationNotificationMode')) return;
 
           if (isPropertyResolved(variablesMeta, 'provider\0name')) {
             providerName = resolveProviderName(configuration);

--- a/test/fixtures/programmatic/checkForChanges/serverless.yml
+++ b/test/fixtures/programmatic/checkForChanges/serverless.yml
@@ -16,4 +16,4 @@ functions:
   fnIndividually:
     handler: fnIndividually.handler
     package:
-      exclude: fn.js
+      patterns: '!fn.js'

--- a/test/fixtures/programmatic/functionLayers/serverless.yml
+++ b/test/fixtures/programmatic/functionLayers/serverless.yml
@@ -18,8 +18,8 @@ layers:
     path: testLayer
 
 package:
-  exclude:
-    - extra_layers/**
+  patterns:
+    - '!extra_layers/**'
 
 functions:
   layerFunc:

--- a/test/fixtures/programmatic/packaging/serverless.yml
+++ b/test/fixtures/programmatic/packaging/serverless.yml
@@ -2,6 +2,7 @@ service: service
 
 configValidationMode: error
 frameworkVersion: '*'
+disabledDeprecations: LOAD_VARIABLES_FROM_ENV_FILES
 
 provider:
   name: aws

--- a/test/fixtures/programmatic/requestSchema/serverless.yml
+++ b/test/fixtures/programmatic/requestSchema/serverless.yml
@@ -1,4 +1,5 @@
 service: service
+disabledDeprecations: AWS_API_GATEWAY_SCHEMAS
 
 provider:
   name: aws

--- a/test/integration/aws/eventBridge.test.js
+++ b/test/integration/aws/eventBridge.test.js
@@ -50,6 +50,7 @@ describe('AWS - Event Bridge Integration Test', () => {
       arnEventBusArn = (await createEventBus(arnEventBusName)).EventBusArn;
       // update the YAML file with the arn
       await serviceData.updateConfig({
+        disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'],
         functions: {
           eventBusDefaultArn: {
             events: [

--- a/test/integrationPackage/fixtures/individually-function/serverless.yml
+++ b/test/integrationPackage/fixtures/individually-function/serverless.yml
@@ -12,15 +12,13 @@ functions:
     handler: handler.hello
     package:
       individually: true
-      include:
+      patterns:
         - handler.js
-      exclude:
-        - handler2.js
+        - '!handler2.js'
   hello2:
     handler: handler2.hello
     package:
       individually: true
-      include:
+      patterns:
         - handler2.js
-      exclude:
-        - handler.js
+        - '!handler.js'

--- a/test/integrationPackage/fixtures/individually/serverless.yml
+++ b/test/integrationPackage/fixtures/individually/serverless.yml
@@ -14,14 +14,12 @@ functions:
   hello:
     handler: handler.hello
     package:
-      include:
+      patterns:
         - handler.js
-      exclude:
-        - handler2.js
+        - '!handler2.js'
   hello2:
     handler: handler2.hello
     package:
-      include:
+      patterns:
         - handler2.js
-      exclude:
-        - handler.js
+        - '!handler.js'

--- a/test/integrationPackage/lambda-files.tests.js
+++ b/test/integrationPackage/lambda-files.tests.js
@@ -62,7 +62,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
     await spawn('npm', ['init', '--yes'], { cwd });
     await fs.appendFile(
       path.resolve(cwd, 'serverless.yml'),
-      '\npackage: {exclude: ["package*.json"]}\n'
+      '\npackage: {patterns: ["!package*.json"]}\n'
     );
     await spawn('npm', ['i', 'lodash'], { cwd });
     await spawn(serverlessExec, ['package'], { cwd });
@@ -75,7 +75,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
     expect(nonNodeModulesFiles).to.deep.equal(['handler.js']);
   });
 
-  it('handles package individually with include/excludes correctly', async () => {
+  it('handles package individually with patterns correctly', async () => {
     await fse.copy(fixturePaths.individually, cwd);
     await spawn(serverlessExec, ['package'], { cwd });
     expect(await listZipFiles(path.join(cwd, '.serverless/hello.zip'))).to.deep.equal([
@@ -86,7 +86,7 @@ describe('Integration test - Packaging - Lambda Files', function () {
     ]);
   });
 
-  it('handles package individually on function level with include/excludes correctly', async () => {
+  it('handles package individually on function level with patterns correctly', async () => {
     await fse.copy(fixturePaths.individuallyFunction, cwd);
     await spawn(serverlessExec, ['package'], { cwd });
     expect(await listZipFiles(path.join(cwd, '.serverless/hello.zip'))).to.deep.equal([

--- a/test/mochaPatch.js
+++ b/test/mochaPatch.js
@@ -52,9 +52,6 @@ BbPromise.config({
   longStackTraces: true,
 });
 
-// In order to ensure that telemetry is not mistakenly emitted during test runs
-process.env.SLS_TELEMETRY_DISABLED = '1';
-
 const { runnerEmitter } = require('@serverless/test/setup/patch');
 
 runnerEmitter.on('runner', (runner) => {

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const expect = require('chai').expect;
+const chai = require('chai');
+
+chai.use(require('chai-as-promised'));
+
+const { expect } = chai;
+
 const Serverless = require('../../../lib/Serverless');
 const semverRegex = require('semver-regex');
 const path = require('path');
@@ -237,20 +242,18 @@ describe('test/unit/lib/Serverless.test.js', () => {
           expect(serverless.isLocalStub).to.be.true;
         }));
 
-      it('Should report deprecation notice when "enableLocalInstallationFallback" is set', () =>
-        runServerless({
-          fixture: 'locallyInstalledServerless',
-          configExt: { enableLocalInstallationFallback: false },
-          command: 'print',
-          modulesCacheStub: {},
-        }).then(({ serverless }) => {
-          expect(Array.from(serverless.triggeredDeprecations)).to.deep.equal([
-            'DISABLE_LOCAL_INSTALLATION_FALLBACK_SETTING',
-          ]);
-          expect(serverless._isInvokedByGlobalInstallation).to.be.false;
-          expect(serverless.isLocallyInstalled).to.be.false;
-          expect(serverless.isLocalStub).to.not.exist;
-        }));
+      it('Should report deprecation notice when "enableLocalInstallationFallback" is set', async () =>
+        expect(
+          runServerless({
+            fixture: 'locallyInstalledServerless',
+            configExt: { enableLocalInstallationFallback: false },
+            command: 'print',
+            modulesCacheStub: {},
+          })
+        ).to.eventually.be.rejected.and.have.property(
+          'code',
+          'REJECTED_DEPRECATION_DISABLE_LOCAL_INSTALLATION_FALLBACK_SETTING'
+        ));
 
       it('Should not fallback to local when "enableLocalInstallationFallback" set to false', async () => {
         const { serverless } = await runServerless({

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -31,7 +31,6 @@ chai.use(require('sinon-chai'));
 const expect = chai.expect;
 
 describe('PluginManager', () => {
-  const env = resolveAwsEnv();
   let pluginManager;
   let serverless;
 
@@ -159,9 +158,11 @@ describe('PluginManager', () => {
           options: {
             resource: {
               usage: 'The resource you want to deploy (e.g. --resource db)',
+              type: 'string',
             },
             function: {
               usage: 'The function you want to deploy (e.g. --function create)',
+              type: 'string',
             },
           },
           commands: {
@@ -171,9 +172,11 @@ describe('PluginManager', () => {
               options: {
                 resource: {
                   usage: 'The resource you want to deploy (e.g. --resource db)',
+                  type: 'string',
                 },
                 function: {
                   usage: 'The function you want to deploy (e.g. --function create)',
+                  type: 'string',
                 },
               },
             },
@@ -209,9 +212,11 @@ describe('PluginManager', () => {
           options: {
             resource: {
               usage: 'The resource you want to deploy (e.g. --resource db)',
+              type: 'string',
             },
             function: {
               usage: 'The function you want to deploy (e.g. --function create)',
+              type: 'string',
             },
           },
           commands: {
@@ -222,9 +227,11 @@ describe('PluginManager', () => {
               options: {
                 resource: {
                   usage: 'The resource you want to deploy (e.g. --resource db)',
+                  type: 'string',
                 },
                 function: {
                   usage: 'The function you want to deploy (e.g. --function create)',
+                  type: 'string',
                 },
               },
             },
@@ -1997,10 +2004,17 @@ describe('PluginManager', () => {
     this.timeout(1000 * 60 * 10);
 
     let serverlessInstance;
+    let env;
     const serverlessExec = require('../../../serverlessBinary');
 
+    before(() => {
+      env = resolveAwsEnv();
+      // Test may be run against deprecated Node.js versions
+      env.SLS_DEPRECATION_DISABLE = 'OUTDATED_NODEJS';
+    });
+
     beforeEach(() => {
-      serverlessInstance = new Serverless();
+      serverlessInstance = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
       return serverlessInstance.init().then(() => {
         // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows.
         const tmpDir = getTmpDirPath();

--- a/test/unit/lib/classes/Service.test.js
+++ b/test/unit/lib/classes/Service.test.js
@@ -91,6 +91,9 @@ describe('Service', () => {
       runServerless({
         fixture: 'aws',
         configExt: {
+          provider: {
+            lambdaHashingVersion: 20201221,
+          },
           functions: [
             {
               a: {},

--- a/test/unit/lib/classes/Variables.test.js
+++ b/test/unit/lib/classes/Variables.test.js
@@ -603,16 +603,13 @@ describe('Variables', () => {
           })
         ).to.be.fulfilled;
       });
-      it('should do nothing useful on * when not wrapped in quotes', () => {
+      it('should do nothing useful on * when not wrapped in quotes', async () => {
         service.custom = {
           val0: '${self:custom.*}',
         };
         const expected = { val0: undefined };
-        return expect(
-          serverless.variables.populateObject(service.custom).then((result) => {
-            expect(result).to.eql(expected);
-          })
-        ).to.be.fulfilled;
+        const result = await serverless.variables.populateObject(service.custom);
+        expect(result).to.eql(expected);
       });
       it('should properly populate overwrites where the middle value is valid', () => {
         service.custom = {

--- a/test/unit/lib/classes/Variables.test.js
+++ b/test/unit/lib/classes/Variables.test.js
@@ -1207,19 +1207,16 @@ module.exports = {
         .should.eventually.eql('my stage is prod');
     });
 
-    it('should not allow partially double-quoted string', () => {
+    it('should not allow partially double-quoted string', async () => {
       const property = '${opt:stage, prefix"prod"suffix}';
       serverless.variables.options = {};
       const handleUnresolvedSpy = sinon.spy(serverless.variables, 'handleUnresolved');
-      return serverless.variables
-        .populateProperty(property)
-        .should.become(undefined)
-        .then(() => {
-          expect(handleUnresolvedSpy.callCount).to.equal(1);
-        })
-        .finally(() => {
-          handleUnresolvedSpy.restore();
-        });
+      try {
+        expect(await serverless.variables.populateProperty(property)).to.equal(undefined);
+        expect(handleUnresolvedSpy.callCount).to.equal(1);
+      } finally {
+        handleUnresolvedSpy.restore();
+      }
     });
 
     it('should allow a boolean with value true if overwrite syntax provided', () => {

--- a/test/unit/lib/cli/commands-schema/resolve-final.test.js
+++ b/test/unit/lib/cli/commands-schema/resolve-final.test.js
@@ -20,6 +20,7 @@ describe('test/unit/lib/cli/commands-schema/resolve-final.test.js', () => {
                       resourceGroup: {
                         usage: 'Resource group for the service',
                         shortcut: 'g',
+                        type: 'string',
                       },
                     },
                   },
@@ -32,6 +33,7 @@ describe('test/unit/lib/cli/commands-schema/resolve-final.test.js', () => {
                   dryrun: {
                     usage: 'Get a summary for what the deployment would look like',
                     shortcut: 'd',
+                    type: 'boolean',
                   },
                 },
               },
@@ -91,6 +93,7 @@ describe('test/unit/lib/cli/commands-schema/resolve-final.test.js', () => {
                       resourceGroup: {
                         usage: 'Resource group for the service',
                         shortcut: 'g',
+                        type: 'string',
                       },
                     },
                   },
@@ -103,6 +106,7 @@ describe('test/unit/lib/cli/commands-schema/resolve-final.test.js', () => {
                   dryrun: {
                     usage: 'Get a summary for what the deployment would look like',
                     shortcut: 'd',
+                    type: 'boolean',
                   },
                 },
               },

--- a/test/unit/lib/cli/ensure-supported-command.test.js
+++ b/test/unit/lib/cli/ensure-supported-command.test.js
@@ -57,8 +57,9 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
       },
       () => resolveInput()
     );
-    ensureSupportedCommand();
-    expect(triggeredDeprecations.has('UNSUPPORTED_CLI_OPTIONS')).to.be.true;
+    expect(() => ensureSupportedCommand())
+      .to.throw(ServerlessError)
+      .with.property('code', 'REJECTED_DEPRECATION_UNSUPPORTED_CLI_OPTIONS');
   });
 
   it('should reject missing options', async () => {

--- a/test/unit/lib/cli/resolve-configuration-path.test.js
+++ b/test/unit/lib/cli/resolve-configuration-path.test.js
@@ -13,7 +13,7 @@ const resolveServerlessConfigPath = require('../../../../lib/cli/resolve-configu
 const resolveInput = require('../../../../lib/cli/resolve-input');
 const { triggeredDeprecations } = require('../../../../lib/utils/logDeprecation');
 
-describe('test/unit/lib/cli/resolve-service-config-path.test.js', () => {
+describe('test/unit/lib/cli/resolve-configuration-path.test.js', () => {
   let configurationPath;
   afterEach(async () => {
     if (!configurationPath) return;

--- a/test/unit/lib/cli/resolve-configuration-path.test.js
+++ b/test/unit/lib/cli/resolve-configuration-path.test.js
@@ -9,9 +9,10 @@ const path = require('path');
 const fs = require('fs').promises;
 const fse = require('fs-extra');
 const overrideArgv = require('process-utils/override-argv');
+const overrideEnv = require('process-utils/override-env');
+const requireUncached = require('ncjsm/require-uncached');
 const resolveServerlessConfigPath = require('../../../../lib/cli/resolve-configuration-path');
 const resolveInput = require('../../../../lib/cli/resolve-input');
-const { triggeredDeprecations } = require('../../../../lib/utils/logDeprecation');
 
 describe('test/unit/lib/cli/resolve-configuration-path.test.js', () => {
   let configurationPath;
@@ -68,10 +69,8 @@ describe('test/unit/lib/cli/resolve-configuration-path.test.js', () => {
       ])
     );
     beforeEach(() => {
-      triggeredDeprecations.clear();
       resolveInput.clear();
     });
-    after(() => triggeredDeprecations.clear());
 
     it('should accept absolute path, pointing configuration in current working directory', async () => {
       await overrideArgv(
@@ -83,15 +82,26 @@ describe('test/unit/lib/cli/resolve-configuration-path.test.js', () => {
     });
 
     it('should temporarily support nested path', async () => {
-      await overrideArgv(
-        {
-          args: ['serverless', '--config', 'nested/custom.yml'],
-        },
-        async () => {
-          expect(await resolveServerlessConfigPath()).to.equal(path.resolve('nested/custom.yml'));
-          expect(triggeredDeprecations.has('NESTED_CUSTOM_CONFIGURATION_PATH')).to.be.true;
-        }
-      );
+      await overrideEnv(async () => {
+        process.env.SLS_DEPRECATION_NOTIFICATION_MODE = 'warn';
+        const uncached = requireUncached(() => ({
+          resolveServerlessConfigPath: require('../../../../lib/cli/resolve-configuration-path'),
+          triggeredDeprecations: require('../../../../lib/utils/logDeprecation')
+            .triggeredDeprecations,
+        }));
+        await overrideArgv(
+          {
+            args: ['serverless', '--config', 'nested/custom.yml'],
+          },
+          async () => {
+            expect(await uncached.resolveServerlessConfigPath()).to.equal(
+              path.resolve('nested/custom.yml')
+            );
+            expect(uncached.triggeredDeprecations.has('NESTED_CUSTOM_CONFIGURATION_PATH')).to.be
+              .true;
+          }
+        );
+      });
     });
     it('should reject unsupported extension', async () => {
       await overrideArgv(
@@ -155,10 +165,8 @@ describe('test/unit/lib/cli/resolve-configuration-path.test.js', () => {
       ])
     );
     beforeEach(() => {
-      triggeredDeprecations.clear();
       resolveInput.clear();
     });
-    after(() => triggeredDeprecations.clear());
 
     it('should support custom cwd', async () => {
       expect(await resolveServerlessConfigPath({ cwd: 'normal' })).to.equal(

--- a/test/unit/lib/cli/resolve-input.test.js
+++ b/test/unit/lib/cli/resolve-input.test.js
@@ -10,6 +10,8 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
     let data;
     before(() => {
       resolveInput.clear();
+      delete require.cache[require.resolve('../../../../lib/utils/logDeprecation')];
+      process.env.SLS_DEPRECATION_DISABLE = 'CLI_OPTIONS_BEFORE_COMMAND';
       data = overrideArgv(
         {
           args: [

--- a/test/unit/lib/configSchema.test.js
+++ b/test/unit/lib/configSchema.test.js
@@ -15,7 +15,7 @@ describe('test/unit/lib/configSchema.test.js', () => {
       errorMessage: "should have required property 'name'",
       description: 'service required properties',
       mutation: {
-        service: {},
+        provider: { name: null },
       },
     },
     {
@@ -28,40 +28,10 @@ describe('test/unit/lib/configSchema.test.js', () => {
     },
     {
       isValid: false,
-      errorMessage: 'should match pattern "^[a-zA-Z][0-9a-zA-Z-]+$"',
-      description: 'service name in object typed service',
-      mutation: {
-        service: { name: '1-first-number-is-not-allowed' },
-      },
-    },
-    {
-      isValid: false,
-      errorMessage: 'should match pattern "^arn:aws[a-z-]*:kms',
-      description: 'service awsKmsKeyArn',
-      mutation: {
-        service: {
-          name: 'some-service',
-          awsKmsKeyArn: 'invalidArn',
-        },
-      },
-    },
-    {
-      isValid: true,
-      description: 'service awsKmsKeyArn',
-      mutation: {
-        service: {
-          name: 'some-service',
-          awsKmsKeyArn: 'arn:aws:kms:us-east-1:123456789012:key/some-hash',
-        },
-      },
-    },
-    {
-      isValid: false,
       errorMessage: 'unrecognized property',
       description: 'service unknown property',
       mutation: {
-        service: {
-          name: 'some-service',
+        provider: {
           unknownProp: 'this is not supported',
         },
       },
@@ -108,8 +78,7 @@ describe('test/unit/lib/configSchema.test.js', () => {
           individually: true,
           path: undefined,
           artifact: 'path/to/my-artifact.zip',
-          exclude: ['.git/**', '.travis.yml'],
-          include: ['src/**', 'handler.js'],
+          patterns: ['!.git/**', '!.travis.yml', 'src/**', 'handler.js'],
           excludeDevDependencies: false,
         },
       },

--- a/test/unit/lib/configSchema.test.js
+++ b/test/unit/lib/configSchema.test.js
@@ -3,7 +3,7 @@
 const runServerless = require('../../utils/run-serverless');
 const expect = require('chai').expect;
 
-describe('#configSchema', () => {
+describe('test/unit/lib/configSchema.test.js', () => {
   const cases = [
     {
       isValid: true,

--- a/test/unit/lib/configuration/variables/eventually-report-resolution-errors.test.js
+++ b/test/unit/lib/configuration/variables/eventually-report-resolution-errors.test.js
@@ -43,18 +43,15 @@ describe('test/unit/lib/configuration/variables/eventually-report-resolution-err
     it('should log deprecation with no "variablesResolutionMode" set', () => {
       const configuration = { foo: '${foo:raz' };
       const variablesMeta = resolveMeta(configuration);
-      let stdoutData = '';
-      overrideArgv({ args: ['serverless', 'foo'] }, () =>
-        overrideStdoutWrite(
-          (data) => (stdoutData += data),
-          () =>
-            expect(
-              eventuallyReportResolutionErrors(process.cwd(), configuration, variablesMeta)
-            ).to.equal(true)
-        )
+      overrideArgv(
+        { args: ['serverless', 'foo'] },
+        () => () =>
+          expect(() =>
+            eventuallyReportResolutionErrors(process.cwd(), configuration, variablesMeta)
+          )
+            .to.throw(ServerlessError)
+            .with.property('code', 'REJECTED_DEPRECATION_VARIABLES_RESOLUTION_ERROR')
       );
-
-      expect(stdoutData).to.include('NEW_VARIABLES_RESOLVER');
     });
     it('should throw with no "variablesResolutionMode" set', () => {
       const configuration = { foo: '${foo:raz', variablesResolutionMode: 20210326 };

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js
@@ -35,7 +35,8 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
     variablesMeta = resolveMeta(configuration);
     serverlessInstance = new Serverless({
       configuration,
-      configurationPath: process.cwd(),
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
       isConfigurationResolved: true,
       hasResolvedCommandsExternally: true,
       commands: ['package'],

--- a/test/unit/lib/plugins/aws/configCredentials.test.js
+++ b/test/unit/lib/plugins/aws/configCredentials.test.js
@@ -37,7 +37,7 @@ describe('AwsConfigCredentials', () => {
   });
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
     return serverless.init().then(() => {
       const options = {
         provider: 'aws',

--- a/test/unit/lib/plugins/aws/customResources/index.test.js
+++ b/test/unit/lib/plugins/aws/customResources/index.test.js
@@ -204,14 +204,16 @@ describe('#addCustomResourceToService()', () => {
       ]);
     }));
 
-  it('should use custom role when cfnRole is provided', async () => {
+  it('should use custom role when deployment role is provided', async () => {
     const role = 'arn:aws:iam::999999999999:role/my-role';
     const { cfTemplate } = await runServerless({
       fixture: 'function',
       command: 'package',
       configExt: {
         provider: {
-          cfnRole: role,
+          iam: {
+            deploymentRole: role,
+          },
         },
         functions: {
           foo: {
@@ -219,12 +221,6 @@ describe('#addCustomResourceToService()', () => {
             events: [
               { s3: { bucket: 'my-bucket', existing: true } },
               { cognitoUserPool: { pool: 'my-user-pool', trigger: 'PreSignUp', existing: true } },
-              {
-                eventBridge: {
-                  eventBus: 'arn:aws:events:us-east-1:12345:event-bus/default',
-                  schedule: 'rate(10 minutes)',
-                },
-              },
             ],
           },
         },
@@ -235,8 +231,7 @@ describe('#addCustomResourceToService()', () => {
     expect([
       Resources.CustomDashresourceDashexistingDashs3LambdaFunction.Properties.Role, // S3
       Resources.CustomDashresourceDashexistingDashcupLambdaFunction.Properties.Role, // Cognito User Pool
-      Resources.CustomDashresourceDasheventDashbridgeLambdaFunction.Properties.Role, // Event Bridge
-    ]).to.eql([role, role, role]);
+    ]).to.eql([role, role]);
   });
 
   it('should setup CloudWatch Logs when logs.frameworkLambda is true', () => {

--- a/test/unit/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -260,6 +260,7 @@ describe('createStack #2', () => {
       fixture: 'function',
       command: 'deploy',
       configExt: {
+        disabledDeprecations: ['PROVIDER_IAM_SETTINGS'],
         provider: {
           iam: {
             deploymentRole: 'arn:aws:iam::123456789012:role/role-a',
@@ -281,6 +282,7 @@ describe('createStack #2', () => {
       fixture: 'function',
       command: 'deploy',
       configExt: {
+        disabledDeprecations: ['PROVIDER_IAM_SETTINGS'],
         provider: {
           cfnRole: 'arn:aws:iam::123456789012:role/role-b',
         },

--- a/test/unit/lib/plugins/aws/deployFunction.test.js
+++ b/test/unit/lib/plugins/aws/deployFunction.test.js
@@ -22,7 +22,7 @@ describe('AwsDeployFunction', () => {
   let cryptoStub;
 
   beforeEach(async () => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
     serverless.servicePath = true;
     serverless.service.environment = {
       vars: {},
@@ -588,7 +588,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         },
         functions: {
           foo: {
-            awsKmsKeyArn: kmsKeyArn,
+            kmsKeyArn,
             description,
             handler,
             environment: {
@@ -708,7 +708,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
             VARIABLE: 'value',
           },
           memorySize,
-          role,
+          iam: { role },
           timeout,
           vpc: {
             securityGroupIds: ['sg-111', 'sg-222'],
@@ -790,7 +790,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
         },
         functions: {
           foo: {
-            awsKmsKeyArn: kmsKeyArn,
+            kmsKeyArn,
             description,
             handler,
             environment: {
@@ -825,6 +825,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       lastLifecycleHookName: 'deploy:function:deploy',
       awsRequestStubMap,
       configExt: {
+        disabledDeprecations: ['AWS_KMS_KEY_ARN'],
         functions: {
           foo: {
             handler: 'index.handler',
@@ -853,6 +854,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       lastLifecycleHookName: 'deploy:function:deploy',
       awsRequestStubMap,
       configExt: {
+        disabledDeprecations: ['AWS_KMS_KEY_ARN', 'SERVICE_OBJECT_NOTATION'],
         functions: {
           foo: {
             handler: 'index.handler',
@@ -882,6 +884,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       lastLifecycleHookName: 'deploy:function:deploy',
       awsRequestStubMap,
       configExt: {
+        disabledDeprecations: ['AWS_KMS_KEY_ARN', 'SERVICE_OBJECT_NOTATION'],
         functions: {
           foo: {
             handler: 'index.handler',
@@ -910,6 +913,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
       lastLifecycleHookName: 'deploy:function:deploy',
       awsRequestStubMap,
       configExt: {
+        disabledDeprecations: ['AWS_KMS_KEY_ARN'],
         functions: {
           foo: {
             handler: 'index.handler',

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -312,7 +312,6 @@ describe('UsagePlan', () => {
   const serverlessConfigurationExtension = {
     provider: {
       name: 'aws',
-      usagePlan: {},
     },
     functions: {
       foo: {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -16,7 +16,7 @@ describe('#validate()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
@@ -1792,6 +1792,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js', 
           fixture: 'function',
           command: 'package',
           configExt: {
+            disabledDeprecations: ['CLOUDFRONT_CACHE_BEHAVIOR_FORWARDED_VALUES_AND_TTL'],
             functions: {
               foo: {
                 handler: 'myLambdaAtEdge.handler',

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
@@ -1646,7 +1646,7 @@ describe('AwsCompileCloudFrontEvents', () => {
   });
 });
 
-describe('lib/plugins/aws/package/compile/events/cloudFront/index.new.test.js', () => {
+describe('test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js', () => {
   describe.skip('TODO: Removal notice', () => {
     it('should show preconfigured notice on "sls remove" if service has cloudFront event', async () => {
       // Replaces

--- a/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -138,7 +138,10 @@ describe('EventBridgeEvents', () => {
     before(async () => {
       const { cfTemplate, awsNaming } = await runServerless({
         fixture: 'function',
-        configExt: serverlessConfigurationExtension,
+        configExt: {
+          disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'],
+          ...serverlessConfigurationExtension,
+        },
         command: 'package',
       });
       cfResources = cfTemplate.Resources;
@@ -238,6 +241,7 @@ describe('EventBridgeEvents', () => {
         runServerless({
           fixture: 'function',
           configExt: {
+            disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'],
             functions: {
               foo: {
                 events: [

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -236,6 +236,7 @@ describe('AwsCompileFunctions', () => {
       const { cfTemplate } = await runServerless({
         fixture: 'function',
         configExt: {
+          disabledDeprecations: ['PROVIDER_IAM_SETTINGS'],
           provider: {
             role: 'role-a',
             iam: { role: 'role-b' },
@@ -1478,6 +1479,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
             name: 'service',
             awsKmsKeyArn: 'arn:aws:kms:region:accountid:pro/vider',
           },
+          disabledDeprecations: ['SERVICE_OBJECT_NOTATION', 'AWS_KMS_KEY_ARN'],
           provider: {
             vpc: {
               subnetIds: ['subnet-01010101'],

--- a/test/unit/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
@@ -169,48 +169,6 @@ describe('mergeCustomProviderResources', () => {
       ).to.deep.equal(coreCloudFormationTemplate.Outputs.ServerlessDeploymentBucketName);
     });
 
-    it('should create non-existent resource / attributes for resources.extensions.*', () => {
-      awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources = {};
-
-      awsPackage.serverless.service.resources = {
-        extensions: {
-          SampleResource: {
-            Properties: {
-              PropertyA: 'new',
-            },
-            DependsOn: ['new'],
-            Metadata: {
-              key: 'value',
-              anotherKey: {
-                key2: 'value2',
-              },
-            },
-          },
-        },
-      };
-
-      awsPackage.mergeCustomProviderResources();
-      expect(awsPackage.serverless.service.provider.compiledCloudFormationTemplate.extensions).to
-        .not.exist;
-
-      expect(
-        awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources
-      ).to.deep.equal({
-        SampleResource: {
-          Properties: {
-            PropertyA: 'new',
-          },
-          DependsOn: ['new'],
-          Metadata: {
-            key: 'value',
-            anotherKey: {
-              key2: 'value2',
-            },
-          },
-        },
-      });
-    });
-
     it('should overwrite for resources.extensions.*.{CreationPolicy,DeletionPolicy,UpdatePolicy,UpdateReplacePolicy}', () => {
       awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources = {
         SampleResource: {

--- a/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeIamTemplates.test.js
@@ -18,11 +18,12 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
       expect(cfTemplate.Resources).to.not.have.property(iamRoleLambdaExecution);
     });
 
-    it('should not create role resource with `provider.role`', async () => {
+    it('should not create role resource with deprecated `provider.role`', async () => {
       const { cfTemplate, awsNaming } = await runServerless({
         fixture: 'function',
         command: 'package',
         configExt: {
+          disabledDeprecations: ['PROVIDER_IAM_SETTINGS'],
           provider: {
             name: 'aws',
             role: 'arn:aws:iam::YourAccountNumber:role/YourIamRole',
@@ -179,6 +180,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           fixture: 'function',
           command: 'package',
           configExt: {
+            disabledDeprecations: ['PROVIDER_IAM_SETTINGS'],
             provider: {
               iamRoleStatements: [
                 {
@@ -245,6 +247,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           fixture: 'function',
           command: 'package',
           configExt: {
+            disabledDeprecations: ['PROVIDER_IAM_SETTINGS'],
             provider: {
               iam: {
                 role: {

--- a/test/unit/lib/plugins/install.test.js
+++ b/test/unit/lib/plugins/install.test.js
@@ -29,7 +29,7 @@ describe('Install', () => {
 
     serviceDir = tmpDir;
 
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
     install = new Install(serverless);
     return serverless.init().then(() => {
       install.serverless.cli = new serverless.classes.CLI();

--- a/test/unit/lib/plugins/package/lib/packageService.test.js
+++ b/test/unit/lib/plugins/package/lib/packageService.test.js
@@ -49,12 +49,16 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
         awsRequestStubMap: mockedDescribeStacksResponse,
         configExt: {
           package: {
-            exclude: ['dir1/**', '!dir1/subdir3/**'],
-            include: ['dir1/subdir2/**', '!dir1/subdir2/subsubdir1'],
+            patterns: [
+              '!dir1/**',
+              'dir1/subdir3/**',
+              'dir1/subdir2/**',
+              '!dir1/subdir2/subsubdir1',
+            ],
           },
           functions: {
             fnIndividual: {
-              package: { include: 'dir1/subdir4/**', exclude: 'dir3/**' },
+              package: { patterns: ['dir1/subdir4/**', '!dir3/**'] },
             },
           },
         },
@@ -170,12 +174,16 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
         configExt: {
           package: {
             individually: true,
-            exclude: ['dir1/**', '!dir1/subdir3/**'],
-            include: ['dir1/subdir2/**', '!dir1/subdir2/subsubdir1'],
+            patterns: [
+              '!dir1/**',
+              'dir1/subdir3/**',
+              'dir1/subdir2/**',
+              '!dir1/subdir2/subsubdir1',
+            ],
           },
           functions: {
             fnIndividual: {
-              package: { include: 'dir1/subdir4/**', exclude: 'dir3/**' },
+              package: { patterns: ['dir1/subdir4/**', '!dir3/**'] },
             },
           },
           plugins: {
@@ -228,13 +236,12 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
         configExt: {
           package: {
             artifact: 'artifact.zip',
-            exclude: ['dir1', '!dir1/subdir3/**'],
-            include: ['dir1/subdir2/**', '!dir1/subdir2/subsubdir1'],
+            patterns: ['!dir1', 'dir1/subdir3/**', 'dir1/subdir2/**', '!dir1/subdir2/subsubdir1'],
           },
           functions: {
             fnIndividual: {
               handler: 'index.handler',
-              package: { individually: true, include: 'dir1/subdir3/**', exclude: 'dir1/subdir2' },
+              package: { individually: true, patterns: ['dir1/subdir3/**', '!dir1/subdir2'] },
             },
             fnArtifact: {
               handler: 'index.handler',

--- a/test/unit/lib/plugins/package/lib/packageService.test.js
+++ b/test/unit/lib/plugins/package/lib/packageService.test.js
@@ -13,7 +13,7 @@ chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
 const { expect } = require('chai');
 
-describe('lib/plugins/package/lib/packageService.test.js', () => {
+describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
   const mockedDescribeStacksResponse = {
     CloudFormation: {
       describeStacks: {

--- a/test/unit/lib/plugins/package/package.test.js
+++ b/test/unit/lib/plugins/package/package.test.js
@@ -16,7 +16,7 @@ describe('Package', () => {
   let pkg;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
     return serverless.init().then(() => {
       options = {
         stage: 'dev',

--- a/test/unit/lib/plugins/slstats.test.js
+++ b/test/unit/lib/plugins/slstats.test.js
@@ -11,7 +11,7 @@ describe('SlStats', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
     return serverless.init().then(() => {
       slStats = new SlStats(serverless);
     });

--- a/test/unit/lib/utils/getCommandSuggestion.test.js
+++ b/test/unit/lib/utils/getCommandSuggestion.test.js
@@ -8,7 +8,7 @@ describe('#getCommandSuggestion', () => {
   let serverless;
 
   before(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
     return serverless.init();
   });
 

--- a/test/unit/lib/utils/logDeprecation.test.js
+++ b/test/unit/lib/utils/logDeprecation.test.js
@@ -2,7 +2,6 @@
 
 const sandbox = require('sinon');
 const expect = require('chai').expect;
-const mockRequire = require('mock-require');
 const overrideEnv = require('process-utils/override-env');
 const overrideStdoutWrite = require('process-utils/override-stdout-write');
 const runServerless = require('../../../utils/run-serverless');
@@ -11,10 +10,9 @@ const ServerlessError = require('../../../../lib/serverless-error');
 describe('#logDeprecation()', () => {
   let restoreEnv;
   let originalEnv;
-  let logDeprecation;
 
   beforeEach(() => {
-    logDeprecation = mockRequire.reRequire('../../../../lib/utils/logDeprecation');
+    delete require.cache[require.resolve('../../../../lib/utils/logDeprecation')];
     ({ originalEnv, restoreEnv } = overrideEnv());
   });
 
@@ -24,6 +22,7 @@ describe('#logDeprecation()', () => {
   });
 
   it('Should log deprecation message if not disabled and first time', () => {
+    const logDeprecation = require('../../../../lib/utils/logDeprecation');
     let stdoutData = '';
     overrideStdoutWrite(
       (data) => (stdoutData += data),
@@ -37,7 +36,8 @@ describe('#logDeprecation()', () => {
 
   it('Should not log deprecation if disabled in env.SLS_DEPRECATION_DISABLE', () => {
     process.env.SLS_DEPRECATION_DISABLE = 'CODE1';
-    logDeprecation = mockRequire.reRequire('../../../../lib/utils/logDeprecation');
+    const logDeprecation = require('../../../../lib/utils/logDeprecation');
+
     let stdoutData = '';
     overrideStdoutWrite(
       (data) => (stdoutData += data),
@@ -49,6 +49,7 @@ describe('#logDeprecation()', () => {
   it('Should not log deprecation if disabled in serviceConfig', () => {
     // We need original process env variables for npm-conf
     Object.assign(process.env, originalEnv);
+    const logDeprecation = require('../../../../lib/utils/logDeprecation');
     return runServerless({
       fixture: 'function',
       configExt: { disabledDeprecations: ['CODE1'] },
@@ -66,7 +67,7 @@ describe('#logDeprecation()', () => {
 
   it('Should not log deprecation if disabled by wildcard in env', () => {
     process.env.SLS_DEPRECATION_DISABLE = '*';
-    logDeprecation = mockRequire.reRequire('../../../../lib/utils/logDeprecation');
+    const logDeprecation = require('../../../../lib/utils/logDeprecation');
     let stdoutData = '';
     overrideStdoutWrite(
       (data) => (stdoutData += data),
@@ -77,6 +78,7 @@ describe('#logDeprecation()', () => {
 
   it('Should not log deprecation if disabled by wildcard in service config', () => {
     Object.assign(process.env, originalEnv);
+    const logDeprecation = require('../../../../lib/utils/logDeprecation');
     return runServerless({
       fixture: 'function',
       configExt: { disabledDeprecations: '*' },
@@ -94,14 +96,14 @@ describe('#logDeprecation()', () => {
 
   it('Should throw on deprecation if env.SLS_DEPRECATION_NOTIFICATION_MODE=error', () => {
     process.env.SLS_DEPRECATION_NOTIFICATION_MODE = 'error';
-    logDeprecation = mockRequire.reRequire('../../../../lib/utils/logDeprecation');
+    const logDeprecation = require('../../../../lib/utils/logDeprecation');
     expect(() => logDeprecation('CODE1', 'Start using deprecation log'))
       .to.throw(ServerlessError)
       .with.property('code', 'REJECTED_DEPRECATION_CODE1');
   });
 
   it('Should throw on deprecation if error notifications mode set in service config', () => {
-    logDeprecation = mockRequire.reRequire('../../../../lib/utils/logDeprecation');
+    const logDeprecation = require('../../../../lib/utils/logDeprecation');
     expect(() =>
       logDeprecation('CODE1', 'Start using deprecation log', {
         serviceConfig: { deprecationNotificationMode: 'error' },
@@ -116,6 +118,7 @@ describe('#logDeprecation()', () => {
     overrideStdoutWrite(
       (data) => (stdoutData += data),
       () => {
+        const logDeprecation = require('../../../../lib/utils/logDeprecation');
         logDeprecation('CODE1', 'Start using deprecation log');
         expect(stdoutData).to.include('Start using deprecation log');
         stdoutData = '';

--- a/test/unit/lib/utils/renameService.test.js
+++ b/test/unit/lib/utils/renameService.test.js
@@ -23,7 +23,7 @@ describe('renameService', () => {
 
     serviceDir = tmpDir;
 
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
     return serverless.init();
   });
 

--- a/test/unit/lib/utils/report-deprecated-properties.test.js
+++ b/test/unit/lib/utils/report-deprecated-properties.test.js
@@ -1,12 +1,23 @@
 'use strict';
 
 const expect = require('chai').expect;
-const report = require('../../../../lib/utils/report-deprecated-properties');
-const { triggeredDeprecations } = require('../../../../lib/utils/logDeprecation');
+const requireUncached = require('ncjsm/require-uncached');
+
 const overrideStdoutWrite = require('process-utils/override-stdout-write');
 
 describe('report-deprecated-properties', () => {
   let stdoutData = '';
+  let report;
+  let triggeredDeprecations;
+
+  before(() => {
+    process.env.SLS_DEPRECATION_NOTIFICATION_MODE = 'warn';
+    requireUncached(() => {
+      report = require('../../../../lib/utils/report-deprecated-properties');
+      ({ triggeredDeprecations } = require('../../../../lib/utils/logDeprecation'));
+    });
+  });
+
   afterEach(() => {
     stdoutData = '';
     triggeredDeprecations.clear();


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9024

Additionally:
- Ensure that deprecations settings are visible at early stage of command processing
- Ensure to not report lambda hashing deprecations for docker builds
- Upgrade tests to not test deprecated forms when not testing them intentionally

With https://github.com/serverless/test/pull/101 test configuration will be updated to automatically throw whenever deprecations are approached (let's merge it first, and publish new version of `@serverless/test`, to ensure we have all updates needed to prevent fails)
