### PR TITLE
fix(CLI): Mark `dashboard` command with optional service dependency

### DIFF
--- a/lib/cli/commands-schema/no-service.js
+++ b/lib/cli/commands-schema/no-service.js
@@ -132,6 +132,7 @@ commands.set('create', {
 commands.set('dashboard', {
   usage: 'Open the Serverless dashboard',
   lifecycleEvents: ['dashboard'],
+  serviceDependencyMode: 'optional',
 });
 
 commands.set('generate-event', {


### PR DESCRIPTION
Mark `dashboard` command with optional service dependency mode. It is needed for internal initiative that aims to improve `serverless dashboard` command behavior. Rest of implementation will be submitted as separate PR in `dashboard-plugin` repository.