### PR TITLE
Fix `functions[]` validation (ignore `null` values)

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -211,6 +211,10 @@ class Service {
       );
     }
     Object.entries(this.functions).forEach(([functionName, functionObj]) => {
+      if (functionObj == null) {
+        delete this.functions[functionName];
+        return;
+      }
       if (!_.isObject(functionObj)) {
         throw new ServerlessError(
           `Unexpected "${functionName}" function configuration: Expected object received ${util.inspect(

--- a/test/unit/lib/classes/Service.test.js
+++ b/test/unit/lib/classes/Service.test.js
@@ -135,7 +135,7 @@ describe('Service', () => {
           command: 'package',
           configExt: {
             functions: {
-              bar: null,
+              bar: true,
             },
           },
         })


### PR DESCRIPTION
Exposed in integration test fail https://github.com/serverless/serverless/runs/3084121219?check_suite_focus=true

Where given function is removed by overriding it with `null`. Such setup should work without issues
