### PR TITLE
fix(AWS Lambda): Recognize `Fn::If` function for `environment`

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -495,7 +495,11 @@ class AwsProvider {
             type: 'object',
             patternProperties: {
               '^[A-Za-z_][a-zA-Z0-9_]*$': {
-                anyOf: [{ const: '' }, { $ref: '#/definitions/awsCfInstruction' }],
+                anyOf: [
+                  { const: '' },
+                  { $ref: '#/definitions/awsCfInstruction' },
+                  { $ref: '#/definitions/awsCfIf' },
+                ],
               },
             },
             additionalProperties: false,

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1385,6 +1385,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               providerEnvVarA: 'providerEnvVarAValue',
               providerEnvVarB: 'providerEnvVarBValue',
               sharedEnvVar: 'valueFromProvider',
+              providerCfIfEnvVar: { 'Fn::If': ['cond', 'first', 'second'] },
             },
             memorySize: 4096,
             runtime: 'nodejs10.x',


### PR DESCRIPTION
Related to: https://github.com/serverless/serverless/pull/8852#issuecomment-909439919

I've updated the setting for `environment` only as updating it universally is unfortunately a bit more time-consuming as we need to review each case separately as some of them try to extract info from CF intrinsic functions. 