### PR TITLE
refactor(AWS API Gateway): Adjust deprecation for `identitySource`

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -50,7 +50,7 @@ Starting with `v3.0.0`, `-v` will no longer be supported as alias for `--verbose
 
 Deprecation code: `AWS_API_GATEWAY_DEFAULT_IDENTITY_SOURCE`
 
-Starting with `v3.0.0`, `functions[].events[].http.authorizer.identitySource` will no longer be set to "method.request.header.Authorization" by default. If you want to keep this setting, please set it explicitly in your configuration. If you do not want this to be set, please set it explicitly to `null`.
+Starting with v3.0.0, `functions[].events[].http.authorizer.identitySource` will no longer be set to "method.request.header.Authorization" by default for authorizers of "request" type with caching disabled ("resultTtlInSeconds" set to "0"). If you want to keep this setting, please set it explicitly in your configuration. If you do not want this to be set, please set it explicitly to "null".
 
 <a name="DISABLE_DEFAULT_OUTPUT_EXPORT_NAMES"><div>&nbsp;</div></a>
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -268,26 +268,20 @@ class AwsCompileApigEvents {
           this.serverless.service.provider.name === 'aws' &&
           Object.values(this.serverless.service.functions).some(({ events }) =>
             events.some(({ http }) => {
-              if (http && http.authorizer) {
-                if (_.isObject(http.authorizer)) {
-                  // Deprecation should not apply to already existing, external authorizers
-                  if (http.authorizer.authorizerId) return false;
-                  // Deprecation should not apply to `aws_iam` authorization type
-                  if (http.authorizer.type && http.authorizer.type.toUpperCase() === 'AWS_IAM') {
-                    return false;
-                  }
-                  return http.authorizer.identitySource === undefined;
-                }
-                // Authorizer is defined as a string and we want to check if its `aws_iam` - in such case the deprecation will not apply
-                return !(http.authorizer.toUpperCase() === 'AWS_IAM');
-              }
-              return false;
+              return (
+                http &&
+                _.isObject(http.authorizer) &&
+                http.authorizer.type &&
+                http.authorizer.type.toUpperCase() === 'REQUEST' &&
+                http.authorizer.identitySource === undefined &&
+                http.authorizer.resultTtlInSeconds === 0
+              );
             })
           )
         ) {
           this.serverless._logDeprecation(
             'AWS_API_GATEWAY_DEFAULT_IDENTITY_SOURCE',
-            'Starting with v3.0.0, "functions[].events[].http.authorizer.identitySource" will no longer be set to "method.request.header.Authorization" by default.\nIf you want to keep this setting, please set it explicitly in your configuration. If you do not want this to be set, please set it explicitly to "null".'
+            'Starting with v3.0.0, "functions[].events[].http.authorizer.identitySource" will no longer be set to "method.request.header.Authorization" by default for authorizers of "request" type with caching disabled ("resultTtlInSeconds" set to "0").\nIf you want to keep this setting, please set it explicitly in your configuration. If you do not want this to be set, please set it explicitly to "null".'
           );
         }
 

--- a/test/fixtures/programmatic/apiGatewayExtended/serverless.yml
+++ b/test/fixtures/programmatic/apiGatewayExtended/serverless.yml
@@ -56,7 +56,6 @@ functions:
           method: GET
           authorizer:
             name: authorizer
-            identitySource: null
   apiKeys:
     handler: core.apiKeys
     events:


### PR DESCRIPTION
Related to: https://github.com/serverless/serverless/issues/9458

After investigating further the issue with failing integration test related to changes from original PR, I've discovered that my initial understanding was wrong and the deprecation should only apply to narrower scope (authorizers with `request` type and with caching disabled). It will change the planned approach a little bit and keep the configuration approaches a bit different for `http` and `httpApi` authorizers. Please let me know what do you think @medikoo 