### PR TITLE
Documentation: switch to HTTP APIs by default

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -14,9 +14,9 @@ layout: Doc
 
 # HTTP API
 
-HTTP APIs are a special flavored [API Gateway](https://aws.amazon.com/api-gateway/) implementation which offer more features and improved performance. They have some benefits and drawbacks compared to the traditional API Gateway REST APIs. Read the differences in the [AWS Documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html).
+HTTP APIs are part of [API Gateway v2](https://aws.amazon.com/api-gateway/), which offers more features and improved performance at a lower cost. They have some drawbacks compared to traditional [API Gateway v1 REST APIs](./apigateway.md): read the differences in the [AWS Documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html).
 
-The Serverless Framework makes it possible to setup [API Gateway](https://aws.amazon.com/api-gateway/) HTTP APIs via the `httpApi` event.
+The Serverless Framework makes it possible to setup [API Gateway HTTP APIs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html) via the `httpApi` event.
 
 ## Event Definition
 

--- a/docs/providers/aws/guide/events.md
+++ b/docs/providers/aws/guide/events.md
@@ -32,9 +32,7 @@ functions:
   createUser: # Function name
     handler: handler.createUser # Reference to file handler.js & exported function 'createUser'
     events: # All events associated with this function
-      - http:
-          path: users/create
-          method: post
+      - httpApi: 'POST /users/create'
 ```
 
 Events are objects, which can contain event-specific information.
@@ -49,15 +47,9 @@ functions:
   createUser: # Function name
     handler: handler.users # Reference to file handler.js & exported function 'users'
     events: # All events associated with this function
-      - http:
-          path: users/create
-          method: post
-      - http:
-          path: users/update
-          method: put
-      - http:
-          path: users/delete
-          method: delete
+      - httpApi: 'POST /users/create'
+      - httpApi: 'PUT /users/update'
+      - httpApi: 'DELETE /users/delete'
 ```
 
 ## Types
@@ -74,9 +66,7 @@ functions:
   createUser: # Function name
     handler: handler.users # Reference to file handler.js & exported function 'users'
     events: # All events associated with this function
-      - http:
-          path: users/{id}
-          method: get
+      - httpApi: 'GET /users/{id}'
 ```
 
 ## Deploying

--- a/docs/providers/aws/guide/intro.md
+++ b/docs/providers/aws/guide/intro.md
@@ -71,10 +71,10 @@ service: users
 functions: # Your "Functions"
   usersCreate:
     events: # The "Events" that trigger this function
-      - http: post users/create
+      - httpApi: 'POST /users/create'
   usersDelete:
     events:
-      - http: delete users/delete
+      - httpApi: 'DELETE /users/delete'
 
 resources: # The "Resources" your "Functions" use.  Raw AWS CloudFormation goes in here.
 ```
@@ -88,14 +88,14 @@ _serverless.json_
     "usersCreate": {
       "events": [
         {
-          "http": "post users/create"
+          "httpApi": "POST /users/create"
         }
       ]
     },
     "usersDelete": {
       "events": [
         {
-          "http": "delete users/delete"
+          "httpApi": "DELETE /users/delete"
         }
       ]
     }
@@ -117,14 +117,14 @@ module.exports = {
     usersCreate: {
       events: [
         {
-          http: 'post users/create',
+          httpApi: 'POST /users/create',
         },
       ],
     },
     usersDelete: {
       events: [
         {
-          http: 'delete users/delete',
+          httpApi: 'DELETE /users/delete',
         },
       ],
     },
@@ -145,14 +145,14 @@ const serverlessConfiguration: Serverless = {
     usersCreate: {
       events: [
         {
-          http: 'post users/create',
+          httpApi: 'POST /users/create',
         },
       ],
     },
     usersDelete: {
       events: [
         {
-          http: 'delete users/delete',
+          httpApi: 'DELETE /users/delete',
         },
       ],
     },

--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -112,9 +112,7 @@ functions:
   package:
     artifact: hello.jar
   events:
-    - http:
-        path: hello
-        method: get
+    - httpApi: 'GET /hello'
 ```
 
 #### Artifacts hosted on S3

--- a/docs/providers/aws/guide/quick-start.md
+++ b/docs/providers/aws/guide/quick-start.md
@@ -73,7 +73,7 @@ Looking to get started with something other than Node or Python? No problem. You
 
 ### Set up an endpoint
 
-An Event is anything that can trigger your serverless functions. In this case, you need to define an endpoint in your `serverless.yml` that will trigger your serverless function.
+An Event is anything that can trigger your serverless functions. You can define an endpoint in your `serverless.yml` that will trigger your serverless function.
 
 ```yaml
 functions:
@@ -81,9 +81,7 @@ functions:
     handler: handler.hello
     # Add the following lines:
     events:
-      - http:
-          path: hello
-          method: post
+      - httpApi: 'POST /hello'
 ```
 
 ### Deploy the Service
@@ -99,7 +97,7 @@ serverless deploy -v
 Replace the URL in the following curl command with your returned endpoint URL, which you can find in the `sls deploy` output, to hit your URL endpoint.
 
 ```bash
-$ curl -X POST https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/dev/hello
+$ curl -X POST https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/hello
 ```
 
 ### Invoke your Service's function
@@ -127,7 +125,7 @@ serverless invoke -f hello -d '{"body": "not a json string"}' # causes a JSON pa
 ```
 
 ```bash
-$ curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/dev/hello --data-binary 'not a json string' # causes a JSON parsing error so error Insights will populate
+$ curl https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/hello --data-binary 'not a json string' # causes a JSON parsing error so error Insights will populate
 ```
 
 ## Cleanup

--- a/docs/providers/aws/guide/resources.md
+++ b/docs/providers/aws/guide/resources.md
@@ -115,10 +115,7 @@ functions:
   write-post:
     handler: handler.writePost
     events:
-      - http:
-          method: post
-          path: ${self:service}/api/posts/new
-          cors: true
+      - httpApi: 'POST /api/posts/new'
 
 resources:
   extensions:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -351,7 +351,15 @@ functions:
       arn: arn:aws:elasticfilesystem:us-east-1:111111111111:access-point/fsap-a1a1a1a1a1a1a1a1a # ARN of EFS Access Point
       localMountPath: /mnt/example # path under which EFS will be mounted and accessible by Lambda function
     events: # The Events that trigger this Function
-      - http: # This creates an API Gateway HTTP endpoint which can be used to trigger this function.  Learn more in "events/apigateway"
+      - httpApi: # HTTP API endpoint (API Gateway v2)
+          method: GET
+          path: /some-get-path/{param}
+          authorizer: # Optional
+            name: someJwtAuthorizer # References by name authorizer defined in provider.httpApi.authorizers section
+            scopes: # Optional
+              - user.id
+              - user.email
+      - http: # REST API endpoint (API Gateway v1)
           path: users/create # Path for this endpoint
           method: get # HTTP method for this endpoint
           cors: true # Turn on CORS for this endpoint, but don't forget to return the right header in your response
@@ -385,14 +393,6 @@ functions:
                 name: ModelName  # Optional: Name of the API Gateway model
                 description: "Some description" # Optional: Description of the API Gateway model
                 schema: ${file(model_schema.json)} # Schema for selected content type
-      - httpApi: # HTTP API endpoint
-          method: GET
-          path: /some-get-path/{param}
-          authorizer: # Optional
-            name: someJwtAuthorizer # References by name authorizer defined in provider.httpApi.authorizers section
-            scopes: # Optional
-              - user.id
-              - user.email
       - websocket:
           route: $connect
           routeResponseSelectionExpression: $default # optional, setting this enables callbacks on websocket requests for two-way communication

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -141,11 +141,11 @@ functions:
   usersCreate: # A Function
     handler: users.create
     events: # The Events that trigger this Function
-      - http: post users/create
+      - httpApi: 'POST /users/create'
   usersDelete: # A Function
     handler: users.delete
     events: # The Events that trigger this Function
-      - http: delete users/delete
+      - httpApi: 'DELETE /users/delete'
 
 # The "Resources" your "Functions" use.  Raw AWS CloudFormation goes in here.
 resources:


### PR DESCRIPTION
This PR updates the documentation to use HTTP APIs by default, instead of REST APIs.

Related pull request in serverless/examples: https://github.com/serverless/examples/pull/634 

TODO:

- [ ] Finish https://github.com/serverless/examples/pull/634
- [ ] Prepare PR to use the new "HTTP API" examples in the interactive onboarding

The goal is to merge everything at the same time, so that the documentation, the onboarding and the examples are consistent. This is why those PR are in draft for now.