### PR TITLE
docs: Adjust spelling in Node SDK guide

### DIFF
--- a/docs/guides/sdk/nodejs.md
+++ b/docs/guides/sdk/nodejs.md
@@ -79,7 +79,7 @@ module.exports.handler = async (event, context) => {
 };
 ```
 
-Example from context with an sync function:
+Example from context with a sync function:
 
 ```javascript
 module.exports.handler = async (event, context) => {


### PR DESCRIPTION
Just seemed a bit confusing to have 'an' precede sync, made me look twice to see which case was truly sync versus async

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->
There is a section of the node.js sdk guide where 'an' precedes both async and sync, should have just an 'a' preceding sync function, not 'an' as it implies async is following word due to it starting with a vowel, made me look a couple times
