### PR TITLE
refactor(CLI): Introduce modern warning about resource limit

### DIFF
--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -74,7 +74,7 @@ class AwsInfo {
         BbPromise.bind(this).then(this.displayStackOutputs),
 
       'after:aws:info:gatherData': () => {
-        if (this.gatheredData.info.resourceCount >= 450) {
+        if (this.gatheredData && this.gatheredData.info.resourceCount >= 450) {
           log.warning(
             `You have ${
               this.gatheredData.info.resourceCount
@@ -89,7 +89,6 @@ class AwsInfo {
         if (this.serverless.processedInput.commands.join(' ') !== 'info') return;
 
         writeText(
-          null,
           `${style.aside('service:')} ${this.serverless.service.service}`,
           `${style.aside('stage:')} ${this.provider.getStage()}`,
           `${style.aside('region:')} ${this.provider.getRegion()}`,


### PR DESCRIPTION
Addresses: serverless/serverless#9860

It looks like modern logs for this warning has been omitted previously, it brings it back to warn users that are approaching resource limit in CloudFormation

![warnlimit](https://user-images.githubusercontent.com/17499590/136965439-48f329be-c53b-4170-9f4d-7eca8e04dec8.png)

