### PR TITLE
fix(AWS API Gateway): Ensure `MinimumCompressionSize` can be 0

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -97,7 +97,7 @@ module.exports = {
       );
     }
 
-    if (apiGateway.minimumCompressionSize) {
+    if (apiGateway.minimumCompressionSize != null) {
       const minimumCompressionSize = apiGateway.minimumCompressionSize;
 
       _.merge(

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -221,4 +221,21 @@ describe('lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js'
       'Fn::If': ['Condition', 'FirstVal', 'SecondVal'],
     });
   });
+
+  it('should support `provider.apiGateway.minimumCompressionSize to be set to 0`', async () => {
+    const { cfTemplate } = await runServerless({
+      fixture: 'apiGateway',
+      command: 'package',
+      configExt: {
+        provider: {
+          apiGateway: {
+            minimumCompressionSize: 0,
+          },
+        },
+      },
+    });
+    const resource = cfTemplate.Resources.ApiGatewayRestApi;
+
+    expect(resource.Properties.MinimumCompressionSize).to.equal(0);
+  });
 });


### PR DESCRIPTION
No linked issue for this one - only noticed this when trying to implement the property myself.

Change overview:
- `minimumCompressionSize` is allowed to be set to 0, however, due to the conditional statement any `0` values will not be added to the properties at deployment time
- Commit fixes the above issue and adds a test to ensure the fix