### PR TITLE
refactor(Telemetry): Include `commandUsage` in case of error

### DIFF
--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -180,6 +180,7 @@ module.exports = async (exception, options = {}) => {
         serviceDir,
         configuration,
         serverless,
+        commandUsage: exceptionTokens.commandUsage,
       });
       const failureReason = {
         kind: isUserError ? 'user' : 'programmer',

--- a/lib/cli/interactive-setup/index.js
+++ b/lib/cli/interactive-setup/index.js
@@ -11,34 +11,45 @@ const steps = {
   deploy: require('./deploy'),
 };
 
-module.exports = async (context) => {
-  context = { ...context, inquirer, history: new Map() };
-  const stepsDetails = new Map();
-  for (const [stepName, step] of Object.entries(steps)) {
-    delete context.stepHistory;
-    delete context.inapplicabilityReasonCode;
-    const stepData = await step.isApplicable(context);
-    stepsDetails.set(stepName, {
-      isApplicable: Boolean(stepData),
-      inapplicabilityReasonCode: context.inapplicabilityReasonCode,
-      timestamp: Date.now(),
-      configuredQuestions: step.configuredQuestions,
-    });
-    if (stepData) {
-      process.stdout.write('\n');
-      context.stepHistory = new StepHistory();
-      context.history.set(stepName, context.stepHistory);
-      await step.run(context, stepData);
-    }
-  }
-
-  const commandUsage = Array.from(stepsDetails.entries()).map(([step, stepDetails]) => {
-    const stepHistory = context.history.get(step);
+const generateCommandUsage = (stepsDetails, history) => {
+  return Array.from(stepsDetails.entries()).map(([step, stepDetails]) => {
+    const stepHistory = history.get(step);
     return {
       name: step,
       ...stepDetails,
       history: stepHistory ? stepHistory.toJSON() : [],
     };
   });
-  return { commandUsage, configuration: context.configuration };
+};
+
+module.exports = async (context) => {
+  context = { ...context, inquirer, history: new Map() };
+  const stepsDetails = new Map();
+  try {
+    for (const [stepName, step] of Object.entries(steps)) {
+      delete context.stepHistory;
+      delete context.inapplicabilityReasonCode;
+      const stepData = await step.isApplicable(context);
+      stepsDetails.set(stepName, {
+        isApplicable: Boolean(stepData),
+        inapplicabilityReasonCode: context.inapplicabilityReasonCode,
+        timestamp: Date.now(),
+        configuredQuestions: step.configuredQuestions,
+      });
+      if (stepData) {
+        process.stdout.write('\n');
+        context.stepHistory = new StepHistory();
+        context.history.set(stepName, context.stepHistory);
+        await step.run(context, stepData);
+      }
+    }
+  } catch (err) {
+    err.commandUsage = generateCommandUsage(stepsDetails, context.history);
+    throw err;
+  }
+
+  return {
+    commandUsage: generateCommandUsage(stepsDetails, context.history),
+    configuration: context.configuration,
+  };
 };

--- a/lib/utils/tokenize-exception.js
+++ b/lib/utils/tokenize-exception.js
@@ -14,6 +14,7 @@ module.exports = (exception) => {
       message: exception.message,
       isUserError: userErrorNames.has(exception.name),
       code: exception.code,
+      commandUsage: exception.commandUsage,
     };
   }
   return {

--- a/test/unit/lib/cli/interactive-setup/index.test.js
+++ b/test/unit/lib/cli/interactive-setup/index.test.js
@@ -4,6 +4,12 @@
 
 const spawn = require('child-process-ext/spawn');
 const path = require('path');
+const proxyquire = require('proxyquire');
+const chai = require('chai');
+
+const { expect } = chai;
+
+chai.use(require('chai-as-promised'));
 
 const serverlessPath = path.resolve(__dirname, '../../../../../scripts/serverless.js');
 const templatesPath = path.resolve(__dirname, '../../../../../lib/plugins/create/templates');
@@ -72,5 +78,19 @@ describe('test/unit/lib/cli/interactive-setup/index.test.js', () => {
     slsProcess.stderr.pipe(process.stderr);
 
     await slsProcessPromise;
+  });
+
+  it('should attach `commandUsage` to thrown error', async () => {
+    const mockedInteractiveSetup = proxyquire('../../../../../lib/cli/interactive-setup', {
+      './service': {
+        isApplicable: () => {
+          throw new Error('Error during processing');
+        },
+      },
+    });
+
+    await expect(mockedInteractiveSetup({})).to.be.eventually.rejected.and.have.property(
+      'commandUsage'
+    );
   });
 });

--- a/test/unit/lib/utils/tokenize-exception.test.js
+++ b/test/unit/lib/utils/tokenize-exception.test.js
@@ -31,4 +31,11 @@ describe('test/unit/lib/utils/tokenize-exception.test.js', () => {
     expect(errorTokens.message).to.equal('null');
     expect(errorTokens.isUserError).to.equal(false);
   });
+
+  it('Should tokenize error with `commandUsage`', () => {
+    const err = new ServerlessError('Some error', 'ERR_CODE');
+    err.commandUsage = [];
+    const errorTokens = tokenizeError(err);
+    expect(errorTokens.commandUsage).to.deep.equal([]);
+  });
 });


### PR DESCRIPTION
Reported internally, report `commandUsage` to better understand what might've caused an error during interactive flow