### PR TITLE
Address shortcomings in AWS API Gateway validation schema

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -183,7 +183,7 @@ class AwsCompileApigEvents {
           properties: {
             async: { type: 'boolean' },
             authorizer: authorizerSchema,
-            connectionId: { type: 'string' },
+            connectionId: { $ref: '#/definitions/awsCfInstruction' },
             connectionType: { anyOf: ['vpc-link', 'VPC_LINK'].map(caseInsensitive) },
             cors: corsSchema,
             integration: {

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -41,7 +41,7 @@ const requestParametersSchema = {
         type: 'object',
         properties: {
           required: { type: 'boolean' },
-          mappedValue: { type: 'string' },
+          mappedValue: { $ref: '#/definitions/awsCfInstruction' },
         },
         additionalProperties: false,
       },

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -124,7 +124,7 @@ const requestSchema = {
       type: 'object',
       additionalProperties: { type: 'string' },
     },
-    uri: { type: 'string' },
+    uri: { $ref: '#/definitions/awsCfInstruction' },
   },
   additionalProperties: false,
 };


### PR DESCRIPTION
Closes: #9885 

@medikoo As for your last comment, I don't think there's a problem as the only issue there was with `mappedValue` property and `required` property still has to be provided, so I don't think we have any issue there. 