### PR TITLE
feat(AWS Lambda): Recognize `python3.9` as valid runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -530,6 +530,7 @@ class AwsProvider {
               'python3.6',
               'python3.7',
               'python3.8',
+              'python3.9',
               'ruby2.5',
               'ruby2.7',
             ],


### PR DESCRIPTION
In response to: https://aws.amazon.com/about-aws/whats-new/2021/08/aws-lambda-adds-support-python-3-9/

I've tested locally that deployments with new runtime work without issues 