### PR TITLE
Remove support for object notation for `service` property

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -91,13 +91,10 @@ class Service {
 
     // `service` (read by dashboard plugin)
     if (_.isObject(configurationInput.service)) {
-      this.serverless._logDeprecation(
-        'SERVICE_OBJECT_NOTATION',
-        'Starting from next major object notation for "service" property will no longer be ' +
-          'recognized. Set "service" property directly with service name.'
+      throw new ServerlessError(
+        'Object notation for "service" property is not supported. Set "service" property directly with service name.',
+        'SERVICE_OBJECT_NOTATION'
       );
-      this.serviceObject = configurationInput.service;
-      this.service = configurationInput.service.name;
     } else {
       this.serviceObject = { name: configurationInput.service };
       this.service = configurationInput.service;

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -114,6 +114,7 @@ const schema = {
       required: ['name'],
       additionalProperties: false,
     },
+    // TODO: Should be changed when the validation is performed against `configurationInput`
     service: {
       anyOf: [
         { $ref: '#/definitions/serviceName' },
@@ -121,7 +122,6 @@ const schema = {
           type: 'object',
           properties: {
             name: { $ref: '#/definitions/serviceName' },
-            awsKmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
           },
           additionalProperties: false,
           required: ['name'],


### PR DESCRIPTION
BREAKING CHANGE: Object notation is no longer supported for `service` property.
Set name directly to `service`.

