### PR TITLE
CLI: Improve handling of service outputs in modern logs

### DIFF
--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -24,6 +24,13 @@ module.exports = {
     }
 
     legacy.consoleLog(message);
+    if (this.serverless.processedInput.commands.join(' ') === 'info') {
+      this.serverless.addServiceOutputSection('service', this.serverless.service.service);
+      this.serverless.addServiceOutputSection('stage', this.provider.getStage());
+      this.serverless.addServiceOutputSection('region', this.provider.getRegion());
+      this.serverless.addServiceOutputSection('stack', this.provider.naming.getStackName());
+    }
+
     return message;
   },
 

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const { progress, writeText, style } = require('@serverless/utils/log');
+const { progress, style } = require('@serverless/utils/log');
 const writeServiceOutputs = require('../../../cli/write-service-outputs');
 const validate = require('../lib/validate');
 const getStackInfo = require('./getStackInfo');
@@ -87,13 +87,6 @@ class AwsInfo {
 
       'finalize': () => {
         if (this.serverless.processedInput.commands.join(' ') !== 'info') return;
-
-        writeText(
-          `${style.aside('service:')} ${this.serverless.service.service}`,
-          `${style.aside('stage:')} ${this.provider.getStage()}`,
-          `${style.aside('region:')} ${this.provider.getRegion()}`,
-          `${style.aside('stack:')} ${this.provider.naming.getStackName()}`
-        );
         writeServiceOutputs(this.serverless.serviceOutputs);
       },
     };


### PR DESCRIPTION
At first I've tried to keep general stack info outside of `addServiceOutputSection` interface, still it doesn't work will with eventual extensions added by the plugins, e.g. it resulted with dashboard URL put in the middle of table, where it should stay at the top. This patch ensures expected order