### PR TITLE
feat(Templates): Add  automatic source maps stacktrace to `aws-nodejs-typescript`

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/package.json
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "@middy/core": "^1.5.2",
-    "@middy/http-json-body-parser": "^1.5.2",
-    "source-map-support": "^0.5.19"
+    "@middy/http-json-body-parser": "^1.5.2"
   },
   "devDependencies": {
     "@serverless/typescript": "^2.23.0",

--- a/lib/plugins/create/templates/aws-nodejs-typescript/serverless.ts
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/serverless.ts
@@ -21,6 +21,7 @@ const serverlessConfiguration: AWS = {
     },
     environment: {
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+      NODE_OPTIONS: '--enable-source-maps --stack-trace-limit=1000',
     },
     lambdaHashingVersion: '20201221',
   },

--- a/lib/plugins/create/templates/aws-nodejs-typescript/src/functions/hello/handler.ts
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/src/functions/hello/handler.ts
@@ -1,5 +1,3 @@
-import 'source-map-support/register';
-
 import type { ValidatedEventAPIGatewayProxyEvent } from '@libs/apiGateway';
 import { formatJSONResponse } from '@libs/apiGateway';
 import { middyfy } from '@libs/lambda';


### PR DESCRIPTION
This PR add automatic source maps in errors stacktrace.
The line `import 'source-map-support/register';` will no longer be needed in a handler.

Exemple stack trace with source maps:
![image](https://user-images.githubusercontent.com/19605940/133450247-8c6750bb-e3fe-4f6c-bc83-63c48e5d8836.png)
