### PR TITLE
feat(AWS API Gateway): Support `enabled` for `apiKeys` config

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -608,7 +608,7 @@ In case an exception is thrown in your lambda function AWS will send an error me
 
 ### Setting API keys for your Rest API
 
-You can specify a list of API keys to be used by your service Rest API by adding an `apiKeys` array property to the `provider.apiGateway` object in `serverless.yml`. You'll also need to explicitly specify which endpoints are `private` and require one of the api keys to be included in the request by adding a `private` boolean property to the `http` event object you want to set as private. API Keys are created globally, so if you want to deploy your service to different stages make sure your API key contains a stage variable as defined below. When using API keys, you can optionally define usage plan quota and throttle, using `usagePlan` object.
+You can specify a list of API keys to be used by your service Rest API by adding an `apiKeys` array property to the `provider.apiGateway` object in `serverless.yml`. You'll also need to explicitly specify which endpoints are `private` and require one of the api keys to be included in the request by adding a `private` boolean property to the `http` event object you want to set as private. API Keys are created globally, so if you want to deploy your service to different stages make sure your API key contains a stage variable as defined below. When using API keys, you can optionally define usage plan quota and throttle, using `usagePlan` object. Additionally, you can also disable selected API keys by setting `enabled` property to `false`.
 
 When setting the value, you need to be aware that changing value will require replacement and CloudFormation doesn't allow
 two API keys with the same name. It means that you need to change the name also when changing the value. If you don't care

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -117,6 +117,7 @@ provider:
         value: myFirstKeyValue
         description: myFirstKeyDescription
         customerId: myFirstKeyCustomerId
+        enabled: true # Optional, true by default, can be used to disable API key without deleting the resource
       - ${opt:stage}-myFirstKey
       - ${env:MY_API_KEY} # you can hide it in a serverless variable
     minimumCompressionSize: 1024 # Compress response when larger than specified size in bytes (must be between 0 and 10485760)

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
@@ -7,10 +7,12 @@ function createApiKeyResource(that, apiKey) {
   const value = _.isObject(apiKey) && apiKey.value ? apiKey.value : undefined;
   const description = _.isObject(apiKey) ? apiKey.description : undefined;
   const customerId = _.isObject(apiKey) ? apiKey.customerId : undefined;
+  const enabled = _.isObject(apiKey) && apiKey.enabled != null ? apiKey.enabled : true;
+
   const resourceTemplate = {
     Type: 'AWS::ApiGateway::ApiKey',
     Properties: {
-      Enabled: true,
+      Enabled: enabled,
       Name: name,
       Value: value,
       Description: description,

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -287,6 +287,7 @@ class AwsProvider {
               value: { type: 'string' },
               description: { type: 'string' },
               customerId: { type: 'string' },
+              enabled: { type: 'boolean' },
             },
             additionalProperties: false,
           },


### PR DESCRIPTION
Closes: #9137 

Replaces work started in: https://github.com/serverless/serverless/pull/9137/files