### PR TITLE
New deprecations logging mode

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -19,7 +19,11 @@ disabledDeprecations:
 
 ## Notifications mode
 
-By default deprecations are logged as warnings. If there's an intention to work with _deprecation_ free service, reporting mode can be switched so approached deprecation is reported with a thrown error.
+By default deprecations are logged, after command finalizes with a warning summary (`warn:summary` mode)
+
+Alternatively deprecation warnings can be displayed as they're discovered, on the go, that can be turned on with `warn` mode (this mode is automatically pursued on in case we fallback to locally installed Serverless Framework installation)
+
+If there's an intention to work with _deprecation_ free service, reporting mode can be switched to `error`, so approached deprecation is reported with a thrown error.
 
 Mode can be set via environment variable: `SLS_DEPRECATION_NOTIFICATION_MODE=error` or via top level service configuration setting:
 
@@ -29,7 +33,7 @@ deprecationNotificationMode: error
 
 Note:
 
-- Configuration setting is ineffective for deprecations reported before service configuration is read.
+- In service configuration setting is ineffective for deprecations reported before service configuration is read.
 - `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
 
 <a name="CLI_DEPLOY_FUNCTION_OPTION"><div>&nbsp;</div></a>

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -29,7 +29,7 @@ enableLocalInstallationFallback: false # If set to 'true', guarantees that it's 
 useDotenv: false # If set to 'true', environment variables will be automatically loaded from .env files
 variablesResolutionMode: null # To crash on variable resolution errors (as coming from new resolver), set this value to "20210326"
 unresolvedVariablesNotificationMode: warn # If set to 'error', references to variables that cannot be resolved will result in an error being thrown (applies to legacy resolver)
-deprecationNotificationMode: warn # If set to 'error' any reported deprection will result in an error being thrown
+deprecationNotificationMode: warn:summary # 'warn' reports deprecations on the go, 'error' will result with an exception being thrown on first approached deprecation
 
 disabledDeprecations: # Disable deprecation logs by their codes. Default is empty.
   - DEP_CODE_1 # Deprecation code to disable

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -150,7 +150,10 @@ class Serverless {
   }
 
   async init() {
-    if (!this._isInvokedByGlobalInstallation) {
+    if (this._isInvokedByGlobalInstallation) {
+      logDeprecation.defaultMode = 'warn';
+      logDeprecation.flushBuffered();
+    } else {
       if (this._shouldReportMissingServiceDeprecation) {
         this._logDeprecation(
           'MISSING_SERVICE_CONFIGURATION',
@@ -236,6 +239,8 @@ class Serverless {
     ) {
       return;
     }
+    logDeprecation.defaultMode = 'warn';
+    logDeprecation.flushBuffered();
     this.cli.log('Running "serverless" installed locally (in service node_modules)');
     // TODO: Replace below fallback logic with more straightforward one at top of the CLI
     // when we willl drop support for the "disableLocalInstallationFallback" setting

--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -10,6 +10,7 @@ const sfeVersion = require('@serverless/dashboard-plugin/package.json').version;
 const { platformClientVersion } = require('@serverless/dashboard-plugin');
 const ServerlessError = require('../serverless-error');
 const tokenizeException = require('../utils/tokenize-exception');
+const logDeprecation = require('../utils/logDeprecation');
 const resolveIsLocallyInstalled = require('../utils/is-locally-installed');
 const isTelemetryDisabled = require('../utils/telemetry/areDisabled');
 const { storeLocally: storeTelemetryLocally, send: sendTelemetry } = require('../utils/telemetry');
@@ -150,6 +151,8 @@ module.exports = async (exception, options = {}) => {
   })();
   consoleLog(chalk.yellow(`     Components Version:        ${componentsVersion}`));
   consoleLog(' ');
+
+  logDeprecation.printSummary();
 
   if (
     !isTelemetryDisabled &&

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -21,7 +21,7 @@ const schema = {
       // User is free to add any properties for its own purpose
     },
     deprecationsNotificationMode: {
-      enum: ['error', 'warn'],
+      enum: ['error', 'warn', 'warn:summary'],
     },
     disabledDeprecations: {
       anyOf: [

--- a/lib/utils/logDeprecation.js
+++ b/lib/utils/logDeprecation.js
@@ -28,9 +28,21 @@ const resolveDisabledDeprecationsByService = weakMemoizee((serviceConfig) => {
   return new Set(disabledDeprecations);
 });
 
-const isErrorNotificationMode = (serviceConfig) => {
-  if (notificationModeByEnv) return notificationModeByEnv === 'error';
-  return _.get(serviceConfig, 'deprecationNotificationMode') === 'error';
+const resolveMode = (serviceConfig) => {
+  switch (notificationModeByEnv) {
+    case 'error':
+    case 'warn':
+      return notificationModeByEnv;
+    default:
+  }
+  const modeByConfig = _.get(serviceConfig, 'deprecationNotificationMode');
+  switch (modeByConfig) {
+    case 'error':
+    case 'warn':
+      return modeByConfig;
+    default:
+      return module.exports.defaultMode;
+  }
 };
 
 function writeDeprecation(code, message) {
@@ -70,7 +82,7 @@ module.exports = (code, message, { serviceConfig } = {}) => {
       }
     }
 
-    if (isErrorNotificationMode(serviceConfig)) {
+    if (resolveMode(serviceConfig) === 'error') {
       throw new ServerlessError(
         `${message}\n  More Info: https://www.serverless.com/framework/docs/deprecations/#${code}`,
         `REJECTED_DEPRECATION_${code}`
@@ -84,3 +96,4 @@ module.exports = (code, message, { serviceConfig } = {}) => {
 };
 
 module.exports.triggeredDeprecations = triggeredDeprecations;
+module.exports.defaultMode = 'warn';

--- a/lib/utils/logDeprecation.js
+++ b/lib/utils/logDeprecation.js
@@ -10,6 +10,7 @@ const disabledDeprecationCodesByEnv = extractCodes(process.env.SLS_DEPRECATION_D
 const notificationModeByEnv = process.env.SLS_DEPRECATION_NOTIFICATION_MODE;
 
 const triggeredDeprecations = new Set();
+const bufferedDeprecations = [];
 
 function extractCodes(codesStr) {
   if (!codesStr) {
@@ -82,18 +83,56 @@ module.exports = (code, message, { serviceConfig } = {}) => {
       }
     }
 
-    if (resolveMode(serviceConfig) === 'error') {
-      throw new ServerlessError(
-        `${message}\n  More Info: https://www.serverless.com/framework/docs/deprecations/#${code}`,
-        `REJECTED_DEPRECATION_${code}`
-      );
+    switch (resolveMode(serviceConfig)) {
+      case 'error':
+        throw new ServerlessError(
+          `${message}\n  More Info: https://www.serverless.com/framework/docs/deprecations/#${code}`,
+          `REJECTED_DEPRECATION_${code}`
+        );
+      case 'warn':
+        writeDeprecation(code, message);
+        return;
+      default:
+        bufferedDeprecations.push({ message, code });
     }
-
-    writeDeprecation(code, message);
   } finally {
     triggeredDeprecations.add(code);
   }
 };
 
 module.exports.triggeredDeprecations = triggeredDeprecations;
-module.exports.defaultMode = 'warn';
+module.exports.defaultMode = 'warn:summary';
+
+module.exports.flushBuffered = () => {
+  try {
+    for (const { code, message } of bufferedDeprecations) writeDeprecation(code, message);
+  } finally {
+    bufferedDeprecations.length = 0;
+  }
+};
+
+module.exports.printSummary = () => {
+  if (!bufferedDeprecations.length) return;
+  try {
+    if (bufferedDeprecations.length === 1) {
+      const { code, message } = bufferedDeprecations[0];
+      writeDeprecation(code, message);
+      return;
+    }
+
+    const prefix = 'Serverless: ';
+    process.stdout.write(`${prefix}${chalk.bold.keyword('orange')('Deprecation warnings:')}\n\n`);
+    for (const { code, message } of bufferedDeprecations) {
+      const messageLines = chalk.bold(message).split('\n');
+      if (!code.startsWith('EXT_')) {
+        messageLines.push(
+          `More Info: https://www.serverless.com/framework/docs/deprecations/#${code}`
+        );
+      }
+
+      process.stdout.write(chalk.keyword('orange')(`${messageLines.join('\n')}\n\n`));
+    }
+  } finally {
+    bufferedDeprecations.length = 0;
+  }
+};

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -23,6 +23,7 @@ const {
 const generateTelemetryPayload = require('../lib/utils/telemetry/generatePayload');
 const processBackendNotificationRequest = require('../lib/utils/processBackendNotificationRequest');
 const isTelemetryDisabled = require('../lib/utils/telemetry/areDisabled');
+const logDeprecation = require('../lib/utils/logDeprecation');
 
 let command;
 let options;
@@ -63,6 +64,7 @@ const processSpanPromise = (async () => {
     // If version number request, show it and abort
     if (options.version) {
       await require('../lib/cli/render-version')();
+      logDeprecation.printSummary();
       return;
     }
 
@@ -84,7 +86,6 @@ const processSpanPromise = (async () => {
     const isPropertyResolved = require('../lib/configuration/variables/is-property-resolved');
     const eventuallyReportVariableResolutionErrors = require('../lib/configuration/variables/eventually-report-resolution-errors');
     const filterSupportedOptions = require('../lib/cli/filter-supported-options');
-    const logDeprecation = require('../lib/utils/logDeprecation');
 
     let configurationPath = null;
     let providerName;
@@ -410,6 +411,9 @@ const processSpanPromise = (async () => {
           configurationFilename,
           options,
         });
+
+      logDeprecation.printSummary();
+
       hasTelemetryBeenReported = true;
       if (!isTelemetryDisabled) {
         await storeTelemetryLocally(
@@ -690,6 +694,8 @@ const processSpanPromise = (async () => {
         // Run command
         await serverless.run();
       }
+
+      logDeprecation.printSummary();
 
       hasTelemetryBeenReported = true;
       if (!isTelemetryDisabled && !isHelpRequest && serverless.isTelemetryReportedExternally) {

--- a/test/unit/lib/utils/logDeprecation.test.js
+++ b/test/unit/lib/utils/logDeprecation.test.js
@@ -23,6 +23,7 @@ describe('test/unit/lib/utils/logDeprecation.test.js', () => {
 
   it('should log deprecation message if not disabled and first time', () => {
     const logDeprecation = require('../../../../lib/utils/logDeprecation');
+    logDeprecation.defaultMode = 'warn';
     let stdoutData = '';
     overrideStdoutWrite(
       (data) => (stdoutData += data),
@@ -119,6 +120,7 @@ describe('test/unit/lib/utils/logDeprecation.test.js', () => {
       (data) => (stdoutData += data),
       () => {
         const logDeprecation = require('../../../../lib/utils/logDeprecation');
+        logDeprecation.defaultMode = 'warn';
         logDeprecation('CODE1', 'Start using deprecation log');
         expect(stdoutData).to.include('Start using deprecation log');
         stdoutData = '';
@@ -126,5 +128,39 @@ describe('test/unit/lib/utils/logDeprecation.test.js', () => {
       }
     );
     expect(stdoutData).to.equal('');
+  });
+
+  it('should expose working `flushBuffered` method', () => {
+    let stdoutData = '';
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () => {
+        const logDeprecation = require('../../../../lib/utils/logDeprecation');
+        logDeprecation('CODE1', 'First deprecation');
+        expect(stdoutData).to.not.include('First deprecation');
+        logDeprecation('CODE2', 'Second deprecation');
+        expect(stdoutData).to.not.include('Second deprecation');
+        logDeprecation.flushBuffered();
+      }
+    );
+    expect(stdoutData).to.include('First deprecation');
+    expect(stdoutData).to.include('Second deprecation');
+  });
+
+  it('should expose working `printSummary` method', () => {
+    let stdoutData = '';
+    overrideStdoutWrite(
+      (data) => (stdoutData += data),
+      () => {
+        const logDeprecation = require('../../../../lib/utils/logDeprecation');
+        logDeprecation('CODE1', 'First deprecation');
+        expect(stdoutData).to.not.include('First deprecation');
+        logDeprecation('CODE2', 'Second deprecation');
+        expect(stdoutData).to.not.include('Second deprecation');
+        logDeprecation.printSummary();
+      }
+    );
+    expect(stdoutData).to.include('First deprecation');
+    expect(stdoutData).to.include('Second deprecation');
   });
 });

--- a/test/unit/lib/utils/logDeprecation.test.js
+++ b/test/unit/lib/utils/logDeprecation.test.js
@@ -7,7 +7,7 @@ const overrideStdoutWrite = require('process-utils/override-stdout-write');
 const runServerless = require('../../../utils/run-serverless');
 const ServerlessError = require('../../../../lib/serverless-error');
 
-describe('#logDeprecation()', () => {
+describe('test/unit/lib/utils/logDeprecation.test.js', () => {
   let restoreEnv;
   let originalEnv;
 
@@ -21,7 +21,7 @@ describe('#logDeprecation()', () => {
     restoreEnv();
   });
 
-  it('Should log deprecation message if not disabled and first time', () => {
+  it('should log deprecation message if not disabled and first time', () => {
     const logDeprecation = require('../../../../lib/utils/logDeprecation');
     let stdoutData = '';
     overrideStdoutWrite(
@@ -34,7 +34,7 @@ describe('#logDeprecation()', () => {
     expect(stdoutData).to.include('https://www.serverless.com/framework/docs/deprecations/#CODE1');
   });
 
-  it('Should not log deprecation if disabled in env.SLS_DEPRECATION_DISABLE', () => {
+  it('should not log deprecation if disabled in env.SLS_DEPRECATION_DISABLE', () => {
     process.env.SLS_DEPRECATION_DISABLE = 'CODE1';
     const logDeprecation = require('../../../../lib/utils/logDeprecation');
 
@@ -46,7 +46,7 @@ describe('#logDeprecation()', () => {
     expect(stdoutData).to.equal('');
   });
 
-  it('Should not log deprecation if disabled in serviceConfig', () => {
+  it('should not log deprecation if disabled in serviceConfig', () => {
     // We need original process env variables for npm-conf
     Object.assign(process.env, originalEnv);
     const logDeprecation = require('../../../../lib/utils/logDeprecation');
@@ -65,7 +65,7 @@ describe('#logDeprecation()', () => {
     });
   });
 
-  it('Should not log deprecation if disabled by wildcard in env', () => {
+  it('should not log deprecation if disabled by wildcard in env', () => {
     process.env.SLS_DEPRECATION_DISABLE = '*';
     const logDeprecation = require('../../../../lib/utils/logDeprecation');
     let stdoutData = '';
@@ -76,7 +76,7 @@ describe('#logDeprecation()', () => {
     expect(stdoutData).to.equal('');
   });
 
-  it('Should not log deprecation if disabled by wildcard in service config', () => {
+  it('should not log deprecation if disabled by wildcard in service config', () => {
     Object.assign(process.env, originalEnv);
     const logDeprecation = require('../../../../lib/utils/logDeprecation');
     return runServerless({
@@ -94,7 +94,7 @@ describe('#logDeprecation()', () => {
     });
   });
 
-  it('Should throw on deprecation if env.SLS_DEPRECATION_NOTIFICATION_MODE=error', () => {
+  it('should throw on deprecation if env.SLS_DEPRECATION_NOTIFICATION_MODE=error', () => {
     process.env.SLS_DEPRECATION_NOTIFICATION_MODE = 'error';
     const logDeprecation = require('../../../../lib/utils/logDeprecation');
     expect(() => logDeprecation('CODE1', 'Start using deprecation log'))
@@ -102,7 +102,7 @@ describe('#logDeprecation()', () => {
       .with.property('code', 'REJECTED_DEPRECATION_CODE1');
   });
 
-  it('Should throw on deprecation if error notifications mode set in service config', () => {
+  it('should throw on deprecation if error notifications mode set in service config', () => {
     const logDeprecation = require('../../../../lib/utils/logDeprecation');
     expect(() =>
       logDeprecation('CODE1', 'Start using deprecation log', {
@@ -113,7 +113,7 @@ describe('#logDeprecation()', () => {
       .with.property('code', 'REJECTED_DEPRECATION_CODE1');
   });
 
-  it('Should not log deprecation twice', () => {
+  it('should not log deprecation twice', () => {
     let stdoutData = '';
     overrideStdoutWrite(
       (data) => (stdoutData += data),


### PR DESCRIPTION
_(proposed internally by @skierkowski)_

So far deprecation warning logs are reported on the go, which may result with not great UX experience (especially if at least few are logged).

This improvement changes the approach, so all approached deprecations are logged in single summary block after command finalizes. This improves deprecations visibility, and reduces log clutter when ongoing process logs are concerned.

New logging way was introduced as third `warn:summary` deprecations logging mode, which was also set as default.

To avoid compatibility issues with other Framework versions, in case when local fallback occurs, mode is switched to `warn`, and local version is also ensured to log deprecations with `warn` mode (so one that was default so far).

This will be improved in v3, which will have way more reliable local fallback mechanism (then we will also respect `warn:summary` as a default)

Examples of a log output before and after, for service which has three deprecations reported (and apart of that there's a configuration validation warning):

_Success case (before):_

<img width="1258" alt="Screenshot 2021-07-05 at 18 43 15" src="https://user-images.githubusercontent.com/122434/124500979-02c7b080-ddc1-11eb-9967-18d88c117eef.png">

_Success case (after):_

<img width="1069" alt="Screenshot 2021-07-05 at 18 43 27" src="https://user-images.githubusercontent.com/122434/124501013-12df9000-ddc1-11eb-8240-f531dcb1d42c.png">

_Error case (before):_

<img width="1256" alt="Screenshot 2021-07-05 at 18 43 43" src="https://user-images.githubusercontent.com/122434/124501043-212dac00-ddc1-11eb-8ac7-b64b417614d2.png">

_Error case (after):_

<img width="1055" alt="Screenshot 2021-07-05 at 18 43 53" src="https://user-images.githubusercontent.com/122434/124501061-2db20480-ddc1-11eb-88ee-43a27ce3b6ad.png">
