### PR TITLE
CLI: Recognize `--verbose` option in `info` command

### DIFF
--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -83,6 +83,11 @@ commands.set('info', {
       usage: 'Hide secrets from the output (e.g. API Gateway key values)',
       type: 'boolean',
     },
+    verbose: {
+      usage: 'List stack outputs',
+      shortcut: 'v',
+      type: 'boolean',
+    },
   },
   lifecycleEvents: ['info'],
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

This option wasn't documented as `info` command option, while internally is supported: https://github.com/serverless/serverless/blob/cc24bc2ae280237b3d439e1934ab75710e0f259f/lib/plugins/aws/info/display.js#L148

Closes: #9691 


