### PR TITLE
docs: Removed duplicated paragraph

### DIFF
--- a/docs/providers/aws/events/streams.md
+++ b/docs/providers/aws/events/streams.md
@@ -77,8 +77,6 @@ functions:
 This configuration sets up a disabled Kinesis stream event for the `preprocess` function which has a batch size of `100`. The starting position is
 `LATEST`.
 
-**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
-
 ```yml
 functions:
   preprocess:
@@ -106,8 +104,6 @@ The `batchWindow` property specifies a maximum amount of time to wait before tri
 
 For more information, read the [AWS release announcement](https://aws.amazon.com/about-aws/whats-new/2019/09/aws-lambda-now-supports-custom-batch-window-for-kinesis-and-dynamodb-event-sources/) for this property.
 
-**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
-
 ```yml
 functions:
   preprocess:
@@ -126,8 +122,6 @@ This configuration provides the ability to recursively split a failed batch and 
 
 [Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-bisectbatchonfunctionerror)
 
-**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
-
 ```yml
 functions:
   preprocess:
@@ -145,8 +139,6 @@ This configuration sets up the maximum number of times to retry when the functio
 **Note:** Serverless only sets this property if you explicitly add it to the stream configuration (see example below).
 
 [Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumretryattempts)
-
-**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
 
 ```yml
 functions:
@@ -168,8 +160,6 @@ This configuration sets up the maximum age of a record that Lambda sends to a fu
 **Note:** Serverless only sets this property if you explicitly add it to the stream configuration (see example below).
 
 [Related AWS documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html#cfn-lambda-eventsourcemapping-maximumrecordageinseconds)
-
-**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
 
 ```yml
 functions:
@@ -255,8 +245,6 @@ The `parallelizationFactor` property specifies the number of concurrent Lambda i
 
 For more information, read the [AWS release announcement](https://aws.amazon.com/blogs/compute/new-aws-lambda-scaling-controls-for-kinesis-and-dynamodb-event-sources/) for this property.
 
-**Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.
-
 ```yml
 functions:
   preprocess:
@@ -272,8 +260,6 @@ functions:
 This configuration allows customers to automatically checkpoint records that have been successfully processed for Amazon Kinesis and Amazon DynamoDB Streams.
 
 For more information, read the [AWS release announcement](https://aws.amazon.com/about-aws/whats-new/2020/12/aws-lambda-launches-checkpointing-for-amazon-kinesis-and-amazon-dynamodb-streams/)
-
-Note: Serverless only sets this property if you explicitly add it to the stream configuration (see example below).
 
 ```yml
 functions:


### PR DESCRIPTION
The following paragraph was duplicated in many sections of the page:

> **Note:** The `stream` event will hook up your existing streams to a Lambda function. Serverless won't create a new stream for you.

I think this was because of contributors copy/pasting that along the way. When reading the page it felt really weird reading that over and over.

If there was a reason this paragraph was there in every section feel free to close.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->