### PR TITLE
fix(Plugins): Improve error message when a plugin is missing

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -187,11 +187,14 @@ class PluginManager {
               return null;
             }
 
+            const isLocalPlugin = name.startsWith('./');
+
             throw new ServerlessError(
               [
                 `Serverless plugin "${name}" not found.`,
                 ' Make sure it\'s installed and listed in the "plugins" section',
                 ' of your serverless config file.',
+                isLocalPlugin ? '' : ` Run "serverless plugin install -n ${name}" to install it.`,
               ].join(''),
               'PLUGIN_NOT_FOUND'
             );


### PR DESCRIPTION
When new Serverless Framework users deploy for the very first time, 6.3% of them will face a "Plugin not found" error:

<img width="1244" alt="Screen 2021-08-03 16-50" src="https://user-images.githubusercontent.com/720328/128036570-0fc221df-d220-45e0-b582-fdedda870ed8.png">

We should aim to fix the issue upstream. But in the meantime, a simple way to improve the experience is to make the error message more actionable:

<img width="956" alt="Screen 2021-08-03 16-49" src="https://user-images.githubusercontent.com/720328/128036718-edca3f8b-54f2-4649-a190-90e6755752a5.png">
