### PR TITLE
Remove `-v` alias for `--verbose`

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -438,16 +438,6 @@ class Serverless {
       }
     }
 
-    if (
-      process.argv.slice(2).includes('-v') &&
-      _.get(resolveCliInput().commandSchema, 'options.verbose.shortcut') === 'v'
-    ) {
-      this._logDeprecation(
-        'CLI_VERBOSE_OPTION_ALIAS',
-        'Starting with v3.0.0, "-v" will no longer be supported as alias for "--verbose" option. Please use "--verbose" flag instead.'
-      );
-    }
-
     if (resolveCliInput().commands[0] !== 'plugin') {
       // merge arrays after variables have been populated
       // (https://github.com/serverless/serverless/issues/3511)

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -19,7 +19,6 @@ commands.set('deploy', {
     },
     'verbose': {
       usage: 'Show all stack events during deployment',
-      shortcut: 'v',
       type: 'boolean',
     },
     'force': {
@@ -89,7 +88,6 @@ commands.set('info', {
     },
     verbose: {
       usage: 'List stack outputs',
-      shortcut: 'v',
       type: 'boolean',
     },
   },
@@ -232,7 +230,6 @@ commands.set('remove', {
   options: {
     verbose: {
       usage: 'Show all stack events during deployment',
-      shortcut: 'v',
       type: 'boolean',
     },
   },
@@ -249,7 +246,6 @@ commands.set('rollback', {
     },
     verbose: {
       usage: 'Show all stack events during deployment',
-      shortcut: 'v',
       type: 'boolean',
     },
   },


### PR DESCRIPTION
BREAKING CHANGE: The `--verbose` CLI flag does no longer support `-v` alias


