### PR TITLE
CLI: Improve modern logs for create stack

### DIFF
--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -131,7 +131,7 @@ module.exports = async (exception, options = {}) => {
 
   const platform = process.platform;
   const nodeVersion = process.version.replace(/^[v|V]/, '');
-  const installationModePostfix = await (async () => {
+  const installationModePostfix = (() => {
     if (isStandaloneExecutable) return ' (standalone)';
     if (isLocallyInstalled != null) return isLocallyInstalled ? ' (local)' : '';
     return resolveIsLocallyInstalled() ? ' (local)' : '';

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -108,9 +108,8 @@ module.exports = {
                   }
                 }
 
-                if (completedResources.size || inProgressResources.size) {
+                if ((completedResources.size || inProgressResources.size) && action !== 'create') {
                   const progressMessagePrefix = (() => {
-                    if (action === 'create') return 'Creating';
                     if (action === 'update') return 'Updating';
                     if (action === 'delete') return 'Removing';
                     throw new Error(`Unrecgonized action: ${action}`);

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -7,6 +7,7 @@ const identity = require('ext/function/identity');
 const ServerlessError = require('../../../serverless-error');
 const { log, legacy, progress, style } = require('@serverless/utils/log');
 
+const mainProgress = progress.get('main');
 const validStatuses = new Set(['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'DELETE_COMPLETE']);
 
 const normalizerPattern = /(?<!^)([A-Z])/g;
@@ -115,13 +116,11 @@ module.exports = {
                 })();
 
                 if (operationPhrase && (completedResources.size || inProgressResources.size)) {
-                  progress
-                    .get('main')
-                    .notice(
-                      `${operationPhrase} CloudFormation stack (${completedResources.size}/${
-                        completedResources.size + inProgressResources.size
-                      })`
-                    );
+                  mainProgress.notice(
+                    `${operationPhrase} CloudFormation stack (${completedResources.size}/${
+                      completedResources.size + inProgressResources.size
+                    })`
+                  );
                 }
                 // Prepare for next monitoring action
                 loggedEventIds.add(event.EventId);

--- a/lib/plugins/aws/lib/monitorStack.js
+++ b/lib/plugins/aws/lib/monitorStack.js
@@ -108,16 +108,15 @@ module.exports = {
                   }
                 }
 
-                const operationPhrase = (() => {
-                  if (action === 'create') return 'Creating';
-                  if (action === 'update') return 'Updating';
-                  if (action === 'delete') return 'Removing';
-                  return '';
-                })();
-
-                if (operationPhrase && (completedResources.size || inProgressResources.size)) {
+                if (completedResources.size || inProgressResources.size) {
+                  const progressMessagePrefix = (() => {
+                    if (action === 'create') return 'Creating';
+                    if (action === 'update') return 'Updating';
+                    if (action === 'delete') return 'Removing';
+                    throw new Error(`Unrecgonized action: ${action}`);
+                  })();
                   mainProgress.notice(
-                    `${operationPhrase} CloudFormation stack (${completedResources.size}/${
+                    `${progressMessagePrefix} CloudFormation stack (${completedResources.size}/${
                       completedResources.size + inProgressResources.size
                     })`
                   );

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -15,7 +15,7 @@ if (require('../lib/utils/tabCompletion/isSupported') && process.argv[2] === 'co
 
 // Setup log writing
 require('@serverless/utils/log-reporters/node');
-const { progress } = require('@serverless/utils/log');
+const { legacy, log, progress } = require('@serverless/utils/log');
 
 const handleError = require('../lib/cli/handle-error');
 const {
@@ -870,16 +870,22 @@ const processSpanPromise = (async () => {
       try {
         await dashboardErrorHandler(error, serverless.invocationId);
       } catch (dashboardErrorHandlerError) {
-        const log = require('@serverless/utils/log');
         const tokenizeException = require('../lib/utils/tokenize-exception');
         const exceptionTokens = tokenizeException(dashboardErrorHandlerError);
-        log(
+        legacy.log(
           `Publication to Serverless Dashboard errored with:\n${' '.repeat('Serverless: '.length)}${
             exceptionTokens.isUserError || !exceptionTokens.stack
               ? exceptionTokens.message
               : exceptionTokens.stack
           }`,
           { color: 'orange' }
+        );
+        log.warning(
+          `Publication to Serverless Dashboard errored with:\n${' '.repeat('Serverless: '.length)}${
+            exceptionTokens.isUserError || !exceptionTokens.stack
+              ? exceptionTokens.message
+              : exceptionTokens.stack
+          }`
         );
       }
       throw error;


### PR DESCRIPTION
Addresses: #9860 

- Ensured no resources progress on create stack (as it's only about addition of deployment bucket)
- Ensured empty line at the end of the output (from the google doc feedback)