### PR TITLE
Variables: Drop old engine related deprecation

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -992,13 +992,6 @@ class Variables {
       );
     }
 
-    if (!this.service.unresolvedVariablesNotificationMode) {
-      this.serverless._logDeprecation(
-        'VARIABLES_ERROR_ON_UNRESOLVED',
-        'Unresolved variable references will be communicated with a thrown error, starting from next major'
-      );
-    }
-
     logWarning(
       `A valid ${varType} to satisfy the declaration '${variableString}' could not be found.`
     );

--- a/lib/configuration/variables/eventually-report-resolution-errors.js
+++ b/lib/configuration/variables/eventually-report-resolution-errors.js
@@ -40,8 +40,6 @@ module.exports = (configurationPath, configuration, variablesMeta) => {
         'to adapt to new behavior now',
       { serviceConfig: configuration }
     );
-    // Hack to not duplicate the warning with similar deprecation
-    logDeprecation.triggeredDeprecations.add('VARIABLES_ERROR_ON_UNRESOLVED');
   }
 
   return true;

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -297,8 +297,6 @@ const processSpanPromise = (async () => {
             if (
               !ensureResolvedProperty('provider\0stage', { shouldSilentlyReturnIfLegacyMode: true })
             ) {
-              // Hack to not duplicate the warning with similar deprecation
-              logDeprecation.triggeredDeprecations.add('VARIABLES_ERROR_ON_UNRESOLVED');
               return;
             }
 

--- a/test/unit/lib/classes/Variables.test.js
+++ b/test/unit/lib/classes/Variables.test.js
@@ -1216,7 +1216,6 @@ module.exports = {
     it('should not allow partially double-quoted string', async () => {
       const property = '${opt:stage, prefix"prod"suffix}';
       serverless.variables.options = {};
-      serverless.configurationInput.disabledDeprecations = ['VARIABLES_ERROR_ON_UNRESOLVED'];
       const handleUnresolvedSpy = sinon.spy(serverless.variables, 'handleUnresolved');
       try {
         expect(await serverless.variables.populateProperty(property)).to.equal(undefined);
@@ -2866,8 +2865,8 @@ describe('test/unit/lib/classes/Variables.test.js', () => {
     });
 
     describe('when unresolvedVariablesNotificationMode is set to "warn"', () => {
-      it('prints warnings to the console but no deprecation message', async () => {
-        const { serverless, stdoutData } = await runServerless({
+      it('should warn', async () => {
+        const { stdoutData } = await runServerless({
           fixture: 'variables-legacy',
           command: 'print',
           configExt: {
@@ -2881,11 +2880,6 @@ describe('test/unit/lib/classes/Variables.test.js', () => {
           },
           shouldUseLegacyVariablesResolver: true,
         });
-
-        expect(Array.from(serverless.triggeredDeprecations)).not.to.contain(
-          'VARIABLES_ERROR_ON_UNRESOLVED'
-        );
-
         expect(stdoutData).to.include('Serverless Warning');
         expect(stdoutData).to.include('A valid environment variable to satisfy the declaration');
         expect(stdoutData).to.include('A valid option to satisfy the declaration');
@@ -2895,12 +2889,11 @@ describe('test/unit/lib/classes/Variables.test.js', () => {
     });
 
     describe('when unresolvedVariablesNotificationMode is not set', () => {
-      it('should warn and print a deprecation message', async () => {
-        const { serverless } = await runServerless({
+      it('should warn', async () => {
+        const { stdoutData } = await runServerless({
           fixture: 'variables-legacy',
           command: 'print',
           configExt: {
-            disabledDeprecations: ['VARIABLES_ERROR_ON_UNRESOLVED'],
             custom: {
               myVariable1: '${env:missingEnvVar}',
               myVariable2: '${opt:missingOpt}',
@@ -2911,9 +2904,11 @@ describe('test/unit/lib/classes/Variables.test.js', () => {
           shouldUseLegacyVariablesResolver: true,
         });
 
-        expect(Array.from(serverless.triggeredDeprecations)).to.contain(
-          'VARIABLES_ERROR_ON_UNRESOLVED'
-        );
+        expect(stdoutData).to.include('Serverless Warning');
+        expect(stdoutData).to.include('A valid environment variable to satisfy the declaration');
+        expect(stdoutData).to.include('A valid option to satisfy the declaration');
+        expect(stdoutData).to.include('A valid service attribute to satisfy the declaration');
+        expect(stdoutData).to.include('A valid file to satisfy the declaration');
       });
     });
   });


### PR DESCRIPTION
Old variables engine will be removed with next major, so there's no point to communicate breaking changes that were supposed to introduced if it was to stay

