### PR TITLE
feat(Lambda): Add CF function support to reservedConcurrency

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -14,6 +14,7 @@ const path = require('path');
 const spawnExt = require('child-process-ext/spawn');
 const ServerlessError = require('../../serverless-error');
 const awsRequest = require('../../aws/request');
+const { cfValue } = require('../../utils/aws-schema-get-cf-value');
 const deepSortObjectByKey = require('../../utils/deepSortObjectByKey');
 const { progress, legacy, log } = require('@serverless/utils/log');
 
@@ -1270,7 +1271,7 @@ class AwsProvider {
               additionalProperties: false,
             },
             provisionedConcurrency: { type: 'integer', minimum: 1 },
-            reservedConcurrency: { type: 'integer', minimum: 0 },
+            reservedConcurrency: cfValue({ type: 'integer', minimum: 0 }),
             role: { $ref: '#/definitions/awsLambdaRole' },
             runtime: { $ref: '#/definitions/awsLambdaRuntime' },
             tags: { $ref: '#/definitions/awsResourceTags' },


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

I didn't create an explicit issue for this, but this is something I'm running into and figured the same approach I used for my last PR would suffice. If you want an issue explicitly created for this, let me know.

This just fixes another validation issue where serverless configuration validation isn't accepting native CF functions, so I've fixed this as well.
