### PR TITLE
docs: azure/guide/intro Function App -> Services

### DIFF
--- a/docs/providers/azure/README.md
+++ b/docs/providers/azure/README.md
@@ -30,7 +30,7 @@ If you have any questions, [search the forums](https://forum.serverless.com?utm_
         <li><a href="./guide/quick-start.md">Quickstart</a></li>
         <li><a href="./guide/installation.md">Installation</a></li>
         <li><a href="./guide/credentials.md">Credentials</a></li>
-        <li><a href="./guide/function-apps.md">Function Apps</a></li>
+        <li><a href="./guide/services.md">Services</a></li>
         <li><a href="./guide/functions.md">Functions</a></li>
         <li><a href="./guide/events.md">Events</a></li>
         <li><a href="./guide/deploying.md">Deploying</a></li>

--- a/docs/providers/azure/cli-reference/create.md
+++ b/docs/providers/azure/cli-reference/create.md
@@ -2,7 +2,7 @@
 title: Serverless Framework Commands - Azure Functions - Create
 menuText: create
 menuOrder: 1
-description: Creates a new Function App in your current working directory
+description: Creates a new Service in your current working directory
 layout: Doc
 -->
 
@@ -14,16 +14,16 @@ layout: Doc
 
 # Azure - Create
 
-Creates a new Function App in the current working directory based on the specified
+Creates a new Service in the current working directory based on the specified
 template.
 
-**Create Function App in current working directory:**
+**Create Service in current working directory:**
 
 ```bash
 serverless create --template azure-nodejs
 ```
 
-**Create Function App in new folder:**
+**Create Service in new folder:**
 
 ```bash
 serverless create --template azure-nodejs --path myFunctionApp
@@ -34,8 +34,8 @@ serverless create --template azure-nodejs --path myFunctionApp
 - `--template` or `-t` The name of one of the available templates. **Required if --template-url and --template-path are not present**.
 - `--template-url` or `-u` A URL pointing to a remotely hosted template. **Required if --template and --template-path are not present**.
 - `--template-path` The local path of your template. **Required if --template and --template-url are not present**.
-- `--path` or `-p` The path where the Function App should be created.
-- `--name` or `-n` the name of the Function App in `serverless.yml`.
+- `--path` or `-p` The path where the Service should be created.
+- `--name` or `-n` the name of the Service in `serverless.yml`.
 
 ## Provided lifecycle events
 
@@ -52,39 +52,39 @@ Most commonly used templates:
 
 ## Examples
 
-### Creating a new Function App
+### Creating a new Service
 
 ```bash
-serverless create --template azure-nodejs --name my-function-app
+serverless create --template azure-nodejs --name my-service
 ```
 
-This example will generate scaffolding for a Function App with `Azure` as a provider
+This example will generate scaffolding for a Service with `Azure` as a provider
 and `nodejs` as runtime. The scaffolding will be generated in the current working
 directory.
 
-### Creating a named Function App in a (new) directory
+### Creating a named Service in a (new) directory
 
 ```bash
-serverless create --template azure-nodejs --path my-function-app
+serverless create --template azure-nodejs --path my-service
 ```
 
-This example will generate scaffolding for a Function App with `Azure` as a provider
-and `nodejs` as runtime. The scaffolding will be generated in the `my-function-app` directory. This directory will be created if not present. Otherwise
+This example will generate scaffolding for a Service with `Azure` as a provider
+and `nodejs` as runtime. The scaffolding will be generated in the `my-service` directory. This directory will be created if not present. Otherwise
 Serverless will use the already present directory.
 
-Additionally Serverless will rename the Function App according to the path you
-provide. In this example the Function App will be renamed to `my-function-app`.
+Additionally Serverless will rename the Service according to the path you
+provide. In this example the Service will be renamed to `my-service`.
 
-### Creating a new Function App using a local template
+### Creating a new Service using a local template
 
 ```bash
-serverless create --template-path path/to/my/template/folder --path path/to/my/app --name my-function-app
+serverless create --template-path path/to/my/template/folder --path path/to/my/app --name my-service
 ```
 
-This will copy the `path/to/my/template/folder` folder into `path/to/my/app` and rename the Function App to `my-function-app`.
+This will copy the `path/to/my/template/folder` folder into `path/to/my/app` and rename the Service to `my-service`.
 
-### Create Function App in new folder using a custom template
+### Create Service in new folder using a custom template
 
 ```bash
-serverless create --template-url https://github.com/serverless/serverless/tree/master/lib/plugins/create/templates/azure-nodejs --path myFunction App
+serverless create --template-url https://github.com/serverless/serverless/tree/master/lib/plugins/create/templates/azure-nodejs --path myService
 ```

--- a/docs/providers/azure/cli-reference/deploy-function.md
+++ b/docs/providers/azure/cli-reference/deploy-function.md
@@ -14,4 +14,4 @@ layout: Doc
 
 # Azure - Deploy Function
 
-The `serverless deploy function` command is not supported within the `serverless-azure-functions` plugin. Functions within a Function App are deployed as a unit and cannot be separated.
+The `serverless deploy function` command is not supported within the `serverless-azure-functions` plugin. Functions within a Service are deployed as a unit and cannot be separated.

--- a/docs/providers/azure/cli-reference/deploy-list.md
+++ b/docs/providers/azure/cli-reference/deploy-list.md
@@ -16,7 +16,7 @@ layout: Doc
 
 The `sls deploy list` command will list information about your deployments.
 
-You can see all deployments to your Azure Function App with the timestamp of deployment.
+You can see all deployments to your Azure Service with the timestamp of deployment.
 
 The displayed information is useful when rolling back a deployment or function via `serverless rollback`.
 

--- a/docs/providers/azure/cli-reference/invoke.md
+++ b/docs/providers/azure/cli-reference/invoke.md
@@ -31,7 +31,7 @@ serverless invoke --function functionName
 - `--path` or `-p` The path to a json file with input data to be passed to the invoked function. This path is relative to the root directory of the service.
 - `--data` or `-d` Stringified JSON data to be used as input to the function
 
-You can also run `invoke local` to invoke a locally running function app or `invoke apim` to invoke a function via the configured APIM endpoint.
+You can also run `invoke local` to invoke a locally running service or `invoke apim` to invoke a function via the configured APIM endpoint.
 
 ## Provided lifecycle events
 

--- a/docs/providers/azure/events/cosmosdb.md
+++ b/docs/providers/azure/events/cosmosdb.md
@@ -22,7 +22,7 @@ Full documentation can be found on
 # Events
 
 This setup describe how to write the data received, when someone
-accesses the Function App at `api/cosmos` via a `POST` request
+accesses the Service at `api/cosmos` via a `POST` request
 , to [Cosmos DB](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-cosmosdb-v2#output---javascript-examples)
 
 ## Serverless.yml

--- a/docs/providers/azure/events/http.md
+++ b/docs/providers/azure/events/http.md
@@ -14,7 +14,7 @@ layout: Doc
 
 # HTTP Trigger
 
-Azure Functions has an API endpoint created for each Function App. This service
+Azure Functions has an API endpoint created for each Service. This service
 allows you to define public HTTP endpoints for your serverless functions.
 
 To create HTTP endpoints as Event sources for your Azure Functions, use the
@@ -29,7 +29,7 @@ to learn the full functionality.
 ### Simple HTTP Endpoint
 
 This setup specifies that the `hello` function should be run when someone
-accesses the Function App at `api/example/hello` via a `GET` request.
+accesses the Service at `api/example/hello` via a `GET` request.
 
 Here's an example:
 
@@ -112,4 +112,4 @@ on the context object (i.e. `context.req`)
 ### CORS Support
 
 You can set up CORS following the instructions on
-[azure.com](https://docs.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings#manage-cors).
+[azure.com](https://docs.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-service-settings#manage-cors).

--- a/docs/providers/azure/guide/credentials.md
+++ b/docs/providers/azure/guide/credentials.md
@@ -89,7 +89,7 @@ Save this somewhere secure.
 
 ##### 5. Set up environment variables
 
-Add the following environment variables to the shell session or CI/CD tool that will be used for deployment of your Azure Function App:
+Add the following environment variables to the shell session or CI/CD tool that will be used for deployment of your Azure Service:
 
 ```sh
 # bash

--- a/docs/providers/azure/guide/deploying.md
+++ b/docs/providers/azure/guide/deploying.md
@@ -14,7 +14,7 @@ layout: Doc
 
 # Azure - Deploying
 
-The `serverless-azure-functions` plugin can deploy a Function App as well as other resources (storage account, App Insights, API Management, etc.). Here is some guidance on using the `deploy` command.
+The `serverless-azure-functions` plugin can deploy a Service as well as other resources (storage account, App Insights, API Management, etc.). Here is some guidance on using the `deploy` command.
 
 ### How It Works
 

--- a/docs/providers/azure/guide/intro.md
+++ b/docs/providers/azure/guide/intro.md
@@ -43,9 +43,9 @@ Anything that triggers an Azure Function to execute is regarded by the Framework
 
 When you define an event for your Azure Function in the Serverless Framework, the Framework will automatically translate this into [bindings](https://docs.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings) needed for that event and configure your functions to listen to it.
 
-### Function App
+### Services
 
-A **Function App** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application. It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file by default entitled `serverless.yml` (or `serverless.json` or `serverless.js`). It looks like this:
+A **Service** is the Framework's unit of organization. You can think of it as a project file, though you can have multiple services for a single application. It's where you define your Functions, the Events that trigger them, and the Resources your Functions use, all in one file by default entitled `serverless.yml` (or `serverless.json` or `serverless.js`). It looks like this:
 
 ```yml
 # serverless.yml

--- a/docs/providers/azure/guide/plugins.md
+++ b/docs/providers/azure/guide/plugins.md
@@ -21,15 +21,15 @@ A Plugin is custom JavaScript code that creates new or extends existing commands
 
 ## Installing Plugins
 
-External Plugins are added on a per function app basis and are not applied globally.
-Make sure you are in your function app's root directory, then install the
+External Plugins are added on a per service basis and are not applied globally.
+Make sure you are in your service's root directory, then install the
 corresponding Plugin with the help of npm:
 
 ```
 npm i --save custom-serverless-plugin
 ```
 
-We need to tell Serverless that we want to use the plugin inside our function app. We do this by adding the name of the Plugin to the `plugins` section in the `serverless.yml` file.
+We need to tell Serverless that we want to use the plugin inside our service. We do this by adding the name of the Plugin to the `plugins` section in the `serverless.yml` file.
 
 ```yml
 # serverless.yml file

--- a/docs/providers/azure/guide/quick-start.md
+++ b/docs/providers/azure/guide/quick-start.md
@@ -16,10 +16,10 @@ We try to keep this page up to date, but the **most** up to date documentation c
 2. Serverless CLI `v1.9.0+`. You can run `npm i -g serverless` if you don't already have it.
 3. An Azure account. If you don't already have one, you can sign up for a [free trial](https://azure.microsoft.com/en-us/free/) that includes \$200 of free credit.
 
-### Create a new Azure Function App
+### Create a new Azure Service
 
 ```bash
-# Create Azure Function App from template
+# Create Azure Service from template
 # Templates include: azure-nodejs, azure-python, azure-dotnet
 $ sls create -t azure-nodejs -p <appName>
 # Move into project directory
@@ -30,26 +30,26 @@ $ npm install
 
 The `serverless.yml` file contains the configuration for your service. For more details on its configuration, see [the docs](https://github.com/serverless/serverless-azure-functions/blob/master/docs/CONFIG.md).
 
-### Running Function App Locally (`offline` plugin)
+### Running Service Locally (`offline` plugin)
 
 At the root of your project directory, run:
 
 ```bash
-# Builds necessary function bindings files and starts the function app
+# Builds necessary function bindings files and starts the service
 $ sls offline
 ```
 
 The `offline` process will generate a directory for each of your functions, which will contain a file titled `function.json`. This will contain a relative reference to your handler file & exported function from that file as long as they are referenced correctly in `serverless.yml`.
 
-After the necessary files are generated, it will start the function app from within the same shell. For HTTP functions, the local URLs will be displayed in the console when the function app is initialized.
+After the necessary files are generated, it will start the service from within the same shell. For HTTP functions, the local URLs will be displayed in the console when the service is initialized.
 
-To build the files _without_ spawning the process to start the function app, run:
+To build the files _without_ spawning the process to start the service, run:
 
 ```bash
 $ sls offline build
 ```
 
-To simply start the function app _without_ building the files, run:
+To simply start the service _without_ building the files, run:
 
 ```bash
 $ sls offline start
@@ -71,7 +71,7 @@ This works for `sls offline` or `sls offline start`
 
 ### Dry-Run Deployment
 
-Before you deploy your new function app, you may want to double check the resources that will be created, their generated names and other basic configuration info. You can run:
+Before you deploy your new service, you may want to double check the resources that will be created, their generated names and other basic configuration info. You can run:
 
 ```bash
 # -d is short for --dryrun
@@ -86,7 +86,7 @@ For a more detailed look into the generated ARM template for your resource group
 $ sls deploy --dryrun --arm
 ```
 
-### Deploy Your Function App
+### Deploy Your Service
 
 Deploy your new service to Azure! The first time you do this, you will be asked to authenticate with your Azure account, so the `serverless` CLI can manage Functions on your behalf. Simply follow the provided instructions, and the deployment will continue as soon as the authentication process is completed.
 
@@ -96,7 +96,7 @@ $ sls deploy
 
 For more advanced deployment scenarios, see our [deployment docs](https://github.com/serverless/serverless-azure-functions/blob/master/docs/DEPLOY.md)
 
-### Get a Summary of Your Deployed Function App
+### Get a Summary of Your Deployed Service
 
 To see a basic summary of your application (same format as the dry-run summary above), run:
 
@@ -116,7 +116,7 @@ You can also get information services with different stages, regions or resource
 $ sls info --stage prod --region westus2
 ```
 
-### Test Your Function App
+### Test Your Service
 
 Invoke your HTTP functions without ever leaving the CLI using:
 
@@ -133,7 +133,7 @@ $ sls invoke -f <functionName>
 
 ##### Example
 
-After deploying template function app, run
+After deploying template service, run
 
 ```bash
 $ sls invoke -f hello -d '{"name": "Azure"}'
@@ -151,15 +151,15 @@ If you have your service running locally (in another terminal), you can run:
 $ sls invoke local -f hello -p data.json
 ```
 
-If you configured your function app to [run with APIM](./docs/examples/apim.md), you can run:
+If you configured your service to [run with APIM](./docs/examples/apim.md), you can run:
 
 ```bash
 $ sls invoke apim -f hello -p data.json
 ```
 
-### Roll Back Your Function App
+### Roll Back Your Service
 
-To roll back your function app to a previous deployment, simply select a timestamp of a previous deployment and use `rollback` command.
+To roll back your service to a previous deployment, simply select a timestamp of a previous deployment and use `rollback` command.
 
 ```bash
 # List all deployments to know the timestamp for rollback
@@ -179,7 +179,7 @@ Timestamp: 1561479444
 Datetime: 2019-06-25T16:17:24+00:00
 -----------
 
-# Rollback Function App to timestamp
+# Rollback Service to timestamp
 $ sls rollback -t 1561479506
 ```
 
@@ -187,9 +187,9 @@ This will update the app code and infrastructure to the selected previous deploy
 
 For more details, check out our [rollback docs](https://github.com/serverless/serverless-azure-functions/blob/master/docs/ROLLBACK.md).
 
-### Deleting Your Function App
+### Deleting Your Service
 
-If at any point you no longer need your service, you can run the following command to delete the resource group containing your Azure Function App and other depoloyed resources using:
+If at any point you no longer need your service, you can run the following command to delete the resource group containing your Azure Service and other depoloyed resources using:
 
 ```bash
 $ sls remove
@@ -205,7 +205,7 @@ $ sls remove --force
 
 ### Creating or removing Azure Functions
 
-To create a new Azure Function within your function app, run the following command from within your app's directory:
+To create a new Azure Function within your service, run the following command from within your app's directory:
 
 ```bash
 # -n or --name for name of new function
@@ -214,7 +214,7 @@ $ sls func add -n {functionName}
 
 This will create a new handler file at the root of your project with the title `{functionName}.js`. It will also update `serverless.yml` to contain the new function.
 
-To remove an existing Azure Function from your function app, run the following command from within your app's directory:
+To remove an existing Azure Function from your service, run the following command from within your app's directory:
 
 ```bash
 # -n or --name for name of function to remove
@@ -277,8 +277,8 @@ The getting started walkthrough illustrates the interactive login experience, wh
 ### Example Usage
 
 - **[Visit our sample repos](https://github.com/serverless/serverless-azure-functions/blob/master/docs/examples/samples.md) for full projects with different use cases**
-- Check out our [integration test configurations](https://github.com/serverless/serverless-azure-functions/tree/master/integrationTests/configurations). We use these to validate that we can package, deploy, invoke and remove function apps of all the major runtime configurations that we support, so these are a pretty good example of things that should work
-- [Configuring API Management](https://github.com/serverless/serverless-azure-functions/blob/master/docs/examples/apim.md) that sits in front of function app
+- Check out our [integration test configurations](https://github.com/serverless/serverless-azure-functions/tree/master/integrationTests/configurations). We use these to validate that we can package, deploy, invoke and remove services of all the major runtime configurations that we support, so these are a pretty good example of things that should work
+- [Configuring API Management](https://github.com/serverless/serverless-azure-functions/blob/master/docs/examples/apim.md) that sits in front of service
 
 ### Logging Verbosity
 

--- a/docs/providers/azure/guide/services.md
+++ b/docs/providers/azure/guide/services.md
@@ -112,7 +112,7 @@ When you deploy a service, all of the Functions, and Events in your `serverless.
 To deploy a service, first `cd` into the relevant service directory:
 
 ```bash
-cd my-function-app
+cd my-service
 ```
 
 Then use the `deploy` command:

--- a/docs/providers/azure/guide/services.md
+++ b/docs/providers/azure/guide/services.md
@@ -1,33 +1,33 @@
 <!--
-title: Serverless Framework - Azure Functions Guide - Function Apps
-menuText: Function Apps
+title: Serverless Framework - Azure Functions Guide - Services
+menuText: Services
 menuOrder: 4
-description: How to manage and configure serverless function apps, which contain your Azure Functions, their events and resources.
+description: How to manage and configure serverless services, which contain your Azure Functions, their events and resources.
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/azure/guide/function-apps)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/azure/guide/services)
 
 <!-- DOCS-SITE-LINK:END -->
 
-# Azure - Function Apps
+# Azure - Services
 
-A `function app` is like a project. It's where you define your Azure Functions, the `events` that trigger them and any `resources` they require, all in a file called `serverless.yml`.
+A `service` is like a project. It's where you define your Azure Functions, the `events` that trigger them and any `resources` they require, all in a file called `serverless.yml`.
 
-To get started building your first Serverless Framework project, create a `function app`.
+To get started building your first Serverless Framework project, create a `service`.
 
 ## Organization
 
-In the beginning of an application, many people use a single function app to define all of the Functions, Events and Resources for that project. This is what we recommend in the beginning.
+In the beginning of an application, many people use a single service to define all of the Functions, Events and Resources for that project. This is what we recommend in the beginning.
 
 ```bash
 myFunctionApp/
   serverless.yml  # Contains all functions and infrastructure resources
 ```
 
-However, as your application grows, you can break it out into multiple function apps. A lot of people organize their function apps by workflows or data models, and group the functions related to those workflows and data models together in the function app.
+However, as your application grows, you can break it out into multiple services. A lot of people organize their services by workflows or data models, and group the functions related to those workflows and data models together in the service.
 
 ```bash
 users/
@@ -42,7 +42,7 @@ This makes sense since related functions usually use common infrastructure resou
 
 ## Creation
 
-To get started, you can simply use the `create` command to generate a new function app:
+To get started, you can simply use the `create` command to generate a new service:
 
 ```bash
 serverless create -t azure-nodejs --path <my-app>
@@ -58,17 +58,17 @@ You'll see the following files in your working directory:
 
 ### serverless.yml
 
-Each `function app` configuration is managed in the `serverless.yml` file. The main responsibilities of this file are:
+Each `service` configuration is managed in the `serverless.yml` file. The main responsibilities of this file are:
 
-- Declare a function app
-- Define one or more functions in the function app
-  - Define the provider the function app will be deployed to (and the runtime if provided)
-  - Define any custom plugins to be used
-  - Define events that trigger each function to execute (e.g. HTTP requests)
-  - Allow events listed in the `events` section to automatically create the resources required for the event upon deployment
-  - Allow flexible configuration using Serverless Variables
+- Declare a service
+- Define one or more functions in the service
+- Define the provider the service will be deployed to (and the runtime if provided)
+- Define any custom plugins to be used
+- Define events that trigger each function to execute (e.g. HTTP requests)
+- Allow events listed in the `events` section to automatically create the resources required for the event upon deployment
+- Allow flexible configuration using Serverless Variables
 
-You can see the name of the function app, the provider configuration and the first function inside the `functions` definition which points to the `handler.js` file. Any further function app configuration will be done in this file.
+You can see the name of the service, the provider configuration and the first function inside the `functions` definition which points to the `handler.js` file. Any further service configuration will be done in this file.
 
 ```yml
 # serverless.yml
@@ -107,9 +107,9 @@ The `hello/goodbye.js` files contains your function code. There are two function
 
 ## Deployment
 
-When you deploy a function app, all of the Functions, and Events in your `serverless.yml` are translated into calls to the platform API to dynamically define those resources.
+When you deploy a service, all of the Functions, and Events in your `serverless.yml` are translated into calls to the platform API to dynamically define those resources.
 
-To deploy a function app, first `cd` into the relevant function app directory:
+To deploy a service, first `cd` into the relevant service directory:
 
 ```bash
 cd my-function-app
@@ -125,17 +125,17 @@ Check out the [deployment guide](https://serverless.com/framework/docs/providers
 
 ## Removal
 
-To easily remove your function app from your Azure Functions account, you can use the `remove` command.
+To easily remove your service from your Azure Functions account, you can use the `remove` command.
 
 Run `serverless remove -v` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
 
-Serverless will start the removal and informs you about it's process on the console. A success message is printed once the whole function app is removed.
+Serverless will start the removal and informs you about it's process on the console. A success message is printed once the whole service is removed.
 
-The removal process removes the entire resource group containing your function app with its ancillary resources.
+The removal process removes the entire resource group containing your service with its ancillary resources.
 
 ## Version Pinning
 
-The Serverless framework is usually installed globally via `npm i -g serverless`. This way you have the Serverless CLI available for all your function apps.
+The Serverless framework is usually installed globally via `npm i -g serverless`. This way you have the Serverless CLI available for all your services.
 
 Installing tools globally has the downside that the version can't be pinned inside package.json. This can lead to issues if you upgrade Serverless, but your colleagues or CI system don't. You can now use a new feature in your serverless.yml which is available only in the latest version without worrying that your CI system will deploy with an old version of Serverless.
 
@@ -165,11 +165,11 @@ frameworkVersion: ^2.1.0 # >=2.1.0 && <3.0.0
 …
 ```
 
-## Installing Serverless in an existing function app
+## Installing Serverless in an existing service
 
-If you already have a Serverless function app, and would prefer to lock down the framework version using `package.json`, then you can install Serverless as follows:
+If you already have a Serverless service, and would prefer to lock down the framework version using `package.json`, then you can install Serverless as follows:
 
 ```bash
-# from within a function app
+# from within a service
 npm i serverless --save-dev
 ```

--- a/docs/providers/azure/guide/workflow.md
+++ b/docs/providers/azure/guide/workflow.md
@@ -19,21 +19,21 @@ Intro. Quick recommendations and tips for various processes.
 ### Development Workflow
 
 1. Write your functions
-2. Run function app locally by using `sls offline` and `npm start` (or `func host start`). See [quickstart](./quick-start).
-3. Use `serverless deploy` to deploy your function app (preferably in a CI/CD environment)
+2. Run service locally by using `sls offline` and `npm start` (or `func host start`). See [quickstart](./quick-start).
+3. Use `serverless deploy` to deploy your service (preferably in a CI/CD environment)
 4. Use `serverless invoke -f myFunction` to test your Azure Functions.
 
 ### Larger Projects
 
-- Break your application/project into multiple Function Apps.
-- Model your Function Apps around Data Models or Workflows.
-- Keep the Functions and Resources in your Function Apps to a minimum.
+- Break your application/project into multiple Services.
+- Model your Services around Data Models or Workflows.
+- Keep the Functions and Resources in your Services to a minimum.
 
 ## Cheat Sheet
 
 A handy list of commands to use when developing with the Serverless Framework.
 
-##### Create A Function App:
+##### Create A Service:
 
 Install the boilerplate application:
 
@@ -59,7 +59,7 @@ serverless install -u [GITHUB URL OF SERVICE]
 
 ##### Deploy
 
-Use this when you have made changes to your Function App
+Use this when you have made changes to your Service
 
 ```
 sls deploy


### PR DESCRIPTION
Swap "Function App" for "Services" in the azure intro guide.
Rename function-apps.md to services.md
Replace "Function Apps" for "Services" in services.md