### PR TITLE
Upgrade `filesize` to v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "essentials": "^1.1.1",
     "ext": "^1.5.0",
     "fastest-levenshtein": "^1.0.12",
-    "filesize": "^7.0.0",
+    "filesize": "^8.0.0",
     "fs-extra": "^9.1.0",
     "get-stdin": "^8.0.0",
     "globby": "^11.0.4",

--- a/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -314,7 +314,7 @@ describe('uploadArtifacts', () => {
       sinon.spy(awsDeploy.serverless.cli, 'log');
 
       return awsDeploy.uploadFunctionsAndLayers().then(() => {
-        const expected = 'Uploading service new-service.zip file to S3 (1 KB)...';
+        const expected = 'Uploading service new-service.zip file to S3 (1.02 kB)...';
         expect(awsDeploy.serverless.cli.log.calledWithExactly(expected)).to.be.equal(true);
       });
     });

--- a/test/unit/lib/plugins/aws/deployFunction.test.js
+++ b/test/unit/lib/plugins/aws/deployFunction.test.js
@@ -266,7 +266,7 @@ describe('AwsDeployFunction', () => {
 
       await awsDeployFunction.deployFunction();
 
-      const expected = 'Uploading function: first (1 KB)...';
+      const expected = 'Uploading function: first (1.02 kB)...';
       expect(readFileSyncStub.calledOnce).to.equal(true);
       expect(statSyncStub.calledOnce).to.equal(true);
       expect(awsDeployFunction.serverless.cli.log.calledWithExactly(expected)).to.be.equal(true);


### PR DESCRIPTION
Per [CHANGELOG](https://github.com/avoidwork/filesize.js/blob/master/CHANGELOG.md) no breaking changes that affect us.

Still it appears that there were some fixes which required an update to our tests.

Default setting in v7 and v8 was to show 2 decimals after `.`, still in v7 it seemed not consistent, where v8 is listing `1.02 kB`, the v7 was listing `1 KB`.

I think it's good to adapt to consistency of v8, therefore I've adjusted our tests.

_This util is strictly used to show filesize in our user directed logs, and any formatting changes there are not breaking in any way_