### PR TITLE
feat(Telemetry): Handle interruptions and persist telemetry data

### DIFF
--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -72,7 +72,7 @@ process.on('SIGINT', () => {
       serverless,
       commandUsage,
     });
-    storeTelemetryLocally({ ...telemetryPayload, outcome: 'interrupted' });
+    storeTelemetryLocally({ ...telemetryPayload, outcome: 'interrupt' });
   }
   process.exit(1);
 });
@@ -445,16 +445,17 @@ const processSpanPromise = (async () => {
 
       hasTelemetryBeenReported = true;
       if (!isTelemetryDisabled) {
-        storeTelemetryLocally(
-          generateTelemetryPayload({
+        storeTelemetryLocally({
+          ...generateTelemetryPayload({
             command,
             options,
             commandSchema,
             serviceDir,
             configuration: configurationFromInteractive,
             commandUsage,
-          })
-        );
+          }),
+          outcome: 'success',
+        });
         await sendTelemetry({ serverlessExecutionSpan: processSpanPromise });
       }
       return;


### PR DESCRIPTION
Due to `inquirer` limitations, addtional mechanism for keeping the process alive had to be implemented. 

Addresses: https://github.com/serverless/serverless/issues/9367

Before merging this PR, corresponding backend PR has to be finalized