### PR TITLE
feat(AWS HTTP API): Always apply `provider.tags` to HTTP API

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -36,6 +36,14 @@ Note:
 - In service configuration setting is ineffective for deprecations reported before service configuration is read.
 - `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
 
+<a name="AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY"><div>&nbsp;</div></a>
+
+## Ineffective property `provider.httpApi.useProviderTags`
+
+Deprecation code: `AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY`
+
+Starting with "v3.0.0", property `provider.httpApi.useProviderTags` is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration.
+
 <a name="S3_TRANSFER_ACCELERATION_ON_EXISTING_BUCKET"><div>&nbsp;</div></a>
 
 ## Attempt to enable S3 Transfer Acceleration on provided S3 buckets

--- a/lib/plugins/aws/package/compile/events/httpApi.js
+++ b/lib/plugins/aws/package/compile/events/httpApi.js
@@ -43,6 +43,17 @@ class HttpApiEvents {
     serverless.httpApiEventsPlugin = this;
 
     this.hooks = {
+      'initialize': () => {
+        if (
+          this.serverless.service.provider.name === 'aws' &&
+          _.get(this.serverless.service.provider.httpApi, 'useProviderTags')
+        ) {
+          this.serverless._logDeprecation(
+            'AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY',
+            'Property "provider.httpApi.useProviderTags" is no longer effective as provider tags are applied to Http Api Gateway by default. You can safely remove this property from your configuration.'
+          );
+        }
+      },
       'package:compileEvents': () => {
         this.resolveConfiguration();
         if (!this.config.routes.size) return;

--- a/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/httpApi.test.js
@@ -1168,4 +1168,23 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
       });
     });
   });
+
+  it('should trigger a deprecation when `provider.httpApi.useProviderTags` is set', async () => {
+    await expect(
+      runServerless({
+        fixture: 'httpApi',
+        configExt: {
+          provider: {
+            httpApi: {
+              useProviderTags: true,
+            },
+          },
+        },
+        command: 'package',
+      })
+    ).to.eventually.be.rejected.and.have.property(
+      'code',
+      'REJECTED_DEPRECATION_AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY'
+    );
+  });
 });


### PR DESCRIPTION
Ensures to remove previous deprecation and configure new one for the deprecated property.



