### PR TITLE
fix(AWS HTTP API): Always allow to define catch-all route (#9840) 

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -8,7 +8,7 @@ const ServerlessError = require('../../../../../serverless-error');
 const { logWarning } = require('../../../../../classes/Error');
 const resolveLambdaTarget = require('../../../utils/resolveLambdaTarget');
 
-const allowedMethods = new Set(['GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', 'HEAD', 'DELETE']);
+const allowedMethods = new Set(['ANY', 'GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', 'HEAD', 'DELETE']);
 const methodPattern = new RegExp(`^(?:\\*|${Array.from(allowedMethods).join('|')})$`, 'i');
 const methodPathPattern = new RegExp(
   `^(?:\\*|(${Array.from(allowedMethods).join('|')}) (\\/\\S*))$`,
@@ -532,29 +532,11 @@ Object.defineProperties(
             method = String(method).toUpperCase();
             if (method === '*') {
               method = 'ANY';
-              if (
-                Array.from(allowedMethods, (allowedMethod) => `${allowedMethod} ${path}`).some(
-                  (duplicateRouteKey) => routes.has(duplicateRouteKey)
-                )
-              ) {
-                throw new ServerlessError(
-                  `Duplicate method for "${path}" path in function ${functionName} for httpApi event in serverless.yml`,
-                  'DUPLICATE_HTTP_API_METHOD'
-                );
-              }
-            } else {
-              if (!allowedMethods.has(method)) {
-                throw new ServerlessError(
-                  `Invalid "method" property in function ${functionName} for httpApi event in serverless.yml`,
-                  'INVALID_HTTP_API_METHOD'
-                );
-              }
-              if (routes.has(`ANY ${path}`)) {
-                throw new ServerlessError(
-                  `Duplicate method for "${path}" path in function ${functionName} for httpApi event in serverless.yml`,
-                  'DUPLICATE_HTTP_API_METHOD'
-                );
-              }
+            } else if (!allowedMethods.has(method)) {
+              throw new ServerlessError(
+                `Invalid "method" property in function ${functionName} for httpApi event in serverless.yml`,
+                'INVALID_HTTP_API_METHOD'
+              );
             }
             event.resolvedMethod = method;
             event.resolvedPath = path;
@@ -614,6 +596,9 @@ Object.defineProperties(
           if (shouldFillCorsMethods) {
             if (event.resolvedMethod === 'ANY') {
               for (const allowedMethod of allowedMethods) {
+                if (allowedMethod === 'ANY') {
+                  continue;
+                }
                 cors.allowedMethods.add(allowedMethod);
               }
             } else {

--- a/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
@@ -39,7 +39,11 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
             payload: {
               handler: 'index.handler',
               httpApi: { payload: '1.0' },
-              events: [{ httpApi: { method: 'get', path: '/payload' } }],
+              events: [{ httpApi: { method: 'options', path: '/payload' } }],
+            },
+            payloadCatchAll: {
+              handler: 'index.handler',
+              events: [{ httpApi: 'ANY /payload' }],
             },
           },
         },
@@ -96,6 +100,20 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
 
     it('should configure method catch all endpoint', () => {
       const routeKey = 'ANY /method-catch-all';
+      const resource = cfResources[naming.getHttpApiRouteLogicalId(routeKey)];
+      expect(resource.Type).to.equal('AWS::ApiGatewayV2::Route');
+      expect(resource.Properties.RouteKey).to.equal(routeKey);
+    });
+
+    it('should configure endpoint with specific method and path', () => {
+      const routeKey = 'OPTIONS /payload';
+      const resource = cfResources[naming.getHttpApiRouteLogicalId(routeKey)];
+      expect(resource.Type).to.equal('AWS::ApiGatewayV2::Route');
+      expect(resource.Properties.RouteKey).to.equal(routeKey);
+    });
+
+    it('should configure method catch all endpoint with same path as a specific method endpoint', () => {
+      const routeKey = 'ANY /payload';
       const resource = cfResources[naming.getHttpApiRouteLogicalId(routeKey)];
       expect(resource.Type).to.equal('AWS::ApiGatewayV2::Route');
       expect(resource.Properties.RouteKey).to.equal(routeKey);


### PR DESCRIPTION
Closes: #9840

---

Removes couple checks to allows for configs such as the following:

```yaml
functions:
  handler:
    handler: handler.handler
    events:
      - httpApi: OPTIONS /a
      - httpApi: ANY /a
```

That is, catch-all's that shadow other routes with same paths are allowed.