### PR TITLE
Support `error` hook to be triggered on command error

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -16,6 +16,7 @@ const { storeLocally: storeTelemetryLocally, send: sendTelemetry } = require('..
 const generateTelemetryPayload = require('../utils/telemetry/generatePayload');
 const processBackendNotificationRequest = require('../utils/processBackendNotificationRequest');
 const isTelemetryDisabled = require('../utils/telemetry/areDisabled');
+const tokenizeException = require('../utils/tokenize-exception');
 
 const requireServicePlugin = (serviceDir, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
@@ -637,6 +638,17 @@ class PluginManager {
 
     try {
       await this.invoke(commandsArray);
+    } catch (error) {
+      try {
+        for (const { hook } of this.getHooks(['error'])) await hook(error);
+      } catch (subError) {
+        const subErrorMeta = tokenizeException(subError);
+        this.serverless.cli.log(
+          `Warning: "error" hook crashed with: ${subErrorMeta.stack || subErrorMeta.message}`
+        );
+      } finally {
+        throw error; // eslint-disable-line no-unsafe-finally
+      }
     } finally {
       if (deferredBackendNotificationRequest) {
         await processBackendNotificationRequest(await deferredBackendNotificationRequest);


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Allows to attach command wide catch handler, which otherwise is challenging to construct due to lifecycle engine design

Needed for #9860 (in context of #9934)