### PR TITLE
Fix documentation for CloudFront cache behaviour

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -90,7 +90,7 @@ provider:
         EnableAcceptEncodingBrotli: true # optional
         EnableAcceptEncodingGzip: true
         HeadersConfig:
-          HeadersBehavior: whitelist # Possible values are 'none' and 'whitelist'
+          HeaderBehavior: whitelist # Possible values are 'none' and 'whitelist'
           Headers:
             - authorization
             - content-type


### PR DESCRIPTION
The header behaviour should be `HeaderBehaviour` an extra `s` is currently within the documentation
