### PR TITLE
Variables: Fix new sources resolution error message at old resolver

### DIFF
--- a/lib/classes/Variables.js
+++ b/lib/classes/Variables.js
@@ -566,11 +566,23 @@ class Variables {
         }
       }
       if (!ret) {
-        const errorMessage = [
-          `Invalid variable reference syntax for variable ${variableString}.`,
-          ' You can only reference env vars, options, & files.',
-          ' You can check our docs for more info.',
-        ].join('');
+        const errorMessage = (() => {
+          if (variableString.startsWith('aws:') || variableString.startsWith('sls:')) {
+            return [
+              `Cannot resolve "${variableString.slice(
+                0,
+                variableString.indexOf(':') + 1
+              )}*" variable sources with old variables resolver.`,
+              'Set "variablesResolutionMode: 20210326" in your service config to ' +
+                'unconditionally switch to the new resolver',
+            ].join('\n');
+          }
+          return [
+            `Invalid variable reference syntax for variable ${variableString}.`,
+            ' You can only reference env vars, options, & files.',
+            ' You can check our docs for more info.',
+          ].join('');
+        })();
         ret = BbPromise.reject(
           new ServerlessError(errorMessage, 'INVALID_VARIABLE_REFERENCE_SYNTAX')
         );


### PR DESCRIPTION
I've observed in few reports that occasionally users deal with non-intuitive error message when variable resolution falls back to old resolver and it attempts to resolve sources which are only supported by new resolver.

e.g.: https://github.com/serverless/serverless/pull/9662#issuecomment-904092188, https://github.com/serverless/serverless/issues/9861, https://github.com/serverless/serverless/issues/9729

This patch should help clear the confusion.

_Before_:

<img width="914" alt="Screenshot 2021-08-27 at 13 41 15" src="https://user-images.githubusercontent.com/122434/131122348-6cd4244e-4b09-4cb5-9cc1-7e846b4aa7f0.png">

_After_:

<img width="671" alt="Screenshot 2021-08-27 at 13 43 17" src="https://user-images.githubusercontent.com/122434/131122369-80361c6b-eac2-4618-975d-9f53d35bb9f4.png">

