### PR TITLE
fix(AWS EventBridge): Ensure proper support for `deadLetterConfig`

### DIFF
--- a/docs/providers/aws/events/event-bridge.md
+++ b/docs/providers/aws/events/event-bridge.md
@@ -189,7 +189,7 @@ functions:
 
 ## Adding a DLQ to an event rule
 
-DeadLetterConfig is not available for custom resources, only for native CloudFormation.
+DeadLetterQueueArn is not available for custom resources, only for native CloudFormation.
 
 ```yml
 functions:
@@ -201,11 +201,10 @@ functions:
           pattern:
             source:
               - saas.external
-          deadLetterConfig:
-            targetArn:
-              Fn::GetAtt:
-                - QueueName
-                - Arn
+          deadLetterQueueArn:
+            Fn::GetAtt:
+              - QueueName
+              - Arn
 ```
 
 ## Adding a retry policy to an event rule
@@ -222,7 +221,7 @@ functions:
           pattern:
             source:
               - saas.external
-          deadLetterConfig:
+          deadLetterQueueArn:
             Fn::GetAtt:
               - QueueName
               - Arn

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -568,6 +568,13 @@ functions:
             inputPathsMap:
               eventTime: '$.time'
             inputTemplate: '{"time": <eventTime>, "key1": "value1"}'
+          retryPolicy:
+            maximumEventAge: 3600
+            maximumRetryAttempts: 3
+          deadLetterQueueArn:
+            Fn::GetAtt:
+              - QueueName
+              - Arn
       - cloudFront:
           eventType: viewer-response
           includeBody: true

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -102,15 +102,7 @@ class AwsCompileEventBridgeEvents {
             },
           },
         },
-        deadLetterConfig: {
-          type: 'object',
-          properties: {
-            targetArn: {
-              $ref: '#/definitions/awsArn',
-            },
-          },
-          additionalProperties: false,
-        },
+        deadLetterQueueArn: { $ref: '#/definitions/awsArn' },
       },
       anyOf: [{ required: ['pattern'] }, { required: ['schedule'] }],
     });
@@ -142,7 +134,7 @@ class AwsCompileEventBridgeEvents {
             const InputPath = event.eventBridge.inputPath;
             let InputTransformer = event.eventBridge.inputTransformer;
             let RetryPolicy = event.eventBridge.retryPolicy;
-            let DeadLetterConfig = event.eventBridge.deadLetterConfig;
+            let DeadLetterConfig;
 
             const RuleName = makeAndHashRuleName({
               functionName: FunctionName,
@@ -185,7 +177,7 @@ class AwsCompileEventBridgeEvents {
               };
             }
 
-            if (DeadLetterConfig) {
+            if (event.eventBridge.deadLetterQueueArn) {
               if (!shouldUseCloudFormation) {
                 throw new ServerlessError(
                   'Configuring DeadLetterConfig is not supported for EventBrigde integration backed by Custom Resources. Please use "provider.eventBridge.useCloudFormation" setting to use native CloudFormation support for EventBridge.',
@@ -193,7 +185,7 @@ class AwsCompileEventBridgeEvents {
                 );
               }
               DeadLetterConfig = {
-                TargetArn: DeadLetterConfig.targetArn,
+                Arn: event.eventBridge.deadLetterQueueArn,
               };
             }
 
@@ -509,6 +501,18 @@ class AwsCompileEventBridgeEvents {
   }
 
   configureTarget({ target, Input, InputPath, InputTransformer, RetryPolicy, DeadLetterConfig }) {
+    if (RetryPolicy) {
+      target = Object.assign(target, {
+        RetryPolicy,
+      });
+    }
+
+    if (DeadLetterConfig) {
+      target = Object.assign(target, {
+        DeadLetterConfig,
+      });
+    }
+
     if (Input) {
       target = Object.assign(target, {
         Input: JSON.stringify(Input),
@@ -524,20 +528,6 @@ class AwsCompileEventBridgeEvents {
     if (InputTransformer) {
       target = Object.assign(target, {
         InputTransformer,
-      });
-      return target;
-    }
-
-    if (RetryPolicy) {
-      target = Object.assign(target, {
-        RetryPolicy,
-      });
-      return target;
-    }
-
-    if (DeadLetterConfig) {
-      target = Object.assign(target, {
-        DeadLetterConfig,
       });
       return target;
     }

--- a/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -307,7 +307,7 @@ describe('EventBridgeEvents', () => {
       );
     });
 
-    it('should fail when trying to set DeadLetterConfig', async () => {
+    it('should fail when trying to set DeadLetterQueueArn', async () => {
       await expect(
         runServerless({
           fixture: 'function',
@@ -318,10 +318,8 @@ describe('EventBridgeEvents', () => {
                 events: [
                   {
                     eventBridge: {
-                      deadLetterConfig: {
-                        targetArn: {
-                          'Fn::GetAtt': ['not-supported', 'Arn'],
-                        },
+                      deadLetterQueueArn: {
+                        'Fn::GetAtt': ['not-supported', 'Arn'],
                       },
                       pattern: {
                         source: ['aws.something'],
@@ -398,10 +396,8 @@ describe('EventBridgeEvents', () => {
         maximumRetryAttempts: 9,
       };
 
-      const deadLetterConfig = {
-        targetArn: {
-          'Fn::GetAtt': ['test', 'Arn'],
-        },
+      const deadLetterQueueArn = {
+        'Fn::GetAtt': ['test', 'Arn'],
       };
 
       const getRuleResourceEndingWith = (resources, ending) =>
@@ -475,7 +471,7 @@ describe('EventBridgeEvents', () => {
                       eventBus: eventBusName,
                       schedule,
                       pattern,
-                      deadLetterConfig,
+                      deadLetterQueueArn,
                     },
                   },
                 ],
@@ -547,10 +543,10 @@ describe('EventBridgeEvents', () => {
         });
       });
 
-      it('should support deadLetterConfig configuration', () => {
+      it('should support deadLetterQueueArn configuration', () => {
         const deadLetterConfigRuleTarget = getRuleResourceEndingWith(cfResources, '7').Properties
           .Targets[0];
-        expect(deadLetterConfigRuleTarget.DeadLetterConfig).to.have.property('TargetArn');
+        expect(deadLetterConfigRuleTarget.DeadLetterConfig).to.have.property('Arn');
       });
 
       it('should create a rule that depends on created EventBus', () => {


### PR DESCRIPTION
Fixes issue reported here: https://github.com/serverless/serverless/pull/9903#issuecomment-930540004

I've also simplified the setting to avoid using nested `arn` or `targetArn` property as the `deadLetterConfig` has only single `arn` property. @medikoo Please let me know what do you think about it - do you think it's worth to still keep that nested? 

Additionally, I've spotted and fixed a bug with setting the target config when more properties are involved. 

I've manually tested it and it seems to work correctly :+1: 
