### PR TITLE
Test: Cover `serverless-step-functions` plugin

### DIFF
--- a/test/fixtures/programmatic/curated-plugins/package.json
+++ b/test/fixtures/programmatic/curated-plugins/package.json
@@ -8,6 +8,7 @@
     "serverless-dotenv-plugin": "3.9.0",
     "serverless-iam-roles-per-function": "3.2.0",
     "serverless-plugin-typescript": "1.1.9",
-    "typescript": "4.3.5"
+    "typescript": "4.3.5",
+    "serverless-step-functions": "2.32.0"
   }
 }


### PR DESCRIPTION
Part of #9025 initiative

This is last plugin with over 1k users, and i will stop here.

I've also proposed a variable resolution related fix to a plugin repo: https://github.com/serverless-operations/serverless-step-functions/pull/451

