### PR TITLE
Telemetry improvements and fixes

### DIFF
--- a/lib/utils/telemetry/generatePayload.js
+++ b/lib/utils/telemetry/generatePayload.js
@@ -222,6 +222,7 @@ module.exports = ({
 
   const payload = {
     ciName,
+    isTtyTerminal: process.stdin.isTTY,
     cliName: 'serverless',
     command,
     commandOptionNames,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "promise-queue": "^2.2.5",
     "replaceall": "^0.1.6",
     "semver": "^7.3.5",
+    "signal-exit": "^3.0.3",
     "tabtab": "^3.0.2",
     "tar": "^6.1.0",
     "timers-ext": "^0.1.7",

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -51,29 +51,36 @@ process.once('uncaughtException', (error) => {
   });
 });
 
-process.once('SIGINT', () => {
-  clearTimeout(keepAliveTimer);
-  // If there's another SIGINT listener (command that works as deamon or reads stdin input)
-  // then let the other listener decide how process will exit
-  const isOtherSigintListener = Boolean(process.listenerCount('SIGINT'));
-  if (
-    commandSchema &&
-    !hasTelemetryBeenReported &&
-    !isTelemetryDisabled &&
-    (serverless ? serverless.isTelemetryReportedExternally : true)
-  ) {
-    const telemetryPayload = generateTelemetryPayload({
-      command,
-      options,
-      commandSchema,
-      serviceDir,
-      configuration,
-      serverless,
-      commandUsage,
-    });
-    storeTelemetryLocally({ ...telemetryPayload, outcome: 'interrupt' });
-  }
-  if (!isOtherSigintListener) process.exit(130);
+require('signal-exit/signals').forEach((signal) => {
+  process.once(signal, () => {
+    clearTimeout(keepAliveTimer);
+    // If there's another listener (e.g. we're in deamon context or reading stdin input)
+    // then let the other listener decide how process will exit
+    const isOtherSigintListener = Boolean(process.listenerCount(signal));
+    if (
+      commandSchema &&
+      !hasTelemetryBeenReported &&
+      !isTelemetryDisabled &&
+      (serverless ? serverless.isTelemetryReportedExternally : true)
+    ) {
+      const telemetryPayload = generateTelemetryPayload({
+        command,
+        options,
+        commandSchema,
+        serviceDir,
+        configuration,
+        serverless,
+        commandUsage,
+      });
+      storeTelemetryLocally({ ...telemetryPayload, outcome: 'interrupt', interruptSignal: signal });
+    }
+
+    if (isOtherSigintListener) return;
+    // Follow recommendation from signal-exit:
+    // https://github.com/tapjs/signal-exit/blob/654117d6c9035ff6a805db4d4acf1f0c820fcb21/index.js#L97-L98
+    if (process.platform === 'win32' && signal === 'SIGHUP') signal = 'SIGINT';
+    process.kill(process.pid, signal);
+  });
 });
 
 const humanizePropertyPathKeys = require('../lib/configuration/variables/humanize-property-path-keys');

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -14,16 +14,12 @@ if (require('../lib/utils/tabCompletion/isSupported') && process.argv[2] === 'co
 }
 
 const handleError = require('../lib/cli/handle-error');
-const humanizePropertyPathKeys = require('../lib/configuration/variables/humanize-property-path-keys');
-
 const {
   storeLocally: storeTelemetryLocally,
   send: sendTelemetry,
 } = require('../lib/utils/telemetry');
 const generateTelemetryPayload = require('../lib/utils/telemetry/generatePayload');
-const processBackendNotificationRequest = require('../lib/utils/processBackendNotificationRequest');
 const isTelemetryDisabled = require('../lib/utils/telemetry/areDisabled');
-const logDeprecation = require('../lib/utils/logDeprecation');
 
 let command;
 let options;
@@ -79,6 +75,10 @@ process.once('SIGINT', () => {
   }
   if (!isOtherSigintListener) process.exit(130);
 });
+
+const humanizePropertyPathKeys = require('../lib/configuration/variables/humanize-property-path-keys');
+const processBackendNotificationRequest = require('../lib/utils/processBackendNotificationRequest');
+const logDeprecation = require('../lib/utils/logDeprecation');
 
 const processSpanPromise = (async () => {
   try {

--- a/test/unit/lib/utils/telemetry/generatePayload.test.js
+++ b/test/unit/lib/utils/telemetry/generatePayload.test.js
@@ -19,9 +19,16 @@ const versions = {
 };
 
 describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
+  let isTTYCache;
   before(() => {
     // In order for tests below to return `commandDurationMs`
     EvalError.$serverlessCommandStartTime = process.hrtime();
+    isTTYCache = process.stdin.isTTY;
+    process.stdin.isTTY = true;
+  });
+
+  after(() => {
+    process.stdin.isTTY = isTTYCache;
   });
 
   beforeEach(() => {
@@ -117,6 +124,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
     delete payload.commandDurationMs;
     expect(payload).to.deep.equal({
       cliName: 'serverless',
+      isTtyTerminal: true,
       command: 'print',
       commandOptionNames: [],
       isConfigValid: true,
@@ -180,6 +188,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
     delete payload.commandDurationMs;
     expect(payload).to.deep.equal({
       cliName: 'serverless',
+      isTtyTerminal: true,
       command: 'print',
       commandOptionNames: [],
       isConfigValid: false, // No schema for custom provider
@@ -244,6 +253,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
     delete payload.commandDurationMs;
     expect(payload).to.deep.equal({
       cliName: 'serverless',
+      isTtyTerminal: true,
       command: 'print',
       commandOptionNames: [],
       isConfigValid: null,
@@ -298,6 +308,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
     delete payload.commandDurationMs;
     expect(payload).to.deep.equal({
       cliName: 'serverless',
+      isTtyTerminal: true,
       command: 'config',
       commandOptionNames: [],
       isAutoUpdateEnabled: false,
@@ -335,6 +346,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
       command: '',
       commandOptionNames: [],
       cliName: 'serverless',
+      isTtyTerminal: true,
       isConfigValid: null,
       config: {
         configValidationMode: 'warn',
@@ -381,6 +393,7 @@ describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
     delete payload.commandDurationMs;
     expect(payload).to.deep.equal({
       cliName: 'serverless',
+      isTtyTerminal: true,
       command: 'plugin list',
       commandOptionNames: [],
       isAutoUpdateEnabled: false,


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

- Fix handling of `SIGINT` signal (it prevented other attached listeners from working, that was also the source of the CI fails, as: https://github.com/serverless/serverless/runs/3000015103?check_suite_focus=true). This fix ensures that we do not block other listeners, and if there's none set, we pass through the signal (so process exits with `130` code, as it was before this listener was introduced)
- Report all interruption signals (to folllow that was also outlined in spec at #9367 still it was somehow missed), and report with telemetry which signal we faced
- Report whether we're in context of TTY terminal (that'll further help detect human users)
