### PR TITLE
refactor(Telemetry): Use `prompt-with-history`

### DIFF
--- a/lib/cli/interactive-setup/aws-credentials.js
+++ b/lib/cli/interactive-setup/aws-credentials.js
@@ -3,6 +3,7 @@
 const chalk = require('chalk');
 const _ = require('lodash');
 const inquirer = require('@serverless/utils/inquirer');
+const promptWithHistory = require('@serverless/utils/inquirer/prompt-with-history');
 const memoizee = require('memoizee');
 const AWS = require('aws-sdk');
 
@@ -78,37 +79,33 @@ const getProviders = memoizee(
 );
 
 const awsAccessKeyIdInput = async ({ stepHistory }) => {
-  const accessKeyId = (
-    await inquirer.prompt({
-      message: 'AWS Access Key Id:',
-      type: 'input',
-      name: 'accessKeyId',
-      validate: (input) => {
-        if (isValidAwsAccessKeyId(input.trim())) return true;
-        return 'AWS Access Key Id seems not valid.\n   Expected something like AKIAIOSFODNN7EXAMPLE';
-      },
-    })
-  ).accessKeyId.trim();
-  stepHistory.set('accessKeyId', '_user_provided_');
+  const accessKeyId = await promptWithHistory({
+    message: 'AWS Access Key Id:',
+    type: 'input',
+    name: 'accessKeyId',
+    stepHistory,
+    validate: (input) => {
+      if (isValidAwsAccessKeyId(input.trim())) return true;
+      return 'AWS Access Key Id seems not valid.\n   Expected something like AKIAIOSFODNN7EXAMPLE';
+    },
+  });
   return accessKeyId;
 };
 
 const awsSecretAccessKeyInput = async ({ stepHistory }) => {
-  const secretAccessKey = (
-    await inquirer.prompt({
-      message: 'AWS Secret Access Key:',
-      type: 'input',
-      name: 'secretAccessKey',
-      validate: (input) => {
-        if (isValidAwsSecretAccessKey(input.trim())) return true;
-        return (
-          'AWS Secret Access Key seems not valid.\n' +
-          '   Expected something like wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-        );
-      },
-    })
-  ).secretAccessKey.trim();
-  stepHistory.set('secretAccessKey', '_user_provided_');
+  const secretAccessKey = await promptWithHistory({
+    message: 'AWS Secret Access Key:',
+    type: 'input',
+    name: 'secretAccessKey',
+    stepHistory,
+    validate: (input) => {
+      if (isValidAwsSecretAccessKey(input.trim())) return true;
+      return (
+        'AWS Secret Access Key seems not valid.\n' +
+        '   Expected something like wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+      );
+    },
+  });
   return secretAccessKey;
 };
 
@@ -148,19 +145,13 @@ const credentialsSetupChoice = async (context, providers) => {
     { name: 'Skip', value: CREDENTIALS_SETUP_CHOICE.SKIP }
   );
 
-  const result = (
-    await inquirer.prompt({
-      message,
-      type: 'list',
-      name: 'credentialsSetupChoice',
-      choices: credentialsSetupChoices,
-    })
-  ).credentialsSetupChoice;
-
-  context.stepHistory.set(
-    'credentialsSetupChoice',
-    result.startsWith('_') ? result : '_user_provided_'
-  );
+  const result = await promptWithHistory({
+    message,
+    type: 'list',
+    name: 'credentialsSetupChoice',
+    choices: credentialsSetupChoices,
+    stepHistory: context.stepHistory,
+  });
   return result;
 };
 
@@ -173,22 +164,22 @@ const steps = {
   ensureAwsAccount: async ({ stepHistory }) => {
     if (await confirm('Do you have an AWS account?', { name: 'hasAwsAccount' })) return;
     openBrowser('https://portal.aws.amazon.com/billing/signup');
-    await inquirer.prompt({
+    await promptWithHistory({
       message: 'Press Enter to continue after creating an AWS account',
       name: 'createAwsAccountPrompt',
+      stepHistory,
     });
-    stepHistory.set('createAwsAccountPrompt', true);
   },
   ensureAwsCredentials: async ({ options, configuration, stepHistory }) => {
     const region = options.region || configuration.provider.region || 'us-east-1';
     openBrowser(
       `https://console.aws.amazon.com/iam/home?region=${region}#/users$new?step=final&accessKey&userNames=serverless&permissionType=policies&policies=arn:aws:iam::aws:policy%2FAdministratorAccess`
     );
-    await inquirer.prompt({
+    await promptWithHistory({
       message: 'Press Enter to continue after creating an AWS user with access keys',
       name: 'generateAwsCredsPrompt',
+      stepHistory,
     });
-    stepHistory.set('generateAwsCredsPrompt', true);
   },
   inputAwsCredentials: async (context) => {
     const accessKeyId = await awsAccessKeyIdInput(context);
@@ -218,14 +209,16 @@ const steps = {
 
       const timeoutDuration = 1000 * 30; // 30 seconds
       showSkipPromptTimeout = setTimeout(() => {
+        const promptName = 'skipProviderSetup';
+        stepHistory.start(promptName);
         inquirerPrompt = inquirer.prompt({
           message:
             '\n [If you approached an issue when setting up a provider, you may press Enter to skip this step]',
-          name: 'skipProviderSetup',
+          name: promptName,
         });
 
         inquirerPrompt.then(() => {
-          stepHistory.set('skipProviderSetup', true);
+          stepHistory.finalize(promptName, true);
           resolve(null);
         });
       }, timeoutDuration);

--- a/lib/cli/interactive-setup/dashboard-login.js
+++ b/lib/cli/interactive-setup/dashboard-login.js
@@ -4,20 +4,19 @@ const _ = require('lodash');
 const { ServerlessSDK } = require('@serverless/platform-client');
 const login = require('@serverless/dashboard-plugin/lib/login');
 const configUtils = require('@serverless/utils/config');
+const promptWithHistory = require('@serverless/utils/inquirer/prompt-with-history');
 
-const loginOrRegisterQuestion = async (inquirer) =>
-  (
-    await inquirer.prompt({
-      message: 'Do you want to login/register to Serverless Dashboard?',
-      type: 'confirm',
-      name: 'shouldLoginOrRegister',
-    })
-  ).shouldLoginOrRegister;
+const loginOrRegisterQuestion = async (stepHistory) =>
+  promptWithHistory({
+    message: 'Do you want to login/register to Serverless Dashboard?',
+    type: 'confirm',
+    name: 'shouldLoginOrRegister',
+    stepHistory,
+  });
 
 const steps = {
   loginOrRegister: async (context) => {
-    const result = await loginOrRegisterQuestion(context.inquirer);
-    context.stepHistory.set('shouldLoginOrRegister', result);
+    const result = await loginOrRegisterQuestion(context.stepHistory);
     if (result) {
       await login({ isInteractive: true });
     }

--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -5,6 +5,7 @@ const chalk = require('chalk');
 const accountUtils = require('@serverless/utils/account');
 const configUtils = require('@serverless/utils/config');
 const { ServerlessSDK } = require('@serverless/platform-client');
+const promptWithHistory = require('@serverless/utils/inquirer/prompt-with-history');
 const { writeOrgAndApp } = require('./utils');
 const {
   getPlatformClientWithAccessKey,
@@ -13,92 +14,83 @@ const {
 
 const isValidAppName = RegExp.prototype.test.bind(/^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$/);
 
-const orgUpdateConfirm = async (inquirer, stepHistory) => {
+const orgUpdateConfirm = async (stepHistory) => {
   process.stdout.write(
     "Service has monitoring enabled, but it is configured with the 'org' to which you do not have access\n\n"
   );
-  const shouldUpdateOrg = (
-    await inquirer.prompt({
-      message: 'Would you like to update it?',
-      type: 'confirm',
-      name: 'shouldUpdateOrg',
-    })
-  ).shouldUpdateOrg;
-  stepHistory.set('shouldUpdateOrg', shouldUpdateOrg);
+  const shouldUpdateOrg = await promptWithHistory({
+    message: 'Would you like to update it?',
+    type: 'confirm',
+    name: 'shouldUpdateOrg',
+    stepHistory,
+  });
   return shouldUpdateOrg;
 };
-const appUpdateConfirm = async (inquirer, appName, orgName, stepHistory) => {
+
+const appUpdateConfirm = async (appName, orgName, stepHistory) => {
   process.stdout.write(
     "Service seems to have monitoring enabled, but configured app doesn't seem to exist in an organization.\n\n"
   );
 
-  const appUpdateType = (
-    await inquirer.prompt({
-      message: 'What would you like to do?',
-      type: 'list',
-      name: 'appUpdateType',
-      choices: [
-        { name: `Create '${appName}' app in '${orgName}' org`, value: 'create' },
-        {
-          name: 'Switch to one of the existing apps (or create new one with different name)',
-          value: 'chooseExisting',
-        },
-        { name: "Skip, I'll sort this out manually", value: 'skip' },
-      ],
-    })
-  ).appUpdateType;
-  stepHistory.set('appUpdateType', appUpdateType);
+  const appUpdateType = await promptWithHistory({
+    message: 'What would you like to do?',
+    type: 'list',
+    name: 'appUpdateType',
+    stepHistory,
+    choices: [
+      { name: `Create '${appName}' app in '${orgName}' org`, value: '_create_' },
+      {
+        name: 'Switch to one of the existing apps (or create new one with different name)',
+        value: '_choose_existing_',
+      },
+      { name: "Skip, I'll sort this out manually", value: '_skip_' },
+    ],
+  });
   return appUpdateType;
 };
 
-const orgsChoice = async (inquirer, orgNames, stepHistory) => {
-  const orgName = (
-    await inquirer.prompt({
-      message: 'What org do you want to add this to?',
-      type: 'list',
-      name: 'orgName',
-      choices: [...orgNames, { name: '[Skip]', value: '_skip_' }],
-    })
-  ).orgName;
-  stepHistory.set('orgName', orgName.startsWith('_') ? orgName : '_user_provided_');
+const orgsChoice = async (orgNames, stepHistory) => {
+  const orgName = await promptWithHistory({
+    message: 'What org do you want to add this to?',
+    type: 'list',
+    name: 'orgName',
+    choices: [...orgNames, { name: '[Skip]', value: '_skip_' }],
+    stepHistory,
+  });
   return orgName;
 };
 
-const appNameChoice = async (inquirer, appNames, stepHistory) => {
-  const appName = (
-    await inquirer.prompt({
-      message: 'What application do you want to add this to?',
-      type: 'list',
-      name: 'appName',
-      choices: Array.from(appNames).concat({ name: '[create a new app]', value: '_create_' }),
-    })
-  ).appName;
-  stepHistory.set('appName', appName.startsWith('_') ? appName : '_user_provided_');
+const appNameChoice = async (appNames, stepHistory) => {
+  const appName = await promptWithHistory({
+    message: 'What application do you want to add this to?',
+    type: 'list',
+    name: 'appName',
+    choices: Array.from(appNames).concat({ name: '[create a new app]', value: '_create_' }),
+    stepHistory,
+  });
   return appName;
 };
 
-const appNameInput = async (inquirer, appNames, stepHistory) => {
-  const appName = (
-    await inquirer.prompt({
-      message: 'What do you want to name this application?',
-      type: 'input',
-      name: 'newAppName',
-      validate: (input) => {
-        input = input.trim();
-        if (!isValidAppName(input)) {
-          return (
-            'App name is not valid.\n' +
-            '   - It should only contain lowercase alphanumeric and hyphens.\n' +
-            '   - It should start and end with an alphanumeric character.\n' +
-            "   - Shouldn't exceed 128 characters"
-          );
-        }
-        if (appNames.includes(input)) return 'App of this name already exists';
-        return true;
-      },
-    })
-  ).newAppName.trim();
-  stepHistory.set('newAppName', '_user_provided_');
+const appNameInput = async (appNames, stepHistory) => {
+  const appName = await promptWithHistory({
+    message: 'What do you want to name this application?',
+    type: 'input',
+    name: 'newAppName',
+    stepHistory,
+    validate: (input) => {
+      input = input.trim();
+      if (!isValidAppName(input)) {
+        return (
+          'App name is not valid.\n' +
+          '   - It should only contain lowercase alphanumeric and hyphens.\n' +
+          '   - It should start and end with an alphanumeric character.\n' +
+          "   - Shouldn't exceed 128 characters"
+        );
+      }
+      if (appNames.includes(input)) return 'App of this name already exists';
+      return true;
+    },
+  });
   return appName;
 };
 
@@ -140,7 +132,7 @@ const steps = {
       isDashboardAppPreconfigured,
     }
   ) => {
-    const { inquirer, history, stepHistory } = context;
+    const { history, stepHistory } = context;
     if (!orgName) {
       orgName = await (async () => {
         // We only want to automatically select the single available org in situations where user explicitly
@@ -154,7 +146,7 @@ const steps = {
         ) {
           return orgNames.values().next().value;
         }
-        return orgsChoice(inquirer, orgNames, stepHistory);
+        return orgsChoice(orgNames, stepHistory);
       })();
     }
 
@@ -171,9 +163,9 @@ const steps = {
       if (!apps.length) {
         newAppName = context.configuration.service;
       } else {
-        appName = await appNameChoice(inquirer, appNames, stepHistory);
+        appName = await appNameChoice(appNames, stepHistory);
         if (appName === '_create_') {
-          newAppName = await appNameInput(inquirer, appNames, stepHistory);
+          newAppName = await appNameInput(appNames, stepHistory);
         }
       }
     }
@@ -181,14 +173,14 @@ const steps = {
       ({ appName } = await sdk.apps.create({ orgName, app: { name: newAppName } }));
     }
     if (isDashboardMonitoringOverridenByCli && isDashboardAppPreconfigured) {
-      const { shouldOverrideDashboardConfig } = await inquirer.prompt({
+      const shouldOverrideDashboardConfig = await promptWithHistory({
         message:
           'Are you sure you want to update monitoring settings ' +
           `to ${chalk.bold(`app: ${appName}, org: ${orgName}`)}`,
         type: 'confirm',
         name: 'shouldOverrideDashboardConfig',
+        stepHistory,
       });
-      stepHistory.set('shouldOverrideDashboardConfig', shouldOverrideDashboardConfig);
       if (!shouldOverrideDashboardConfig) {
         delete context.configuration.app;
         delete context.configuration.org;
@@ -341,27 +333,26 @@ module.exports = {
     };
   },
   async run(context, stepData) {
-    const { inquirer, configuration, options, stepHistory } = context;
+    const { configuration, options, stepHistory } = context;
     if (!stepData.orgName) delete configuration.org;
     if (!stepData.appName && !stepData.newAppName) delete configuration.app;
     if (!options.org && !options.app) {
       if (stepData.isDashboardMonitoringPreconfigured) {
         if (!stepData.orgName) {
-          if (!(await orgUpdateConfirm(inquirer, stepHistory))) return;
+          if (!(await orgUpdateConfirm(stepHistory))) return;
         } else if (stepData.newAppName) {
           const appUpdateTypeChoice = await appUpdateConfirm(
-            inquirer,
             stepData.newAppName,
             stepData.orgName,
             stepHistory
           );
           switch (appUpdateTypeChoice) {
-            case 'create':
+            case '_create_':
               break;
-            case 'chooseExisting':
+            case '_choose_existing_':
               delete stepData.newAppName;
               break;
-            case 'skip':
+            case '_skip_':
               return;
             default:
               throw new Error('Unexpected app update type');

--- a/lib/cli/interactive-setup/deploy.js
+++ b/lib/cli/interactive-setup/deploy.js
@@ -2,7 +2,8 @@
 
 const Serverless = require('../../Serverless');
 const chalk = require('chalk');
-const { confirm, doesServiceInstanceHaveLinkedProvider } = require('./utils');
+const promptWithHistory = require('@serverless/utils/inquirer/prompt-with-history');
+const { doesServiceInstanceHaveLinkedProvider } = require('./utils');
 const _ = require('lodash');
 const overrideStdoutWrite = require('process-utils/override-stdout-write');
 const { getDashboardInteractUrl } = require('@serverless/dashboard-plugin/lib/dashboard');
@@ -132,11 +133,12 @@ module.exports = {
   },
   async run({ configuration, configurationFilename, serviceDir, stepHistory }) {
     const serviceName = configuration.service;
-    const shouldDeploy = await confirm('Do you want to deploy your project?', {
+    const shouldDeploy = await promptWithHistory({
       name: 'shouldDeploy',
+      message: 'Do you want to deploy your project?',
+      stepHistory,
+      type: 'confirm',
     });
-    stepHistory.set('shouldDeploy', shouldDeploy);
-
     if (!shouldDeploy) {
       printMessage({
         serviceName,

--- a/lib/cli/interactive-setup/service.js
+++ b/lib/cli/interactive-setup/service.js
@@ -4,7 +4,7 @@ const { join } = require('path');
 const chalk = require('chalk');
 const fsp = require('fs').promises;
 const spawn = require('child-process-ext/spawn');
-const inquirer = require('@serverless/utils/inquirer');
+const promptWithHistory = require('@serverless/utils/inquirer/prompt-with-history');
 const resolveConfigurationPath = require('../resolve-configuration-path');
 const readConfiguration = require('../../configuration/read');
 const resolveVariables = require('../../configuration/variables');
@@ -33,17 +33,15 @@ const initializeProjectChoices = [
 ];
 
 const projectTypeChoice = async (stepHistory) => {
-  const projectType = (
-    await inquirer.prompt({
-      message: 'What do you want to make?',
-      type: 'list',
-      name: 'projectType',
-      choices: initializeProjectChoices,
-      pageSize: 13,
-    })
-  ).projectType;
-
-  stepHistory.set('projectType', projectType);
+  const projectType = await promptWithHistory({
+    message: 'What do you want to make?',
+    type: 'list',
+    name: 'projectType',
+    choices: initializeProjectChoices,
+    pageSize: 13,
+    recordRawAnswerInHistory: true,
+    stepHistory,
+  });
   return projectType;
 };
 
@@ -54,29 +52,26 @@ const INVALID_PROJECT_NAME_MESSAGE =
   "   - Shouldn't exceed 128 characters";
 
 const projectNameInput = async (workingDir, projectType, stepHistory) => {
-  const projectName = (
-    await inquirer.prompt({
-      message: 'What do you want to call this project?',
-      type: 'input',
-      name: 'projectName',
-      default: projectType ? `${projectType}-project` : null,
-      validate: async (input) => {
-        input = input.trim();
-        if (!isValidServiceName(input)) {
-          return INVALID_PROJECT_NAME_MESSAGE;
-        }
+  const projectName = await promptWithHistory({
+    message: 'What do you want to call this project?',
+    type: 'input',
+    name: 'projectName',
+    stepHistory,
+    default: projectType ? `${projectType}-project` : null,
+    validate: async (input) => {
+      input = input.trim();
+      if (!isValidServiceName(input)) {
+        return INVALID_PROJECT_NAME_MESSAGE;
+      }
 
-        try {
-          await fsp.access(join(workingDir, input));
-          return `Path ${input} is already taken`;
-        } catch {
-          return true;
-        }
-      },
-    })
-  ).projectName.trim();
-
-  stepHistory.set('projectName', '_user_provided_');
+      try {
+        await fsp.access(join(workingDir, input));
+        return `Path ${input} is already taken`;
+      } catch {
+        return true;
+      }
+    },
+  });
   return projectName;
 };
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@serverless/components": "^3.13.4",
     "@serverless/dashboard-plugin": "^5.4.3",
     "@serverless/platform-client": "^4.2.5",
-    "@serverless/utils": "^5.3.0",
+    "@serverless/utils": "^5.6.0",
     "ajv": "^6.12.6",
     "ajv-keywords": "^3.5.2",
     "archiver": "^5.3.0",

--- a/test/unit/lib/cli/interactive-setup/aws-credentials.test.js
+++ b/test/unit/lib/cli/interactive-setup/aws-credentials.test.js
@@ -348,10 +348,10 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['credentialsSetupChoice', '_local_'],
-          ['createAwsAccountPrompt', true],
-          ['generateAwsCredsPrompt', true],
-          ['accessKeyId', '_user_provided_'],
-          ['secretAccessKey', '_user_provided_'],
+          ['createAwsAccountPrompt', '_continuation_'],
+          ['generateAwsCredsPrompt', '_continuation_'],
+          ['accessKeyId', '_user_input_'],
+          ['secretAccessKey', '_user_input_'],
         ])
       );
     });
@@ -373,9 +373,9 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['credentialsSetupChoice', '_local_'],
-          ['generateAwsCredsPrompt', true],
-          ['accessKeyId', '_user_provided_'],
-          ['secretAccessKey', '_user_provided_'],
+          ['generateAwsCredsPrompt', '_continuation_'],
+          ['accessKeyId', '_user_input_'],
+          ['secretAccessKey', '_user_input_'],
         ])
       );
       return resolveFileProfiles().then((profiles) => {
@@ -401,7 +401,8 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['credentialsSetupChoice', '_local_'],
-          ['generateAwsCredsPrompt', true],
+          ['generateAwsCredsPrompt', '_continuation_'],
+          ['accessKeyId', undefined],
         ])
       );
     });
@@ -424,8 +425,9 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['credentialsSetupChoice', '_local_'],
-          ['generateAwsCredsPrompt', true],
-          ['accessKeyId', '_user_provided_'],
+          ['generateAwsCredsPrompt', '_continuation_'],
+          ['accessKeyId', '_user_input_'],
+          ['secretAccessKey', undefined],
         ])
       );
     });
@@ -683,7 +685,7 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       );
       expect(stdoutData).to.include('Selected provider was successfully linked');
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['credentialsSetupChoice', '_user_provided_']])
+        new Map([['credentialsSetupChoice', '_user_choice_']])
       );
     });
 
@@ -753,7 +755,7 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       );
 
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['credentialsSetupChoice', '_user_provided_']])
+        new Map([['credentialsSetupChoice', '_user_choice_']])
       );
     });
 

--- a/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -245,8 +245,9 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
     ).to.eventually.be.rejected.and.have.property('code', 'INVALID_ANSWER');
     expect(context.stepHistory.valuesMap()).to.deep.equal(
       new Map([
-        ['orgName', '_user_provided_'],
+        ['orgName', '_user_choice_'],
         ['appName', '_create_'],
+        ['newAppName', undefined],
       ])
     );
   });
@@ -278,7 +279,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
 
   it('Should recognize an invalid app and allow to opt out', async () => {
     configureInquirerStub(inquirer, {
-      list: { appUpdateType: 'skip' },
+      list: { appUpdateType: '_skip_' },
     });
     const { servicePath: serviceDir, serviceConfig: configuration } = await fixtures.setup(
       'aws-loggedin-wrongapp-service'
@@ -298,7 +299,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
     });
     expect(context.configuration.org).to.equal('testinteractivecli');
     expect(context.configuration.app).to.equal('not-created-app');
-    expect(context.stepHistory.valuesMap()).to.deep.equal(new Map([['appUpdateType', 'skip']]));
+    expect(context.stepHistory.valuesMap()).to.deep.equal(new Map([['appUpdateType', '_skip_']]));
   });
 
   describe('Monitoring setup', () => {
@@ -340,8 +341,8 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
-          ['orgName', '_user_provided_'],
-          ['appName', '_user_provided_'],
+          ['orgName', '_user_choice_'],
+          ['appName', '_user_choice_'],
         ])
       );
     });
@@ -386,8 +387,8 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
-          ['orgName', '_user_provided_'],
-          ['appName', '_user_provided_'],
+          ['orgName', '_user_choice_'],
+          ['appName', '_user_choice_'],
         ])
       );
     });
@@ -759,8 +760,8 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
-          ['orgName', '_user_provided_'],
-          ['appName', '_user_provided_'],
+          ['orgName', '_user_choice_'],
+          ['appName', '_user_choice_'],
         ])
       );
     });
@@ -807,8 +808,8 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
-          ['orgName', '_user_provided_'],
-          ['appName', '_user_provided_'],
+          ['orgName', '_user_choice_'],
+          ['appName', '_user_choice_'],
           ['shouldOverrideDashboardConfig', true],
         ])
       );
@@ -854,8 +855,8 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
-          ['orgName', '_user_provided_'],
-          ['appName', '_user_provided_'],
+          ['orgName', '_user_choice_'],
+          ['appName', '_user_choice_'],
           ['shouldOverrideDashboardConfig', true],
         ])
       );
@@ -900,7 +901,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
         'Your project has been setup with org testinteractivecli and app other-app'
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['appName', '_user_provided_']])
+        new Map([['appName', '_user_choice_']])
       );
     });
 
@@ -944,9 +945,9 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
-          ['orgName', '_user_provided_'],
+          ['orgName', '_user_choice_'],
           ['appName', '_create_'],
-          ['newAppName', '_user_provided_'],
+          ['newAppName', '_user_input_'],
         ])
       );
     });
@@ -994,8 +995,8 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['shouldUpdateOrg', true],
-          ['orgName', '_user_provided_'],
-          ['appName', '_user_provided_'],
+          ['orgName', '_user_choice_'],
+          ['appName', '_user_choice_'],
         ])
       );
     });
@@ -1041,7 +1042,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
         'Your project has been setup with org testinteractivecli and app other-app'
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['appName', '_user_provided_']])
+        new Map([['appName', '_user_choice_']])
       );
     });
   });
@@ -1163,7 +1164,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
         'Your project has been setup with org testinteractivecli and app other-app'
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['appName', '_user_provided_']])
+        new Map([['appName', '_user_choice_']])
       );
     });
   });
@@ -1171,7 +1172,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
   describe('Monitoring setup when invalid app', () => {
     it('Should recognize an invalid app and allow to create it', async () => {
       configureInquirerStub(inquirer, {
-        list: { appUpdateType: 'create' },
+        list: { appUpdateType: '_create_' },
       });
       const { servicePath: serviceDir, serviceConfig: configuration } = await fixtures.setup(
         'aws-loggedin-service',
@@ -1213,12 +1214,14 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       expect(stripAnsi(stdoutData)).to.include(
         'Your project has been setup with org testinteractivecli and app not-created-app'
       );
-      expect(context.stepHistory.valuesMap()).to.deep.equal(new Map([['appUpdateType', 'create']]));
+      expect(context.stepHistory.valuesMap()).to.deep.equal(
+        new Map([['appUpdateType', '_create_']])
+      );
     });
 
     it('Should recognize an invalid app and allow to replace it with existing one', async () => {
       configureInquirerStub(inquirer, {
-        list: { appUpdateType: 'chooseExisting', appName: 'other-app' },
+        list: { appUpdateType: '_choose_existing_', appName: 'other-app' },
       });
       const { servicePath: serviceDir, serviceConfig: configuration } = await fixtures.setup(
         'aws-loggedin-service',
@@ -1262,8 +1265,8 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
-          ['appUpdateType', 'chooseExisting'],
-          ['appName', '_user_provided_'],
+          ['appUpdateType', '_choose_existing_'],
+          ['appName', '_user_choice_'],
         ])
       );
     });

--- a/test/unit/lib/cli/interactive-setup/service.test.js
+++ b/test/unit/lib/cli/interactive-setup/service.test.js
@@ -111,7 +111,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['projectType', 'aws-nodejs'],
-          ['projectName', '_user_provided_'],
+          ['projectName', '_user_input_'],
         ])
       );
     });
@@ -156,7 +156,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['projectType', 'aws-nodejs'],
-          ['projectName', '_user_provided_'],
+          ['projectName', '_user_input_'],
         ])
       );
     });
@@ -203,7 +203,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['projectType', 'aws-nodejs'],
-          ['projectName', '_user_provided_'],
+          ['projectName', '_user_input_'],
         ])
       );
     });
@@ -248,7 +248,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['projectType', 'aws-nodejs'],
-          ['projectName', '_user_provided_'],
+          ['projectName', '_user_input_'],
         ])
       );
     });
@@ -288,7 +288,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['projectType', 'aws-nodejs'],
-          ['projectName', '_user_provided_'],
+          ['projectName', '_user_input_'],
         ])
       );
     });
@@ -306,7 +306,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       expect(stats.isFile()).to.be.true;
 
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['projectName', '_user_provided_']])
+        new Map([['projectName', '_user_input_']])
       );
     });
 
@@ -374,7 +374,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       );
 
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['projectName', '_user_provided_']])
+        new Map([['projectName', '_user_input_']])
       );
     });
 
@@ -415,7 +415,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       );
 
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['projectName', '_user_provided_']])
+        new Map([['projectName', '_user_input_']])
       );
     });
 
@@ -440,7 +440,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       expect(context.stepHistory.valuesMap()).to.deep.equal(
         new Map([
           ['projectType', 'aws-nodejs'],
-          ['projectName', '_user_provided_'],
+          ['projectName', '_user_input_'],
         ])
       );
     });
@@ -460,7 +460,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
         'INVALID_TEMPLATE'
       );
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['projectName', '_user_provided_']])
+        new Map([['projectName', '_user_input_']])
       );
     });
 
@@ -485,7 +485,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       );
 
       expect(context.stepHistory.valuesMap()).to.deep.equal(
-        new Map([['projectName', '_user_provided_']])
+        new Map([['projectName', '_user_input_']])
       );
     });
   });
@@ -504,7 +504,12 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       'INVALID_ANSWER'
     );
 
-    expect(context.stepHistory.valuesMap()).to.deep.equal(new Map([['projectType', 'aws-nodejs']]));
+    expect(context.stepHistory.valuesMap()).to.deep.equal(
+      new Map([
+        ['projectType', 'aws-nodejs'],
+        ['projectName', undefined],
+      ])
+    );
   });
 
   it('Should not allow project creation in a directory in which already service is configured when `name` flag provided', async () => {
@@ -534,7 +539,12 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       'INVALID_ANSWER'
     );
 
-    expect(context.stepHistory.valuesMap()).to.deep.equal(new Map([['projectType', 'aws-nodejs']]));
+    expect(context.stepHistory.valuesMap()).to.deep.equal(
+      new Map([
+        ['projectType', 'aws-nodejs'],
+        ['projectName', undefined],
+      ])
+    );
   });
 
   it('Should not allow project creation using an invalid project name when `name` flag provided', async () => {


### PR DESCRIPTION
Use `promptWithHistory` that will automatically record questions in step history. There is one exception where we still use `inquirer.prompt` directly, but it was easier to make an exception here in my opinion as we have to access original prompt from inquirer than to change the implementation just for this case. 

Before merging this PR, corresponding backend PRs have to be merged and deployed.

Addresses: #9367 