### PR TITLE
CLI: Refactor to modern interface remaining verbose logs that affect deploy operation

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -7,6 +7,7 @@ const ensureValue = require('type/value/ensure');
 const ensureArray = require('type/array/ensure');
 const ensureIterable = require('type/iterable/ensure');
 const ensurePlainObject = require('type/plain-object/ensure');
+const { legacy, log } = require('@serverless/utils/log');
 const _ = require('lodash');
 const CLI = require('./classes/CLI');
 const Config = require('./classes/Config');
@@ -420,8 +421,12 @@ class Serverless {
       // `variables.populateService`. Below lines ensure they're set
       this.variables.loadVariableSyntax();
       this.variables.options = this.pluginManager.cliOptions;
+      log.info(
+        'Skipping variables resolution with old resolver ' +
+          '(new resolver reported no more variables to resolve)'
+      );
       if (process.env.SLS_DEBUG) {
-        this.cli.log(
+        legacy.log(
           'Skipping variables resolution with old resolver ' +
             '(new resolver reported no more variables to resolve)'
         );

--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -17,9 +17,13 @@ const wait = require('timers-ext/promise/sleep');
 const chalk = require('chalk');
 
 // Activate AWS SDK logging
-if (process.env.SLS_DEBUG) {
-  sdk.config.logger = require('@serverless/utils/log');
-}
+const awsLog = log.get('aws');
+sdk.config.logger = {
+  log: (...args) => {
+    if (process.env.SLS_DEBUG) legacy.log(...args);
+    awsLog.debug(...args);
+  },
+};
 
 // Use HTTPS Proxy (Optional)
 const proxy =

--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -5,7 +5,7 @@ const memoize = require('memoizee');
 const PromiseQueue = require('promise-queue');
 const sdk = require('aws-sdk');
 const ServerlessError = require('../../lib/serverless-error');
-const log = require('@serverless/utils/log');
+const { legacy, log } = require('@serverless/utils/log');
 const HttpsProxyAgent = require('https-proxy-agent');
 const url = require('url');
 const https = require('https');
@@ -18,7 +18,7 @@ const chalk = require('chalk');
 
 // Activate AWS SDK logging
 if (process.env.SLS_DEBUG) {
-  sdk.config.logger = log;
+  sdk.config.logger = require('@serverless/utils/log');
 }
 
 // Use HTTPS Proxy (Optional)
@@ -158,7 +158,15 @@ async function awsRequest(service, method, ...args) {
         const jitter = Math.random() * 3000 - 1000;
         // backoff is between 4 and 7 seconds
         const backOff = BASE_BACKOFF + jitter;
-        log(
+        log.info(
+          [
+            `Recoverable error occurred (${e.message}), sleeping for ~${Math.round(
+              backOff / 1000
+            )} seconds.`,
+            `Try ${nextTryNum} of ${MAX_RETRIES}`,
+          ].join(' ')
+        );
+        legacy.log(
           [
             `Recoverable error occurred (${e.message}), sleeping for ~${Math.round(
               backOff / 1000

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -17,6 +17,7 @@ const generateTelemetryPayload = require('../utils/telemetry/generatePayload');
 const processBackendNotificationRequest = require('../utils/processBackendNotificationRequest');
 const isTelemetryDisabled = require('../utils/telemetry/areDisabled');
 const tokenizeException = require('../utils/tokenize-exception');
+const { legacy, log } = require('@serverless/utils/log');
 
 const requireServicePlugin = (serviceDir, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
@@ -282,9 +283,8 @@ class PluginManager {
 
   loadCommand(pluginName, details, key, isEntryPoint) {
     const commandIsEntryPoint = details.type === 'entrypoint' || isEntryPoint;
-    if (process.env.SLS_DEBUG && !commandIsEntryPoint) {
-      this.serverless.cli.log(`Load command ${key}`);
-    }
+    if (process.env.SLS_DEBUG && !commandIsEntryPoint) legacy.log(`Load command ${key}`);
+    log.get('lifecycle:command:register').debug(key);
     // Check if there is already an alias for the same path as the command
     const aliasCommand = this.getAliasCommandTarget(key.split(':'));
     if (aliasCommand) {
@@ -574,11 +574,18 @@ class PluginManager {
     const events = this.getEvents(command);
     const hooks = this.getHooks(events);
 
+    log
+      .get('lifecycle:command:invoke')
+      .debug(
+        `Invoke ${commandsArray.join(':')}${
+          !hooks.length ? ' (noop due to no registered hooks)' : ''
+        }`
+      );
     if (process.env.SLS_DEBUG) {
-      this.serverless.cli.log(`Invoke ${commandsArray.join(':')}`);
+      legacy.log(`Invoke ${commandsArray.join(':')}`);
       if (hooks.length === 0) {
         const warningMessage = 'Warning: The command you entered did not catch on any hooks';
-        this.serverless.cli.log(warningMessage);
+        legacy.log(warningMessage);
       }
     }
 

--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -4,6 +4,7 @@ const { ServerlessError, logWarning } = require('./Error');
 const util = require('util');
 const _ = require('lodash');
 const semver = require('semver');
+const { legacy, log } = require('@serverless/utils/log');
 const resolveCliInput = require('../cli/resolve-input');
 const currentVersion = require('../../package').version;
 
@@ -71,12 +72,19 @@ class Service {
       );
       ymlVersion = null;
     }
-    if (!this.isLocallyInstalled && !ymlVersion && process.env.SLS_DEBUG) {
-      this.serverless.cli.log(
+    if (!this.isLocallyInstalled && !ymlVersion) {
+      log.info(
         'To ensure safe major version upgrades ensure "frameworkVersion" setting in ' +
           'service configuration ' +
           `(recommended setup: "frameworkVersion: ^${currentVersion}")\n`
       );
+      if (process.env.SLS_DEBUG) {
+        legacy.log(
+          'To ensure safe major version upgrades ensure "frameworkVersion" setting in ' +
+            'service configuration ' +
+            `(recommended setup: "frameworkVersion: ^${currentVersion}")\n`
+        );
+      }
     }
     if (
       ymlVersion &&

--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const isObject = require('type/object/is');
 const chalk = require('chalk');
+const stripAnsi = require('strip-ansi');
 const isStandaloneExecutable = require('../utils/isStandaloneExecutable');
 const resolveLocalServerlessPath = require('./resolve-local-serverless-path');
 const slsVersion = require('./../../package').version;
@@ -145,8 +146,11 @@ module.exports = async (exception, options = {}) => {
     )
   );
 
-  const errorMsg =
-    exceptionTokens.stack && !isUserError ? exceptionTokens.stack : exceptionTokens.message;
+  // TODO: Ideally after migrating to new logger complete this strip should not be needed
+  //       (it can be removed after we clear all chalk error message decorations from internals)
+  const errorMsg = stripAnsi(
+    exceptionTokens.stack && !isUserError ? exceptionTokens.stack : exceptionTokens.message
+  );
   writeText(style.error('\nError:'));
   if (errorMsg) {
     writeText(`  ${errorMsg.split('\n').join('\n  ')}`);

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -68,9 +68,7 @@ class AwsDeploy {
 
     this.hooks = {
       'initialize': () => {
-        const isDeployCommand =
-          this.serverless.processedInput.commands.length === 1 &&
-          this.serverless.processedInput.commands[0] === 'deploy';
+        const isDeployCommand = this.serverless.processedInput.commands.join(' ') === 'deploy';
         if (isDeployCommand && !this.options.function) {
           log.notice(
             `\nDeploying ${this.serverless.service.service} to stage ${this.serverless

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -11,7 +11,7 @@ const validateTemplate = require('./lib/validateTemplate');
 const updateStack = require('../lib/updateStack');
 const existsDeploymentBucket = require('./lib/existsDeploymentBucket');
 const path = require('path');
-const { style, log, progress } = require('@serverless/utils/log');
+const { style, log, progress, writeText } = require('@serverless/utils/log');
 const memoize = require('memoizee');
 
 class AwsDeploy {
@@ -119,15 +119,6 @@ class AwsDeploy {
       'aws:deploy:deploy:updateStack': async () => {
         if (this.serverless.service.provider.shouldNotDeploy) return;
         await this.updateStack();
-        log.notice(
-          `\n${style.noticeSymbol('✔')} Service deployed to stack ${this.serverless
-            .getProvider('aws')
-            .naming.getStackName()} ${style.aside(
-            `(${Math.floor(
-              (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
-            )}s)`
-          )}\n`
-        );
       },
 
       // Deploy finalize inner lifecycle
@@ -156,6 +147,39 @@ class AwsDeploy {
               )}s)`
             )}`
           );
+        }
+      },
+
+      'finalize': () => {
+        if (this.serverless.processedInput.commands.join(' ') !== 'deploy') return;
+        if (this.options.function) return;
+        if (this.serverless.service.provider.shouldNotDeploy) {
+          log.notice(
+            `\n${style.noticeSymbol('∅')} No changes to deploy. Deployment skipped. ${style.aside(
+              `(${Math.floor(
+                (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
+              )}s)`
+            )}`
+          );
+          return;
+        }
+        log.notice(
+          `\n${style.noticeSymbol('✔')} Service deployed to stack ${this.serverless
+            .getProvider('aws')
+            .naming.getStackName()} ${style.aside(
+            `(${Math.floor(
+              (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
+            )}s)`
+          )}\n`
+        );
+        if (this.serverless.serviceOutputs) {
+          for (const [section, entries] of this.serverless.serviceOutputs) {
+            if (typeof entries === 'string') {
+              writeText(`${style.aside(`${section}:`)} ${entries}`);
+            } else {
+              writeText(`${style.aside(`${section}:\n`)}  ${entries.join('\n  ')}`);
+            }
+          }
         }
       },
     };

--- a/lib/plugins/aws/deploy/lib/checkForChanges.js
+++ b/lib/plugins/aws/deploy/lib/checkForChanges.js
@@ -8,7 +8,7 @@ const BbPromise = require('bluebird');
 const _ = require('lodash');
 const normalizeFiles = require('../../lib/normalizeFiles');
 const ServerlessError = require('../../../../serverless-error');
-const { style, legacy, log } = require('@serverless/utils/log');
+const { legacy } = require('@serverless/utils/log');
 
 module.exports = {
   async checkForChanges() {
@@ -188,13 +188,6 @@ module.exports = {
 
           const message = ['Service files not changed. Skipping deployment...'].join('');
           legacy.log(message, 'Serverless', { color: 'orange' });
-          log.notice(
-            `\n${style.noticeSymbol('∅')} No changes to deploy. Deployment skipped. ${style.aside(
-              `(${Math.floor(
-                (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
-              )}s)`
-            )}`
-          );
         }
       });
     }

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const { style, legacy, writeText, isVerboseMode } = require('@serverless/utils/log');
+const { legacy, isVerboseMode } = require('@serverless/utils/log');
 
 module.exports = {
   displayServiceInfo() {
@@ -182,17 +182,5 @@ module.exports = {
     }
 
     return message;
-  },
-
-  displayServiceOutputs() {
-    if (this.serverless.serviceOutputs && !this.serverless.service.provider.shouldNotDeploy) {
-      for (const [section, entries] of this.serverless.serviceOutputs) {
-        if (typeof entries === 'string') {
-          writeText(`${style.aside(`${section}:`)} ${entries}`);
-        } else {
-          writeText(`${style.aside(`${section}:\n`)}  ${entries.join('\n  ')}`);
-        }
-      }
-    }
   },
 };

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -28,7 +28,6 @@ class AwsInfo {
               'displayFunctions',
               'displayLayers',
               'displayStackOutputs',
-              'displayServiceOutputs',
             ],
           },
         },
@@ -63,8 +62,6 @@ class AwsInfo {
 
       'aws:info:displayStackOutputs': async () =>
         BbPromise.bind(this).then(this.displayStackOutputs),
-
-      'aws:info:displayServiceOutputs': async () => await this.displayServiceOutputs(),
     };
   }
 }

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -3,6 +3,7 @@
 const BbPromise = require('bluebird');
 const chalk = require('chalk');
 const wait = require('timers-ext/promise/sleep');
+const identity = require('ext/function/identity');
 const ServerlessError = require('../../../serverless-error');
 const { log, legacy, progress, style } = require('@serverless/utils/log');
 
@@ -59,7 +60,7 @@ module.exports = {
               // Loop through stack events
               stackEvents.forEach((event) => {
                 if (loggedEventIds.has(event.EventId)) return;
-                let eventStatus = event.ResourceStatus || null;
+                const eventStatus = event.ResourceStatus || null;
                 // Keep track of stack status
                 if (
                   event.ResourceType === 'AWS::CloudFormation::Stack' &&
@@ -83,14 +84,13 @@ module.exports = {
                   )
                 );
                 if (this.options.verbose) {
-                  if (eventStatus && eventStatus.endsWith('FAILED')) {
-                    eventStatus = chalk.red(eventStatus);
-                  } else if (eventStatus && eventStatus.endsWith('PROGRESS')) {
-                    eventStatus = chalk.yellow(eventStatus);
-                  } else if (eventStatus && eventStatus.endsWith('COMPLETE')) {
-                    eventStatus = chalk.green(eventStatus);
-                  }
-                  let eventLog = `CloudFormation - ${eventStatus} - `;
+                  const decorator = (() => {
+                    if (eventStatus && eventStatus.endsWith('FAILED')) return chalk.red;
+                    if (eventStatus && eventStatus.endsWith('PROGRESS')) return chalk.yellow;
+                    if (eventStatus && eventStatus.endsWith('COMPLETE')) return chalk.green;
+                    return identity;
+                  })();
+                  let eventLog = `CloudFormation - ${decorator(eventStatus)} - `;
                   eventLog += `${event.ResourceType} - `;
                   eventLog += `${event.LogicalResourceId}`;
                   legacy.consoleLog(eventLog);

--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -116,14 +116,16 @@ class AwsPackage {
       },
 
       'finalize': () => {
-        log.notice();
-        log.notice(
-          `${style.noticeSymbol('✔')} Service packaged ${style.aside(
-            `(${Math.floor(
-              (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
-            )}s)`
-          )}`
-        );
+        if (this.serverless.processedInput.commands.join(' ') === 'package') {
+          log.notice();
+          log.notice(
+            `${style.noticeSymbol('✔')} Service packaged ${style.aside(
+              `(${Math.floor(
+                (Date.now() - this.serverless.pluginManager.commandRunStartTime) / 1000
+              )}s)`
+            )}`
+          );
+        }
       },
     };
   }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "replaceall": "^0.1.6",
     "semver": "^7.3.5",
     "signal-exit": "^3.0.3",
+    "strip-ansi": "^6.0.0",
     "tabtab": "^3.0.2",
     "tar": "^6.1.11",
     "timers-ext": "^0.1.7",
@@ -105,7 +106,6 @@
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
     "standard-version": "^9.3.1",
-    "strip-ansi": "^6.0.0",
     "ws": "^7.5.5",
     "xml2js": "^0.4.23"
   },

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -18,7 +18,7 @@ describe('#request', () => {
       proxyquire('../../../../lib/aws/request', {
         'aws-sdk': { config: configStub },
       });
-      expect(typeof configStub.logger).to.equal('function');
+      expect(typeof configStub.logger.log).to.equal('function');
     });
   });
 

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -70,9 +70,7 @@ describe('#request', () => {
             Key: 'test-key',
           }
         )
-      ).to.be.rejectedWith(
-        'AWS provider credentials not found. Learn how to set up AWS provider credentials in our docs here: <\u001b[32mhttp://slss.io/aws-creds-setup\u001b[39m>.'
-      );
+      ).to.be.rejectedWith('AWS provider credentials not found.');
     });
   });
 

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -1520,27 +1520,6 @@ describe('PluginManager', () => {
       return expect(pluginManager.run(commandsArray)).to.be.rejectedWith(Error);
     });
 
-    it('should show warning if in debug mode and the given command has no hooks', () => {
-      const consoleLogStub = sinon.stub(pluginManager.serverless.cli, 'log').returns();
-      process.env.SLS_DEBUG = '*';
-      class HooklessPlugin {
-        constructor() {
-          this.commands = {
-            foo: {},
-          };
-        }
-      }
-
-      pluginManager.addPlugin(HooklessPlugin);
-
-      const commandsArray = ['foo'];
-
-      return pluginManager.run(commandsArray).then(() => {
-        expect(consoleLogStub.called).is.equal(true);
-        pluginManager.serverless.cli.log.restore();
-      });
-    });
-
     it('should run the hooks in the correct order', () => {
       class CorrectHookOrderPluginMock {
         constructor() {
@@ -1796,29 +1775,6 @@ describe('PluginManager', () => {
       const commandsArray = ['foo'];
 
       return expect(pluginManager.spawn(commandsArray)).to.eventually.be.rejectedWith(Error);
-    });
-
-    it('should show warning in debug mode and when the given command has no hooks', () => {
-      const consoleLogStub = sinon.stub(pluginManager.serverless.cli, 'log').returns();
-
-      process.env.SLS_DEBUG = '*';
-
-      class HooklessPlugin {
-        constructor() {
-          this.commands = {
-            foo: {},
-          };
-        }
-      }
-
-      pluginManager.addPlugin(HooklessPlugin);
-
-      const commandsArray = ['foo'];
-
-      return pluginManager.run(commandsArray).then(() => {
-        expect(consoleLogStub.called).is.equal(true);
-        pluginManager.serverless.cli.log.restore();
-      });
     });
 
     describe('when invoking a command', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -221,6 +221,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
   });
 
   it('should not create schedule resources when no scheduled event is given', async () => {
-    expect(run([])).to.be.eventually.empty;
+    expect(await run([])).to.be.empty;
   });
 });

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -366,6 +366,7 @@ describe('test/unit/lib/plugins/aws/provider.test.js', () => {
           SharedIniFileCredentials,
           EnvironmentCredentials,
           CloudFormation: FakeCloudFormation,
+          config: {},
         },
         'aws-sdk/lib/metadata_service': FakeMetadataService,
       };


### PR DESCRIPTION
Addresses #9860

Some verbose logs are triggered via `--verbose` but some (mostly command agnostic, as not all commands support `--verbose` flag) are triggered via `SLS_DEBUG=*`

This PR converts all remaining those which were exposed with `SLS_DEBUG=*` flag. Some of those logs qualify as indeed _debug_ logs and those were propagated to _debug_ log level (in future to be displayed with `--debug` flag)

Additionally:
- Fixed issue, where `package` command summary was displayed after `deploy` command
- Fixed timing of final status log messages. Now they're guaranteed to be displayed at the end of command processing
- Fix CF stack updates progress bar messaging (due to internal destructive operations triggered only in verbose mode, these messaging was different in verbose mode, and that was not expected)
- Ensure to strip any colors with which error message may be configured (e.g. in case of Credential error, in error message link is decorated with green color)
- Fixed improper promise handing in AWS schedule tests (regression introduced with https://github.com/serverless/serverless/pull/9892 cc @federicojasson) which in some scenarios caused no further tests output being printed