### PR TITLE
update AWS apiGateway event to allow request uri as string or ARN

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -124,7 +124,7 @@ const requestSchema = {
       type: 'object',
       additionalProperties: { type: 'string' },
     },
-    uri: { type: 'string' },
+    uri: { anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsArn' }] },
   },
   additionalProperties: false,
 };


### PR DESCRIPTION
Update requestSchema to allow URI to leverage either a string or an Arn.. otherwise using Fn::GetAttr flops.

```yaml
functions:
  webhookEventsSQSBatchProcessor:
    handler: handler
    dependsOn:
      - sqsWebhookEventsQueue
    events:
      - sqs:
          arn:
            Fn::GetAtt: [sqsWebhookEventsQueue, Arn]
          batchSize: 100
          maximumBatchingWindow: 30
      - http:
          path: webhook/events
          method: POST
          integration: AWS
          request:
            uri:
              Fn::GetAtt: [sqsWebhookEventsQueue, Arn]
            template:
              application/json: '{ "httpMethod" : "$context.httpMethod" }'
            passThrough: NEVER
```
