### PR TITLE
Upgrade `filesize` to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dotenv": "^10.0.0",
     "essentials": "^1.1.1",
     "fastest-levenshtein": "^1.0.12",
-    "filesize": "^6.4.0",
+    "filesize": "^7.0.0",
     "fs-extra": "^9.1.0",
     "get-stdin": "^8.0.0",
     "globby": "^11.0.4",


### PR DESCRIPTION
Feels as safe upgrade

[Changelog](https://github.com/avoidwork/filesize.js/blob/master/CHANGELOG.md#700-1) mentions [ESM introduction](https://github.com/avoidwork/filesize.js/commit/4c4363ac7481c8fa6f036d85f9f898d146216bb9) as reason for major bump, but that doesn't look as breaking change (reported that at https://github.com/avoidwork/filesize.js/issues/135)