### PR TITLE
fix: max httpApi timeout

### DIFF
--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -611,29 +611,29 @@ Object.defineProperties(
         const functionTimeout =
           Number(functionData.timeout) || Number(this.serverless.service.provider.timeout) || 6;
 
-        if (functionTimeout > 29) {
+        if (functionTimeout > 30) {
           logWarning(
             `Function (${functionName}) timeout setting (${functionTimeout}) is greater than ` +
-              'maximum allowed timeout for HTTP API endpoint (29s). ' +
+              'maximum allowed timeout for HTTP API endpoint (30s). ' +
               'This may introduce a situation where endpoint times out ' +
               'for a succesful lambda invocation.'
           );
           log.warning(
             `Function (${functionName}) timeout setting (${functionTimeout}) is greater than ` +
-              'maximum allowed timeout for HTTP API endpoint (29s). ' +
+              'maximum allowed timeout for HTTP API endpoint (30s). ' +
               'This may introduce a situation where endpoint times out ' +
               'for a succesful lambda invocation.'
           );
         } else if (functionTimeout === 30) {
           logWarning(
             `Function (${functionName}) timeout setting (${functionTimeout}) may not provide ` +
-              'enough room to process an HTTP API request (of which timeout is limited to 29s). ' +
+              'enough room to process an HTTP API request (of which timeout is limited to 30s). ' +
               'This may introduce a situation where endpoint times out ' +
               'for a succesful lambda invocation.'
           );
           log.warning(
             `Function (${functionName}) timeout setting (${functionTimeout}) may not provide ` +
-              'enough room to process an HTTP API request (of which timeout is limited to 29s). ' +
+              'enough room to process an HTTP API request (of which timeout is limited to 30s). ' +
               'This may introduce a situation where endpoint times out ' +
               'for a succesful lambda invocation.'
           );
@@ -642,7 +642,7 @@ Object.defineProperties(
         // It's a margin needed for some side processing time on AWS side.
         // Otherwise there's a risk of observing 503 status for successfully resolved invocation
         // (which just fit function timeout setting)
-        routeTargetData.timeout = Math.min(functionTimeout + 0.5, 29.5);
+        routeTargetData.timeout = Math.min(functionTimeout + 0.5, 30);
       }
     }),
     compileIntegration: d(function (routeTargetData) {

--- a/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
@@ -45,10 +45,15 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
               handler: 'index.handler',
               events: [{ httpApi: 'ANY /payload' }],
             },
+            customTimeout: {
+              handler: 'index.handler',
+              events: [{ httpApi: 'ANY /custom-timeout' }],
+              timeout: 29,
+            },
             maxTimeout: {
               handler: 'index.handler',
-              events: [{ httpApi: 'ANY /timeout' }],
-              timeout: 29,
+              events: [{ httpApi: 'ANY /max-timeout' }],
+              timeout: 30,
             },
           },
         },
@@ -124,14 +129,19 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
       expect(resource.Properties.RouteKey).to.equal(routeKey);
     });
 
-    it('should ensure higher timeout than function', () => {
+    it('should ensure higher timeout than function default value', () => {
       const resource = cfResources[naming.getHttpApiIntegrationLogicalId('foo')];
       expect(resource.Properties.TimeoutInMillis).to.equal(6500);
     });
 
-    it('should provide 0.5s time margin to function integration max timeout', () => {
-      const resource = cfResources[naming.getHttpApiIntegrationLogicalId('maxTimeout')];
+    it('should provide 0.5s time margin to custom function integration timeout', () => {
+      const resource = cfResources[naming.getHttpApiIntegrationLogicalId('customTimeout')];
       expect(resource.Properties.TimeoutInMillis).to.equal(29500);
+    });
+
+    it('should limit function maximum integration timeout to 30s', () => {
+      const resource = cfResources[naming.getHttpApiIntegrationLogicalId('maxTimeout')];
+      expect(resource.Properties.TimeoutInMillis).to.equal(30000);
     });
 
     it('should configure lambda permissions', () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #9677

The issue pointed out that the time margin was not being added to the maximum timeout value. The Math.min method was considering 29 as the maximum value, therefore, when passing the limit value, the additional 0.5 seconds was not considered.

I also added a new unit test to consider the case.
