### PR TITLE
refactor: Replace `fse.readdir` with `fs.promises.readdir`

### DIFF
--- a/lib/utils/telemetry/index.js
+++ b/lib/utils/telemetry/index.js
@@ -129,7 +129,7 @@ async function send(options = {}) {
   if (!telemetryUrl) return null;
   let dirFilenames;
   try {
-    dirFilenames = await fse.readdir(cacheDirPath);
+    dirFilenames = await fsp.readdir(cacheDirPath);
   } catch (readdirError) {
     if (readdirError.code !== 'ENOENT') logError('Cannot access cache dir', readdirError);
     return null;

--- a/scripts/pkg/upload/world.js
+++ b/scripts/pkg/upload/world.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const fsp = require('fs').promises;
 const fetch = require('node-fetch');
 const chalk = require('chalk');
 
@@ -37,7 +38,7 @@ module.exports = async (versionTag, { isLegacyVersion }) => {
     request(`${API_URL}${releaseId}/assets`, requestOptions)
   );
 
-  const distFileBasenames = await fs.promises.readdir(distPath);
+  const distFileBasenames = await fsp.readdir(distPath);
   await Promise.all(
     distFileBasenames
       .map(async (distFileBasename) => {

--- a/test/unit/lib/utils/telemetry/index.test.js
+++ b/test/unit/lib/utils/telemetry/index.test.js
@@ -55,7 +55,7 @@ describe('test/unit/lib/utils/telemetry/index.test.js', () => {
   afterEach(async () => {
     usedOptions = null;
     usedUrl = null;
-    const dirFilenames = await fse.readdir(cacheDirPath);
+    const dirFilenames = await fsp.readdir(cacheDirPath);
     await Promise.all(
       dirFilenames.map(async (filename) => fsp.unlink(path.join(cacheDirPath, filename)))
     );
@@ -64,7 +64,7 @@ describe('test/unit/lib/utils/telemetry/index.test.js', () => {
   it('`storeLocally` should persist an event in cacheDir', async () => {
     const payload = { test: 'payloadvalue' };
     storeLocally(payload);
-    const dirFilenames = await fse.readdir(cacheDirPath);
+    const dirFilenames = await fsp.readdir(cacheDirPath);
     expect(dirFilenames.length).to.equal(1);
     const persistedEvent = await fse.readJson(path.join(cacheDirPath, dirFilenames[0]));
     expect(persistedEvent.payload).to.deep.equal(payload);
@@ -76,12 +76,12 @@ describe('test/unit/lib/utils/telemetry/index.test.js', () => {
     await cacheEvent();
     await send();
     expect(usedUrl).to.equal(telemetryUrl);
-    const dirFilenames = await fse.readdir(cacheDirPath);
+    const dirFilenames = await fsp.readdir(cacheDirPath);
     expect(dirFilenames.filter(isFilename).length).to.equal(1);
 
     expectedState = 'success';
     await send();
-    const dirFilenamesAfterSend = await fse.readdir(cacheDirPath);
+    const dirFilenamesAfterSend = await fsp.readdir(cacheDirPath);
     expect(dirFilenamesAfterSend.filter(isFilename).length).to.equal(0);
 
     // Check that one event was send with request
@@ -91,10 +91,10 @@ describe('test/unit/lib/utils/telemetry/index.test.js', () => {
   it('Should ditch stale events at `send`', async () => {
     await Promise.all([cacheEvent(0), cacheEvent(0), cacheEvent(), cacheEvent(), cacheEvent(0)]);
     expectedState = 'success';
-    const dirFilenames = await fse.readdir(cacheDirPath);
+    const dirFilenames = await fsp.readdir(cacheDirPath);
     expect(dirFilenames.filter(isFilename).length).to.equal(5);
     await send();
-    const dirFilenamesAfterSend = await fse.readdir(cacheDirPath);
+    const dirFilenamesAfterSend = await fsp.readdir(cacheDirPath);
     expect(dirFilenamesAfterSend.filter(isFilename).length).to.equal(0);
     // Check if only two events were send with request
     expect(JSON.parse(usedOptions.body)).to.have.lengthOf(2);
@@ -104,7 +104,7 @@ describe('test/unit/lib/utils/telemetry/index.test.js', () => {
     expectedState = 'responseBodyError';
     await cacheEvent();
     await send();
-    const dirFilenames = await fse.readdir(cacheDirPath);
+    const dirFilenames = await fsp.readdir(cacheDirPath);
     expect(dirFilenames.filter(isFilename).length).to.equal(0);
   });
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Addresses: #8605 
