### PR TITLE
CLI: Generalize handling of main progress points

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -536,29 +536,29 @@ class PluginManager {
     );
   }
 
-  getEvents(command) {
-    return command.lifecycleEvents
-      ? command.lifecycleEvents.reduce(
-          (acc, event) =>
-            acc.concat([
-              `before:${command.key}:${event}`,
-              `${command.key}:${event}`,
-              `after:${command.key}:${event}`,
-            ]),
-          []
-        )
-      : [];
-  }
-
   getPlugins() {
     return this.plugins;
   }
 
-  getHooks(lifecycleEventNames) {
-    if (!Array.isArray(lifecycleEventNames)) lifecycleEventNames = [lifecycleEventNames];
-    return _.flatten(
-      lifecycleEventNames.map((lifecycleEventName) => this.hooks[lifecycleEventName] || [])
-    );
+  getLifecycleEventsData(command) {
+    const lifecycleEventsData = [];
+    let hooksLength = 0;
+    for (const lifecycleEventSubName of command.lifecycleEvents || []) {
+      const lifecycleEventName = `${command.key}:${lifecycleEventSubName}`;
+      const hooksData = {
+        before: this.hooks[`before:${lifecycleEventName}`] || [],
+        at: this.hooks[lifecycleEventName] || [],
+        after: this.hooks[`after:${lifecycleEventName}`] || [],
+      };
+      hooksLength += hooksData.before.length + hooksData.at.length + hooksData.after.length;
+      lifecycleEventsData.push({
+        command,
+        lifecycleEventSubName,
+        lifecycleEventName,
+        hooksData,
+      });
+    }
+    return { lifecycleEventsData, hooksLength };
   }
 
   async invoke(commandsArray, allowEntryPoints) {
@@ -573,36 +573,39 @@ class PluginManager {
     this.assignDefaultOptions(command);
     this.validateOptions(command);
 
-    const events = this.getEvents(command);
-    const hooks = this.getHooks(events);
+    const { lifecycleEventsData, hooksLength } = this.getLifecycleEventsData(command);
 
     log
       .get('lifecycle:command:invoke')
       .debug(
         `Invoke ${commandsArray.join(':')}${
-          !hooks.length ? ' (noop due to no registered hooks)' : ''
+          !hooksLength ? ' (noop due to no registered hooks)' : ''
         }`
       );
     if (process.env.SLS_DEBUG) {
       legacy.log(`Invoke ${commandsArray.join(':')}`);
-      if (hooks.length === 0) {
+      if (hooksLength === 0) {
         const warningMessage = 'Warning: The command you entered did not catch on any hooks';
         legacy.log(warningMessage);
       }
     }
 
-    for (const hook of hooks) {
-      try {
-        await hook.hook();
-      } catch (error) {
-        if (error instanceof TerminateHookChain) {
-          if (process.env.SLS_DEBUG) {
-            this.serverless.cli.log(`Terminate ${commandsArray.join(':')}`);
-          }
-          return;
-        }
-        throw error;
+    try {
+      for (const {
+        hooksData: { before, at, after },
+      } of lifecycleEventsData) {
+        for (const { hook } of before) await hook();
+        for (const { hook } of at) await hook();
+        for (const { hook } of after) await hook();
       }
+    } catch (error) {
+      if (error instanceof TerminateHookChain) {
+        if (process.env.SLS_DEBUG) {
+          this.serverless.cli.log(`Terminate ${commandsArray.join(':')}`);
+        }
+        return;
+      }
+      throw error;
     }
   }
 
@@ -628,7 +631,7 @@ class PluginManager {
     this.commandRunStartTime = Date.now();
     if (resolveCliInput().commands[0] !== 'plugin') {
       // first initialize hooks
-      for (const { hook } of this.getHooks(['initialize'])) await hook();
+      for (const { hook } of this.hooks.initialize || []) await hook();
     }
 
     let deferredBackendNotificationRequest;
@@ -655,7 +658,7 @@ class PluginManager {
       await this.invoke(commandsArray);
     } catch (commandException) {
       try {
-        for (const { hook } of this.getHooks(['error'])) await hook(commandException);
+        for (const { hook } of this.hooks.error || []) await hook(commandException);
       } catch (errorHookException) {
         const errorHookExceptionMeta = tokenizeException(errorHookException);
         this.serverless.cli.log(
@@ -670,7 +673,7 @@ class PluginManager {
     }
 
     try {
-      for (const { hook } of this.getHooks(['finalize'])) await hook();
+      for (const { hook } of this.hooks.finalize || []) await hook();
     } catch (finalizeHookException) {
       await deferredBackendNotificationRequest;
       throw finalizeHookException;

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -554,9 +554,11 @@ class PluginManager {
     return this.plugins;
   }
 
-  getHooks(events) {
-    const eventsArray = [].concat(events);
-    return eventsArray.reduce((acc, event) => acc.concat(this.hooks[event] || []), []);
+  getHooks(lifecycleEventNames) {
+    if (!Array.isArray(lifecycleEventNames)) lifecycleEventNames = [lifecycleEventNames];
+    return _.flatten(
+      lifecycleEventNames.map((lifecycleEventName) => this.hooks[lifecycleEventName] || [])
+    );
   }
 
   async invoke(commandsArray, allowEntryPoints) {

--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -17,7 +17,9 @@ const generateTelemetryPayload = require('../utils/telemetry/generatePayload');
 const processBackendNotificationRequest = require('../utils/processBackendNotificationRequest');
 const isTelemetryDisabled = require('../utils/telemetry/areDisabled');
 const tokenizeException = require('../utils/tokenize-exception');
-const { legacy, log } = require('@serverless/utils/log');
+const { legacy, log, progress } = require('@serverless/utils/log');
+
+const mainProgress = progress.get('main');
 
 const requireServicePlugin = (serviceDir, pluginPath, localPluginsPath) => {
   if (localPluginsPath && !pluginPath.startsWith('./')) {
@@ -561,6 +563,15 @@ class PluginManager {
     return { lifecycleEventsData, hooksLength };
   }
 
+  async runHooks(hookName, hooks) {
+    const mainProgressTitles = _.get(resolveCliInput().commandSchema, 'mainProgressTitles');
+    if (mainProgressTitles) {
+      const mainProgressTitle = mainProgressTitles.get(hookName);
+      if (mainProgressTitle) mainProgress.notice(mainProgressTitle);
+    }
+    for (const { hook } of hooks) await hook();
+  }
+
   async invoke(commandsArray, allowEntryPoints) {
     const command = this.getCommand(commandsArray, allowEntryPoints);
     if (command.type === 'container') {
@@ -592,11 +603,12 @@ class PluginManager {
 
     try {
       for (const {
+        lifecycleEventName,
         hooksData: { before, at, after },
       } of lifecycleEventsData) {
-        for (const { hook } of before) await hook();
-        for (const { hook } of at) await hook();
-        for (const { hook } of after) await hook();
+        await this.runHooks(`before:${lifecycleEventName}`, before);
+        await this.runHooks(lifecycleEventName, at);
+        await this.runHooks(`after:${lifecycleEventName}`, after);
       }
     } catch (error) {
       if (error instanceof TerminateHookChain) {

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -34,6 +34,7 @@ commands.set('deploy', {
       type: 'boolean',
     },
   },
+  // TODO: Remove deprecated events with v3
   lifecycleEvents: [
     'deprecated#cleanup->package:cleanup',
     'deprecated#initialize->package:initialize',

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -45,6 +45,15 @@ commands.set('deploy', {
     'deploy',
     'finalize',
   ],
+  mainProgressTitles: new Map([
+    ['before:package:cleanup', 'Packaging'],
+    ['before:aws:deploy:deploy:createStack', 'Retrieving CloudFormation stack info'],
+    ['before:aws:deploy:deploy:checkForChanges', 'Retrieving CloudFormation stack info'],
+    ['before:aws:deploy:deploy:uploadArtifacts', 'Uploading'],
+    ['before:aws:deploy:deploy:validateTemplate', 'Updating CloudFormation stack'],
+    ['before:aws:info:validate', 'Retrieving CloudFormation stack info'],
+    ['after:deploy:deploy', 'Updating'],
+  ]),
 });
 
 commands.set('deploy function', {

--- a/lib/cli/commands-schema/service.js
+++ b/lib/cli/commands-schema/service.js
@@ -25,6 +25,7 @@ commands.set('package', {
     'compileEvents',
     'finalize',
   ],
+  mainProgressTitles: new Map([['before:package:cleanup', 'Packaging']]),
 });
 
 commands.set('plugin install', {

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -11,7 +11,7 @@ const validateTemplate = require('./lib/validateTemplate');
 const updateStack = require('../lib/updateStack');
 const existsDeploymentBucket = require('./lib/existsDeploymentBucket');
 const path = require('path');
-const { style, log, progress, writeText } = require('@serverless/utils/log');
+const { style, log, writeText } = require('@serverless/utils/log');
 const memoize = require('memoizee');
 
 class AwsDeploy {
@@ -124,7 +124,6 @@ class AwsDeploy {
       // Deploy finalize inner lifecycle
       'aws:deploy:finalize:cleanup': async () => {
         if (this.serverless.service.provider.shouldNotDeploy) return;
-        progress.get('main').notice('Updating');
         log.info('Updating');
         await this.cleanupS3Bucket();
         if (this.options.package || this.serverless.service.package.path) {

--- a/lib/plugins/aws/lib/updateStack.js
+++ b/lib/plugins/aws/lib/updateStack.js
@@ -74,7 +74,6 @@ module.exports = {
     const templateUrl = `https://${s3Endpoint}/${this.bucketName}/${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`;
 
     legacy.log('Updating Stack...');
-    progress.get('main').notice('Updating CloudFormation stack');
     log.info('Updating CloudFormation stack');
     const stackName = this.provider.naming.getStackName();
     let stackTags = { STAGE: this.provider.getStage() };

--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 const micromatch = require('micromatch');
 const ServerlessError = require('../../../serverless-error');
 const parseS3URI = require('../../aws/utils/parse-s3-uri');
-const { legacy, progress, log } = require('@serverless/utils/log');
+const { legacy, log } = require('@serverless/utils/log');
 
 module.exports = {
   defaultExcludes: [
@@ -68,7 +68,6 @@ module.exports = {
 
   async packageService() {
     legacy.log('Packaging service...');
-    progress.get('main').notice('Packaging');
     log.info();
     log.info('Packaging');
     let shouldPackageService = false;

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",
     "@serverless/eslint-config": "^3.0.0",
-    "@serverless/test": "^8.3.1",
+    "@serverless/test": "^8.4.0",
     "adm-zip": "^0.5.6",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -1168,64 +1168,6 @@ describe('PluginManager', () => {
     });
   });
 
-  describe('#getEvents()', () => {
-    beforeEach(() => {
-      pluginManager.addPlugin(SynchronousPluginMock);
-    });
-
-    it('should get all the matching events for a root level command in the correct order', () => {
-      const command = pluginManager.getCommand(['deploy']);
-      const events = pluginManager.getEvents(command);
-
-      expect(events[0]).to.equal('before:deploy:resources');
-      expect(events[1]).to.equal('deploy:resources');
-      expect(events[2]).to.equal('after:deploy:resources');
-      expect(events[3]).to.equal('before:deploy:functions');
-      expect(events[4]).to.equal('deploy:functions');
-      expect(events[5]).to.equal('after:deploy:functions');
-    });
-
-    it('should get all the matching events for a nested level command in the correct order', () => {
-      const command = pluginManager.getCommand(['deploy', 'onpremises']);
-      const events = pluginManager.getEvents(command);
-
-      expect(events[0]).to.equal('before:deploy:onpremises:resources');
-      expect(events[1]).to.equal('deploy:onpremises:resources');
-      expect(events[2]).to.equal('after:deploy:onpremises:resources');
-      expect(events[3]).to.equal('before:deploy:onpremises:functions');
-      expect(events[4]).to.equal('deploy:onpremises:functions');
-      expect(events[5]).to.equal('after:deploy:onpremises:functions');
-    });
-  });
-
-  describe('#getHooks()', () => {
-    beforeEach(() => {
-      pluginManager.addPlugin(SynchronousPluginMock);
-    });
-
-    it('should get hooks for an event with some registered', () => {
-      expect(pluginManager.getHooks(['deploy:functions']))
-        .to.be.an('Array')
-        .with.length(1);
-    });
-
-    it('should have the plugin name and function on the hook', () => {
-      const hooks = pluginManager.getHooks(['deploy:functions']);
-      expect(hooks[0].pluginName).to.equal('SynchronousPluginMock');
-      expect(hooks[0].hook).to.be.a('Function');
-    });
-
-    it('should not get hooks for an event that does not have any', () => {
-      expect(pluginManager.getHooks(['deploy:resources']))
-        .to.be.an('Array')
-        .with.length(0);
-    });
-
-    it('should accept a single event in place of an array', () => {
-      expect(pluginManager.getHooks('deploy:functions')).to.be.an('Array').with.length(1);
-    });
-  });
-
   describe('#getPlugins()', () => {
     beforeEach(() => {
       mockRequire('ServicePluginMock1', ServicePluginMock1);


### PR DESCRIPTION
Addresses #9860 

To this point main progress titles were configured within internal logic, which shared some issues:
- It was hard to deduct what exactly progress steps are configured for given command
- Was susceptible to gaps, as plugins could inject with some _before_ or _after_ hooks into logic points then attributed to not right progress steps

With this change, main progress steps are configured directly on command schema by referencing lifecycle engine events which mark the start of a given step.

