### PR TITLE
Throw error on duplicate plugin definition

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -137,11 +137,10 @@ class PluginManager {
 
     // don't load plugins twice
     if (this.plugins.some((plugin) => plugin instanceof Plugin)) {
-      this.serverless._logDeprecation(
-        'DUPLICATE_PLUGIN_DEFINITION',
-        'Starting with "v3.0.0", duplicate plugin definition will result in an error instead of a warning. To ensure seamless upgrade, please remove duplicate plugins from your configuration.'
+      throw new ServerlessError(
+        'Encountered duplicate plugin definition. Please remove duplicate plugins from your configuration.',
+        'DUPLICATE_PLUGIN_DEFINITION'
       );
-      return null;
     }
 
     this.loadCommands(pluginInstance);

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -1951,4 +1951,16 @@ describe('test/unit/lib/classes/PluginManager.test.js', () => {
     expect(typeof plugin.utils.progress.create).to.equal('function');
     expect(typeof plugin.utils.writeText).to.equal('function');
   });
+
+  it('should error out for duplicate plugin definiton', async () => {
+    await expect(
+      runServerless({
+        fixture: 'plugin',
+        command: 'print',
+        configExt: {
+          plugins: ['./plugin', './plugin'],
+        },
+      })
+    ).to.be.eventually.rejected.and.have.property('code', 'DUPLICATE_PLUGIN_DEFINITION');
+  });
 });


### PR DESCRIPTION
BREAKING CHANGE: Duplicate plugin definition in configuration will now result
in an error instead of a warning.

