### PR TITLE
refactor: Use `getCompiledTemplateS3Suffix` from `provider.naming`

### DIFF
--- a/lib/plugins/aws/deploy/lib/validateTemplate.js
+++ b/lib/plugins/aws/deploy/lib/validateTemplate.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const getCompiledTemplateS3Suffix = require('../../lib/naming').getCompiledTemplateS3Suffix;
 const getS3EndpointForRegion = require('../../utils/getS3EndpointForRegion');
 const ServerlessError = require('../../../../serverless-error');
 
@@ -8,7 +7,7 @@ module.exports = {
   async validateTemplate() {
     const bucketName = this.bucketName;
     const artifactDirectoryName = this.serverless.service.package.artifactDirectoryName;
-    const compiledTemplateFileName = getCompiledTemplateS3Suffix();
+    const compiledTemplateFileName = this.provider.naming.getCompiledTemplateS3Suffix();
     const s3Endpoint = getS3EndpointForRegion(this.provider.getRegion());
     this.serverless.cli.log('Validating template...');
     const params = {


### PR DESCRIPTION
This makes sure that the specific `naming` instance really is the "source of truth".

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}
