### PR TITLE
fix(AWS CloudFront): Recognize `behavior.TrustedKeyGroups` in schema

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -163,6 +163,7 @@ class AwsCompileCloudFrontEvents {
         ViewerProtocolPolicy: {
           enum: ['allow-all', 'redirect-to-https', 'https-only'],
         },
+        TrustedKeyGroups: { type: 'array', items: { type: 'string' } },
       },
       additionalProperties: false,
     };

--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -163,7 +163,16 @@ class AwsCompileCloudFrontEvents {
         ViewerProtocolPolicy: {
           enum: ['allow-all', 'redirect-to-https', 'https-only'],
         },
-        TrustedKeyGroups: { type: 'array', items: { type: 'string' } },
+        TrustedKeyGroups: {
+          anyOf: [
+            {
+              type: 'array',
+              items: {
+                anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfRef' }],
+              },
+            },
+          ],
+        },
       },
       additionalProperties: false,
     };

--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -164,14 +164,10 @@ class AwsCompileCloudFrontEvents {
           enum: ['allow-all', 'redirect-to-https', 'https-only'],
         },
         TrustedKeyGroups: {
-          anyOf: [
-            {
-              type: 'array',
-              items: {
-                anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfRef' }],
-              },
-            },
-          ],
+          type: 'array',
+          items: {
+            anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfRef' }],
+          },
         },
       },
       additionalProperties: false,


### PR DESCRIPTION
Closes: #9595

This PR is built on top of https://github.com/serverless/serverless/pull/9598 addressing https://github.com/serverless/serverless/pull/9598#issuecomment-874777145 also:

> In addition - is it possible to reference these groups e.g. with CF intrinsic functions such as Ref, etc? If yes, we should also allow schema to accept them.

I found [one example](https://github.com/awslabs/amplify-video/issues/249#issuecomment-831432822) were `Ref` is used when defining a trusted key group. But I doubt it _has_ to be a ref since the example resource in the initial issue (see it's `serverless.yrml`) uses a value like `abcdef ` which is obviously not using `Ref`. So I think we should not add intrinsic function constraint to that piece of schema.

