### PR TITLE
CLI: Fix issues related to version reporting with a local fallback

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -285,6 +285,10 @@ class Serverless {
       const resolveInput = require('./cli/resolve-input');
       resolveInput.clear();
       const { options, isHelpRequest } = resolveInput(commandsSchema);
+      if (options.version) {
+        require('./cli/render-version')();
+        return;
+      }
       if (
         !this.isConfigurationInputResolved &&
         this.serviceDir &&

--- a/lib/utils/isStandaloneExecutable.js
+++ b/lib/utils/isStandaloneExecutable.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = Boolean(process.pkg);
+module.exports = Boolean(process.pkg && __dirname.startsWith('/snapshot/'));


### PR DESCRIPTION
- In case of a fallback from some versions (e.g. 2.18.0) on `sls -v` fallback is done directly to `Serverless` instance (in latest we directly fallback to version resolver if provided in a fallback version), and with latest versions it generated the _help_ output and not _version_ output. Addressed by ensuring to render version if `version` option is detected
- Standalone detection was broken for cases, when from standalone global we fallen back to installed locally version.
Detection was based on shape of `process` object, as in this case we're in context of `node` process as provided by _standalone_, detection suggested we're using standalone install (while it's only Node.js that's used from standalone package, and it's Framework installed locally that's executed)
