### PR TITLE
Remove support for deprecated `cloudfront.behavior` properties

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloudFront.js
+++ b/lib/plugins/aws/package/compile/events/cloudFront.js
@@ -124,37 +124,6 @@ class AwsCompileCloudFrontEvents {
             },
           ],
         },
-        ForwardedValues: {
-          type: 'object',
-          properties: {
-            Cookies: {
-              anyOf: [
-                {
-                  type: 'object',
-                  properties: {
-                    Forward: { enum: ['all', 'none'] },
-                  },
-                  additionalProperties: false,
-                  required: ['Forward'],
-                },
-                {
-                  type: 'object',
-                  properties: {
-                    Forward: { const: 'whitelist' },
-                    WhitelistedNames: { type: 'array', items: { type: 'string' } },
-                  },
-                  additionalProperties: false,
-                  required: ['Forward', 'WhitelistedNames'],
-                },
-              ],
-            },
-            Headers: { type: 'array', items: { type: 'string' } },
-            QueryString: { type: 'boolean' },
-            QueryStringCacheKeys: { type: 'array', items: { type: 'string' } },
-          },
-          additionalProperties: false,
-          required: ['QueryString'],
-        },
         CachePolicyId: { type: 'string' },
         Compress: { type: 'boolean' },
         FieldLevelEncryptionId: { type: 'string' },
@@ -205,32 +174,6 @@ class AwsCompileCloudFrontEvents {
     });
 
     this.hooks = {
-      'initialize': () => {
-        if (
-          this.serverless.service.provider.name === 'aws' &&
-          Object.values(this.serverless.service.functions).some(({ events }) =>
-            events.some(({ cloudFront: eventObject }) => {
-              const behaviorConfig = eventObject && eventObject.behavior;
-              if (!behaviorConfig) return false;
-              return (
-                behaviorConfig.ForwardedValues ||
-                behaviorConfig.MinTTL !== undefined ||
-                behaviorConfig.MaxTTL !== undefined ||
-                behaviorConfig.DefaultTTL !== undefined
-              );
-            })
-          )
-        ) {
-          this.serverless._logDeprecation(
-            'CLOUDFRONT_CACHE_BEHAVIOR_FORWARDED_VALUES_AND_TTL',
-            'Cloudfront has deprecated the use of the ForwardedValues, MinTTL, MaxTTL' +
-              'and DefaultTTL field to configure cache behavior.' +
-              'Please use "provider.cloudfront.cachePolicies" to define Cache Policies' +
-              'and reference it here with "cachePolicy.name" property.' +
-              'You can also reference existing policies with "cachePolicy.id".'
-          );
-        }
-      },
       'package:initialize': this.validate.bind(this),
       'before:package:compileFunctions': this.prepareFunctions.bind(this),
       'package:compileEvents': () => {
@@ -440,30 +383,7 @@ class AwsCompileCloudFrontEvents {
             };
             let shouldAssignCachePolicy = true;
             if (event.cloudFront.behavior) {
-              if (
-                event.cloudFront.behavior.ForwardedValues ||
-                event.cloudFront.behavior.MinTTL !== undefined ||
-                event.cloudFront.behavior.MaxTTL !== undefined ||
-                event.cloudFront.behavior.DefaultTTL !== undefined
-              ) {
-                behavior.ForwardedValues = { QueryString: false };
-                shouldAssignCachePolicy = false;
-              }
               Object.assign(behavior, event.cloudFront.behavior);
-            }
-
-            if (
-              (event.cloudFront.cachePolicy ||
-                (event.cloudFront.behavior && event.cloudFront.behavior.CachePolicyId)) &&
-              !shouldAssignCachePolicy
-            ) {
-              throw new ServerlessError(
-                'Both cachePolicy and deprecated fields ForwardedValues, MinTTL, MaxTTL' +
-                  'and DefaultTTL found in function ${functionObj.name} configuration.' +
-                  'Specifying a cachePolicy override those deprecated parameters.' +
-                  'Please remove one of the cache behavior definition.',
-                'CACHE_POLICY_ID_AND_DEPRECATED_FIELDS_USED'
-              );
             }
 
             if (event.cloudFront.behavior && event.cloudFront.behavior.CachePolicyId) {
@@ -492,7 +412,7 @@ class AwsCompileCloudFrontEvents {
               shouldAssignCachePolicy = false;
             }
 
-            // Assigning default cache policy only if neither cache policy reference nor any of the ForwardedValues, MinTTL, MaxTTL, and DefaultTTL deprecated fields is defined.
+            // Assigning default cache policy only if cache policy reference is not defined.
             if (shouldAssignCachePolicy) {
               // Assigning default Managed-CachingOptimized Cache Policy.
               // See details at https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-policies-list


### PR DESCRIPTION
BREAKING CHANGE: Support for `MinTTL`, `MaxTTL`, `DefaultTTL` and
`ForwardedValues` on `cloudfront.behavior` has been removed.

Reported internally