### PR TITLE
fix(CLI Onboarding): Ensure credentials resolution before deploy

### DIFF
--- a/lib/cli/interactive-setup/deploy.js
+++ b/lib/cli/interactive-setup/deploy.js
@@ -101,7 +101,7 @@ const configurePlugin = (serverless, originalStdWrite) => {
 
 module.exports = {
   async isApplicable(context) {
-    const { configuration, serviceDir, history, options } = context;
+    const { configuration, serviceDir, options } = context;
     if (!serviceDir) {
       context.inapplicabilityReasonCode = 'NOT_IN_SERVICE_DIRECTORY';
       return false;
@@ -114,9 +114,6 @@ module.exports = {
       context.inapplicabilityReasonCode = 'NON_AWS_PROVIDER';
       return false;
     }
-
-    // If `awsCredentials` step was not executed, we should proceed as it means that user has available credentials
-    if (!history.has('awsCredentials')) return true;
 
     // We want to proceed if the service instance has a linked provider
     if (

--- a/test/unit/lib/cli/interactive-setup/deploy.test.js
+++ b/test/unit/lib/cli/interactive-setup/deploy.test.js
@@ -37,16 +37,6 @@ describe('test/unit/lib/cli/interactive-setup/deploy.test.js', () => {
     expect(context.inapplicabilityReasonCode).to.equal('NON_AWS_PROVIDER');
   });
 
-  it('Should be applied, if awsCredentials step was not executed which means user already had credentials', async () =>
-    expect(
-      await step.isApplicable({
-        configuration: { provider: { name: 'aws' } },
-        serviceDir: '/foo',
-        options: {},
-        history: new Map(),
-      })
-    ).to.equal(true));
-
   it('Should be applied if user configured local credentials', async () => {
     await overrideEnv(
       { variables: { AWS_ACCESS_KEY_ID: 'somekey', AWS_SECRET_ACCESS_KEY: 'somesecret' } },


### PR DESCRIPTION
Reported internally, do not rely on previously executed steps based on history but always resolve/ensure credentials existence. 