### PR TITLE
docs: Remove Pro and Enterprise references

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -89,11 +89,11 @@ choco upgrade serverless
 npm update -g serverless
 ```
 
-## Set up your free Pro account
+## Set up your free Dashboard account
 
-Learn more about [Serverless Framework Pro](https://serverless.com/pro/) and [sign up for free](https://app.serverless.com).
+Learn more about the [Serverless Framework Dashboard](https://serverless.com/framework/) and [sign up for free](https://app.serverless.com).
 
-Once you’ve signed up for Pro, login to your Pro dashboard from the CLI:
+Once you’ve signed up, login to your dashboard from the CLI:
 
 ```bash
 serverless login

--- a/docs/guides/cicd/best-practices.md
+++ b/docs/guides/cicd/best-practices.md
@@ -13,7 +13,7 @@ layout: Doc
 
 # Serverless CI/CD Best Practices
 
-Serverless Framework Pro provides a lot of capabilities out of the box to help you manage and deploy
+Serverless Framework provides a lot of capabilities out of the box to help you manage and deploy
 your services. As your teams grow and the number of services grow, it can be difficult to know
 the best way to organize your services for scale.
 

--- a/docs/guides/cicd/custom-scripts.md
+++ b/docs/guides/cicd/custom-scripts.md
@@ -13,7 +13,7 @@ layout: Doc
 
 # Custom scripts
 
-Serverless Framework Pro runs three primary operations on your repository when you have CI/CD configured: (1) install NPM packages via `npm install`, (2) run tests, if present, with `npm test`, and (3) deploy your service using `sls deploy`. You can run custom scripts before or after each of these steps if you need to customize the pipeline further.
+Serverless Framework runs three primary operations on your repository when you have CI/CD configured: (1) install NPM packages via `npm install`, (2) run tests, if present, with `npm test`, and (3) deploy your service using `sls deploy`. You can run custom scripts before or after each of these steps if you need to customize the pipeline further.
 
 To run custom scripts before & after NPM install and running tests, use the lifecycle hooks built into `scripts` of your `package.json` file. The `preinstall`, `postinstall`, `pretest`, and `posttest`, scripts are run automatically at each of these steps.
 

--- a/docs/guides/cicd/faq.md
+++ b/docs/guides/cicd/faq.md
@@ -45,10 +45,6 @@ Yes! Serverless CI/CD is designed around the Serverless Framework to provide a s
 Anything you can deploy with the Serverless Framework you can deploy with Serverless CI/CD. The Serverless Framework is
 extensible with Plugins , so it works with a broad range of services.
 
-## Is Serverless CI/CD also available for Serverless Framework Pro Enterprise tier?
-
-Yes, Serverless CI/CD works with the Serverless Framework Pro Enterprise tier and it is available for self-hosting.
-
 ## Are all runtimes supported?
 
 Only the most popular runtimes, Node and Python, are currently supported. These two runtimes account for about 90% of

--- a/docs/guides/cicd/notifications.md
+++ b/docs/guides/cicd/notifications.md
@@ -13,7 +13,7 @@ layout: Doc
 
 # Notifications
 
-Serverless Framework Pro has integrated Slack, email, SNS and webhook notifications for CI/CD status updates.
+Serverless Framework has integrated Slack, email, SNS and webhook notifications for CI/CD status updates.
 
 Notifications for CI/CD events are not setup by default, so you will not get notified of deployments starting,
 completing of failing. These notifications must be added manually.

--- a/docs/guides/cicd/preview-deployments.md
+++ b/docs/guides/cicd/preview-deployments.md
@@ -37,7 +37,7 @@ Branch names may also include characters such as `/` which are invalid character
 
 ## Automatically deleting preview deployments (recommended)
 
-The recommended method for deleting preview service instances is to select "Destroy stage and resources when branch is deleted". If the changes in the PR are accepted then they will be merged and then the branch is deleted. If the changes are rejected the branch is also deleted. Whenever the branch is deleted, Serverless Framework Pro will automatically run `sls remove` on this service instance.
+The recommended method for deleting preview service instances is to select "Destroy stage and resources when branch is deleted". If the changes in the PR are accepted then they will be merged and then the branch is deleted. If the changes are rejected the branch is also deleted. Whenever the branch is deleted, Serverless Framework will automatically run `sls remove` on this service instance.
 
 ## Manually deleting preview deployments
 

--- a/docs/guides/monitoring/README.md
+++ b/docs/guides/monitoring/README.md
@@ -21,7 +21,7 @@ Monitoring is enabled by default when you deploy a Service using the Serverless 
 
 ### Configuration
 
-Serverless Framework, when configured to connect to the Serverless Framework Pro Dashboard, will automatically collect three pieces of diagnostics:
+Serverless Framework, when configured to connect to the dashboard, will automatically collect three pieces of diagnostics:
 
 - Lambda Log Collection
 - AWS Spans
@@ -29,7 +29,7 @@ Serverless Framework, when configured to connect to the Serverless Framework Pro
 
 **Lambda Log Collection**
 
-Serverless Framework Pro will enable log collection by adding a CloudWatch Logs Subscription to send logs that match a particular pattern to our infrastructure for processing. This is used for generating metrics and alerts.
+Serverless Framework will enable log collection by adding a CloudWatch Logs Subscription to send logs that match a particular pattern to our infrastructure for processing. This is used for generating metrics and alerts.grep
 
 When deploying, Serverless Framework will also create an IAM role in your account that allows the Serverless Framework backend to call FilterLogEvents on the CloudWatch Log Groups that are created in the Service being deployed. This is used to display the CloudWatch logs error details views alongside the stack trace.
 
@@ -49,7 +49,7 @@ custom:
 
 **AWS Spans**
 
-Serverless Framework Pro will instrument the use of the AWS SDK to show use of AWS services by your Lambda function. This information provides
+Serverless Framework will instrument the use of the AWS SDK to show use of AWS services by your Lambda function. This information provides
 a valuable visualization of what is happening inside your lambda function, including how long calls to services like DynamoDB, S3 and others are taking.
 
 If you wish to disable AWS Span collection, set fhe following option:
@@ -64,7 +64,7 @@ custom:
 
 **HTTP(s) Spans**
 
-Serverless Framework Pro will instrument the use of HTTP(s) by your Lambda function. Much like the AWS Spans, HTTP(s) spans will provide a
+Serverless Framework will instrument the use of HTTP(s) by your Lambda function. Much like the AWS Spans, HTTP(s) spans will provide a
 visualization of the external communication that your function is invoking, including the duration of those sessions.
 
 If you wish to disable Http Span collection, set fhe following option:
@@ -172,11 +172,11 @@ module.exports.handler = async (event, context) => {
 
 ## Pull-based log ingestion
 
-The default monitoring path for the Serverless Framework Pro involves setting up a Subscription Filter on your CloudWatch Log Group to send selected logs to the Serverless Framework Pro ingestion system.
+The default monitoring path for the Serverless Framework involves setting up a Subscription Filter on your CloudWatch Log Group to send selected logs to the Serverless Framework ingestion system.
 
-AWS currently has a hard limit of one Subscription Filter per Log Group. If you try to deploy with the Serverless Framework Pro plugin, you'll get an error saying the resource limit was exceeded.
+AWS currently has a hard limit of one Subscription Filter per Log Group. If you try to deploy with the Serverless Framework plugin, you'll get an error saying the resource limit was exceeded.
 
-If you want to keep your existing Subscription while still adding Serverless Framework Pro support, you can enable pull-based log ingestion using the following syntax in your `serverless.yml`:
+If you want to keep your existing Subscription while still adding Serverless Framework support, you can enable pull-based log ingestion using the following syntax in your `serverless.yml`:
 
 ```yaml
 custom:
@@ -184,6 +184,6 @@ custom:
     logIngestMode: pull
 ```
 
-With pull-based ingestion, the Serverless Framework Pro infrastructure will periodically request logs from your CloudWatch Log Group and send them into our system.
+With pull-based ingestion, the Serverless Framework infrastructure will periodically request logs from your CloudWatch Log Group and send them into our system.
 
-Please note that using the pull-based log ingestion method will result in delays in ingesting your logs. This delay is usually between 30 and 120 seconds. As such, we recommend only using the pull-based log ingestion method in a development environment or when testing the features of Serverless Framework Pro.
+Please note that using the pull-based log ingestion method will result in delays in ingesting your logs. This delay is usually between 30 and 120 seconds. As such, we recommend only using the pull-based log ingestion method in a development environment or when testing the features of Serverless Framework.

--- a/docs/guides/safeguards.md
+++ b/docs/guides/safeguards.md
@@ -15,8 +15,6 @@ layout: Doc
 
 **Safeguards** is a policy-as-code framework for Serverless Framework which enables you to inspect your serverless.yml file, and the generated Cloud Formation templates, for compliance with security, operational, and organizational, best practices.
 
-Safeguards was a feature of the Serverless Framework Pro dashboard and available under the legacy team tier. On August 1st, 2020, it was open sourced and made available free-of-charge as a stand-alone Serverless Framework Plugin free of charge.
+Safeguards was a feature of the Serverless Framework dashboard and available under the legacy team tier. On August 1st, 2020, it was open sourced and made available free-of-charge as a stand-alone Serverless Framework Plugin free of charge.
 
 You can find the new plugin at [serverless/safeguards-plugin](https://github.com/serverless/safeguards-plugin/).
-
-You can easily migrate your safeguard policies from the SF Pro dashboard to the `@serverless/safegurds-plugin` by following the [Migration from Serverless Framework Pro guide](https://github.com/serverless/safeguards-plugin/#migrating-from-serverless-framework-pro).


### PR DESCRIPTION
Update docs to remove references to "Serverless Framework Pro" and "Serverless Framework Enterprise"