### PR TITLE
Test: Integration tests for popular plugins

### DIFF
--- a/test/fixtures/programmatic/curated-plugins/_setup.js
+++ b/test/fixtures/programmatic/curated-plugins/_setup.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const path = require('path');
+const fsp = require('fs').promises;
+
+const slsDependencyDir = path.resolve(__dirname, 'node_modules/serverless');
+
+// Ensure to remove "serverless" installed as peer-dependency to avoid local fallback
+module.exports = async () => fsp.rm(slsDependencyDir, { recursive: true, force: true });

--- a/test/fixtures/programmatic/curated-plugins/index.js
+++ b/test/fixtures/programmatic/curated-plugins/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports.handler = (event, context, callback) => {
+  callback(null, {
+    statusCode: 200,
+    body: JSON.stringify({ message: 'Test', input: event }, null, 2),
+  });
+};

--- a/test/fixtures/programmatic/curated-plugins/package.json
+++ b/test/fixtures/programmatic/curated-plugins/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "serverless-offline": "7.0.0"
+  }
+}

--- a/test/fixtures/programmatic/curated-plugins/serverless.yml
+++ b/test/fixtures/programmatic/curated-plugins/serverless.yml
@@ -1,0 +1,23 @@
+service: service
+
+configValidationMode: error
+frameworkVersion: '*'
+
+provider:
+  name: aws
+  runtime: nodejs14.x
+  lambdaHashingVersion: 20201221
+
+functions:
+  function:
+    handler: index.handler
+    events:
+      - http:
+          path: foo
+          method: GET
+      - http:
+          path: foo
+          method: POST
+
+plugins:
+  - serverless-offline

--- a/test/integration/curated-plugins.test.js
+++ b/test/integration/curated-plugins.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const { expect } = require('chai');
+const spawn = require('child-process-ext/spawn');
+const got = require('got');
+const fixturesEngine = require('../fixtures/programmatic');
+
+const serverlessExec = require('../serverlessBinary');
+
+describe('test/integration/curated-plugins.test.js', function () {
+  this.timeout(1000 * 60 * 10); // Involves time-taking npm install
+
+  let serviceDir;
+  before(async () => {
+    serviceDir = (await fixturesEngine.setup('curated-plugins')).servicePath;
+  });
+
+  it('should be extended by "serverless-offline"', async () => {
+    const slsProcessPromise = spawn(serverlessExec, ['offline'], {
+      cwd: serviceDir,
+    });
+    const slsProcess = slsProcessPromise.child;
+    let output = '';
+    slsProcess.stdout.on('data', function self(data) {
+      output += data;
+      if (output.includes('server ready:')) {
+        slsProcess.stdout.off('data', self);
+        got('http://localhost:3000/dev/foo')
+          .json()
+          .then(async (responseBody) => {
+            expect(responseBody.message).to.equal('Test');
+          })
+          .finally(() => slsProcess.kill('SIGINT'));
+      }
+    });
+    await slsProcessPromise;
+  });
+});


### PR DESCRIPTION
In this PR just test for `serverless-offline` is introduced.

To ensure tests are robust ideally if (as many as possible) plugins are tested in context of same service.

Addresses #9025 

@mnapoli having that in, you may add test that covers `serverless-lift`