### PR TITLE
feat(AWS Lambda): Prevent external subscription filter removal

### DIFF
--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -267,10 +267,19 @@ module.exports = {
       return false;
     }
 
-    const oldSubscriptionFilters = response.subscriptionFilters.map((subscriptionFilter) => ({
-      ...subscriptionFilter,
-      logicalId: this.getLogicalIdFromFilterName(subscriptionFilter.filterName),
-    }));
+    const oldSubscriptionFilters = await Promise.all(
+      response.subscriptionFilters.map(async (subscriptionFilter) => {
+        const { destinationArn, filterName } = subscriptionFilter;
+        const functionName = this.getFunctionNameFromDestinationArn(destinationArn);
+        const logicalId = this.getLogicalIdFromFilterName(filterName);
+        const stackName = await this.provider
+          .request('CloudFormation', 'describeStackResources', { PhysicalResourceId: functionName })
+          .then(({ StackResources }) => StackResources[0].StackName)
+          .catch(() => null);
+
+        return { destinationArn, logicalId, filterName, stackName };
+      })
+    );
 
     const newSubscriptionFilters = cloudwatchLogEvents.map((cloudwatchLogEvent) => {
       const destinationArn = `arn:${partition}:lambda:${region}:${accountId}:function:${cloudwatchLogEvent.FunctionName}`;
@@ -279,59 +288,49 @@ module.exports = {
         cloudwatchLogEvent.logSubscriptionSerialNumber
       );
 
-      return {
-        destinationArn,
-        logicalId,
-      };
+      return { destinationArn, logicalId };
     });
 
-    const sameDestinationArn = (sf1, sf2) => sf1.destinationArn === sf2.destinationArn;
-    const sameLogicalId = (sf1, sf2) => sf1.logicalId === sf2.logicalId;
-
-    // Old subscription filters which don't have the same destination as any of the new subscription filters.
-    // Currently, these kinds of subscription filters are deleted.
-    // In the future, the behavior will change to not delete filters that were set up externally.
-    const notMatchedOldSubscriptionFilters = oldSubscriptionFilters.filter(
-      (oldSubscriptionFilter) => {
-        const destinationMatchNewSubscriptionFilter = newSubscriptionFilters.find(
-          (newSubscriptionFilter) =>
-            sameDestinationArn(newSubscriptionFilter, oldSubscriptionFilter)
-        );
-        return !destinationMatchNewSubscriptionFilter;
-      }
+    // Deleting external defined subscription filter is dangerous.
+    // If subscription filter defined outside of the service definition cause subscription filter limit exceed, Throw error
+    const stackName = this.provider.naming.getStackName();
+    const externalOldSubscriptionFilters = oldSubscriptionFilters.filter(
+      (oldSubscriptionFilter) => oldSubscriptionFilter.stackName !== stackName
     );
-
-    const numOfSubscriptionFiltersToDelete =
-      notMatchedOldSubscriptionFilters.length +
-      newSubscriptionFilters.length -
-      CLOUDWATCHLOG_LOG_GROUP_EVENT_PER_FUNCTION_LIMIT;
-    if (numOfSubscriptionFiltersToDelete > 0) {
-      await Promise.all(
-        notMatchedOldSubscriptionFilters
-          .slice(0, numOfSubscriptionFiltersToDelete)
-          .map((oldSubscriptionFilter) =>
-            this.provider.request('CloudWatchLogs', 'deleteSubscriptionFilter', {
-              logGroupName,
-              filterName: oldSubscriptionFilter.filterName,
-            })
-          )
+    if (
+      externalOldSubscriptionFilters.length + newSubscriptionFilters.length >
+      CLOUDWATCHLOG_LOG_GROUP_EVENT_PER_FUNCTION_LIMIT
+    ) {
+      const errorMessage = [
+        `Only ${CLOUDWATCHLOG_LOG_GROUP_EVENT_PER_FUNCTION_LIMIT} subscription filters can be configured per log group.`,
+        ` There are subscription filters defined outside of the service definition for "${logGroupName}".`,
+        ' You have to manually delete subscription filters externally configured in log group.',
+      ].join('');
+      throw new ServerlessError(
+        errorMessage,
+        'CLOUDWATCHLOG_LOG_GROUP_EVENT_PER_FUNCTION_LIMIT_EXCEEDED'
       );
     }
 
-    // Old subscription filters which have same destination with one of the new subscription filter, but index of log event in function has been changed.
-    // If log event order changed, we should delete old subscription filters before creation.
-    const logEventOrderChangedOldSubscriptionFilters = oldSubscriptionFilters.filter(
-      (oldSubscriptionFilter) => {
-        const logEventOrderChangedNewSubscriptionFilter = newSubscriptionFilters.find(
-          (newSubscriptionFilter) =>
-            sameDestinationArn(newSubscriptionFilter, oldSubscriptionFilter) &&
-            !sameLogicalId(newSubscriptionFilter, oldSubscriptionFilter)
+    const sameDestinationArn = (sf1, sf2) => sf1.destinationArn === sf2.destinationArn;
+    const sameLogicalId = (sf1, sf2) => sf1.logicalId === sf2.logicalId;
+    const subscriptionFilterComparator = (sf1, sf2) =>
+      sameDestinationArn(sf1, sf2) && sameLogicalId(sf1, sf2);
+
+    const internalOldSubscriptionFilters = oldSubscriptionFilters.filter(
+      (oldSubscriptionFilter) => oldSubscriptionFilter.stackName === stackName
+    );
+    const notMatchedInternalOldSubscriptionFilters = internalOldSubscriptionFilters.filter(
+      (internalOldSubscriptionFilter) => {
+        const matchNewSubscriptionFilter = newSubscriptionFilters.find((newSubscriptionFilter) =>
+          subscriptionFilterComparator(newSubscriptionFilter, internalOldSubscriptionFilter)
         );
-        return logEventOrderChangedNewSubscriptionFilter;
+        return !matchNewSubscriptionFilter;
       }
     );
+
     return Promise.all(
-      logEventOrderChangedOldSubscriptionFilters.map((oldSubscriptionFilter) =>
+      notMatchedInternalOldSubscriptionFilters.map((oldSubscriptionFilter) =>
         this.provider.request('CloudWatchLogs', 'deleteSubscriptionFilter', {
           logGroupName,
           filterName: oldSubscriptionFilter.filterName,
@@ -346,5 +345,12 @@ module.exports = {
     // Note that the stack name can include hyphens
     const split = filterName.split('-');
     return split[split.length - 2];
+  },
+
+  getFunctionNameFromDestinationArn(destinationArn) {
+    // Destination arn format:
+    // arn:{partition}:lambda:{region}:{accountId}:function:{functionName}
+    const split = destinationArn.split(':function:');
+    return split[1];
   },
 };

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -272,13 +272,11 @@ module.exports = {
       response.subscriptionFilters.map(async (subscriptionFilter) => {
         const { destinationArn, filterName } = subscriptionFilter;
         const logicalId = this.getLogicalIdFromFilterName(filterName);
-        const isInternal = await this.provider
-          .request('CloudFormation', 'describeStackResource', {
-            StackName: stackName,
-            LogicalResourceId: logicalId,
-          })
-          .then(({ StackResourceDetail }) => filterName === StackResourceDetail.PhysicalResourceId)
-          .catch(() => false);
+        const isInternal = await this.isInternalSubscriptionFilter(
+          stackName,
+          logicalId,
+          filterName
+        );
 
         return { destinationArn, logicalId, filterName, isInternal };
       })
@@ -346,5 +344,22 @@ module.exports = {
     // Note that the stack name can include hyphens
     const split = filterName.split('-');
     return split[split.length - 2];
+  },
+
+  async isInternalSubscriptionFilter(stackName, logicalResourceId, physicalResourceId) {
+    try {
+      const { StackResourceDetail } = await this.provider.request(
+        'CloudFormation',
+        'describeStackResource',
+        {
+          StackName: stackName,
+          LogicalResourceId: logicalResourceId,
+        }
+      );
+
+      return physicalResourceId === StackResourceDetail.PhysicalResourceId;
+    } catch {
+      return false;
+    }
   },
 };

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -302,8 +302,7 @@ module.exports = {
     ) {
       const errorMessage = [
         `Only ${CLOUDWATCHLOG_LOG_GROUP_EVENT_PER_FUNCTION_LIMIT} subscription filters can be configured per log group.`,
-        ` There are subscription filters defined outside of the service definition for "${logGroupName}".`,
-        ' You have to manually delete subscription filters externally configured in log group.',
+        ` There are subscription filters defined outside of the service definition for "${logGroupName}" that have to be deleted manually.`,
       ].join('');
       throw new ServerlessError(
         errorMessage,

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -292,8 +292,9 @@ module.exports = {
       return { destinationArn, logicalId };
     });
 
-    // Deleting external defined subscription filter is dangerous.
-    // If subscription filter defined outside of the service definition cause subscription filter limit exceed, Throw error
+    // If subscription filters defined externally cause a situation where we cannot create all
+    // subscription filters defined as a part of current service, we want to throw an error
+    // instead of silently removing external filters.
     const externalOldSubscriptionFilters = oldSubscriptionFilters.filter(
       (oldSubscriptionFilter) => !oldSubscriptionFilter.isInternal
     );

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -270,10 +270,9 @@ module.exports = {
     const oldSubscriptionFilters = await Promise.all(
       response.subscriptionFilters.map(async (subscriptionFilter) => {
         const { destinationArn, filterName } = subscriptionFilter;
-        const functionName = this.getFunctionNameFromDestinationArn(destinationArn);
         const logicalId = this.getLogicalIdFromFilterName(filterName);
         const stackName = await this.provider
-          .request('CloudFormation', 'describeStackResources', { PhysicalResourceId: functionName })
+          .request('CloudFormation', 'describeStackResources', { PhysicalResourceId: filterName })
           .then(({ StackResources }) => StackResources[0].StackName)
           .catch(() => null);
 
@@ -345,12 +344,5 @@ module.exports = {
     // Note that the stack name can include hyphens
     const split = filterName.split('-');
     return split[split.length - 2];
-  },
-
-  getFunctionNameFromDestinationArn(destinationArn) {
-    // Destination arn format:
-    // arn:{partition}:lambda:{region}:{accountId}:function:{functionName}
-    const split = destinationArn.split(':function:');
-    return split[1];
   },
 };

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -267,16 +267,20 @@ module.exports = {
       return false;
     }
 
+    const stackName = this.provider.naming.getStackName();
     const oldSubscriptionFilters = await Promise.all(
       response.subscriptionFilters.map(async (subscriptionFilter) => {
         const { destinationArn, filterName } = subscriptionFilter;
         const logicalId = this.getLogicalIdFromFilterName(filterName);
-        const stackName = await this.provider
-          .request('CloudFormation', 'describeStackResources', { PhysicalResourceId: filterName })
-          .then(({ StackResources }) => StackResources[0].StackName)
-          .catch(() => null);
+        const isInternal = await this.provider
+          .request('CloudFormation', 'describeStackResource', {
+            StackName: stackName,
+            LogicalResourceId: logicalId,
+          })
+          .then(({ StackResourceDetail }) => filterName === StackResourceDetail.PhysicalResourceId)
+          .catch(() => false);
 
-        return { destinationArn, logicalId, filterName, stackName };
+        return { destinationArn, logicalId, filterName, isInternal };
       })
     );
 
@@ -292,9 +296,8 @@ module.exports = {
 
     // Deleting external defined subscription filter is dangerous.
     // If subscription filter defined outside of the service definition cause subscription filter limit exceed, Throw error
-    const stackName = this.provider.naming.getStackName();
     const externalOldSubscriptionFilters = oldSubscriptionFilters.filter(
-      (oldSubscriptionFilter) => oldSubscriptionFilter.stackName !== stackName
+      (oldSubscriptionFilter) => !oldSubscriptionFilter.isInternal
     );
     if (
       externalOldSubscriptionFilters.length + newSubscriptionFilters.length >
@@ -316,7 +319,7 @@ module.exports = {
       sameDestinationArn(sf1, sf2) && sameLogicalId(sf1, sf2);
 
     const internalOldSubscriptionFilters = oldSubscriptionFilters.filter(
-      (oldSubscriptionFilter) => oldSubscriptionFilter.stackName === stackName
+      (oldSubscriptionFilter) => oldSubscriptionFilter.isInternal
     );
     const notMatchedInternalOldSubscriptionFilters = internalOldSubscriptionFilters.filter(
       (internalOldSubscriptionFilter) => {

--- a/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -1178,17 +1178,24 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
           },
           CloudFormation: {
             ...commonAwsSdkMock.CloudFormation,
-            describeStackResources: async (params) => {
-              const naming = serverless.getProvider('aws').naming;
-              return {
-                StackResources: [
-                  {
+            describeStackResource: sandbox
+              .stub()
+              .onFirstCall()
+              .resolves({
+                StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
+              })
+              .callsFake(async (params) => {
+                const naming = serverless.getProvider('aws').naming;
+                return {
+                  StackResourceDetail: {
                     StackName: naming.getStackName(),
-                    PhysicalResourceId: params.PhysicalResourceId,
+                    LogicalResourceId: params.LogicalResourceId,
+                    PhysicalResourceId: `${naming.getStackName()}-${
+                      params.LogicalResourceId
+                    }-xxxxx`,
                   },
-                ],
-              };
-            },
+                };
+              }),
           },
           CloudWatchLogs: {
             deleteSubscriptionFilter: deleteStub,
@@ -1247,16 +1254,20 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
           },
           CloudFormation: {
             ...commonAwsSdkMock.CloudFormation,
-            describeStackResources: async (params) => {
-              return {
-                StackResources: [
-                  {
-                    StackName: 'external-stack-dev',
-                    PhysicalResourceId: params.PhysicalResourceId,
-                  },
-                ],
-              };
-            },
+            describeStackResource: sandbox
+              .stub()
+              .onFirstCall()
+              .resolves({
+                StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
+              })
+              .callsFake(async (params) => {
+                const naming = serverless.getProvider('aws').naming;
+                throw new Error(
+                  `Resource ${
+                    params.LogicalResourceId
+                  } does not exist for stack ${naming.getStackName()}`
+                );
+              }),
           },
           CloudWatchLogs: {
             deleteSubscriptionFilter: deleteStub,
@@ -1312,17 +1323,24 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
           },
           CloudFormation: {
             ...commonAwsSdkMock.CloudFormation,
-            describeStackResources: async (params) => {
-              const naming = serverless.getProvider('aws').naming;
-              return {
-                StackResources: [
-                  {
+            describeStackResource: sandbox
+              .stub()
+              .onFirstCall()
+              .resolves({
+                StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
+              })
+              .callsFake(async (params) => {
+                const naming = serverless.getProvider('aws').naming;
+                return {
+                  StackResourceDetail: {
                     StackName: naming.getStackName(),
-                    PhysicalResourceId: params.PhysicalResourceId,
+                    LogicalResourceId: params.LogicalResourceId,
+                    PhysicalResourceId: `${naming.getStackName()}-${
+                      params.LogicalResourceId
+                    }-xxxxx`,
                   },
-                ],
-              };
-            },
+                };
+              }),
           },
           CloudWatchLogs: {
             deleteSubscriptionFilter: deleteStub,
@@ -1387,17 +1405,24 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
           },
           CloudFormation: {
             ...commonAwsSdkMock.CloudFormation,
-            describeStackResources: async (params) => {
-              const naming = serverless.getProvider('aws').naming;
-              return {
-                StackResources: [
-                  {
+            describeStackResource: sandbox
+              .stub()
+              .onFirstCall()
+              .resolves({
+                StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
+              })
+              .callsFake(async (params) => {
+                const naming = serverless.getProvider('aws').naming;
+                return {
+                  StackResourceDetail: {
                     StackName: naming.getStackName(),
-                    PhysicalResourceId: params.PhysicalResourceId,
+                    LogicalResourceId: params.LogicalResourceId,
+                    PhysicalResourceId: `${naming.getStackName()}-${
+                      params.LogicalResourceId
+                    }-xxxxx`,
                   },
-                ],
-              };
-            },
+                };
+              }),
           },
           CloudWatchLogs: {
             deleteSubscriptionFilter: deleteStub,
@@ -1480,17 +1505,24 @@ describe('test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js', () => {
           },
           CloudFormation: {
             ...commonAwsSdkMock.CloudFormation,
-            describeStackResources: async (params) => {
-              const naming = serverless.getProvider('aws').naming;
-              return {
-                StackResources: [
-                  {
+            describeStackResource: sandbox
+              .stub()
+              .onFirstCall()
+              .resolves({
+                StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
+              })
+              .callsFake(async (params) => {
+                const naming = serverless.getProvider('aws').naming;
+                return {
+                  StackResourceDetail: {
                     StackName: naming.getStackName(),
-                    PhysicalResourceId: params.PhysicalResourceId,
+                    LogicalResourceId: params.LogicalResourceId,
+                    PhysicalResourceId: `${naming.getStackName()}-${
+                      params.LogicalResourceId
+                    }-xxxxx`,
                   },
-                ],
-              };
-            },
+                };
+              }),
           },
           CloudWatchLogs: {
             deleteSubscriptionFilter: deleteStub,


### PR DESCRIPTION
Closes: #8276, #9528

#### Changes
1. If external defined subscription filter cause `subscription filter per log group limit` exceed, throw error
2. Delete all not-matched(having same logical id & destination arn) subscription filter defined internally.
Previously, serverless try to delete only if limit exceed. (ex. if there is only 1 not matched subscription filter, the deletion is processed at CloudFormation, not in serverless) => the removal enforcer changed from CF to serverless

Change num#2 was applied to make code simple. If it seems awkward, it can be revert as the previous way (delete only if limit exceed)