### PR TITLE
feat(Variables): Accept case-insensitive strings in `strToBool`

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -726,11 +726,15 @@ provider:
     apiGateway: ${strToBool(${ssm:API_GW_DEBUG_ENABLED})}
 ```
 
-These are examples that explain how the conversion works:
+These are examples that explain how the conversion works after first lowercasing the passed string value:
 
 ```plaintext
 ${strToBool(true)} => true
 ${strToBool(false)} => false
+${strToBool(True)} => true
+${strToBool(False)} => false
+${strToBool(TRUE)} => true
+${strToBool(FALSE)} => false
 ${strToBool(0)} => false
 ${strToBool(1)} => true
 ${strToBool(2)} => Error

--- a/lib/configuration/variables/sources/str-to-bool.js
+++ b/lib/configuration/variables/sources/str-to-bool.js
@@ -16,7 +16,7 @@ module.exports = {
       Error: ServerlessError,
       errorMessage: 'Non-string "strToBool" input:. Received: %v',
       errorCode: 'INVALID_STR_TO_BOOL_SOURCE_VALUE',
-    }).trim();
+    }).trim().toLowerCase();
 
     if (trueStrings.has(stringValue)) return { value: true };
     if (falseStrings.has(stringValue)) return { value: false };

--- a/lib/configuration/variables/sources/str-to-bool.js
+++ b/lib/configuration/variables/sources/str-to-bool.js
@@ -16,7 +16,9 @@ module.exports = {
       Error: ServerlessError,
       errorMessage: 'Non-string "strToBool" input:. Received: %v',
       errorCode: 'INVALID_STR_TO_BOOL_SOURCE_VALUE',
-    }).trim().toLowerCase();
+    })
+      .trim()
+      .toLowerCase();
 
     if (trueStrings.has(stringValue)) return { value: true };
     if (falseStrings.has(stringValue)) return { value: false };

--- a/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
+++ b/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
@@ -31,8 +31,10 @@ describe('test/unit/lib/configuration/variables/sources/str-to-bool.test.js', ()
 
   it('should resolve truthy input', () => expect(configuration.truthy).to.equal(true));
   it('should resolve falsy input', () => expect(configuration.falsy).to.equal(false));
-  it('should resolve uppercase truthy input', () => expect(configuration.truthyUppercase).to.equal(true));
-  it('should resolve mixed case falsy input', () => expect(configuration.falsyMixedCase).to.equal(false));
+  it('should resolve uppercase truthy input', () =>
+    expect(configuration.truthyUppercase).to.equal(true));
+  it('should resolve mixed case falsy input', () =>
+    expect(configuration.falsyMixedCase).to.equal(false));
 
   it('should report with an error missing input', () =>
     expect(variablesMeta.get('noParam').error.code).to.equal('VARIABLE_RESOLUTION_ERROR'));

--- a/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
+++ b/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
@@ -13,6 +13,8 @@ describe('test/unit/lib/configuration/variables/sources/str-to-bool.test.js', ()
     configuration = {
       truthy: "${strToBool('true')}",
       falsy: "${strToBool('false')}",
+      truthyUppercase: "${strToBool('TRUE')}",
+      falsyMixedcase: "${strToBool('False')}",
       noParam: '${strToBool:}',
       invalid: '${strToBool(foo)}',
     };
@@ -29,6 +31,8 @@ describe('test/unit/lib/configuration/variables/sources/str-to-bool.test.js', ()
 
   it('should resolve truthy input', () => expect(configuration.truthy).to.equal(true));
   it('should resolve falsy input', () => expect(configuration.falsy).to.equal(false));
+  it('should resolve truthy input (uppercase)', () => expect(configuration.truthyUppercase).to.equal(true));
+  it('should resolve falsy input (mixedcase)', () => expect(configuration.falsyMixedcase).to.equal(false));
 
   it('should report with an error missing input', () =>
     expect(variablesMeta.get('noParam').error.code).to.equal('VARIABLE_RESOLUTION_ERROR'));

--- a/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
+++ b/test/unit/lib/configuration/variables/sources/str-to-bool.test.js
@@ -14,7 +14,7 @@ describe('test/unit/lib/configuration/variables/sources/str-to-bool.test.js', ()
       truthy: "${strToBool('true')}",
       falsy: "${strToBool('false')}",
       truthyUppercase: "${strToBool('TRUE')}",
-      falsyMixedcase: "${strToBool('False')}",
+      falsyMixedCase: "${strToBool('False')}",
       noParam: '${strToBool:}',
       invalid: '${strToBool(foo)}',
     };
@@ -31,8 +31,8 @@ describe('test/unit/lib/configuration/variables/sources/str-to-bool.test.js', ()
 
   it('should resolve truthy input', () => expect(configuration.truthy).to.equal(true));
   it('should resolve falsy input', () => expect(configuration.falsy).to.equal(false));
-  it('should resolve truthy input (uppercase)', () => expect(configuration.truthyUppercase).to.equal(true));
-  it('should resolve falsy input (mixedcase)', () => expect(configuration.falsyMixedcase).to.equal(false));
+  it('should resolve uppercase truthy input', () => expect(configuration.truthyUppercase).to.equal(true));
+  it('should resolve mixed case falsy input', () => expect(configuration.falsyMixedCase).to.equal(false));
 
   it('should report with an error missing input', () =>
     expect(variablesMeta.get('noParam').error.code).to.equal('VARIABLE_RESOLUTION_ERROR'));


### PR DESCRIPTION
This change simply adds toLowerCase() when assigning stringValue to allow enable a case-insensitive input (True, TRUE, False, False)

Q1: No link.. no traction in slack either when attempting to discuss this.
