### PR TITLE
CLI: Revert from unconditional `.env` support

### DIFF
--- a/lib/cli/conditionally-load-dotenv.js
+++ b/lib/cli/conditionally-load-dotenv.js
@@ -2,11 +2,8 @@
 
 'use strict';
 
-const path = require('path');
 const _ = require('lodash');
 const memoizee = require('memoizee');
-const fileExists = require('../utils/fs/fileExists');
-const logDeprecation = require('../utils/logDeprecation');
 
 module.exports = memoizee(
   async (options, configuration) => {
@@ -14,24 +11,6 @@ module.exports = memoizee(
     if (configuration.useDotenv) {
       require('./load-dotenv')(stage);
       return;
-    }
-
-    const defaultEnvFilePath = path.resolve('.env');
-    const stageEnvFilePath = path.resolve(`.env.${stage}`);
-
-    const [doesStageEnvFileExists, doesDefaultEnvFileExists] = await Promise.all([
-      fileExists(stageEnvFilePath),
-      fileExists(defaultEnvFilePath),
-    ]);
-
-    if (doesDefaultEnvFileExists || doesStageEnvFileExists) {
-      logDeprecation(
-        'LOAD_VARIABLES_FROM_ENV_FILES',
-        'Detected ".env" files. In the next major release variables from ".env" ' +
-          'files will be automatically loaded into the serverless build process. ' +
-          'Set "useDotenv: true" to adopt that behavior now.',
-        { serviceConfig: configuration }
-      );
     }
   },
   {


### PR DESCRIPTION
Internally we decided to not pursue `.env` loading unconditionally as  we were worried to break for users which already use .env files to configure the environment for lambdas, where the same root folder is shared by both service configuration and lambda logic.

This PR is purely about removing the deprecation with which such move was announced

Closes: #8566
