### PR TITLE
feat(AWS HTTP API): Support `shouldStartNameWithService` option

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -446,7 +446,7 @@ provider:
 
 ### Service Naming
 
-You can use the `${service}-${stage}` naming for HTTP Gateway instead the default option `${stage}-${service}`.
+You can use the `shouldStartNameWithService` option to change the naming scheme for HTTP API from the default `${stage}-${service}` to `${service}-${stage}`.
 
 ```yml
 provider:

--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -443,3 +443,13 @@ provider:
   httpApi:
     disableDefaultEndpoint: true
 ```
+
+### Service Naming
+
+You can use the `${service}-${stage}` naming for HTTP Gateway instead the default option `${stage}-${service}`.
+
+```yml
+provider:
+  httpApi:
+    shouldStartNameWithService: true
+```

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -652,7 +652,10 @@ module.exports = {
     ) {
       return `${String(this.provider.serverless.service.provider.httpApi.name)}`;
     }
-    return `${this.provider.getStage()}-${this.provider.serverless.service.service}`;
+
+    return _.get(this.provider.serverless.service.provider.httpApi, 'shouldStartNameWithService')
+      ? `${this.provider.serverless.service.service}-${this.provider.getStage()}`
+      : `${this.provider.getStage()}-${this.provider.serverless.service.service}`;
   },
   getHttpApiLogicalId() {
     return 'HttpApi';

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -924,6 +924,7 @@ class AwsProvider {
                 metrics: { type: 'boolean' },
                 useProviderTags: { const: true },
                 disableDefaultEndpoint: { type: 'boolean' },
+                shouldStartNameWithService: { type: 'boolean' },
               },
               additionalProperties: false,
             },

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -924,7 +924,7 @@ class AwsProvider {
                 metrics: { type: 'boolean' },
                 useProviderTags: { const: true },
                 disableDefaultEndpoint: { type: 'boolean' },
-                shouldStartNameWithService: { type: 'boolean' },
+                shouldStartNameWithService: { const: true },
               },
               additionalProperties: false,
             },

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -1025,4 +1025,28 @@ describe('#naming()', () => {
       );
     });
   });
+
+  describe('#getHttpApiName()', () => {
+    it('should return the composition of service & stage name if custom name not provided and shouldStartNameWithService is true', () => {
+      serverless.service.service = 'myService';
+      serverless.service.provider.httpApi = { shouldStartNameWithService: true };
+      expect(sdk.naming.getHttpApiName()).to.equal(
+        `${serverless.service.service}-${sdk.naming.provider.getStage()}`
+      );
+    });
+
+    it('should return the composition of stage & service name if custom name not provided', () => {
+      serverless.service.service = 'myService';
+      expect(sdk.naming.getHttpApiName()).to.equal(
+        `${sdk.naming.provider.getStage()}-${serverless.service.service}`
+      );
+    });
+
+    it('should return the custom api name if provided', () => {
+      serverless.service.provider.httpApi = { name: 'app-dev-testApi' };
+      serverless.service.service = 'myService';
+      serverless.service.provider.stage = sdk.naming.provider.getStage();
+      expect(sdk.naming.getHttpApiName()).to.equal('app-dev-testApi');
+    });
+  });
 });


### PR DESCRIPTION
**Overview**:  
- Add a option on HTTP API to set the api gateway name starting with the service name.
- Based on Rest API implementation.
- Add unit tests on HTTP API naming function

Closes: [#9631](https://github.com/serverless/serverless/issues/9631)