### PR TITLE
fix(AWS Layers): Support references to external layers

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -28,6 +28,7 @@ module.exports = {
         'AWS Kafka',
         'AWS Kinesis',
         'AWS Lambda',
+        'AWS Layers',
         'AWS Local Invocation',
         'AWS MSK',
         'AWS S3',

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -6,6 +6,7 @@ const crypto = require('crypto');
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
+const log = require('@serverless/utils/log');
 const ServerlessError = require('../../../../serverless-error');
 const deepSortObjectByKey = require('../../../../utils/deepSortObjectByKey');
 const getHashForFilePath = require('../lib/getHashForFilePath');
@@ -735,11 +736,12 @@ function extractLayerConfigurationsFromFunction(functionProperties, cfTemplate) 
   functionProperties.Layers.forEach((potentialLocalLayerObject) => {
     if (potentialLocalLayerObject.Ref) {
       const configuration = cfTemplate.Resources[potentialLocalLayerObject.Ref];
+
       if (!configuration) {
-        throw new ServerlessError(
-          `Could not find reference to layer: ${potentialLocalLayerObject.Ref}. Ensure that you are referencing layer defined in your service.`,
-          'LAMBDA_LAYER_REFERENCE_NOT_FOUND'
-        );
+        if (process.env.SLS_DEBUG) {
+          log(`Could not find reference to layer: ${potentialLocalLayerObject.Ref}.`);
+        }
+        return;
       }
 
       layerConfigurations.push({


### PR DESCRIPTION
Closes: #9797 

This fix will not error out if layer referenced by `Ref` will not be found locally, but rather allow such behavior and let the deployment fail is the layer really cannot be referenced. 