### PR TITLE
Packaging: Validate `package.artifact` paths

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+const fsp = require('fs').promises;
 const globby = require('globby');
 const _ = require('lodash');
 const micromatch = require('micromatch');
@@ -75,7 +76,20 @@ module.exports = {
         this.serverless.cli.log(`Packaging disabled for function: "${functionName}"`);
         return;
       }
-      if (functionObject.package.artifact) return;
+      if (functionObject.package.artifact) {
+        try {
+          await fsp.access(
+            path.resolve(this.serverless.serviceDir, functionObject.package.artifact)
+          );
+          return;
+        } catch (error) {
+          throw new ServerlessError(
+            'Cannot access package artifact at ' +
+              `"${functionObject.package.artifact}" (for "${functionName}"): ${error.message}`,
+            'INVALID_PACKAGE_ARTIFACT_PATH'
+          );
+        }
+      }
       if (functionObject.package.individually || this.serverless.service.package.individually) {
         await this.packageFunction(functionName);
         return;
@@ -93,7 +107,23 @@ module.exports = {
     );
 
     await Promise.all(packagePromises);
-    if (shouldPackageService && !this.serverless.service.package.artifact) await this.packageAll();
+    if (shouldPackageService) {
+      if (this.serverless.service.package.artifact) {
+        try {
+          await fsp.access(
+            path.resolve(this.serverless.serviceDir, this.serverless.service.package.artifact)
+          );
+          return;
+        } catch (error) {
+          throw new ServerlessError(
+            'Cannot access package artifact at ' +
+              `"${this.serverless.service.package.artifact}": ${error.message}`,
+            'INVALID_PACKAGE_ARTIFACT_PATH'
+          );
+        }
+      }
+      await this.packageAll();
+    }
   },
 
   async packageAll() {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Observed in telemetry programmer errors that relate to fact that invalid paths are configured at `package.artifact`.

Framework so far had no dedicated validation for those paths. This PR fixes that
