### PR TITLE
Telemetry: Increase error location coverage

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -2,6 +2,7 @@
 
 const Ajv = require('ajv');
 const _ = require('lodash');
+const ensurePlainObject = require('type/plain-object/ensure');
 const schema = require('../../configSchema');
 const ServerlessError = require('../../serverless-error');
 const normalizeAjvErrors = require('./normalizeAjvErrors');
@@ -56,6 +57,8 @@ const denormalizeUserConfig = (userConfig, { removedValuesMap }) => {
   }
 };
 
+const configurationValidationResults = new WeakMap();
+
 class ConfigSchemaHandler {
   constructor(serverless) {
     this.serverless = serverless;
@@ -67,8 +70,14 @@ class ConfigSchemaHandler {
     deepFreeze(this.schema.properties.package);
   }
 
+  static getConfigurationValidationResult(configuration) {
+    if (!configurationValidationResults.has(ensurePlainObject(configuration))) return null;
+    return configurationValidationResults.get(ensurePlainObject(configuration));
+  }
+
   validateConfig(userConfig) {
     if (!this.schema.properties.provider.properties.name) {
+      configurationValidationResults.set(this.serverless.configurationInput, false);
       if (this.serverless.service.configValidationMode !== 'off') {
         this.serverless.cli.log(
           `${WARNING_PREFIX}: Unrecognized provider '${this.serverless.service.provider.name}'`,
@@ -108,6 +117,9 @@ class ConfigSchemaHandler {
     const denormalizeOptions = normalizeUserConfig(userConfig);
     validate(userConfig);
     denormalizeUserConfig(userConfig, denormalizeOptions);
+    if (!configurationValidationResults.has(this.serverless.configurationInput)) {
+      configurationValidationResults.set(this.serverless.configurationInput, !validate.errors);
+    }
     if (validate.errors && this.serverless.service.configValidationMode !== 'off') {
       const messages = normalizeAjvErrors(validate.errors).map((err) => err.message);
       this.handleErrorMessages(messages);

--- a/lib/utils/telemetry/generatePayload.js
+++ b/lib/utils/telemetry/generatePayload.js
@@ -16,6 +16,8 @@ const resolveIsLocallyInstalled = require('../../utils/is-locally-installed');
 const ci = require('ci-info');
 const AWS = require('aws-sdk');
 
+const configValidationModeValues = new Set(['off', 'warn', 'error']);
+
 const checkIsTabAutocompletionInstalled = async () => {
   try {
     return (await fs.readdir(path.resolve(os.homedir(), '.config/tabtab'))).some((filename) =>
@@ -73,6 +75,10 @@ const getServiceConfig = ({ configuration, options }) => {
     : [];
 
   const result = {
+    // TODO: Update when upgrading the default for next major
+    configValidationMode: configValidationModeValues.has(configuration.configValidationMode)
+      ? configuration.configValidationMode
+      : 'warn',
     provider: {
       name: providerName,
       runtime: defaultRuntime,

--- a/lib/utils/telemetry/generatePayload.js
+++ b/lib/utils/telemetry/generatePayload.js
@@ -9,6 +9,7 @@ const isPlainObject = require('type/plain-object/is');
 const isObject = require('type/object/is');
 const userConfig = require('@serverless/utils/config');
 const isStandalone = require('../isStandaloneExecutable');
+const { getConfigurationValidationResult } = require('../../classes/ConfigSchemaHandler');
 const { triggeredDeprecations } = require('../logDeprecation');
 const isNpmGlobal = require('../npmPackage/isGlobal');
 const resolveLocalServerlessPath = require('../../cli/resolve-local-serverless-path');
@@ -279,6 +280,7 @@ module.exports = async ({
     payload.hasLocalCredentials = isAwsProvider && Boolean(new AWS.Config().credentials);
     payload.npmDependencies = npmDependencies;
     payload.config = getServiceConfig({ configuration, options });
+    payload.isConfigValid = getConfigurationValidationResult(configuration);
     payload.dashboard.orgUid = serverless && serverless.service.orgUid;
   }
 

--- a/lib/utils/telemetry/resolve-error-location.js
+++ b/lib/utils/telemetry/resolve-error-location.js
@@ -14,8 +14,8 @@ const resolveErrorLocation = (exceptionTokens) => {
     const match = line.match(stacktraceLineRegex) || [];
     const matchedPath = match[1] || match[2];
     if (matchedPath) {
-      // Limited to maximum 5 lines in location
-      if (stacktracePaths.push(matchedPath) === 5) break;
+      // Limited to maximum 7 lines in location
+      if (stacktracePaths.push(matchedPath) === 7) break;
     } else if (stacktracePaths.length) break;
   }
 

--- a/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
+++ b/test/unit/lib/classes/ConfigSchemaHandler/index.test.js
@@ -2,6 +2,9 @@
 
 const chai = require('chai');
 const runServerless = require('../../../../utils/run-serverless');
+const {
+  getConfigurationValidationResult,
+} = require('../../../../../lib/classes/ConfigSchemaHandler');
 
 chai.use(require('chai-as-promised'));
 
@@ -69,11 +72,12 @@ describe('test/unit/lib/classes/ConfigSchemaHandler/index.test.js', () => {
   });
 
   describe('#validateConfig', () => {
-    it('should run without errors for valid config', () => {
-      return runServerless({
+    it('should run without errors for valid config', async () => {
+      const { serverless } = await runServerless({
         fixture: 'configSchemaExtensions',
         command: 'info',
       });
+      expect(getConfigurationValidationResult(serverless.configurationInput)).to.be.true;
     });
   });
 

--- a/test/unit/lib/utils/telemetry/generatePayload.test.js
+++ b/test/unit/lib/utils/telemetry/generatePayload.test.js
@@ -120,6 +120,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       command: 'print',
       commandOptionNames: [],
       config: {
+        configValidationMode: 'error',
         provider: {
           name: 'aws',
           runtime: 'nodejs14.x',
@@ -181,6 +182,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       command: 'print',
       commandOptionNames: [],
       config: {
+        configValidationMode: 'warn',
         provider: {
           name: 'customProvider',
           runtime: 'foo',
@@ -243,6 +245,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       command: 'print',
       commandOptionNames: [],
       config: {
+        configValidationMode: 'error',
         provider: {
           name: 'aws',
           runtime: 'nodejs12.x',
@@ -330,6 +333,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       commandOptionNames: [],
       cliName: 'serverless',
       config: {
+        configValidationMode: 'warn',
         provider: {
           name: 'aws',
           runtime: 'nodejs12.x',
@@ -513,6 +517,21 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
         type: 'queue',
       },
     ]);
+  });
+
+  it('Should correctly resolve `configValidationMode` property', async () => {
+    const payload = await generatePayload({
+      command: 'print',
+      commandSchema: commandsSchema.get('print'),
+      options: {},
+      serviceDir: process.cwd(),
+      configuration: {
+        service: 'foo',
+        provider: 'aws',
+        configValidationMode: 'off',
+      },
+    });
+    expect(payload.config.configValidationMode).to.equal('off');
   });
 
   it('Should correctly resolve `hasLocalCredentials` property for AWS provider', async () => {

--- a/test/unit/lib/utils/telemetry/generatePayload.test.js
+++ b/test/unit/lib/utils/telemetry/generatePayload.test.js
@@ -119,6 +119,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       cliName: 'serverless',
       command: 'print',
       commandOptionNames: [],
+      isConfigValid: true,
       config: {
         configValidationMode: 'error',
         provider: {
@@ -181,6 +182,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       cliName: 'serverless',
       command: 'print',
       commandOptionNames: [],
+      isConfigValid: false, // No schema for custom provider
       config: {
         configValidationMode: 'warn',
         provider: {
@@ -244,6 +246,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       cliName: 'serverless',
       command: 'print',
       commandOptionNames: [],
+      isConfigValid: null,
       config: {
         configValidationMode: 'error',
         provider: {
@@ -332,6 +335,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       command: '',
       commandOptionNames: [],
       cliName: 'serverless',
+      isConfigValid: null,
       config: {
         configValidationMode: 'warn',
         provider: {

--- a/test/unit/lib/utils/telemetry/resolve-error-location.test.js
+++ b/test/unit/lib/utils/telemetry/resolve-error-location.test.js
@@ -5,7 +5,7 @@ const expect = require('chai').expect;
 const resolveErrorLocation = require('../../../../../lib/utils/telemetry/resolve-error-location');
 const tokenizeException = require('../../../../../lib/utils/tokenize-exception');
 
-describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
+describe('test/unit/lib/utils/telemetry/resolve-error-location.test.js', () => {
   it('should be null when stack missing', () => {
     const err = new Error('test');
     delete err.stack;

--- a/test/unit/lib/utils/telemetry/resolve-error-location.test.js
+++ b/test/unit/lib/utils/telemetry/resolve-error-location.test.js
@@ -57,7 +57,7 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
       );
     });
 
-    it('should return at most 5 lines', () => {
+    it('should return at most 7 lines', () => {
       const err = new Error('test');
       err.stack =
         'Error:\n' +
@@ -66,6 +66,10 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
         '    at Test.Runnable.run (/home/xxx/serverless/node_modules/mocha/lib/runnable.js:354:5)\n' +
         '    at Runner.runTest (/home/xxx/serverless/node_modules/mocha/lib/runner.js:677:10)\n' +
         '    at next (/home/xxx/serverless/node_modules/mocha/lib/runner.js:801:12)\n' +
+        '    at next (/home/xxx/serverless/node_modules/mocha/lib/runner.js:802:12)\n' +
+        '    at next (/home/xxx/serverless/node_modules/mocha/lib/runner.js:803:12)\n' +
+        '    at next (/home/xxx/serverless/node_modules/mocha/lib/runner.js:804:12)\n' +
+        '    at next (/home/xxx/serverless/node_modules/mocha/lib/runner.js:805:12)\n' +
         '    at next (/home/xxx/serverless/node_modules/mocha/lib/runner.js:594:14)\n';
       const result = resolveErrorLocation(tokenizeException(err));
       expect(result).to.equal(
@@ -75,6 +79,8 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
           '^:354:5',
           '/node_modules/mocha/lib/runner.js:677:10',
           '^:801:12',
+          '^:802:12',
+          '^:803:12',
         ].join('\n')
       );
     });
@@ -101,7 +107,7 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
       );
     });
 
-    it('should return at most 5 lines and use `/` path separator', () => {
+    it('should return at most 7 lines and use `/` path separator', () => {
       const err = new Error('test');
       err.stack =
         'Error:\n' +
@@ -110,6 +116,10 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
         '    at Test.Runnable.run (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runnable.js:354:5)\r\n' +
         '    at Runner.runTest (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:677:10)\r\n' +
         '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:801:12)\r\n' +
+        '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:802:12)\r\n' +
+        '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:803:12)\r\n' +
+        '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:804:12)\r\n' +
+        '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:805:12)\r\n' +
         '    at next (C:\\home\\xxx\\serverless\\node_modules\\mocha\\lib\\runner.js:594:14)\r\n';
       const result = resolveErrorLocation(tokenizeException(err));
       expect(result).to.equal(
@@ -119,6 +129,8 @@ describe('test/unit/lib/utils/resolve-error-location.test.js', () => {
           '^:354:5',
           '/node_modules/mocha/lib/runner.js:677:10',
           '^:801:12',
+          '^:802:12',
+          '^:803:12',
         ].join('\n')
       );
     });


### PR DESCRIPTION
In some errors, 5 lines limit appers as not good enough (requires a more demanding investigation) to well coin the source of the issue, e.g.

```
fs.js:474:3
^:375:35
/serverless/lib/utils/fs/readFileSync.js:7:24
/serverless/lib/classes/Utils.js:78:12
/serverless/lib/classes/YamlParser.js:12:40
```

I think it's not harmful to increase it to 7

Additionally:
- Optimize tests to not rely on `runServerless` when it's not justified
- Add `config.configValidationMode` and  `isConfigValid` to generated report (as it's important for programmer errors filtering)