### PR TITLE
test: Ensure proper `aws-sdk` patch in `provider` tests

### DIFF
--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -359,12 +359,15 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
           this.secretAccessKey = 'secret';
         }
       }
+      class FakeMetadataService {}
+
       const modulesCacheStub = {
         'aws-sdk': {
           SharedIniFileCredentials,
           EnvironmentCredentials,
           CloudFormation: FakeCloudFormation,
         },
+        'aws-sdk/lib/metadata_service': FakeMetadataService,
       };
       const { serverless } = await runServerless({
         fixture: 'aws',


### PR DESCRIPTION
I've noticed that we have failing tests on `master` and I was able to reproduce it locally with `2.973.0` version of `aws-sdk`. With that release, the internals of `aws-sdk` has changed which caused one of our tests to fail as the mock of `aws-sdk` caused the logic that attaches `AWS.util.loadConfig` to not be executed. 