### PR TITLE
Ensure right deprecation code for `deploy -f` deprecation

### DIFF
--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -34,7 +34,7 @@ class Deploy {
           this.serverless.processedInput.commands.length === 1 &&
           this.serverless.processedInput.commands[0] === 'deploy';
         if (isDeployCommand && this.options.function) {
-          this.serverless.logDeprecation(
+          this.serverless._logDeprecation(
             'CLI_DEPLOY_FUNCTION_OPTION',
             'Starting with v3.0.0, `--function` or `-f` option for `deploy` command will be removed. In order to deploy a single function, please use `deploy function` command instead.'
           );


### PR DESCRIPTION
Just saw in reports, that this depredation is reported with `EXT_` prefix, as it uses our public function (dedicated for plugin usage) and not internal.

Downside was that there was no link to documentation presented. 

This patch fixes that
