### PR TITLE
docs: Improve `versionFunctions` description

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -463,14 +463,14 @@ functions:
 
 By default, the framework creates function versions for every deploy. This behavior is optional, and can be turned off in cases where you don't invoke past versions by their qualifier. If you would like to do this, you can invoke your functions as `arn:aws:lambda:....:function/myFunc:3` to invoke version 3 for example.
 
+Versions are not cleaned up by serverless, so make sure you use a plugin or other tool to prune sufficiently old versions. The framework can't clean up versions because it doesn't have information about whether older versions are invoked or not. This feature adds to the number of total stack outputs and resources because a function version is a separate resource from the function it refers to.
+
 To turn off this feature, set the provider-level option `versionFunctions`.
 
 ```yml
 provider:
   versionFunctions: false
 ```
-
-These versions are not cleaned up by serverless, so make sure you use a plugin or other tool to prune sufficiently old versions. The framework can't clean up versions because it doesn't have information about whether older versions are invoked or not. This feature adds to the number of total stack outputs and resources because a function version is a separate resource from the function it refers to.
 
 ## Dead Letter Queue (DLQ)
 

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -465,7 +465,7 @@ By default, the framework creates function versions for every deploy. This behav
 
 Versions are not cleaned up by serverless, so make sure you use a plugin or other tool to prune sufficiently old versions. The framework can't clean up versions because it doesn't have information about whether older versions are invoked or not. This feature adds to the number of total stack outputs and resources because a function version is a separate resource from the function it refers to.
 
-To turn off this feature, set the provider-level option `versionFunctions`.
+To turn off function versioning, set the provider-level option `versionFunctions`.
 
 ```yml
 provider:


### PR DESCRIPTION
_This is purely a documentation rephrasing and does not have a preexisting issue associated._

When the previous paragraph mentions turning off versioning it becomes unclear what "these versions" refers to. Placing the paragraph earlier makes its relation with the default behavior less ambiguous.

I'm genuinely not sure that the "versions are not cleaned up" behavior relates to the default setting or if it actually relates to the `versionFunctions: false` setting - feel free to close this PR if I've misunderstood.