### PR TITLE
refactor(CLI): Deprecate `-v` as alias for `--verbose`

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -36,6 +36,14 @@ Note:
 - In service configuration setting is ineffective for deprecations reported before service configuration is read.
 - `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
 
+<a name="CLI_VERBOSE_OPTION_ALIAS"><div>&nbsp;</div></a>
+
+## CLI `-v` alias for `--verbose` option
+
+Deprecation code: `CLI_VERBOSE_OPTION_ALIAS`
+
+Starting with `v3.0.0`, `-v` will no longer be supported as alias for `--verbose` option. Please use `--verbose` flag instead.
+
 <a name="AWS_API_GATEWAY_DEFAULT_IDENTITY_SOURCE"><div>&nbsp;</div></a>
 
 ## Default `identitySource` for `http.authorizer`
@@ -58,7 +66,7 @@ Starting with `v3.0.0`, it will not be possible to disable default export names 
 
 Deprecation code: `CLI_DEPLOY_FUNCTION_OPTION'`
 
-Starting with v3.0.0, `--function` or `-f` option for `deploy` command will be removed. In order to deploy a single function, please use `deploy function` command instead.
+Starting with `v3.0.0`, `--function` or `-f` option for `deploy` command will be removed. In order to deploy a single function, please use `deploy function` command instead.
 
 <a name="CHANGE_OF_DEFAULT_RUNTIME_TO_NODEJS14X"><div>&nbsp;</div></a>
 

--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -404,7 +404,6 @@ class Serverless {
       return;
     }
     this.cli.suppressLogIfPrintCommand(this.processedInput);
-
     // make sure the command exists before doing anything else
     this.pluginManager.validateCommand(this.processedInput.commands);
 
@@ -425,6 +424,16 @@ class Serverless {
             '(new resolver reported no more variables to resolve)'
         );
       }
+    }
+
+    if (
+      process.argv.slice(2).includes('-v') &&
+      _.get(resolveCliInput().commandSchema, 'options.verbose.shortcut') === 'v'
+    ) {
+      this._logDeprecation(
+        'CLI_VERBOSE_OPTION_ALIAS',
+        'Starting with v3.0.0, "-v" will no longer be supported as alias for "--verbose" option. Please use "--verbose" flag instead.'
+      );
     }
 
     if (resolveCliInput().commands[0] !== 'plugin') {

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -268,6 +268,7 @@ const processSpanPromise = (async () => {
             // If command was not recognized in previous resolution phases
             // parse args again also against schemas commands which require AWS service context
             resolveInput.clear();
+
             ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
               require('../lib/cli/commands-schema/aws-service')
             ));


### PR DESCRIPTION
Closes: #9694 