### PR TITLE
fix(AWS API Gateway): Ensure to attach validator when required

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
@@ -12,15 +12,27 @@ module.exports = {
         resourceName,
         event.http.method
       );
-
+      const template =
+        this.serverless.service.provider.compiledCloudFormationTemplate.Resources[methodLogicalId];
       let validatorLogicalId;
       let validatorName;
 
+      if (
+        event.http.request &&
+        event.http.request.parameters &&
+        // check if any parameters are marked as required
+        Object.values(event.http.request.parameters || {}).some((x) => x)
+      ) {
+        if (!validatorLogicalId) {
+          const requestValidator = this.createRequestValidator();
+          validatorLogicalId = requestValidator.validatorLogicalId;
+          validatorName = requestValidator.validatorName;
+        }
+
+        template.Properties.RequestValidatorId = { Ref: validatorLogicalId };
+      }
+
       if (event.http.request && event.http.request.schemas) {
-        const template =
-          this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-            methodLogicalId
-          ];
         for (const [contentType, schemaConfig] of _.entries(event.http.request.schemas)) {
           let modelLogicalId;
 
@@ -90,10 +102,6 @@ module.exports = {
         }
       } else if (event.http.request && event.http.request.schema) {
         // Old functionality
-        const template =
-          this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-            methodLogicalId
-          ];
         for (const [contentType, schema] of _.entries(event.http.request.schema)) {
           const modelLogicalId = this.provider.naming.getEndpointModelLogicalId(
             resourceName,

--- a/test/fixtures/programmatic/requestParameters/serverless.yml
+++ b/test/fixtures/programmatic/requestParameters/serverless.yml
@@ -1,0 +1,75 @@
+service: service
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  lambdaHashingVersion: 20201221
+
+functions:
+  target:
+    handler: target.handler
+    events:
+      - http:
+          path: no-params
+          method: get
+      - http:
+          path: querystrings-not-required
+          method: get
+          request:
+            parameters:
+              querystrings:
+                url: false
+      - http:
+          path: querystrings-required
+          method: get
+          request:
+            parameters:
+              querystrings:
+                url: true
+      - http:
+          path: headers-not-required
+          method: get
+          request:
+            parameters:
+              headers:
+                foo: false
+      - http:
+          path: headers-required
+          method: get
+          request:
+            parameters:
+              headers:
+                foo: true
+      - http:
+          path: paths-not-required
+          method: get
+          request:
+            parameters:
+              paths:
+                bar: false
+      - http:
+          path: paths-required
+          method: get
+          request:
+            parameters:
+              paths:
+                bar: true
+      - http:
+          path: no-params-with-schema
+          method: get
+          request:
+            schemas:
+              application/json:
+                schema:
+                  $schema: http://json-schema.org/schema#
+      - http:
+          path: params-with-schema
+          method: get
+          request:
+            schemas:
+              application/json:
+                schema:
+                  $schema: http://json-schema.org/schema#
+            parameters:
+              querystrings:
+                url: true

--- a/test/fixtures/programmatic/requestParameters/target.js
+++ b/test/fixtures/programmatic/requestParameters/target.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports.handler = () => {
+  return {
+    statusCode: 200,
+    body: 'OK',
+  };
+};

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -40,6 +40,7 @@ describe('AwsCompileApigEvents', () => {
     let compileRestApiStub;
     let compileResourcesStub;
     let compileMethodsStub;
+    let compileRequestValidatorsStub;
     let compileDeploymentStub;
     let compileUsagePlanStub;
     let compilePermissionsStub;
@@ -51,6 +52,9 @@ describe('AwsCompileApigEvents', () => {
       compileRestApiStub = sinon.stub(awsCompileApigEvents, 'compileRestApi').resolves();
       compileResourcesStub = sinon.stub(awsCompileApigEvents, 'compileResources').resolves();
       compileMethodsStub = sinon.stub(awsCompileApigEvents, 'compileMethods').resolves();
+      compileRequestValidatorsStub = sinon
+        .stub(awsCompileApigEvents, 'compileRequestValidators')
+        .resolves();
       compileDeploymentStub = sinon.stub(awsCompileApigEvents, 'compileDeployment').resolves();
       compileUsagePlanStub = sinon.stub(awsCompileApigEvents, 'compileUsagePlan').resolves();
       compilePermissionsStub = sinon.stub(awsCompileApigEvents, 'compilePermissions').resolves();
@@ -65,6 +69,7 @@ describe('AwsCompileApigEvents', () => {
       awsCompileApigEvents.compileRestApi.restore();
       awsCompileApigEvents.compileResources.restore();
       awsCompileApigEvents.compileMethods.restore();
+      awsCompileApigEvents.compileRequestValidators.restore();
       awsCompileApigEvents.compileDeployment.restore();
       awsCompileApigEvents.compileUsagePlan.restore();
       awsCompileApigEvents.compilePermissions.restore();
@@ -99,7 +104,8 @@ describe('AwsCompileApigEvents', () => {
         expect(compileRestApiStub.calledAfter(validateStub)).to.be.equal(true);
         expect(compileResourcesStub.calledAfter(compileRestApiStub)).to.be.equal(true);
         expect(compileMethodsStub.calledAfter(compileResourcesStub)).to.be.equal(true);
-        expect(compileDeploymentStub.calledAfter(compileMethodsStub)).to.be.equal(true);
+        expect(compileRequestValidatorsStub.calledAfter(compileMethodsStub)).to.be.equal(true);
+        expect(compileDeploymentStub.calledAfter(compileRequestValidatorsStub)).to.be.equal(true);
         expect(compileUsagePlanStub.calledAfter(compileDeploymentStub)).to.be.equal(true);
         expect(compilePermissionsStub.calledAfter(compileUsagePlanStub)).to.be.equal(true);
         expect(compileStageStub.calledAfter(compilePermissionsStub)).to.be.equal(true);


### PR DESCRIPTION
Closes: #5034 

This is a simple bugfix/PR that sets the `RequestValidatorId` when the `function.request.parameters` configuration option is present.