### PR TITLE
docs(AWS IAM): Fix invalid example

### DIFF
--- a/docs/providers/aws/guide/iam.md
+++ b/docs/providers/aws/guide/iam.md
@@ -27,11 +27,11 @@ provider:
       name: custom-role-name
       path: /custom-role-path/
       statements:
-        - Effect: 'Allow',
-          Resource: '*',
-          NotAction: 'iam:DeleteUser',
+        - Effect: 'Allow'
+          Resource: '*'
+          Action: 'iam:DeleteUser'
       managedPolicies:
-        - 'arn:aws:iam::123456789012:user/*',
+        - 'arn:aws:iam::123456789012:user/*'
       permissionsBoundary: arn:aws:iam::123456789012:policy/boundaries
       tags:
         key: value


### PR DESCRIPTION
I think I noticed some mistakes in the IAM documentation (`,` at the end of some lines, which AFAICT is incorrect in YAML).