### PR TITLE
Throw when accelerate flag is used along with custom S3 bucket

### DIFF
--- a/lib/plugins/aws/package/lib/generateCoreTemplate.js
+++ b/lib/plugins/aws/package/lib/generateCoreTemplate.js
@@ -93,9 +93,9 @@ module.exports = {
 
     if (bucketName) {
       if (isS3TransferAccelerationEnabled) {
-        this.serverless._logDeprecation(
-          'S3_TRANSFER_ACCELERATION_ON_EXISTING_BUCKET',
-          'Starting with "v3.0.0", attempt to enable S3 Transfer Acceleration on user provided bucket will result in error instead of a warning. To ensure seamless upgrade, please stop using "--aws-s3-accelerate" flag.'
+        throw new ServerlessError(
+          'It is not possible to enable S3 Transfer Acceleration on an user provided bucket. In order to avoid this error, stop using `--aws-s3-accelerate` flag',
+          'S3_TRANSFER_ACCELERATION_ON_EXISTING_BUCKET'
         );
       }
       this.bucketName = bucketName;

--- a/test/unit/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/generateCoreTemplate.test.js
@@ -5,6 +5,7 @@ const runServerless = require('../../../../../../utils/run-serverless');
 const expect = require('chai').expect;
 
 chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
 
 describe('#generateCoreTemplate()', () => {
   it('should reject non-HTTPS requests to the deployment bucket', () =>
@@ -152,7 +153,7 @@ describe('#generateCoreTemplate()', () => {
       });
     }));
 
-  it('should result in deprecation error for custom bucket and accelerate flag', async () => {
+  it('should result in error for custom bucket and accelerate flag', async () => {
     const bucketName = 'com.serverless.deploys';
 
     await expect(
@@ -171,7 +172,7 @@ describe('#generateCoreTemplate()', () => {
       })
     ).to.eventually.be.rejected.and.have.property(
       'code',
-      'REJECTED_DEPRECATION_S3_TRANSFER_ACCELERATION_ON_EXISTING_BUCKET'
+      'S3_TRANSFER_ACCELERATION_ON_EXISTING_BUCKET'
     );
   });
 


### PR DESCRIPTION
BREAKING CHANGE: Using `--aws-s3-accelerate` flag will result in an error
instead of deprecation when custom S3 bucket is used.

