### PR TITLE
refactor(CLI): Replace `process.stdout` use with modern logs

### DIFF
--- a/lib/cli/handle-error.js
+++ b/lib/cli/handle-error.js
@@ -26,7 +26,7 @@ const writeMessage = (title, message) => {
     line = `${line}-`;
   }
 
-  process.stdout.write(' \n');
+  legacy.consoleLog(' ');
   legacy.consoleLog(chalk.yellow(` ${title} ${line}`));
   legacy.consoleLog(' ');
 

--- a/lib/cli/render-help/command.js
+++ b/lib/cli/render-help/command.js
@@ -21,5 +21,6 @@ module.exports = (commandName) => {
   }
   if (commandSchema) renderOptionsHelp(Object.assign({}, commandSchema.options));
 
-  process.stdout.write('\n');
+  legacy.consoleLog('');
+  writeText();
 };

--- a/lib/cli/render-version.js
+++ b/lib/cli/render-version.js
@@ -5,7 +5,7 @@ const { version } = require('../../package');
 const { version: dashboardPluginVersion } = require('@serverless/dashboard-plugin/package');
 const { version: componentsVersion } = require('@serverless/components/package');
 const { platformClientVersion } = require('@serverless/dashboard-plugin');
-const { legacy, log } = require('@serverless/utils/log');
+const { legacy, log, writeText } = require('@serverless/utils/log');
 const isStandaloneExecutable = require('../utils/isStandaloneExecutable');
 const resolveLocalServerlessPath = require('./resolve-local-serverless-path');
 const chalk = require('chalk');
@@ -54,10 +54,16 @@ module.exports = async () => {
     return '';
   })();
 
-  process.stdout.write(
+  legacy.write(
     `Framework Core: ${version}${installationModePostfix}\n` +
       `Plugin: ${dashboardPluginVersion}\n` +
       `SDK: ${platformClientVersion}\n` +
       `Components: ${componentsVersion}\n`
+  );
+  writeText(
+    `Framework Core: ${version}${installationModePostfix}`,
+    `Plugin: ${dashboardPluginVersion}`,
+    `SDK: ${platformClientVersion}`,
+    `Components: ${componentsVersion}`
   );
 };

--- a/lib/utils/open.js
+++ b/lib/utils/open.js
@@ -14,6 +14,7 @@ const path = require('path');
 const childProcess = require('child_process');
 const fs = require('fs');
 const isWsl = require('is-wsl');
+const { legacy, log } = require('@serverless/utils/log');
 
 const pAccess = promisify(fs.access);
 const pExecFile = promisify(childProcess.execFile);
@@ -158,10 +159,11 @@ module.exports = async (target, options) => {
       }
       subprocess.once('error', (error) => {
         if (process.env.SLS_DEBUG) {
-          process.stdout.write(
+          legacy.write(
             `Serverless: ${chalk.red(`Opening of browser window errored with ${error.stack}`)}\n`
           );
         }
+        log.info(`Opening of browser window errored with ${error.stack}`);
       });
 
       subprocess.unref();

--- a/lib/utils/openBrowser.js
+++ b/lib/utils/openBrowser.js
@@ -5,20 +5,25 @@
 const opn = require('./open');
 const chalk = require('chalk');
 const isDockerContainer = require('is-docker');
+const { legacy, log, style } = require('@serverless/utils/log');
 
 module.exports = function openBrowser(url) {
-  process.stdout.write(
-    `\nIf your browser does not open automatically, please open the URL: ${url}\n\n`
+  legacy.write(`\nIf your browser does not open automatically, please open the URL: ${url}\n\n`);
+  log.notice();
+  log.notice(
+    style.aside(`If your browser does not open automatically, please open this URL: ${url}`)
   );
+  log.notice();
   let browser = process.env.BROWSER;
   if (browser === 'none' || isDockerContainer()) return;
   if (process.platform === 'darwin' && browser === 'open') browser = undefined;
   const options = { wait: false, app: browser };
   opn(url, options).catch((err) => {
     if (process.env.SLS_DEBUG) {
-      process.stdout.write(
+      legacy.write(
         `Serverless: ${chalk.red(`Opening of browser window errored with ${err.stack}`)}\n`
       );
     }
+    log.info(`Opening of browser window errored with ${err.stack}`);
   });
 };

--- a/lib/utils/processBackendNotificationRequest.js
+++ b/lib/utils/processBackendNotificationRequest.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
+const { legacy, log, style } = require('@serverless/utils/log');
 
 const processBackendNotificationRequest = require('@serverless/utils/process-backend-notification-request');
 
@@ -8,5 +9,7 @@ module.exports = (notifications) => {
   const notification = processBackendNotificationRequest(notifications);
   if (!notification) return;
 
-  process.stdout.write(`\n${chalk.gray(notification.message)}\n`);
+  legacy.write(`\n${chalk.gray(notification.message)}\n`);
+  log.notice();
+  log.notice(style.aside(notification.message));
 };


### PR DESCRIPTION
Addresses: #9860

Replace leftover `process.stdout` usages with modern logs