### PR TITLE
refactor(AWS API Gateway): Deprecate default `identitySource`

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -36,6 +36,14 @@ Note:
 - In service configuration setting is ineffective for deprecations reported before service configuration is read.
 - `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
 
+<a name="AWS_API_GATEWAY_DEFAULT_IDENTITY_SOURCE"><div>&nbsp;</div></a>
+
+## Default `identitySource` for `http.authorizer`
+
+Deprecation code: `AWS_API_GATEWAY_DEFAULT_IDENTITY_SOURCE`
+
+Starting with `v3.0.0`, `functions[].events[].http.authorizer.identitySource` will no longer be set to "method.request.header.Authorization" by default. If you want to keep this setting, please set it explicitly in your configuration. If you do not want this to be set, please set it explicitly to `null`.
+
 <a name="DISABLE_DEFAULT_OUTPUT_EXPORT_NAMES"><div>&nbsp;</div></a>
 
 ## Disable default Output Export names

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -266,6 +266,33 @@ class AwsCompileApigEvents {
 
         if (
           this.serverless.service.provider.name === 'aws' &&
+          Object.values(this.serverless.service.functions).some(({ events }) =>
+            events.some(({ http }) => {
+              if (http && http.authorizer) {
+                if (_.isObject(http.authorizer)) {
+                  // Deprecation should not apply to already existing, external authorizers
+                  if (http.authorizer.authorizerId) return false;
+                  // Deprecation should not apply to `aws_iam` authorization type
+                  if (http.authorizer.type && http.authorizer.type.toUpperCase() === 'AWS_IAM') {
+                    return false;
+                  }
+                  return http.authorizer.identitySource === undefined;
+                }
+                // Authorizer is defined as a string and we want to check if its `aws_iam` - in such case the deprecation will not apply
+                return !(http.authorizer.toUpperCase() === 'AWS_IAM');
+              }
+              return false;
+            })
+          )
+        ) {
+          this.serverless._logDeprecation(
+            'AWS_API_GATEWAY_DEFAULT_IDENTITY_SOURCE',
+            'Starting with v3.0.0, "functions[].events[].http.authorizer.identitySource" will no longer be set to "method.request.header.Authorization" by default.\nIf you want to keep this setting, please set it explicitly in your configuration. If you do not want this to be set, please set it explicitly to "null".'
+          );
+        }
+
+        if (
+          this.serverless.service.provider.name === 'aws' &&
           this.serverless.service.provider.apiGateway &&
           this.serverless.service.provider.apiGateway.restApiId &&
           this.serverless.service.provider.tracing &&

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
@@ -231,7 +231,18 @@ describe('#compileAuthorizers() #2', () => {
           },
           authorized: {
             handler: 'index.handler',
-            events: [{ http: { method: 'get', path: '/authorized', authorizer: 'foo' } }],
+            events: [
+              {
+                http: {
+                  method: 'get',
+                  path: '/authorized',
+                  authorizer: {
+                    name: 'foo',
+                    identitySource: 'method.request.header.Authorization',
+                  },
+                },
+              },
+            ],
           },
         },
       },


### PR DESCRIPTION
Addresses: #9458 

Addresses first part of linked issue by introducing deprecation. The breaking change should be introduced with next major release.