### PR TITLE
Recognize accessible configuration parts on validation errors

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -57,6 +57,76 @@ class Service {
     this.serviceFilename = this.serverless.configurationFilename;
 
     const configurationInput = this.serverless.configurationInput;
+
+    this.initialServerlessConfig = configurationInput;
+
+    // TODO: Ideally below approach should be replaced at some point with:
+    // 1. In "initialization" phase: Minimize reliance on service configuration
+    //    to few core properties
+    // 2. Before "run" phase: Validate and normalize (via AJV) `serverless.configurationInput`
+    //    into `serverless.configuration`
+    // 3. In "run" phase: Instead of relying on `serverless.service` rely on
+    //    `serverless.configuration` internally
+
+    // Below comments provide usage feedback helfpul for future refactor process.
+
+    // ## Properties currently accessed at "initialization" phase
+
+    this.disabledDeprecations = configurationInput.disabledDeprecations;
+    this.deprecationNotificationMode = configurationInput.deprecationNotificationMode;
+
+    // `provider` (`provder.name` by many plugin constructs, and few other core properties as
+    //              `provider.stage` are read by dashboard plugin)
+    if (!_.isObject(configurationInput.provider)) {
+      const providerName = configurationInput.provider;
+      this.provider = {
+        name: providerName,
+      };
+    } else {
+      this.provider = configurationInput.provider;
+    }
+    if (this.provider.stage == null) {
+      this.provider.stage = 'dev';
+    }
+
+    // `service` (read by dashboard plugin)
+    if (_.isObject(configurationInput.service)) {
+      this.serverless._logDeprecation(
+        'SERVICE_OBJECT_NOTATION',
+        'Starting from next major object notation for "service" property will no longer be ' +
+          'recognized. Set "service" property directly with service name.'
+      );
+      this.serviceObject = configurationInput.service;
+      this.service = configurationInput.service.name;
+    } else {
+      this.serviceObject = { name: configurationInput.service };
+      this.service = configurationInput.service;
+    }
+
+    // (dashboard plugin)
+    this.app = configurationInput.app;
+    this.tenant = configurationInput.tenant;
+    this.org = configurationInput.org;
+
+    this.plugins = configurationInput.plugins;
+
+    // `package.path` is read by few core plugins at initialization
+    if (configurationInput.package) {
+      this.package = configurationInput.package;
+    }
+
+    // ## Properties accessed at "run" phase
+    this.custom = configurationInput.custom; // (dashboard plugin)
+    this.resources = configurationInput.resources;
+    this.functions = configurationInput.functions || {};
+    this.configValidationMode = configurationInput.configValidationMode || 'warn';
+    this.unresolvedVariablesNotificationMode =
+      configurationInput.unresolvedVariablesNotificationMode;
+    if (this.provider.name === 'aws') {
+      this.layers = configurationInput.layers || {};
+    }
+    this.outputs = configurationInput.outputs;
+
     // basic service level validation
     const version = this.serverless.utils.getVersion();
     let ymlVersion = configurationInput.frameworkVersion;
@@ -112,74 +182,12 @@ class Service {
         'PROVIDER_NAME_MISSING'
       );
     }
-
-    this.initialServerlessConfig = configurationInput;
-
-    // TODO: Ideally below approach should be replaced at some point with:
-    // 1. In "initialization" phase: Minimize reliance on service configuration
-    //    to few core properties
-    // 2. Before "run" phase: Validate and normalize (via AJV) `serverless.configurationInput`
-    //    into `serverless.configuration`
-    // 3. In "run" phase: Instead of relying on `serverless.service` rely on
-    //    `serverless.configuration` internally
-
-    // Below comments provide usage feedback helfpul for future refactor process.
-
-    // ## Properties currently accessed at "initialization" phase
-
-    this.disabledDeprecations = configurationInput.disabledDeprecations;
-    this.deprecationNotificationMode = configurationInput.deprecationNotificationMode;
-
-    // `provider` (`provder.name` by many plugin constructs, and few other core properties as
-    //              `provider.stage` are read by dashboard plugin)
     if (!_.isObject(configurationInput.provider)) {
-      const providerName = configurationInput.provider;
-      configurationInput.provider = {
-        name: providerName,
-      };
+      // Schema uncoditionally expects `provider` to be an object.
+      // Ideally if it's fixed at some point, and either we do not support string notation for
+      // provider, or we support string by schema
+      configurationInput.provider = this.provider;
     }
-    if (configurationInput.provider.stage == null) {
-      configurationInput.provider.stage = 'dev';
-    }
-    this.provider = configurationInput.provider;
-
-    // `service` (read by dashboard plugin)
-    if (_.isObject(configurationInput.service)) {
-      this.serverless._logDeprecation(
-        'SERVICE_OBJECT_NOTATION',
-        'Starting from next major object notation for "service" property will no longer be ' +
-          'recognized. Set "service" property directly with service name.'
-      );
-      this.serviceObject = configurationInput.service;
-      this.service = configurationInput.service.name;
-    } else {
-      this.serviceObject = { name: configurationInput.service };
-      this.service = configurationInput.service;
-    }
-
-    // (dashboard plugin)
-    this.app = configurationInput.app;
-    this.tenant = configurationInput.tenant;
-    this.org = configurationInput.org;
-
-    this.plugins = configurationInput.plugins;
-
-    // `package.path` is read by few core plugins at initialization
-    if (configurationInput.package) {
-      this.package = configurationInput.package;
-    }
-
-    // ## Properties accessed at "run" phase
-    this.custom = configurationInput.custom; // (dashboard plugin)
-    this.resources = configurationInput.resources;
-    this.functions = configurationInput.functions || {};
-    this.configValidationMode = configurationInput.configValidationMode || 'warn';
-    this.unresolvedVariablesNotificationMode =
-      configurationInput.unresolvedVariablesNotificationMode;
-    if (this.provider.name === 'aws') {
-      this.layers = configurationInput.layers || {};
-    }
-    this.outputs = configurationInput.outputs;
 
     return this;
   }


### PR DESCRIPTION
When preparing v3 branch approached an issue, where framework version validation error prevented loading plugins for help output. One of the tests failed on that.

Ensure to apply validation after accessible configuration parts are assigned internally