### PR TITLE
Only call `handleError` if `interactiveOutputPlugin` plugin defined

### DIFF
--- a/lib/cli/interactive-setup/deploy.js
+++ b/lib/cli/interactive-setup/deploy.js
@@ -172,7 +172,9 @@ module.exports = {
         }
       );
     } catch (err) {
-      interactiveOutputPlugin.handleError();
+      if (interactiveOutputPlugin) {
+        interactiveOutputPlugin.handleError();
+      }
       throw err;
     }
 


### PR DESCRIPTION
Reported internally 