### PR TITLE
refactor(Templates): Remove unnecessary `fmt.Sprintf` in `tencent-go`

### DIFF
--- a/lib/plugins/create/templates/tencent-go/index.go
+++ b/lib/plugins/create/templates/tencent-go/index.go
@@ -14,7 +14,7 @@ type DefineEvent struct {
 func hello(ctx context.Context, event DefineEvent) (string, error) {
 	fmt.Println("key1:", event.Key1)
 	fmt.Println("key2:", event.Key2)
-	return fmt.Sprintf("Hello World"), nil
+	return "Hello World", nil
 }
 
 func main() {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Fixed unnecessary use of `fmt.Sprintf()` in [`lib/plugins/create/templates/tencent-go`](https://github.com/serverless/serverless/blob/b751c505c8050e229edb77d44016925c4e52a05e/lib/plugins/create/templates/tencent-go/index.go#L17).
This is a very small fix, but it bothered me.