### PR TITLE
AWS API Gateway: Fix request validator triage

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.js
@@ -21,7 +21,10 @@ module.exports = {
         event.http.request &&
         event.http.request.parameters &&
         // check if any parameters are marked as required
-        Object.values(event.http.request.parameters || {}).some((x) => x)
+        Object.values(event.http.request.parameters || {}).some((x) => {
+          if (!_.isObject(x)) return x;
+          return x.required != null ? x.required : true;
+        })
       ) {
         if (!validatorLogicalId) {
           const requestValidator = this.createRequestValidator();

--- a/test/fixtures/programmatic/requestParameters/serverless.yml
+++ b/test/fixtures/programmatic/requestParameters/serverless.yml
@@ -48,6 +48,14 @@ functions:
               paths:
                 bar: false
       - http:
+          path: paths-not-required-object
+          method: get
+          request:
+            parameters:
+              paths:
+                bar:
+                  required: false
+      - http:
           path: paths-required
           method: get
           request:

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/requestValidator.test.js
@@ -435,6 +435,7 @@ describe('#compileRequestValidators() - parameters', () => {
     'querystrings-not-required',
     'headers-not-required',
     'paths-not-required',
+    'paths-not-required-object',
   ];
 
   const withValidator = [


### PR DESCRIPTION
When diagnosing https://github.com/serverless/serverless/issues/9885 I've noticed that request validator triage in not correct, wen request parameters are configured as objects
