### PR TITLE
fix(AWS EventBridge): Allow intrinsic functions in `pattern`

### DIFF
--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -408,7 +408,7 @@ class AwsCompileEventBridgeEvents {
       Properties: {
         // default event bus is used when EventBusName is not set
         EventBusName: eventBusName === 'default' ? undefined : eventBusName,
-        EventPattern: JSON.stringify(Pattern),
+        EventPattern: Pattern,
         Name: RuleName,
         ScheduleExpression: Schedule,
         State,

--- a/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -514,7 +514,7 @@ describe('EventBridgeEvents', () => {
       });
 
       it('should correctly set EventPattern on a created rule', () => {
-        expect(ruleResource.Properties.EventPattern).to.deep.equal(JSON.stringify(pattern));
+        expect(ruleResource.Properties.EventPattern).to.deep.equal(pattern);
       });
 
       it('should correctly set Input on the target for the created rule', () => {


### PR DESCRIPTION
Fixes #9293 

allows for event bridge patterns using intrinsic functions, like this one:

```yml
    events:
      - eventBridge:
          pattern:
            account:
              - !Sub ${AWS::AccountId}
```

Note: This will only work when using CloudFormtion 

```yml
eventBridge:
    useCloudFormation: true
```
