### PR TITLE
refactor: Bring back `_.flatMap` usage

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -518,10 +518,7 @@ class AwsInvokeLocal {
       configuredEnvVars,
       envVarsFromOptions
     );
-    const envVarsDockerArgs = Object.keys(envVars).reduce(
-      (acc, key) => acc.concat(['--env', `${key}=${envVars[key]}`]),
-      []
-    );
+    const envVarsDockerArgs = _.flatMap(envVars, (value, key) => ['--env', `${key}=${value}`]);
 
     const dockerArgsFromOptions = this.getDockerArgsFromOptions();
     const dockerArgs = ['run', '--rm', '-v', `${artifactPath}:/var/task:ro,delegated`].concat(
@@ -548,11 +545,11 @@ class AwsInvokeLocal {
   }
 
   getDockerArgsFromOptions() {
-    const dockerArgOptions = [].concat(this.options['docker-arg'] || []);
-    return dockerArgOptions.reduce((acc, dockerArgOption) => {
+    const dockerArgOptions = this.options['docker-arg'];
+    return _.flatMap([].concat(dockerArgOptions || []), (dockerArgOption) => {
       const splitItems = dockerArgOption.split(' ');
-      return acc.concat(splitItems[0], splitItems.slice(1).join(' ') || []);
-    }, []);
+      return [splitItems[0], splitItems.slice(1).join(' ')];
+    });
   }
 
   async invokeLocalPython(runtime, handlerPath, handlerName, event, context) {


### PR DESCRIPTION
Reverts #9948 (it covered a bit more originally but other methods were refactored in a meantime)

There was no intention (yet) to get rid of `_.flatMap` in scope of #7747, as reliable alternative in form of `[].flatMap` doesn't work with Node.js v10

PR proposed to refactor it into less readable `[].reduce` logic, which I think reduced readability of logic.

We should keep `_.flatMap` and refactor it into native `[].flatMap` on the grounds of v3 (which will come with dropped support for Node.js v10)

/cc @JonasMatos0 @pgrzesik 
