### PR TITLE
fix(Telemetry): Properly handle not in service dir in credentials

### DIFF
--- a/lib/cli/interactive-setup/aws-credentials.js
+++ b/lib/cli/interactive-setup/aws-credentials.js
@@ -319,7 +319,13 @@ const steps = {
 
 module.exports = {
   async isApplicable(context) {
-    const { configuration, history, options } = context;
+    const { configuration, history, options, serviceDir } = context;
+
+    if (!serviceDir) {
+      context.inapplicabilityReasonCode = 'NOT_IN_SERVICE_DIRECTORY';
+      return false;
+    }
+
     if (
       _.get(configuration, 'provider') !== 'aws' &&
       _.get(configuration, 'provider.name') !== 'aws'

--- a/test/unit/lib/cli/interactive-setup/aws-credentials.test.js
+++ b/test/unit/lib/cli/interactive-setup/aws-credentials.test.js
@@ -57,7 +57,7 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
   it('Should be ineffective, when not at service path', async () => {
     const context = {};
     expect(await step.isApplicable(context)).to.equal(false);
-    expect(context.inapplicabilityReasonCode).to.equal('NON_AWS_PROVIDER');
+    expect(context.inapplicabilityReasonCode).to.equal('NOT_IN_SERVICE_DIRECTORY');
   });
 
   it('Should be ineffective, when not at AWS service', async () => {


### PR DESCRIPTION
Reported internally - properly recognize situation where we're not in service directory