### PR TITLE
Remove explicit `CODECOV_TOKEN`

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -164,10 +164,6 @@ jobs:
         # Workaround taken from https://github.com/actions/runner/issues/241#issuecomment-577360161
         run: script -e -c "npm run coverage"
       - name: Push coverage
-        # TODO: Remove inline token, once support for GA is added on Codecov side
-        # See: https://github.com/codecov/codecov-node/issues/118
-        env:
-          CODECOV_TOKEN: 3898f3e1-f317-453e-a3a9-0462390f93c5
         run: npx codecov
 
   linuxNode10:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -172,10 +172,6 @@ jobs:
         # Workaround taken from https://github.com/actions/runner/issues/241#issuecomment-577360161
         run: script -e -c "npm run coverage"
       - name: Push coverage
-        # TODO: Remove inline token, once support for GA is added on Codecov side
-        # See: https://github.com/codecov/codecov-node/issues/118
-        env:
-          CODECOV_TOKEN: 3898f3e1-f317-453e-a3a9-0462390f93c5
         run: npx codecov
 
   linuxNode10:


### PR DESCRIPTION
Looks like after this got merged, we might no longer need that explicit token: https://github.com/codecov/codecov-node/commit/1109eefb8c266bfc52092f93c1a50c82242c9bfd