### PR TITLE
Check if the package output path contains the service

### DIFF
--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -11,6 +11,7 @@ const uploadArtifacts = require('./lib/uploadArtifacts');
 const validateTemplate = require('./lib/validateTemplate');
 const updateStack = require('../lib/updateStack');
 const existsDeploymentBucket = require('./lib/existsDeploymentBucket');
+const validateCustomPackagePath = require('../../lib/validateCustomPackagePath');
 const path = require('path');
 const { style, log, progress, writeText } = require('@serverless/utils/log');
 const memoize = require('memoizee');
@@ -30,6 +31,7 @@ class AwsDeploy {
 
     Object.assign(
       this,
+      validateCustomPackagePath,
       extendedValidate,
       createStack,
       setBucketName,
@@ -82,6 +84,8 @@ class AwsDeploy {
           log.info(); // Ensure gap between verbose logging
         }
       },
+
+      'deploy:initialize': async () => await this.validateCustomPackagePath(),
 
       'before:deploy:deploy': async () => {
         await this.serverless.pluginManager.spawn('aws:common:validate');

--- a/lib/plugins/aws/lib/validate.js
+++ b/lib/plugins/aws/lib/validate.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const ServerlessError = require('../../../serverless-error');
 
 module.exports = {
@@ -9,6 +10,15 @@ module.exports = {
         'This command can only be run inside a service directory',
         'MISSING_SERVICE_DIRECTORY'
       );
+    }
+
+    if (this.options.package) {
+      if (this.serverless.serviceDir.startsWith(path.resolve(this.options.package))) {
+        throw new ServerlessError(
+          'Package output includes service directory',
+          'INVALID_PACKAGE_ARTIFACT_PATH'
+        );
+      }
     }
 
     this.options.stage = this.provider.getStage();

--- a/lib/plugins/lib/validateCustomPackagePath.js
+++ b/lib/plugins/lib/validateCustomPackagePath.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const path = require('path');
+const ServerlessError = require('../../serverless-error');
+
+function isSubDirectory(serviceDir, packageDir) {
+  if (serviceDir.substr(-1) !== '/') serviceDir += '/';
+  if (packageDir.substr(-1) !== '/') packageDir += '/';
+
+  return serviceDir.startsWith(path.resolve(packageDir));
+}
+
+module.exports = {
+  validateCustomPackagePath() {
+    if (this.options.package) {
+      if (isSubDirectory(this.serverless.serviceDir, this.options.package)) {
+        throw new ServerlessError(
+          'Package output includes service directory',
+          'INVALID_PACKAGE_ARTIFACT_PATH'
+        );
+      }
+    }
+  },
+};

--- a/lib/plugins/package/package.js
+++ b/lib/plugins/package/package.js
@@ -7,6 +7,7 @@ const cliCommandsSchema = require('../../cli/commands-schema');
 const zipService = require('./lib/zipService');
 const packageService = require('./lib/packageService');
 const { legacy } = require('@serverless/utils/log');
+const validateCustomPackagePath = require('../lib/validateCustomPackagePath');
 
 class Package {
   constructor(serverless, options) {
@@ -18,7 +19,7 @@ class Package {
       this.serverless.service.package.path ||
       path.join(this.servicePath || '.', '.serverless');
 
-    Object.assign(this, packageService, zipService);
+    Object.assign(this, validateCustomPackagePath, packageService, zipService);
 
     this.commands = {
       package: {
@@ -33,6 +34,8 @@ class Package {
     };
 
     this.hooks = {
+      'package:initialize': async () => BbPromise.bind(this).then(this.validateCustomPackagePath()),
+
       'package:createDeploymentArtifacts': async () =>
         BbPromise.bind(this).then(this.packageService),
 

--- a/test/unit/lib/plugins/aws/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/lib/validate.test.js
@@ -46,6 +46,12 @@ describe('#validate', () => {
       );
     });
 
+    it('should throw error if the package path includes service', () => {
+      awsPlugin.serverless.serviceDir = '/home/serverless/projects';
+      awsPlugin.options.package = '/home/serverless';
+      expect(() => awsPlugin.validate()).to.throw(ServerlessError);
+    });
+
     // NOTE: starting here, test order is important
 
     it('should default to "dev" if stage is not provided', () => {

--- a/test/unit/lib/plugins/lib/validateCustomPackagePath.test.js
+++ b/test/unit/lib/plugins/lib/validateCustomPackagePath.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const chai = require('chai');
+const path = require('path');
+const runServerless = require('../../../../utils/run-serverless');
+const { getTmpDirPath } = require('../../../../utils/fs');
+
+chai.use(require('chai-as-promised'));
+
+const expect = chai.expect;
+
+describe('#validate', () => {
+  it('should throw error if the package path includes service', () => {
+    expect(
+      runServerless({
+        fixture: 'function',
+        command: 'package',
+        options: {
+          package: path.dirname(getTmpDirPath()),
+        },
+      })
+    ).to.be.eventually.rejected.and.have.property('code', 'INVALID_PACKAGE_ARTIFACT_PATH');
+  });
+});


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9978 

This PR simply checks if the package output directory contains the service directory and throws an error if so. I decided to check the directory paths as strings instead of walking the directory because it should do better at catching deeply nested environments. Let me know what you think!
