### PR TITLE
docs: Adjust `${aws::accountId}` reference example 

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -317,7 +317,8 @@ Account ID of you AWS Account, based on the AWS Credentials that you have config
 
 ```yml
 service: new-service
-provider: aws
+provider: 
+  name: aws
 
 functions:
   func1:

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -317,7 +317,7 @@ Account ID of you AWS Account, based on the AWS Credentials that you have config
 
 ```yml
 service: new-service
-provider: 
+provider:
   name: aws
 
 functions:


### PR DESCRIPTION
Documentation fix.

aws should be at provider.name level


