### PR TITLE
Variables: Improve some resolution scenarios

### DIFF
--- a/lib/configuration/variables/parse.js
+++ b/lib/configuration/variables/parse.js
@@ -48,6 +48,16 @@ const registerVarEscape = () => {
   if (!variables) variables = [];
   variables.push({
     start: escapeVarStart - contextStart,
+    end: index - contextStart,
+    value: '\\'.repeat(Math.ceil((index - 1 - escapeVarStart - 1) / 2)) + value[index - 1],
+  });
+  escapeVarStart = null;
+};
+
+const registerSlashEscape = () => {
+  if (!variables) variables = [];
+  variables.push({
+    start: escapeVarStart - contextStart,
     end: index - 1 - contextStart,
     value: '\\'.repeat(Math.ceil((index - 1 - escapeVarStart - 1) / 2)),
   });
@@ -194,7 +204,7 @@ module.exports = (inputValue) => {
           break;
         case 'maybeVariableOpen':
           if (char === '{') {
-            if (escapeVarStart != null) registerVarEscape();
+            if (escapeVarStart != null) registerSlashEscape();
             state = 'maybeTypeStart';
           } else {
             escapeVarStart = null;

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -531,6 +531,25 @@ Object.defineProperties(
             }
             return meta.value;
           },
+          resolveVariablesInString: async (stringValue) => {
+            stringValue = ensureString(stringValue, {
+              Error: ServerlessError,
+              name: 'variableString',
+              errorCode: 'INVALID_STRING_INPUT_TYPE',
+            });
+            const variableData = parse(stringValue);
+            if (!variableData) return stringValue;
+            const meta = {
+              value: stringValue,
+              variables: variableData,
+            };
+            await this.resolveVariables(resolutionBatchId, propertyPath, meta);
+            if (meta.error) throw meta.error;
+            if (meta.variables) {
+              throw new ServerlessError('Cannot resolve variable', 'MISSING_VARIABLE_DEPENDENCY');
+            }
+            return meta.value;
+          },
         });
         ensurePlainObject(result, {
           errorMessage: `Unexpected "${sourceData.type}" source result: %v`,

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -369,7 +369,7 @@ Object.defineProperties(
           // In such case resolution can be retried in later turn, after missing data is provided.
           //
           // Having `.error` means, resolution errored (with no recovery plan for it)
-          // Such error ideally should be exposed with command crash.
+          // Such error ideally should be exposed with command crash in resolution consumer logic
           return;
         }
 
@@ -520,19 +520,6 @@ Object.defineProperties(
           );
         }
         const resultValue = result.value;
-        if (isPlainObject(resultValue) || Array.isArray(resultValue)) {
-          try {
-            JSON.parse(JSON.stringify(resultValue));
-          } catch (error) {
-            throw new VariableSourceResolutionError(
-              `Source "${sourceData.type}" returned not supported result: "${util.inspect(
-                resultValue
-              )}"`,
-              'UNSUPPORTED_VARIABLE_RESOLUTION_RESULT'
-            );
-          }
-          return result;
-        }
         let normalizedResultValue;
         try {
           normalizedResultValue = JSON.parse(JSON.stringify(resultValue));
@@ -544,7 +531,11 @@ Object.defineProperties(
             'UNSUPPORTED_VARIABLE_RESOLUTION_RESULT'
           );
         }
-        if (resultValue !== normalizedResultValue) {
+        if (
+          !isPlainObject(resultValue) &&
+          !Array.isArray(resultValue) &&
+          resultValue !== normalizedResultValue
+        ) {
           throw new VariableSourceResolutionError(
             `Source "${sourceData.type}" returned not supported result: "${util.inspect(
               resultValue

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -118,7 +118,7 @@ class VariablesResolver {
     // String value is either constructed from more than one variable
     // or is partially constructed with a variable.
     // In such case, end value is always a string, reconstructed below
-    const valueTokens = [];
+    const sourceValues = [];
     const rawValue = valueMeta.value;
     let lastIndex = 0;
     for (const { start, end, value } of valueMeta.variables) {
@@ -133,13 +133,13 @@ class VariablesResolver {
         );
         return;
       }
-      valueTokens.push(rawValue.slice(lastIndex, start), stringValue);
+      sourceValues.push(rawValue.slice(lastIndex, start), stringValue);
       lastIndex = end;
     }
-    valueTokens.push(rawValue.slice(lastIndex));
-    valueMeta.value = valueTokens.join('');
+    sourceValues.push(rawValue.slice(lastIndex));
+    valueMeta.value = sourceValues.join('');
+    valueMeta.sourceValues = sourceValues;
     delete valueMeta.variables;
-    valueMeta.isGeneratedFromMultipleSources = true;
   }
 
   async resolveVariable(resolutionBatchId, propertyPath, variableMeta) {
@@ -376,7 +376,7 @@ Object.defineProperties(
         // Variable(s) for a property where successfully resolved, still it can be an object
         // (or an array) containing a values with variables in it.
         const propertyPathKeys = propertyPath.split('\0');
-        const { value, isGeneratedFromMultipleSources } = valueMeta;
+        const { value, sourceValues } = valueMeta;
 
         const valueEntries = (() => {
           if (isPlainObject(value)) return Object.entries(value);
@@ -387,24 +387,48 @@ Object.defineProperties(
           propertyVariablesMeta = parseEntries(valueEntries, propertyPathKeys, new Map());
         } else if (typeof value === 'string') {
           const valueVariables = (() => {
-            if (isGeneratedFromMultipleSources) {
-              // Do not attempt to parse variables out of strings which are result of concatenation
-              // of values coming from multiple sources.
-              // Main reason, is to not re-attempt to parse values with eventually cleared escapes
-              // (e.g. escaped "\\${source:}" is at this point resolved to "${source:}".
-              // Parsing result string here will make escape in-effective).
-              return null;
+            const silentParse = (sourceValue) => {
+              try {
+                return parse(sourceValue);
+              } catch (error) {
+                error.message = `Cannot resolve variable at "${humanizePropertyPath(
+                  propertyPathKeys
+                )}": Approached variable syntax error in resolved value "${value}": ${
+                  error.message
+                }`;
+                delete valueMeta.value;
+                valueMeta.error = error;
+                return null;
+              }
+            };
+            if (sourceValues) {
+              // Value is a result of concatenation of string values coming from multiple sources.
+              // Parse variables in each string part individually - it's to avoid accidental
+              // resolution of variable-like notation which may surface after joining two values.
+              // Also that way we do not accidentally re-parse an escaped variables notation
+              let baseIndex = 0;
+              let resolvedValueVariables = null;
+              for (const sourceValue of sourceValues) {
+                const sourceValueVariables = silentParse(sourceValue);
+                if (valueMeta.error) return null;
+                if (sourceValueVariables) {
+                  for (const sourceValueVariable of sourceValueVariables) {
+                    if (sourceValueVariable.end) {
+                      sourceValueVariable.start += baseIndex;
+                      sourceValueVariable.end += baseIndex;
+                    } else {
+                      sourceValueVariable.start = baseIndex;
+                      sourceValueVariable.end = baseIndex + sourceValue.length;
+                    }
+                  }
+                  if (!resolvedValueVariables) resolvedValueVariables = [];
+                  resolvedValueVariables.push(...sourceValueVariables);
+                }
+                baseIndex += sourceValue.length;
+              }
+              return resolvedValueVariables;
             }
-            try {
-              return parse(value);
-            } catch (error) {
-              error.message = `Cannot resolve variable at "${humanizePropertyPath(
-                propertyPathKeys
-              )}": Approached variable syntax error in resolved value "${value}": ${error.message}`;
-              delete valueMeta.value;
-              valueMeta.error = error;
-              return null;
-            }
+            return silentParse(value);
           })();
 
           if (valueVariables) {

--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -27,6 +27,7 @@ module.exports = {
     address,
     resolveConfigurationProperty,
     resolveVariable,
+    resolveVariablesInString,
     options,
   }) => {
     if (!params || !params[0]) {
@@ -167,6 +168,7 @@ module.exports = {
     const propertyKeys = address.split('.');
     let result = content;
     for (const propertyKey of propertyKeys) {
+      if (typeof result === 'string') result = await resolveVariablesInString(result);
       result = result[propertyKey];
       if (result == null) return { value: null };
       if (!isResolvedByFunction && isPlainFunction(result)) {

--- a/test/unit/lib/configuration/variables/parse.test.js
+++ b/test/unit/lib/configuration/variables/parse.test.js
@@ -543,8 +543,8 @@ describe('test/unit/lib/configuration/variables/parse.test.js', () => {
       expect(parse('e\\${s:}n\\$${s:}qe\\\\\\${s:}qn\\\\${s:}')).to.deep.equal([
         {
           start: 1,
-          end: 2,
-          value: '',
+          end: 3,
+          value: '$',
         },
         {
           start: 10,
@@ -553,8 +553,8 @@ describe('test/unit/lib/configuration/variables/parse.test.js', () => {
         },
         {
           start: 17,
-          end: 20,
-          value: '\\',
+          end: 21,
+          value: '\\$',
         },
         {
           start: 27,

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -40,6 +40,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       resolvesResultVariablesStringInvalid: '${sourceResultVariables(stringInvalid)}',
       resolveDeepVariablesConcat:
         '${sourceResultVariables(string)}foo${sourceResultVariables(string)}',
+      resolveVariablesInString: "${sourceResolveVariablesInString('${sourceProperty(foo)}')}",
       resolvesVariables: '${sourceResolveVariable("sourceParam(${sourceDirect:})")}',
       resolvesVariablesFallback: '${sourceResolveVariable("sourceMissing:, null"), null}',
       resolvesVariablesInvalid1: '${sourceResolveVariable("sourceDirect(")}',
@@ -92,6 +93,11 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       sourceResolveVariable: {
         resolve: async ({ params, resolveVariable }) => {
           return { value: await resolveVariable(params[0]) };
+        },
+      },
+      sourceResolveVariablesInString: {
+        resolve: async ({ params, resolveVariablesInString }) => {
+          return { value: await resolveVariablesInString(params[0]) };
         },
       },
       sourceResultVariables: {
@@ -247,6 +253,13 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
 
     it('should resolve variables in resolved strings which are subject to concatenation', () => {
       expect(configuration.resolveDeepVariablesConcat).to.equal('234foo234');
+    });
+
+    it('should provide working resolveVariablesInString util', () => {
+      expect(configuration.resolveVariablesInString).to.deep.equal({
+        params: 'param1|param2',
+        varParam: '234',
+      });
     });
 
     // https://github.com/serverless/serverless/issues/9016

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -38,6 +38,8 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       resolvesResultVariablesArray: '${sourceResultVariables(array)}',
       resolvesResultVariablesString: '${sourceResultVariables(string)}',
       resolvesResultVariablesStringInvalid: '${sourceResultVariables(stringInvalid)}',
+      resolveDeepVariablesConcat:
+        '${sourceResultVariables(string)}foo${sourceResultVariables(string)}',
       resolvesVariables: '${sourceResolveVariable("sourceParam(${sourceDirect:})")}',
       resolvesVariablesFallback: '${sourceResolveVariable("sourceMissing:, null"), null}',
       resolvesVariablesInvalid1: '${sourceResolveVariable("sourceDirect(")}',
@@ -241,6 +243,10 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       expect(configuration.resolvesResultVariablesObject).to.deep.equal({ foo: 234 });
       expect(configuration.resolvesResultVariablesArray).to.deep.equal([1, 234]);
       expect(configuration.resolvesResultVariablesString).to.equal(234);
+    });
+
+    it('should resolve variables in resolved strings which are subject to concatenation', () => {
+      expect(configuration.resolveDeepVariablesConcat).to.equal('234foo234');
     });
 
     // https://github.com/serverless/serverless/issues/9016

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -28,6 +28,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       jsPropertyFunctionResolveVariable: '${file(file-property-function-variable.js):property}',
       jsPropertyFunctionResolveVariableMissingSource:
         '${file(file-property-function-variable-missing-source.js):property}',
+      nestedVariablesAddressResolution: '${file(file-variables-nest-1.yaml):n1.n2.n3}',
       nonExistingYaml: '${file(not-existing.yaml), null}',
       nonExistingJson: '${file(not-existing.json), null}',
       nonExistingJs: '${file(not-existing.js), null}',
@@ -103,6 +104,9 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     });
   });
 
+  it('should resolve variables across address resolution', () => {
+    expect(configuration.nestedVariablesAddressResolution).to.deep.equal('result');
+  });
   it('should uncoditionally split "address" property keys by "."', () =>
     expect(configuration.ambiguousAddress).to.equal('object'));
 

--- a/test/unit/lib/configuration/variables/sources/fixture/file-variables-nest-1.yaml
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-variables-nest-1.yaml
@@ -1,0 +1,1 @@
+n1: ${file(./file-variables-nest-2.yaml):root}

--- a/test/unit/lib/configuration/variables/sources/fixture/file-variables-nest-2.yaml
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-variables-nest-2.yaml
@@ -1,0 +1,2 @@
+root:
+  n2: ${file(./file-variables-nest-3.yaml):root}

--- a/test/unit/lib/configuration/variables/sources/fixture/file-variables-nest-3.yaml
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-variables-nest-3.yaml
@@ -1,0 +1,2 @@
+root:
+  n3: result


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

When investigating https://github.com/serverless/serverless/issues/9619 I've discovered a two limitations in variables resolver, which felt as nice to have addressed.

- Support variables resolution in string parts that come from different sources, and which are to be concatenated into one value. More info at https://github.com/serverless/serverless/issues/9619#issuecomment-864921557
- Support on the go resolution of values retrieved from files when resolving the `address`

Additionally cleared one redundancy discovered in configured logic


Closes: #9619
