### PR TITLE
Variables: Enable early `sls:stage` resolution

### DIFF
--- a/lib/configuration/variables/sources/instance-dependent/get-sls.js
+++ b/lib/configuration/variables/sources/instance-dependent/get-sls.js
@@ -20,6 +20,7 @@ module.exports = (serverlessInstance) => {
 
       switch (address) {
         case 'instanceId':
+          if (!serverlessInstance) return { value: null, isPending: true };
           return { value: serverlessInstance.instanceId };
         case 'stage': {
           let stage = options.stage;

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -289,6 +289,7 @@ const processSpanPromise = (async () => {
                 opt: require('../lib/configuration/variables/sources/opt'),
                 self: require('../lib/configuration/variables/sources/self'),
                 strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
+                sls: require('../lib/configuration/variables/sources/instance-dependent/get-sls')(),
               },
               options: filterSupportedOptions(options, { commandSchema, providerName }),
               fulfilledSources: new Set(['file', 'self', 'strToBool']),

--- a/test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js
+++ b/test/unit/lib/configuration/variables/sources/instance-dependent/get-sls.test.js
@@ -14,7 +14,7 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
   let variablesMeta;
   let serverlessInstance;
 
-  const initializeServerless = async ({ configExt, options } = {}) => {
+  const initializeServerless = async ({ configExt, options, setupOptions = {} } = {}) => {
     configuration = {
       service: 'foo',
       provider: {
@@ -47,7 +47,10 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
       serviceDir: process.cwd(),
       configuration,
       variablesMeta,
-      sources: { self: selfSource, sls: getSlsSource(serverlessInstance) },
+      sources: {
+        self: selfSource,
+        sls: getSlsSource(setupOptions.withoutInstance ? null : serverlessInstance),
+      },
       options: options || {},
       fulfilledSources: new Set(['self', 'sls']),
     });
@@ -58,6 +61,13 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
     if (variablesMeta.get('custom\0sls')) throw variablesMeta.get('custom\0sls').error;
     expect(typeof serverlessInstance.instanceId).to.equal('string');
     expect(configuration.custom.sls).to.equal(serverlessInstance.instanceId);
+  });
+
+  it('should keep  ${sls:instanceId} pending when no serverless instance available', async () => {
+    // Dev by default
+    await initializeServerless({ setupOptions: { withoutInstance: true } });
+    expect(variablesMeta.get('custom\0sls')).to.have.property('variables');
+    expect(variablesMeta.get('custom\0sls')).to.not.have.property('error');
   });
 
   it('should resolve ${sls:stage}', async () => {
@@ -75,6 +85,35 @@ describe('test/unit/lib/configuration/variables/sources/instance-dependent/get-s
     expect(configuration.custom.stage).to.equal('prod');
     // Resolves to `--stage=` if the option is set
     await initializeServerless({
+      configExt: {
+        provider: {
+          stage: 'prod',
+        },
+      },
+      options: {
+        stage: 'staging',
+      },
+    });
+    expect(configuration.custom.stage).to.equal('staging');
+  });
+
+  it('should resolve ${sls:stage} when no serverless instance available', async () => {
+    // Dev by default
+    await initializeServerless({ setupOptions: { withoutInstance: true } });
+    expect(configuration.custom.stage).to.equal('dev');
+    // Resolves to provider.stage if it exists
+    await initializeServerless({
+      setupOptions: { withoutInstance: true },
+      configExt: {
+        provider: {
+          stage: 'prod',
+        },
+      },
+    });
+    expect(configuration.custom.stage).to.equal('prod');
+    // Resolves to `--stage=` if the option is set
+    await initializeServerless({
+      setupOptions: { withoutInstance: true },
       configExt: {
         provider: {
           stage: 'prod',


### PR DESCRIPTION
`sls:stage` was introduced to `sls` source which only resolved `instanceId`, which depends on `serverless` instance and due to which it was applied in one of the last resolution phases.

Still `sls:stage` can be resolved at very beginning, and as it serves a very popular use case, it'll be way more optimal to resolve it earliest as possible (to not block resolution of many other properties until `serverless` instance is initiated)
