### PR TITLE
CLI: Enable `env` variables in `provider.stage` property

### DIFF
--- a/lib/configuration/variables/sources/env.js
+++ b/lib/configuration/variables/sources/env.js
@@ -3,6 +3,10 @@
 const ensureString = require('type/string/ensure');
 const ServerlessError = require('../../../serverless-error');
 
+// Used to track env variable dependencies in specific resolution phases
+// This collection is cleared on demand externally
+const missingEnvVariables = new Set();
+
 module.exports = {
   resolve: ({ address, isSourceFulfilled }) => {
     if (!address) {
@@ -17,6 +21,8 @@ module.exports = {
       errorCode: 'INVALID_ENV_SOURCE_ADDRESS',
     });
 
+    if (!process.env[address]) missingEnvVariables.add(address);
     return { value: process.env[address] || null, isPending: !isSourceFulfilled };
   },
+  missingEnvVariables,
 };

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -159,6 +159,45 @@ describe('test/unit/scripts/serverless.test.js', () => {
     ).to.include('fromDefaultEnv: valuefromdefault');
   });
 
+  it('should allow not defined environment variables in provider.stage`', async () => {
+    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('aws', {
+      configExt: {
+        useDotenv: true,
+        provider: {
+          stage: "${env:FOO, 'dev'}",
+        },
+        custom: {
+          fromDefaultEnv: '${env:DEFAULT_ENV_VARIABLE}',
+        },
+      },
+    });
+    await fsp.writeFile(path.resolve(serviceDir, '.env'), 'DEFAULT_ENV_VARIABLE=valuefromdefault');
+    const printOut = String(
+      (await spawn('node', [serverlessPath, 'print'], { cwd: serviceDir })).stdoutBuffer
+    );
+    expect(printOut).to.include('fromDefaultEnv: valuefromdefault');
+    expect(printOut).to.include('stage: dev');
+  });
+
+  it('should report "env" variables resolution conflicts with exception', async () => {
+    const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('aws', {
+      configExt: {
+        useDotenv: true,
+        provider: {
+          stage: "${env:FOO, 'dev'}",
+        },
+      },
+    });
+    await fsp.writeFile(path.resolve(serviceDir, '.env'), 'FOO=test');
+    try {
+      await spawn('node', [serverlessPath, 'print'], { cwd: serviceDir });
+      throw new Error('Unexpected');
+    } catch (error) {
+      expect(error.code).to.equal(1);
+      expect(String(error.stdoutBuffer)).to.include('Environment variable "FOO" which');
+    }
+  });
+
   it('should reject unresolved "plugins" property', async () => {
     try {
       await spawn('node', [serverlessPath, 'print'], {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: https://github.com/serverless/serverless/issues/9880

Implemented solution:
1. Treat _env_ source as _fulfilled_ specifically for `provider.stage` and `useDotenv` resolution.
2. Gather information of missing environment variables which otherwise will influence resolution of those properties
3. After eventual `.env` file is loaded, confirm that no environment variables from above group where loaded from `.env` files. If that's the case throw meaningful error.

