### PR TITLE
fix(Templates): Add `esbuild` to `gitignore` in  `aws-nodejs-typescript`

### DIFF
--- a/lib/plugins/create/templates/aws-nodejs-typescript/.gitignore
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/.gitignore
@@ -5,5 +5,5 @@ jspm_packages
 # Serverless directories
 .serverless
 
-# Webpack directories
-.webpack
+# esbuild directories
+.esbuild


### PR DESCRIPTION
In `aws-nodejs-typescript` template, thanks to #9962, lambda is packaged by esbuild instead of webpack.
Now, `.esbuild` directory is managed by git because `.gitignore` doesn't contain it.
This PR fixes gitignore to ignore `.esbuild` instead of `.webpack`.