### PR TITLE
docs: Add `generate-event` CLI command description

### DIFF
--- a/docs/providers/aws/cli-reference/generate-event.md
+++ b/docs/providers/aws/cli-reference/generate-event.md
@@ -1,0 +1,56 @@
+<!--
+title: Serverless Framework Commands - AWS Lambda - Generate Event
+menuText: generate event
+menuOrder: 21
+description: Generate sample Lambda function event payload
+layout: Doc
+-->
+
+# AWS - Generate Event
+
+Creates sample Lambda function payloads for different types of events.
+
+```bash
+serverless generate-event --type eventType
+```
+
+## Options
+
+- `--type` or `-t` The type of the event to generate payload for. **Required**.
+- `--body` or `-b` The body for the message, request, or stream event.
+
+## Available event types
+
+- aws:alexaSkill
+- aws:alexaSmartHome
+- aws:apiGateway
+- aws:cloudWatch
+- aws:cloudWatchLog
+- aws:cognitoUserPool
+- aws:dynamo
+- aws:iot
+- aws:kinesis
+- aws:s3
+- aws:sns
+- aws:sqs
+- aws:websocket
+
+## Examples
+
+### Generate SQS event payload
+
+```bash
+serverless generate-event -t aws:sqs
+```
+
+### Generate Kinesis event payload with body
+
+```bash
+serverless generate-event -t aws:kinesis -b '{"foo": "bar"}'
+```
+
+### Generate SQS event and save it to a file
+
+```bash
+serverless generate-event -t aws:sqs > event.json
+```

--- a/docs/providers/aws/cli-reference/print.md
+++ b/docs/providers/aws/cli-reference/print.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Print
 menuText: print
-menuOrder: 21
+menuOrder: 22
 description: Print your config with all variables resolved for debugging
 layout: Doc
 -->

--- a/docs/providers/aws/cli-reference/slstats.md
+++ b/docs/providers/aws/cli-reference/slstats.md
@@ -1,7 +1,7 @@
 <!--
 title: Serverless Framework Commands - AWS Lambda - Serverless Stats
 menuText: serverless stats
-menuOrder: 22
+menuOrder: 23
 description: Enables or disables Serverless Statistic logging within the Serverless Framework.
 layout: Doc
 -->


### PR DESCRIPTION
Closes: #9823

I put it low in the menu, just before the `print` command page. I see the pages order is not strictly alphabetical, but rather the commands are put in some logical order. If you think this should be at any other position, let me know, I will change it.