### PR TITLE
Variables: Unconditionally deprecate old vars engine extensions

### DIFF
--- a/lib/configuration/variables/sources/resolve-external-plugin-sources.js
+++ b/lib/configuration/variables/sources/resolve-external-plugin-sources.js
@@ -48,10 +48,7 @@ module.exports = (configuration, resolverConfiguration, externalPlugins) => {
         resolverConfiguration.sources[sourceName] = sourceConfig;
         resolverConfiguration.fulfilledSources.add(sourceName);
       }
-    } else if (
-      externalPlugin.variableResolvers &&
-      configuration.variablesResolutionMode < 20210326
-    ) {
+    } else if (externalPlugin.variableResolvers) {
       logDeprecation(
         'NEW_VARIABLES_RESOLVER',
         `Plugin "${pluginName}" attempts to extend old variables resolver. ` +


### PR DESCRIPTION
When investigating code I've noticed a weird not logical condition which is expected to lead to deprecation when external plugin attempts to provide a new source for old variables engine.

This patch fixes that
