### PR TITLE
fix(AWS HTTP API): Properly handle authorizer function with alias

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -294,8 +294,7 @@ class HttpApiEvents {
     };
 
     if (functionObject && functionObject.targetAlias) {
-      permissionResource.Properties.DependsOn =
-        this.provider.naming.getLambdaLogicalId(functionName);
+      permissionResource.DependsOn = functionObject.targetAlias.logicalId;
     }
     this.cfTemplate.Resources[authorizerPermissionLogicalId] = permissionResource;
   }


### PR DESCRIPTION
Closes: #9848 