### PR TITLE
refactor(Telemetry): Recognize `constructs`

### DIFF
--- a/lib/utils/telemetry/generatePayload.js
+++ b/lib/utils/telemetry/generatePayload.js
@@ -67,7 +67,11 @@ const getServiceConfig = ({ configuration, options }) => {
     };
   })();
 
-  return {
+  const plugins = configuration.plugins
+    ? configuration.plugins.modules || configuration.plugins
+    : [];
+
+  const result = {
     provider: {
       name: providerName,
       runtime: defaultRuntime,
@@ -76,7 +80,7 @@ const getServiceConfig = ({ configuration, options }) => {
         ? options.region || configuration.provider.region || 'us-east-1'
         : _.get(configuration, 'provider.region'),
     },
-    plugins: configuration.plugins ? configuration.plugins.modules || configuration.plugins : [],
+    plugins,
     functions: Object.values(functions)
       .map((functionConfig) => {
         if (!functionConfig) return null;
@@ -96,6 +100,20 @@ const getServiceConfig = ({ configuration, options }) => {
       .filter(Boolean),
     resources,
   };
+
+  // We want to recognize types of constructs from `serverless-lift` plugin if possible
+  if (plugins.includes('serverless-lift') && _.isObject(configuration.constructs)) {
+    result.constructs = Object.values(configuration.constructs)
+      .map((construct) => {
+        if (_.isObject(construct) && construct.type != null) {
+          return { type: construct.type };
+        }
+        return null;
+      })
+      .filter(Boolean);
+  }
+
+  return result;
 };
 
 module.exports = async ({

--- a/test/unit/lib/utils/telemetry/generatePayload.test.js
+++ b/test/unit/lib/utils/telemetry/generatePayload.test.js
@@ -518,4 +518,44 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       new Set(['region', 'format', 'path'])
     );
   });
+
+  it('Should correctly resolve `constructs` property', async () => {
+    const { serverless } = await runServerless({
+      fixture: 'httpApi',
+      command: 'print',
+    });
+    const payload = await generatePayload({
+      command: 'print',
+      commandSchema: commandsSchema.get('print'),
+      options: {},
+      serviceDir: serverless.serviceDir,
+      configuration: {
+        ...serverless.configurationInput,
+        constructs: {
+          jobs: {
+            type: 'queue',
+            worker: {
+              handler: 'some.handler',
+            },
+          },
+          another: {
+            type: 'queue',
+            worker: {
+              handler: 'other.handler',
+            },
+          },
+        },
+        plugins: ['serverless-lift'],
+      },
+    });
+
+    expect(payload.config.constructs).to.deep.equal([
+      {
+        type: 'queue',
+      },
+      {
+        type: 'queue',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Reported internally, recognize `constructs` from `serverless-lift` plugin