### PR TITLE
feat(AWS Schedule): Allow multiple rate expressions in single event

### DIFF
--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -69,3 +69,24 @@ events:
       description: 'your scheduled rate event description'
       rate: rate(2 hours)
 ```
+
+## Specify multiple schedule expressions
+
+An array of schedule expressions (i.e. using either `rate` or `cron` syntax) can be specified, in order to avoid repeating other configuration variables.
+This is specially useful in situations in which there's no other way than using multiple cron expressions to schedule a function.
+
+This will trigger the function at certain times on weekdays and on different times on weekends, using the same input:
+
+```yaml
+functions:
+  foo:
+    handler: foo.handler
+    events:
+      - schedule:
+          rate:
+            - cron(0 0/4 ? * MON-FRI *)
+            - cron(0 2 ? * SAT-SUN *)
+          input:
+            key1: value1
+            key2: value2
+```

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -412,7 +412,7 @@ functions:
       - schedule:
           name: my scheduled event
           description: a description of my scheduled event's purpose
-          rate: rate(10 minutes)
+          rate: rate(10 minutes) # Can also be an array of rate/cron expressions
           enabled: false
           # Note, you can use only one of input, inputPath, or inputTransformer
           input:

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const ServerlessError = require('../../../../../serverless-error');
 
 const rateSyntax = '^rate\\((?:1 (?:minute|hour|day)|(?:1\\d+|[2-9]\\d*) (?:minute|hour|day)s)\\)$';
 const cronSyntax = '^cron\\(\\S+ \\S+ \\S+ \\S+ \\S+ \\S+\\)$';
@@ -21,7 +22,14 @@ class AwsCompileScheduledEvents {
         {
           type: 'object',
           properties: {
-            rate: { type: 'string', pattern: scheduleSyntax },
+            rate: {
+              type: 'array',
+              minItems: 1,
+              items: {
+                type: 'string',
+                pattern: scheduleSyntax,
+              },
+            },
             enabled: { type: 'boolean' },
             name: { type: 'string', minLength: 1, maxLength: 64, pattern: '[\\.\\-_A-Za-z0-9]+' },
             description: { type: 'string', maxLength: 512 },
@@ -77,8 +85,7 @@ class AwsCompileScheduledEvents {
       if (functionObj.events) {
         functionObj.events.forEach((event) => {
           if (event.schedule) {
-            scheduleNumberInFunction++;
-            let ScheduleExpression;
+            let ScheduleExpressions;
             let State;
             let Input;
             let InputPath;
@@ -87,7 +94,8 @@ class AwsCompileScheduledEvents {
             let Description;
 
             if (typeof event.schedule === 'object') {
-              ScheduleExpression = event.schedule.rate;
+              ScheduleExpressions = event.schedule.rate;
+
               State = 'ENABLED';
               if (event.schedule.enabled === false) {
                 State = 'DISABLED';
@@ -97,6 +105,13 @@ class AwsCompileScheduledEvents {
               InputTransformer = event.schedule.inputTransformer;
               Name = event.schedule.name;
               Description = event.schedule.description;
+
+              if (ScheduleExpressions.length > 1 && Name) {
+                throw new ServerlessError(
+                  'You cannot specify a name when defining more than one rate expression',
+                  'SCHEDULE_NAME_NOT_ALLOWED_MULTIPLE_RATES'
+                );
+              }
 
               if (Input && typeof Input === 'object') {
                 if (typeof Input.body === 'string') {
@@ -112,23 +127,27 @@ class AwsCompileScheduledEvents {
                 InputTransformer = this.formatInputTransformer(InputTransformer);
               }
             } else {
-              ScheduleExpression = event.schedule;
+              ScheduleExpressions = [event.schedule];
               State = 'ENABLED';
             }
 
             const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-            const scheduleLogicalId = this.provider.naming.getScheduleLogicalId(
-              functionName,
-              scheduleNumberInFunction
-            );
-            const lambdaPermissionLogicalId =
-              this.provider.naming.getLambdaSchedulePermissionLogicalId(
+            const scheduleId = this.provider.naming.getScheduleId(functionName);
+
+            for (const ScheduleExpression of ScheduleExpressions) {
+              scheduleNumberInFunction++;
+
+              const scheduleLogicalId = this.provider.naming.getScheduleLogicalId(
                 functionName,
                 scheduleNumberInFunction
               );
-            const scheduleId = this.provider.naming.getScheduleId(functionName);
+              const lambdaPermissionLogicalId =
+                this.provider.naming.getLambdaSchedulePermissionLogicalId(
+                  functionName,
+                  scheduleNumberInFunction
+                );
 
-            const scheduleTemplate = `
+              const scheduleTemplate = `
               {
                 "Type": "AWS::Events::Rule",
                 "Properties": {
@@ -147,7 +166,7 @@ class AwsCompileScheduledEvents {
               }
             `;
 
-            const permissionTemplate = `
+              const permissionTemplate = `
               {
                 "Type": "AWS::Lambda::Permission",
                 "Properties": {
@@ -159,19 +178,20 @@ class AwsCompileScheduledEvents {
               }
             `;
 
-            const newScheduleObject = {
-              [scheduleLogicalId]: JSON.parse(scheduleTemplate),
-            };
+              const newScheduleObject = {
+                [scheduleLogicalId]: JSON.parse(scheduleTemplate),
+              };
 
-            const newPermissionObject = {
-              [lambdaPermissionLogicalId]: JSON.parse(permissionTemplate),
-            };
+              const newPermissionObject = {
+                [lambdaPermissionLogicalId]: JSON.parse(permissionTemplate),
+              };
 
-            _.merge(
-              this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-              newScheduleObject,
-              newPermissionObject
-            );
+              _.merge(
+                this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+                newScheduleObject,
+                newPermissionObject
+              );
+            }
           }
         });
       }

--- a/test/fixtures/programmatic/schedule/core.js
+++ b/test/fixtures/programmatic/schedule/core.js
@@ -16,4 +16,10 @@ function scheduleExtended(event, context, callback) {
   return callback(null, event);
 }
 
-module.exports = { scheduleMinimal, scheduleExtended };
+function scheduleExtendedArray(event, context, callback) {
+  const functionName = 'scheduleExtendedArray';
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { scheduleMinimal, scheduleExtended, scheduleExtendedArray };

--- a/test/fixtures/programmatic/schedule/serverless.yml
+++ b/test/fixtures/programmatic/schedule/serverless.yml
@@ -21,3 +21,13 @@ functions:
             inputPathsMap:
               eventTime: '$.time'
             inputTemplate: '{"time": <eventTime>, "name": "transformedInput"}'
+  scheduleExtendedArray:
+    handler: core.scheduleExtendedArray
+    events:
+      - schedule:
+          rate:
+            - cron(* * * * ? *)
+          inputTransformer:
+            inputPathsMap:
+              eventTime: '$.time'
+            inputTemplate: '{"time": <eventTime>, "name": "transformedInput"}'

--- a/test/integration/aws/schedule.test.js
+++ b/test/integration/aws/schedule.test.js
@@ -54,4 +54,21 @@ describe('AWS - Schedule Integration Test', function () {
       });
     });
   });
+
+  describe('Extended Setup (array)', () => {
+    it('should invoke every minute with transformed input', () => {
+      const functionName = 'scheduleExtendedArray';
+
+      return confirmCloudWatchLogs(`/aws/lambda/${stackName}-${functionName}`, async () => {}, {
+        checkIsComplete: (soFarEvents) => {
+          const logs = soFarEvents.reduce((data, event) => data + event.message, '');
+          return logs.includes('transformedInput');
+        },
+      }).then((events) => {
+        const logs = events.reduce((data, event) => data + event.message, '');
+        expect(logs).to.include(functionName);
+        expect(logs).to.include('transformedInput');
+      });
+    });
+  });
 });

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -1,427 +1,323 @@
 'use strict';
 
-const expect = require('chai').expect;
-const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
-const AwsCompileScheduledEvents = require('../../../../../../../../lib/plugins/aws/package/compile/events/schedule');
-const Serverless = require('../../../../../../../../lib/Serverless');
+const runServerless = require('../../../../../../../utils/run-serverless');
 const ServerlessError = require('../../../../../../../../lib/serverless-error');
+const { use: chaiUse, expect } = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 
-// TODO: these tests should be eventually updated to use the newer runServerless approach
-// Reference: https://github.com/serverless/test/blob/master/docs/run-serverless.md
+chaiUse(chaiAsPromised);
 
-describe('AwsCompileScheduledEvents', () => {
-  let serverless;
-  let awsCompileScheduledEvents;
+async function run(events) {
+  const params = {
+    fixture: 'function',
+    command: 'package',
+    configExt: {
+      functions: {
+        test: {
+          handler: 'index.handler',
+          events,
+        },
+      },
+    },
+  };
+  const { awsNaming, cfTemplate } = await runServerless(params);
+  const cfResources = cfTemplate.Resources;
 
-  beforeEach(() => {
-    serverless = new Serverless();
-    serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-    serverless.setProvider('aws', new AwsProvider(serverless));
-    awsCompileScheduledEvents = new AwsCompileScheduledEvents(serverless);
-    awsCompileScheduledEvents.serverless.service.service = 'new-service';
+  const scheduleCfResources = [];
+
+  for (const event of events) {
+    const schedule = event.schedule;
+    let scheduleEvents;
+
+    if (typeof schedule === 'string') {
+      scheduleEvents = [schedule];
+    } else {
+      scheduleEvents = Array.isArray(schedule.rate) ? schedule.rate : [schedule.rate];
+    }
+
+    for (let i = 0; i < scheduleEvents.length; i++) {
+      const index = scheduleCfResources.length + 1;
+
+      const scheduleLogicalId = awsNaming.getScheduleLogicalId('test', index);
+      const scheduleCfResource = cfResources[scheduleLogicalId];
+
+      scheduleCfResources.push(scheduleCfResource);
+    }
+  }
+
+  return scheduleCfResources;
+}
+
+describe('ScheduleEvents', () => {
+  it('should create corresponding resources when schedule events are given', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: false,
+        },
+      },
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: true,
+        },
+      },
+      {
+        schedule: 'rate(10 minutes)',
+      },
+      {
+        schedule: 'cron(5,35 12 ? * 6l 2002-2005)',
+      },
+      {
+        schedule: {
+          rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+        },
+      },
+    ];
+
+    const scheduleCfResources = await run(events);
+
+    for (let i = 0; i < events.length; i += 1) {
+      expect(scheduleCfResources[i].Type).to.equal('AWS::Events::Rule');
+    }
   });
 
-  describe('#constructor()', () => {
-    it('should set the provider variable to an instance of AwsProvider', () =>
-      expect(awsCompileScheduledEvents.provider).to.be.instanceof(AwsProvider));
+  it('should respect enabled variable, defaulting to true', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: false,
+        },
+      },
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: true,
+        },
+      },
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+        },
+      },
+      {
+        schedule: 'rate(10 minutes)',
+      },
+      {
+        schedule: {
+          rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+          enabled: false,
+        },
+      },
+    ];
+
+    const scheduleCfResources = await run(events);
+
+    expect(scheduleCfResources[0].Properties.State).to.equal('DISABLED');
+    expect(scheduleCfResources[1].Properties.State).to.equal('ENABLED');
+    expect(scheduleCfResources[2].Properties.State).to.equal('ENABLED');
+    expect(scheduleCfResources[3].Properties.State).to.equal('ENABLED');
+    expect(scheduleCfResources[4].Properties.State).to.equal('DISABLED');
+    expect(scheduleCfResources[5].Properties.State).to.equal('DISABLED');
   });
 
-  describe('#compileScheduledEvents()', () => {
-    it('should create corresponding resources when schedule events are given', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: false,
-              },
-            },
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: true,
-              },
-            },
-            {
-              schedule: 'rate(10 minutes)',
-            },
-            {
-              schedule: 'cron(5,35 12 ? * 6l 2002-2005)',
-            },
-            {
-              schedule: {
-                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
-              },
-            },
-          ],
+  it('should respect name variable', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: false,
+          name: 'your-scheduled-event-name',
         },
-      };
-
-      awsCompileScheduledEvents.compileScheduledEvents();
-
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule1.Type
-      ).to.equal('AWS::Events::Rule');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule2.Type
-      ).to.equal('AWS::Events::Rule');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule3.Type
-      ).to.equal('AWS::Events::Rule');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstLambdaPermissionEventsRuleSchedule1.Type
-      ).to.equal('AWS::Lambda::Permission');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstLambdaPermissionEventsRuleSchedule2.Type
-      ).to.equal('AWS::Lambda::Permission');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstLambdaPermissionEventsRuleSchedule3.Type
-      ).to.equal('AWS::Lambda::Permission');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstLambdaPermissionEventsRuleSchedule4.Type
-      ).to.equal('AWS::Lambda::Permission');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstLambdaPermissionEventsRuleSchedule5.Type
-      ).to.equal('AWS::Lambda::Permission');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstLambdaPermissionEventsRuleSchedule6.Type
-      ).to.equal('AWS::Lambda::Permission');
-    });
-
-    it('should respect enabled variable, defaulting to true', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: false,
-              },
-            },
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: true,
-              },
-            },
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-              },
-            },
-            {
-              schedule: 'rate(10 minutes)',
-            },
-            {
-              schedule: {
-                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
-                enabled: false,
-              },
-            },
-          ],
+      },
+      {
+        schedule: {
+          rate: ['rate(1 hour)'],
+          enabled: false,
+          name: 'your-scheduled-event-name-array',
         },
-      };
+      },
+    ];
 
-      awsCompileScheduledEvents.compileScheduledEvents();
+    const scheduleCfResources = await run(events);
 
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule1.Properties.State
-      ).to.equal('DISABLED');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule2.Properties.State
-      ).to.equal('ENABLED');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule3.Properties.State
-      ).to.equal('ENABLED');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule4.Properties.State
-      ).to.equal('ENABLED');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule5.Properties.State
-      ).to.equal('DISABLED');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule6.Properties.State
-      ).to.equal('DISABLED');
-    });
+    expect(scheduleCfResources[0].Properties.Name).to.equal('your-scheduled-event-name');
+    expect(scheduleCfResources[1].Properties.Name).to.equal('your-scheduled-event-name-array');
+  });
 
-    it('should respect name variable', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: false,
-                name: 'your-scheduled-event-name',
-              },
-            },
-          ],
+  it('should throw an error if a name is specified when defining more than one rate expression', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+          enabled: false,
+          name: 'your-scheduled-event-name',
         },
-      };
+      },
+    ];
 
-      awsCompileScheduledEvents.compileScheduledEvents();
+    await expect(run(events)).to.be.eventually.rejectedWith(
+      ServerlessError,
+      'You cannot specify a name when defining more than one rate expression'
+    );
+  });
 
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule1.Properties.Name
-      ).to.equal('your-scheduled-event-name');
-    });
-
-    it('should throw an error if a name is specified when defining more than one rate expression', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
-                enabled: false,
-                name: 'your-scheduled-event-name',
-              },
-            },
-          ],
+  it('should respect description variable', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: false,
+          description: 'your scheduled event description',
         },
-      };
-
-      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(ServerlessError);
-    });
-
-    it('should respect description variable', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: false,
-                description: 'your scheduled event description',
-              },
-            },
-            {
-              schedule: {
-                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
-                description: 'your scheduled event description (array)',
-              },
-            },
-          ],
+      },
+      {
+        schedule: {
+          rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+          description: 'your scheduled event description (array)',
         },
-      };
+      },
+    ];
 
-      awsCompileScheduledEvents.compileScheduledEvents();
+    const scheduleCfResources = await run(events);
 
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule1.Properties.Description
-      ).to.equal('your scheduled event description');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule2.Properties.Description
-      ).to.equal('your scheduled event description (array)');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule3.Properties.Description
-      ).to.equal('your scheduled event description (array)');
-    });
+    expect(scheduleCfResources[0].Properties.Description).to.equal(
+      'your scheduled event description'
+    );
+    expect(scheduleCfResources[1].Properties.Description).to.equal(
+      'your scheduled event description (array)'
+    );
+    expect(scheduleCfResources[2].Properties.Description).to.equal(
+      'your scheduled event description (array)'
+    );
+  });
 
-    it('should respect inputPath variable', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: false,
-                inputPath: '$.stageVariables',
-              },
-            },
-            {
-              schedule: {
-                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
-                inputPath: '$.stageVariables',
-              },
-            },
-          ],
+  it('should respect inputPath variable', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: false,
+          inputPath: '$.stageVariables',
         },
-      };
-
-      awsCompileScheduledEvents.compileScheduledEvents();
-
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule1.Properties.Targets[0].InputPath
-      ).to.equal('$.stageVariables');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule2.Properties.Targets[0].InputPath
-      ).to.equal('$.stageVariables');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule3.Properties.Targets[0].InputPath
-      ).to.equal('$.stageVariables');
-    });
-
-    it('should respect input variable', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: false,
-                input: '{"key":"value"}',
-              },
-            },
-            {
-              schedule: {
-                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
-                input: '{"key":"value"}',
-              },
-            },
-          ],
+      },
+      {
+        schedule: {
+          rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+          inputPath: '$.stageVariables',
         },
-      };
+      },
+    ];
 
-      awsCompileScheduledEvents.compileScheduledEvents();
+    const scheduleCfResources = await run(events);
 
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule1.Properties.Targets[0].Input
-      ).to.equal('{"key":"value"}');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule2.Properties.Targets[0].Input
-      ).to.equal('{"key":"value"}');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule3.Properties.Targets[0].Input
-      ).to.equal('{"key":"value"}');
-    });
+    expect(scheduleCfResources[0].Properties.Targets[0].InputPath).to.equal('$.stageVariables');
+    expect(scheduleCfResources[1].Properties.Targets[0].InputPath).to.equal('$.stageVariables');
+    expect(scheduleCfResources[2].Properties.Targets[0].InputPath).to.equal('$.stageVariables');
+  });
 
-    it('should respect input variable as an object', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: false,
-                input: {
-                  key: 'value',
-                },
-              },
-            },
-            {
-              schedule: {
-                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
-                input: {
-                  key: 'value',
-                },
-              },
-            },
-          ],
+  it('should respect input variable', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: false,
+          input: '{"key":"value"}',
         },
-      };
-
-      awsCompileScheduledEvents.compileScheduledEvents();
-
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule1.Properties.Targets[0].Input
-      ).to.equal('{"key":"value"}');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule2.Properties.Targets[0].Input
-      ).to.equal('{"key":"value"}');
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule3.Properties.Targets[0].Input
-      ).to.equal('{"key":"value"}');
-    });
-
-    it('should respect inputTransformer variable', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [
-            {
-              schedule: {
-                rate: ['rate(10 minutes)'],
-                enabled: false,
-                inputTransformer: {
-                  inputPathsMap: {
-                    eventTime: '$.time',
-                  },
-                  inputTemplate: '{"time": <eventTime>, "key1": "value1"}',
-                },
-              },
-            },
-            {
-              schedule: {
-                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
-                inputTransformer: {
-                  inputPathsMap: {
-                    eventTime: '$.time',
-                  },
-                  inputTemplate: '{"time": <eventTime>, "key1": "value1"}',
-                },
-              },
-            },
-          ],
+      },
+      {
+        schedule: {
+          rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+          input: '{"key":"array"}',
         },
-      };
+      },
+    ];
 
-      awsCompileScheduledEvents.compileScheduledEvents();
+    const scheduleCfResources = await run(events);
 
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule1.Properties.Targets[0].InputTransformer
-      ).to.eql({
-        InputTemplate: '{"time": <eventTime>, "key1": "value1"}',
-        InputPathsMap: { eventTime: '$.time' },
-      });
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule2.Properties.Targets[0].InputTransformer
-      ).to.eql({
-        InputTemplate: '{"time": <eventTime>, "key1": "value1"}',
-        InputPathsMap: { eventTime: '$.time' },
-      });
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources.FirstEventsRuleSchedule3.Properties.Targets[0].InputTransformer
-      ).to.eql({
-        InputTemplate: '{"time": <eventTime>, "key1": "value1"}',
-        InputPathsMap: { eventTime: '$.time' },
-      });
-    });
+    expect(scheduleCfResources[0].Properties.Targets[0].Input).to.equal('{"key":"value"}');
+    expect(scheduleCfResources[1].Properties.Targets[0].Input).to.equal('{"key":"array"}');
+    expect(scheduleCfResources[2].Properties.Targets[0].Input).to.equal('{"key":"array"}');
+  });
 
-    it('should not create corresponding resources when scheduled events are not given', () => {
-      awsCompileScheduledEvents.serverless.service.functions = {
-        first: {
-          events: [],
+  it('should respect input variable as an object', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: false,
+          input: {
+            key: 'value',
+          },
         },
-      };
+      },
+      {
+        schedule: {
+          rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+          input: {
+            key: 'array',
+          },
+        },
+      },
+    ];
 
-      awsCompileScheduledEvents.compileScheduledEvents();
+    const scheduleCfResources = await run(events);
 
-      expect(
-        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
-          .Resources
-      ).to.deep.equal({});
+    expect(scheduleCfResources[0].Properties.Targets[0].Input).to.equal('{"key":"value"}');
+    expect(scheduleCfResources[1].Properties.Targets[0].Input).to.equal('{"key":"array"}');
+    expect(scheduleCfResources[2].Properties.Targets[0].Input).to.equal('{"key":"array"}');
+  });
+
+  it('should respect inputTransformer variable', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(10 minutes)',
+          enabled: false,
+          inputTransformer: {
+            inputPathsMap: {
+              eventTime: '$.time',
+            },
+            inputTemplate: '{"time": <eventTime>, "key": "value"}',
+          },
+        },
+      },
+      {
+        schedule: {
+          rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+          inputTransformer: {
+            inputPathsMap: {
+              eventTime: '$.time',
+            },
+            inputTemplate: '{"time": <eventTime>, "key": "array"}',
+          },
+        },
+      },
+    ];
+
+    const scheduleCfResources = await run(events);
+
+    expect(scheduleCfResources[0].Properties.Targets[0].InputTransformer).to.deep.equal({
+      InputTemplate: '{"time": <eventTime>, "key": "value"}',
+      InputPathsMap: { eventTime: '$.time' },
     });
+    expect(scheduleCfResources[1].Properties.Targets[0].InputTransformer).to.deep.equal({
+      InputTemplate: '{"time": <eventTime>, "key": "array"}',
+      InputPathsMap: { eventTime: '$.time' },
+    });
+    expect(scheduleCfResources[2].Properties.Targets[0].InputTransformer).to.deep.equal({
+      InputTemplate: '{"time": <eventTime>, "key": "array"}',
+      InputPathsMap: { eventTime: '$.time' },
+    });
+  });
+
+  it('should not create corresponding resources when scheduled events are not given', async () => {
+    const events = [];
+
+    const scheduleCfResources = await run(events);
+
+    expect(scheduleCfResources).to.be.empty;
   });
 });

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -4,6 +4,10 @@ const expect = require('chai').expect;
 const AwsProvider = require('../../../../../../../../lib/plugins/aws/provider');
 const AwsCompileScheduledEvents = require('../../../../../../../../lib/plugins/aws/package/compile/events/schedule');
 const Serverless = require('../../../../../../../../lib/Serverless');
+const ServerlessError = require('../../../../../../../../lib/serverless-error');
+
+// TODO: these tests should be eventually updated to use the newer runServerless approach
+// Reference: https://github.com/serverless/test/blob/master/docs/run-serverless.md
 
 describe('AwsCompileScheduledEvents', () => {
   let serverless;
@@ -29,13 +33,13 @@ describe('AwsCompileScheduledEvents', () => {
           events: [
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: false,
               },
             },
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: true,
               },
             },
@@ -44,6 +48,11 @@ describe('AwsCompileScheduledEvents', () => {
             },
             {
               schedule: 'cron(5,35 12 ? * 6l 2002-2005)',
+            },
+            {
+              schedule: {
+                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+              },
             },
           ],
         },
@@ -79,6 +88,14 @@ describe('AwsCompileScheduledEvents', () => {
         awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstLambdaPermissionEventsRuleSchedule4.Type
       ).to.equal('AWS::Lambda::Permission');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstLambdaPermissionEventsRuleSchedule5.Type
+      ).to.equal('AWS::Lambda::Permission');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstLambdaPermissionEventsRuleSchedule6.Type
+      ).to.equal('AWS::Lambda::Permission');
     });
 
     it('should respect enabled variable, defaulting to true', () => {
@@ -87,23 +104,29 @@ describe('AwsCompileScheduledEvents', () => {
           events: [
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: false,
               },
             },
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: true,
               },
             },
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
               },
             },
             {
               schedule: 'rate(10 minutes)',
+            },
+            {
+              schedule: {
+                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+                enabled: false,
+              },
             },
           ],
         },
@@ -127,6 +150,14 @@ describe('AwsCompileScheduledEvents', () => {
         awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstEventsRuleSchedule4.Properties.State
       ).to.equal('ENABLED');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule5.Properties.State
+      ).to.equal('DISABLED');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule6.Properties.State
+      ).to.equal('DISABLED');
     });
 
     it('should respect name variable', () => {
@@ -135,7 +166,7 @@ describe('AwsCompileScheduledEvents', () => {
           events: [
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: false,
                 name: 'your-scheduled-event-name',
               },
@@ -152,15 +183,39 @@ describe('AwsCompileScheduledEvents', () => {
       ).to.equal('your-scheduled-event-name');
     });
 
+    it('should throw an error if a name is specified when defining more than one rate expression', () => {
+      awsCompileScheduledEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              schedule: {
+                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+                enabled: false,
+                name: 'your-scheduled-event-name',
+              },
+            },
+          ],
+        },
+      };
+
+      expect(() => awsCompileScheduledEvents.compileScheduledEvents()).to.throw(ServerlessError);
+    });
+
     it('should respect description variable', () => {
       awsCompileScheduledEvents.serverless.service.functions = {
         first: {
           events: [
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: false,
                 description: 'your scheduled event description',
+              },
+            },
+            {
+              schedule: {
+                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
+                description: 'your scheduled event description (array)',
               },
             },
           ],
@@ -173,6 +228,14 @@ describe('AwsCompileScheduledEvents', () => {
         awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstEventsRuleSchedule1.Properties.Description
       ).to.equal('your scheduled event description');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule2.Properties.Description
+      ).to.equal('your scheduled event description (array)');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule3.Properties.Description
+      ).to.equal('your scheduled event description (array)');
     });
 
     it('should respect inputPath variable', () => {
@@ -181,8 +244,14 @@ describe('AwsCompileScheduledEvents', () => {
           events: [
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: false,
+                inputPath: '$.stageVariables',
+              },
+            },
+            {
+              schedule: {
+                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
                 inputPath: '$.stageVariables',
               },
             },
@@ -196,6 +265,14 @@ describe('AwsCompileScheduledEvents', () => {
         awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstEventsRuleSchedule1.Properties.Targets[0].InputPath
       ).to.equal('$.stageVariables');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule2.Properties.Targets[0].InputPath
+      ).to.equal('$.stageVariables');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule3.Properties.Targets[0].InputPath
+      ).to.equal('$.stageVariables');
     });
 
     it('should respect input variable', () => {
@@ -204,8 +281,14 @@ describe('AwsCompileScheduledEvents', () => {
           events: [
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: false,
+                input: '{"key":"value"}',
+              },
+            },
+            {
+              schedule: {
+                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
                 input: '{"key":"value"}',
               },
             },
@@ -219,6 +302,14 @@ describe('AwsCompileScheduledEvents', () => {
         awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstEventsRuleSchedule1.Properties.Targets[0].Input
       ).to.equal('{"key":"value"}');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule2.Properties.Targets[0].Input
+      ).to.equal('{"key":"value"}');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule3.Properties.Targets[0].Input
+      ).to.equal('{"key":"value"}');
     });
 
     it('should respect input variable as an object', () => {
@@ -227,8 +318,16 @@ describe('AwsCompileScheduledEvents', () => {
           events: [
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: false,
+                input: {
+                  key: 'value',
+                },
+              },
+            },
+            {
+              schedule: {
+                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
                 input: {
                   key: 'value',
                 },
@@ -244,6 +343,14 @@ describe('AwsCompileScheduledEvents', () => {
         awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstEventsRuleSchedule1.Properties.Targets[0].Input
       ).to.equal('{"key":"value"}');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule2.Properties.Targets[0].Input
+      ).to.equal('{"key":"value"}');
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule3.Properties.Targets[0].Input
+      ).to.equal('{"key":"value"}');
     });
 
     it('should respect inputTransformer variable', () => {
@@ -252,8 +359,19 @@ describe('AwsCompileScheduledEvents', () => {
           events: [
             {
               schedule: {
-                rate: 'rate(10 minutes)',
+                rate: ['rate(10 minutes)'],
                 enabled: false,
+                inputTransformer: {
+                  inputPathsMap: {
+                    eventTime: '$.time',
+                  },
+                  inputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+                },
+              },
+            },
+            {
+              schedule: {
+                rate: ['cron(0 0/4 ? * MON-FRI *)', 'rate(1 hour)'],
                 inputTransformer: {
                   inputPathsMap: {
                     eventTime: '$.time',
@@ -271,6 +389,20 @@ describe('AwsCompileScheduledEvents', () => {
       expect(
         awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstEventsRuleSchedule1.Properties.Targets[0].InputTransformer
+      ).to.eql({
+        InputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+        InputPathsMap: { eventTime: '$.time' },
+      });
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule2.Properties.Targets[0].InputTransformer
+      ).to.eql({
+        InputTemplate: '{"time": <eventTime>, "key1": "value1"}',
+        InputPathsMap: { eventTime: '$.time' },
+      });
+      expect(
+        awsCompileScheduledEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstEventsRuleSchedule3.Properties.Targets[0].InputTransformer
       ).to.eql({
         InputTemplate: '{"time": <eventTime>, "key1": "value1"}',
         InputPathsMap: { eventTime: '$.time' },


### PR DESCRIPTION
Closes: #9867

This PR adds a feature to allow multiple cron/rate expressions to be specified in a `schedule` event. When doing so, multiple CloudWatch Event  rules are created, sharing the same values for the other attributes (e.g. `input`, `enabled`, etc).