### PR TITLE
Set `frameworkVersion: '3'` in templates and docs

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -23,7 +23,7 @@ service: myService
 
 projectDir: ./ # Boundary of a project in which service is configured. Influences file resolution
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 configValidationMode: warn # Modes for config validation. `error` throws an exception, `warn` logs error to console, `off` disables validation at all. The default is warn.
 enableLocalInstallationFallback: false # If set to 'true', guarantees that it's a locally (for service, in its node_modules) installed framework which processes the command
 useDotenv: false # If set to 'true', environment variables will be automatically loaded from .env files

--- a/docs/providers/azure/guide/serverless.yml.md
+++ b/docs/providers/azure/guide/serverless.yml.md
@@ -20,7 +20,7 @@ Here is a list of all available properties in `serverless.yml` when the provider
 # serverless.yml
 service: azure-nodejs
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: azure

--- a/docs/providers/openwhisk/guide/serverless.yml.md
+++ b/docs/providers/openwhisk/guide/serverless.yml.md
@@ -21,7 +21,7 @@ Here is a list of all available properties in `serverless.yml` when the provider
 
 service: myService
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: openwhisk

--- a/lib/plugins/create/templates/aliyun-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aliyun-nodejs/serverless.yml
@@ -11,7 +11,7 @@
 
 service: aliyun-nodejs
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aliyun

--- a/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
+++ b/lib/plugins/create/templates/aws-alexa-typescript/serverless.yml
@@ -4,7 +4,7 @@ service: aws-alexa-typescript # NOTE: update this with your service name
 #app: your-app-name
 #org: your-org-name
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 plugins:
   - serverless-webpack

--- a/lib/plugins/create/templates/aws-clojure-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-clojure-gradle/serverless.yml
@@ -19,7 +19,7 @@ service: aws-clojure
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-clojurescript-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-clojurescript-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-clojurescript-gradle
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-csharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-csharp/serverless.yml
@@ -18,7 +18,7 @@ service: aws-csharp # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-fsharp/serverless.yml
+++ b/lib/plugins/create/templates/aws-fsharp/serverless.yml
@@ -18,7 +18,7 @@ service: aws-fsharp # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-go-dep/serverless.yml
+++ b/lib/plugins/create/templates/aws-go-dep/serverless.yml
@@ -18,7 +18,7 @@ service: aws-go-dep # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-go-mod/serverless.yml
+++ b/lib/plugins/create/templates/aws-go-mod/serverless.yml
@@ -18,7 +18,7 @@ service: aws-go-mod # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-go/serverless.yml
+++ b/lib/plugins/create/templates/aws-go/serverless.yml
@@ -18,7 +18,7 @@ service: aws-go # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-groovy-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-groovy-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-groovy-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-java-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-java-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-java-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-java-maven/serverless.yml
@@ -18,7 +18,7 @@ service: aws-java-maven # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-kotlin-jvm-gradle-kts/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-gradle-kts/serverless.yml
@@ -18,7 +18,7 @@ service: aws-kotlin-jvm-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-kotlin-jvm-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-kotlin-jvm-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/serverless.yml
@@ -18,7 +18,7 @@ service: aws-kotlin-jvm-maven # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
+++ b/lib/plugins/create/templates/aws-kotlin-nodejs-gradle/serverless.yml
@@ -18,7 +18,7 @@ service: aws-kotlin-nodejs-gradle # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-nodejs-docker/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-docker/serverless.yml
@@ -18,7 +18,7 @@ service: test-aws-nodejs-docker # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs-ecma-script/serverless.yml
@@ -3,7 +3,7 @@ service:
 # app and org for use with dashboard.serverless.com
 #app: your-app-name
 #org: your-org-name
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 # Add the serverless-webpack plugin
 plugins:

--- a/lib/plugins/create/templates/aws-nodejs-typescript/serverless.ts
+++ b/lib/plugins/create/templates/aws-nodejs-typescript/serverless.ts
@@ -4,7 +4,7 @@ import hello from '@functions/hello';
 
 const serverlessConfiguration: AWS = {
   service: 'aws-nodejs-typescript',
-  frameworkVersion: '2',
+  frameworkVersion: '3',
   custom: {
     esbuild: {
       bundle: true,

--- a/lib/plugins/create/templates/aws-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/aws-nodejs/serverless.yml
@@ -18,7 +18,7 @@ service: aws-nodejs # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-provided/serverless.yml
+++ b/lib/plugins/create/templates/aws-provided/serverless.yml
@@ -18,7 +18,7 @@ service: aws-provided # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-python-docker/serverless.yml
+++ b/lib/plugins/create/templates/aws-python-docker/serverless.yml
@@ -18,7 +18,7 @@ service: test-aws-python-docker # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-python/serverless.yml
+++ b/lib/plugins/create/templates/aws-python/serverless.yml
@@ -18,7 +18,7 @@ service: aws-python # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-python3/serverless.yml
+++ b/lib/plugins/create/templates/aws-python3/serverless.yml
@@ -18,7 +18,7 @@ service: aws-python3 # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-ruby/serverless.yml
+++ b/lib/plugins/create/templates/aws-ruby/serverless.yml
@@ -18,7 +18,7 @@ service: aws-ruby # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
+++ b/lib/plugins/create/templates/aws-scala-sbt/serverless.yml
@@ -18,7 +18,7 @@ service: aws-scala-sbt # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: aws

--- a/lib/plugins/create/templates/azure-csharp/serverless.yml
+++ b/lib/plugins/create/templates/azure-csharp/serverless.yml
@@ -15,7 +15,7 @@ service: azure-dotnet # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: azure

--- a/lib/plugins/create/templates/azure-nodejs-typescript/serverless.yml
+++ b/lib/plugins/create/templates/azure-nodejs-typescript/serverless.yml
@@ -15,7 +15,7 @@ service: azure-nodejs-typescript # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 custom:
   webpack:

--- a/lib/plugins/create/templates/azure-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/azure-nodejs/serverless.yml
@@ -15,7 +15,7 @@ service: azure-nodejs # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: azure

--- a/lib/plugins/create/templates/azure-python/serverless.yml
+++ b/lib/plugins/create/templates/azure-python/serverless.yml
@@ -15,7 +15,7 @@ service: azure-python # NOTE: update this with your service name
 
 # You can pin your service to only deploy with a specific Serverless version
 # Check out our docs for more details
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: azure

--- a/lib/plugins/create/templates/cloudflare-workers-enterprise/serverless.yml
+++ b/lib/plugins/create/templates/cloudflare-workers-enterprise/serverless.yml
@@ -1,6 +1,6 @@
 service: hello-world # NOTE: update this with your service name
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: cloudflare

--- a/lib/plugins/create/templates/cloudflare-workers-rust/serverless.yml
+++ b/lib/plugins/create/templates/cloudflare-workers-rust/serverless.yml
@@ -1,6 +1,6 @@
 service: hello-world # NOTE: update this with your service name
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: cloudflare

--- a/lib/plugins/create/templates/cloudflare-workers/serverless.yml
+++ b/lib/plugins/create/templates/cloudflare-workers/serverless.yml
@@ -1,6 +1,6 @@
 service: hello-world # NOTE: update this with your service name
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: cloudflare

--- a/lib/plugins/create/templates/fn-go/serverless.yml
+++ b/lib/plugins/create/templates/fn-go/serverless.yml
@@ -7,7 +7,7 @@
 # The `service` block is the name of the service
 service: hello-world # NOTE: update this with your service name
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 # The `provider` block defines where your service will be deployed
 provider:

--- a/lib/plugins/create/templates/fn-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/fn-nodejs/serverless.yml
@@ -7,7 +7,7 @@
 # The `service` block is the name of the service
 service: hello-world # NOTE: update this with your service name
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 # The `provider` block defines where your service will be deployed
 provider:

--- a/lib/plugins/create/templates/google-go/serverless.yml
+++ b/lib/plugins/create/templates/google-go/serverless.yml
@@ -10,7 +10,7 @@ provider:
   # the path to the credentials file needs to be absolute
   credentials: ~/.gcloud/keyfile.json
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 plugins:
   - serverless-google-cloudfunctions

--- a/lib/plugins/create/templates/google-nodejs-typescript/serverless.ts
+++ b/lib/plugins/create/templates/google-nodejs-typescript/serverless.ts
@@ -2,7 +2,7 @@ import { functions } from '@functions/config';
 
 const serverlessConfiguration = {
   service: 'gcf-nodejs-typescript-template', // NOTE: Don't put the word "google" in here
-  frameworkVersion: '2',
+  frameworkVersion: '3',
   custom: {
     webpack: {
       webpackConfig: './webpack.config.js',

--- a/lib/plugins/create/templates/google-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/google-nodejs/serverless.yml
@@ -12,7 +12,7 @@ provider:
   # the path to the credentials file needs to be absolute
   credentials: ~/.gcloud/keyfile.json
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 plugins:
   - serverless-google-cloudfunctions

--- a/lib/plugins/create/templates/google-python/serverless.yml
+++ b/lib/plugins/create/templates/google-python/serverless.yml
@@ -12,7 +12,7 @@ provider:
   # the path to the credentials file needs to be absolute
   credentials: ~/.gcloud/keyfile.json
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 plugins:
   - serverless-google-cloudfunctions
 

--- a/lib/plugins/create/templates/hello-world/serverless.yml
+++ b/lib/plugins/create/templates/hello-world/serverless.yml
@@ -7,7 +7,7 @@
 # The `service` block is the name of the service
 service: serverless-hello-world
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 # The `provider` block defines where your service will be deployed
 provider:

--- a/lib/plugins/create/templates/knative-docker/serverless.yml
+++ b/lib/plugins/create/templates/knative-docker/serverless.yml
@@ -1,6 +1,6 @@
 service: knative
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 provider:
   name: knative

--- a/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
+++ b/lib/plugins/create/templates/kubeless-nodejs/serverless.yml
@@ -9,7 +9,7 @@
 # Update the service name below with your own service name
 service: capitalize
 
-frameworkVersion: '2'
+frameworkVersion: '3'
 
 # Please ensure the serverless-kubeless provider plugin is installed globally.
 # $ npm install -g serverless-kubeless


### PR DESCRIPTION
Needed as integration test uses the template to provision service and it's currently failing: https://github.com/serverless/serverless/runs/3997391915?check_suite_focus=true