### PR TITLE
Standalone: Fix npm command handling issue

### DIFF
--- a/commands/plugin-install.js
+++ b/commands/plugin-install.js
@@ -110,9 +110,9 @@ const addPluginToServerlessFile = async ({ configurationFilePath, pluginName }) 
 };
 
 const npmInstall = async (name, { serviceDir }) => {
-  const npmCommand = await npmCommandDeferred;
+  const { command, args } = await npmCommandDeferred;
   try {
-    await spawn(npmCommand, ['install', '--save-dev', name], {
+    await spawn(command, [...args, 'install', '--save-dev', name], {
       cwd: serviceDir,
       stdio: 'pipe',
       // To parse quotes used in module versions. E.g. 'serverless@"^1.60.0 || 2"'

--- a/commands/plugin-install.js
+++ b/commands/plugin-install.js
@@ -120,7 +120,7 @@ const npmInstall = async (name, { serviceDir }) => {
       shell: true,
     });
   } catch (error) {
-    process.stdout.write(error.stdBuffer);
+    process.stdout.write(error.stderrBuffer);
     throw error;
   }
 };

--- a/lib/cli/interactive-setup/service.js
+++ b/lib/cli/interactive-setup/service.js
@@ -222,9 +222,9 @@ module.exports = {
 
     if (hasPackageJson) {
       process.stdout.write(`\nInstalling dependencies with "npm" in "${projectName}" folder\n`);
-      const npmCommand = await npmCommandDeferred;
+      const { command, args } = await npmCommandDeferred;
       try {
-        await spawn(npmCommand, ['install'], { cwd: projectDir });
+        await spawn(command, [...args, 'install'], { cwd: projectDir });
       } catch (err) {
         if (err.code === 'ENOENT') {
           process.stdout.write(

--- a/lib/plugins/plugin/install.js
+++ b/lib/plugins/plugin/install.js
@@ -192,8 +192,8 @@ class PluginInstall {
   }
 
   async npmInstall(name) {
-    return npmCommandDeferred.then((npmCommand) =>
-      childProcess.execAsync(`${npmCommand} install --save-dev ${name}`, {
+    return npmCommandDeferred.then(({ command, args }) =>
+      childProcess.execAsync(`${command} ${args.join(' ')} install --save-dev ${name}`, {
         stdio: 'ignore',
       })
     );

--- a/lib/utils/npm-command-deferred.js
+++ b/lib/utils/npm-command-deferred.js
@@ -15,5 +15,7 @@ module.exports = fsp
     }
   )
   .then((isNpmInstalledLocaly) => {
-    return isNpmInstalledLocaly ? `node ${localNpmBinPath}` : 'npm';
+    return isNpmInstalledLocaly
+      ? { command: 'node', args: [localNpmBinPath] }
+      : { command: 'npm', args: [] };
   });

--- a/scripts/pkg/build.js
+++ b/scripts/pkg/build.js
@@ -20,7 +20,7 @@ const spawnOptions = { cwd: serverlessPath, stdio: 'inherit' };
   // It's due to fact that npm tends to issue buggy releases
   // Node.js confirms on given version before including it within its bundle
   // Version mappings reference: https://nodejs.org/en/download/releases/
-  await spawn('npm', ['install', '--no-save', 'npm@6.13.4'], spawnOptions);
+  await spawn('npm', ['install', '--no-save', 'npm@6.14.15'], spawnOptions);
 
   try {
     process.stdout.write('Build binaries\n');

--- a/test/unit/lib/plugins/plugin/install.test.js
+++ b/test/unit/lib/plugins/plugin/install.test.js
@@ -264,7 +264,7 @@ describe('PluginInstall', () => {
       process.chdir(savedCwd);
     });
 
-    it('should install the plugin if it has not been installed yet', () => {
+    it('npmI', () => {
       const packageJson = {
         name: 'test-service',
         description: '',
@@ -278,7 +278,7 @@ describe('PluginInstall', () => {
       return expect(pluginInstall.pluginInstall()).to.be.fulfilled.then(() =>
         Promise.all([
           expect(
-            npmInstallStub.calledWithExactly('npm install --save-dev serverless-plugin-1@latest', {
+            npmInstallStub.calledWithExactly('npm  install --save-dev serverless-plugin-1@latest', {
               stdio: 'ignore',
             })
           ).to.equal(true),
@@ -290,7 +290,7 @@ describe('PluginInstall', () => {
     it('should generate a package.json file in the service directory if not present', () =>
       expect(pluginInstall.pluginInstall()).to.be.fulfilled.then(() => {
         expect(
-          npmInstallStub.calledWithExactly('npm install --save-dev serverless-plugin-1@latest', {
+          npmInstallStub.calledWithExactly('npm  install --save-dev serverless-plugin-1@latest', {
             stdio: 'ignore',
           })
         ).to.equal(true);
@@ -539,7 +539,7 @@ describe('PluginInstall', () => {
       });
       return expect(pluginInstall.installPeerDependencies()).to.be.fulfilled.then(() => {
         expect(
-          npmInstallStub.calledWithExactly('npm install --save-dev some-package@"*"', {
+          npmInstallStub.calledWithExactly('npm  install --save-dev some-package@"*"', {
             stdio: 'ignore',
           })
         ).to.equal(true);
@@ -552,7 +552,7 @@ describe('PluginInstall', () => {
         expect(fse.readJsonSync(servicePackageJsonFilePath)).to.be.deep.equal({
           devDependencies: {},
         });
-        expect(npmInstallStub.calledWithExactly('npm install', { stdio: 'ignore' })).to.equal(
+        expect(npmInstallStub.calledWithExactly('npm  install', { stdio: 'ignore' })).to.equal(
           false
         );
       });


### PR DESCRIPTION
Issue observed in CI fails, after refactoring `plugin install` command.

It appeared npm commands were not configured correctly for `spawn` in the context of _standalone_  installations.

Additionally upgraded to rely on npm that recognizes node.js v14 (as standalone build now is based on Node.js v14)