### PR TITLE
feat(AWS EventBridge): Adjust deprecation of deployment method

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -188,9 +188,11 @@ Starting with v3.0.0, `http.request.schema` property will be replaced by `http.r
 
 Deprecation code: `AWS_EVENT_BRIDGE_CUSTOM_RESOURCE`
 
-Starting with v3.0.0 AWS EventBridge lambda event triggers and all associated EventBridge resources will be deployed using native CloudFormation resources instead of a custom resource that used a lambda to deploy them via the AWS SDK/API.
+Starting with v3.0.0, AWS EventBridge lambda event triggers and all associated EventBridge resources will be, by default, deployed using native CloudFormation resources instead of a custom resource that used a lambda to deploy them via the AWS SDK/API.
 
 Adapt to this behavior now by setting `provider.eventBridge.useCloudFormation: true`.
+
+If you want to keep using the old deployment method for your AWS EventBridge resources, set `provider.eventBridge.useCloudFormation: false` instead.
 
 <a name="NEW_VARIABLES_RESOLVER"><div>&nbsp;</div></a>
 

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -13,14 +13,14 @@ class AwsCompileEventBridgeEvents {
 
     this.hooks = {
       'initialize': () => {
-        if (!_.get(this.serverless.service.provider, 'eventBridge.useCloudFormation')) {
+        if (_.get(this.serverless.service.provider, 'eventBridge.useCloudFormation') == null) {
           const hasFunctionsWithEventBridgeTrigger = Object.values(
             this.serverless.service.functions
           ).some(({ events }) => events.some(({ eventBridge }) => eventBridge));
           if (hasFunctionsWithEventBridgeTrigger) {
             this.serverless._logDeprecation(
               'AWS_EVENT_BRIDGE_CUSTOM_RESOURCE',
-              'AWS EventBridge resources are not being created using native CloudFormation, this is now possible and the use of custom resources is deprecated. Set `eventBridge.useCloudFormation: true` as a provider property to use this now.'
+              'Starting with "v3.0.0", AWS EventBridge resources will be created using native CloudFormation resources by default. It is possible to use that functionality now by setting "eventBridge.useCloudFormation: true" as provider property in your configuration. If you want to keep using the old creation method, set that property to "false" to hide this deprecation message.'
             );
           }
         }

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -851,7 +851,7 @@ class AwsProvider {
             eventBridge: {
               type: 'object',
               properties: {
-                useCloudFormation: { const: true },
+                useCloudFormation: { type: 'boolean' },
               },
               additionalProperties: false,
             },

--- a/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -163,8 +163,12 @@ describe('EventBridgeEvents', () => {
       const { cfTemplate, awsNaming } = await runServerless({
         fixture: 'function',
         configExt: {
-          disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'],
           ...serverlessConfigurationExtension,
+          provider: {
+            eventBridge: {
+              useCloudFormation: false,
+            },
+          },
         },
         command: 'package',
       });
@@ -362,6 +366,21 @@ describe('EventBridgeEvents', () => {
       ).to.be.eventually.rejected.and.have.property(
         'code',
         'ERROR_INVALID_REFERENCE_TO_EVENT_BUS_CUSTOM_RESOURCE'
+      );
+    });
+
+    it('should emit deprecation when `eventBridge.useCloudFormation` is not explicitly set', async () => {
+      await expect(
+        runServerless({
+          fixture: 'function',
+          configExt: {
+            ...serverlessConfigurationExtension,
+          },
+          command: 'package',
+        })
+      ).to.be.eventually.rejected.and.have.property(
+        'code',
+        'REJECTED_DEPRECATION_AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'
       );
     });
   });


### PR DESCRIPTION
Reported internally

This PR adjusts the deprecation and signals that in v3 it will still be possible to use the Custom Resource-based deployment method for EventBridge resources. 