### PR TITLE
refactor(CLI Onboarding): Adjust summary messages in deploy step

### DIFF
--- a/lib/cli/interactive-setup/deploy.js
+++ b/lib/cli/interactive-setup/deploy.js
@@ -15,14 +15,17 @@ const printMessage = ({
   hasBeenDeployed,
   dashboardPlugin,
   isConfiguredWithDashboard,
+  initialContext,
 }) => {
+  const projectInformationSuffix = initialContext.isInServiceContext
+    ? ''
+    : `${chalk.green(' and available in ')}${chalk.white.bold(`./${serviceName}`)}`;
+
   if (isConfiguredWithDashboard) {
     if (hasBeenDeployed) {
       process.stdout.write(
         [
-          `\n${chalk.green('Your project is live and available in ')}${chalk.white.bold(
-            `./${serviceName}`
-          )}`,
+          `\n${chalk.green('Your project is live')}${projectInformationSuffix}`,
           `\n  Run ${chalk.bold('serverless info')} in the project directory`,
           '    View your endpoints and services',
           `\n  Open ${chalk.bold(getDashboardInteractUrl(dashboardPlugin))}`,
@@ -37,9 +40,7 @@ const printMessage = ({
 
     process.stdout.write(
       [
-        `\n${chalk.green(
-          'Your project is ready for deployment and available in '
-        )}${chalk.white.bold(`./${serviceName}`)}`,
+        `\n${chalk.green('Your project is ready for deployment')}${projectInformationSuffix}`,
         `\n  Run ${chalk.bold('serverless deploy')} in the project directory`,
         '    Deploy your newly created service',
         `\n  Run ${chalk.bold('serverless info')} in the project directory after deployment`,
@@ -54,9 +55,7 @@ const printMessage = ({
   if (hasBeenDeployed) {
     process.stdout.write(
       [
-        `\n${chalk.green('Your project is live and available in ')}${chalk.white.bold(
-          `./${serviceName}`
-        )}`,
+        `\n${chalk.green('Your project is live')}${projectInformationSuffix}`,
         `\n  Run ${chalk.bold('serverless info')} in the project directory`,
         '    View your endpoints and services',
         `\n  Run ${chalk.bold('serverless deploy')} in the directory`,
@@ -74,9 +73,7 @@ const printMessage = ({
 
   process.stdout.write(
     [
-      `\n${chalk.green('Your project is ready for deployment and available in ')}${chalk.white.bold(
-        `./${serviceName}`
-      )}`,
+      `\n${chalk.green('Your project is ready for deployment')}${projectInformationSuffix}`,
       `\n  Run ${chalk.bold('serverless deploy')} in the project directory`,
       '    Deploy your newly created service',
       `\n  Run ${chalk.bold('serverless info')} in the project directory after deployment`,
@@ -131,7 +128,7 @@ module.exports = {
     context.inapplicabilityReasonCode = 'NO_CREDENTIALS_CONFIGURED';
     return false;
   },
-  async run({ configuration, configurationFilename, serviceDir, stepHistory }) {
+  async run({ initial, configuration, configurationFilename, serviceDir, stepHistory }) {
     const serviceName = configuration.service;
     const shouldDeploy = await promptWithHistory({
       name: 'shouldDeploy',
@@ -141,6 +138,7 @@ module.exports = {
     });
     if (!shouldDeploy) {
       printMessage({
+        initialContext: initial,
         serviceName,
         hasBeenDeployed: false,
         isConfiguredWithDashboard: Boolean(configuration.org),
@@ -184,6 +182,7 @@ module.exports = {
     }
 
     printMessage({
+      initialContext: initial,
       serviceName,
       hasBeenDeployed: true,
       isConfiguredWithDashboard: Boolean(configuration.org),

--- a/lib/cli/interactive-setup/index.js
+++ b/lib/cli/interactive-setup/index.js
@@ -34,7 +34,9 @@ module.exports = async (context) => {
     });
   };
 
-  commandUsage.initialContext = resolveInitialContext(context);
+  const initialContext = resolveInitialContext(context);
+  commandUsage.initialContext = initialContext;
+  context.initial = initialContext;
 
   for (const [stepName, step] of Object.entries(steps)) {
     delete context.stepHistory;


### PR DESCRIPTION
Closes: https://github.com/serverless/serverless/issues/9822

That's how it's going to look like after changes:

![deployyes](https://user-images.githubusercontent.com/17499590/129204906-7c498da9-967e-4a5d-8f28-cce9f7f6cfa3.png)

![deployno](https://user-images.githubusercontent.com/17499590/129204914-f2c46ce0-2799-4e41-aef0-2dcf225ec494.png)
