### PR TITLE
AWS EventBridge: Fix `MaximumEventAgeInSecond` template reference

### DIFF
--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -180,7 +180,7 @@ class AwsCompileEventBridgeEvents {
               }
 
               RetryPolicy = {
-                MaximumEventAge: RetryPolicy.maximumEventAge,
+                MaximumEventAgeInSeconds: RetryPolicy.maximumEventAge,
                 MaximumRetryAttempts: RetryPolicy.maximumRetryAttempts,
               };
             }

--- a/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -542,7 +542,7 @@ describe('EventBridgeEvents', () => {
         const retryPolicyRuleTarget = getRuleResourceEndingWith(cfResources, '6').Properties
           .Targets[0];
         expect(retryPolicyRuleTarget.RetryPolicy).to.deep.equal({
-          MaximumEventAge: 7200,
+          MaximumEventAgeInSeconds: 7200,
           MaximumRetryAttempts: 9,
         });
       });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Fix issue reported in closed PR: https://github.com/serverless/serverless/pull/9903#issuecomment-929676031
