### PR TITLE
Deprecate API Gateway specific settings on `provider` level

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1649,16 +1649,17 @@ provider:
   name: aws
   runtime: nodejs12.x
 
-  resourcePolicy:
-    - Effect: Allow
-      Principal: '*'
-      Action: execute-api:Invoke
-      Resource:
-        - execute-api:/*/*/*
-      Condition:
-        IpAddress:
-          aws:SourceIp:
-            - '123.123.123.123'
+  apiGateway:
+    resourcePolicy:
+      - Effect: Allow
+        Principal: '*'
+        Action: execute-api:Invoke
+        Resource:
+          - execute-api:/*/*/*
+        Condition:
+          IpAddress:
+            aws:SourceIp:
+              - '123.123.123.123'
 ```
 
 ## Compression

--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -238,20 +238,6 @@ class AwsCompileApigEvents {
       'initialize': () => {
         if (
           this.serverless.service.provider.name === 'aws' &&
-          (this.serverless.service.provider.apiKeys ||
-            this.serverless.service.provider.resourcePolicy ||
-            this.serverless.service.provider.usagePlan)
-        ) {
-          this.serverless._logDeprecation(
-            'AWS_API_GATEWAY_SPECIFIC_KEYS',
-            'Starting with next major version, API Gateway-specific configuration keys ' +
-              '"apiKeys", "resourcePolicy" and "usagePlan" will be relocated from "provider" ' +
-              'to "provider.apiGateway"'
-          );
-        }
-
-        if (
-          this.serverless.service.provider.name === 'aws' &&
           Object.values(this.serverless.service.functions).some(({ events }) =>
             events.some(({ http }) => {
               return (

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.js
@@ -32,18 +32,14 @@ function createApiKeyResource(that, apiKey) {
 
 module.exports = {
   compileApiKeys() {
-    const apiKeys =
-      _.get(this.serverless.service.provider.apiGateway, 'apiKeys') ||
-      this.serverless.service.provider.apiKeys;
+    const apiKeys = _.get(this.serverless.service.provider.apiGateway, 'apiKeys');
     if (apiKeys) {
       const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
       let keyNumber = 0;
       apiKeys.forEach((apiKeyDefinition) => {
         // if multiple API key types are used
         const name = Object.keys(apiKeyDefinition)[0];
-        const usagePlan =
-          _.get(this.serverless.service.provider.apiGateway, 'usagePlan') ||
-          this.serverless.service.provider.usagePlan;
+        const usagePlan = _.get(this.serverless.service.provider.apiGateway, 'usagePlan');
         if (
           _.isObject(apiKeyDefinition) &&
           Array.isArray(usagePlan) &&

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.js
@@ -6,9 +6,7 @@ const { legacy, log } = require('@serverless/utils/log');
 
 module.exports = {
   async disassociateUsagePlan() {
-    const apiKeys =
-      _.get(this.serverless.service.provider.apiGateway, 'apiKeys') ||
-      this.serverless.service.provider.apiKeys;
+    const apiKeys = _.get(this.serverless.service.provider.apiGateway, 'apiKeys');
 
     if (apiKeys && apiKeys.length) {
       legacy.log('Removing usage plan association...');

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -59,9 +59,7 @@ module.exports = {
       },
     });
 
-    const resourcePolicy =
-      _.get(this.serverless.service.provider.apiGateway, 'resourcePolicy') ||
-      this.serverless.service.provider.resourcePolicy;
+    const resourcePolicy = _.get(this.serverless.service.provider.apiGateway, 'resourcePolicy');
     if (resourcePolicy && Object.keys(resourcePolicy).length) {
       const policy = {
         Version: '2012-10-17',

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.js
@@ -20,9 +20,7 @@ function createUsagePlanResource(that, name) {
     },
   };
   const template = _.cloneDeep(resourceTemplate);
-  const usagePlan =
-    _.get(that.serverless.service.provider.apiGateway, 'usagePlan') ||
-    that.serverless.service.provider.usagePlan;
+  const usagePlan = _.get(that.serverless.service.provider.apiGateway, 'usagePlan');
   // this is done for backward compatibility
   if (name === 'default') {
     // create old legacy resources
@@ -97,12 +95,8 @@ function createUsagePlanResource(that, name) {
 
 module.exports = {
   compileUsagePlan() {
-    const apiKeys =
-      _.get(this.serverless.service.provider.apiGateway, 'apiKeys') ||
-      this.serverless.service.provider.apiKeys;
-    const usagePlan =
-      _.get(this.serverless.service.provider.apiGateway, 'usagePlan') ||
-      this.serverless.service.provider.usagePlan;
+    const apiKeys = _.get(this.serverless.service.provider.apiGateway, 'apiKeys');
+    const usagePlan = _.get(this.serverless.service.provider.apiGateway, 'usagePlan');
     if (usagePlan || apiKeys) {
       const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
       this.apiGatewayUsagePlanNames = [];

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.js
@@ -24,9 +24,7 @@ function createUsagePlanKeyResource(that, usagePlanLogicalId, keyNumber, keyName
 
 module.exports = {
   compileUsagePlanKeys() {
-    const apiKeys =
-      _.get(this.serverless.service.provider.apiGateway, 'apiKeys') ||
-      this.serverless.service.provider.apiKeys;
+    const apiKeys = _.get(this.serverless.service.provider.apiGateway, 'apiKeys');
     if (apiKeys) {
       const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
       let keyNumber = 0;

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -748,7 +748,6 @@ class AwsProvider {
               },
               additionalProperties: false,
             },
-            apiKeys: { $ref: '#/definitions/awsApiGatewayApiKeys' },
             apiName: { type: 'string' },
             architecture: { $ref: '#/definitions/awsLambdaArchitecture' },
             cfnRole: { $ref: '#/definitions/awsArn' },
@@ -1096,7 +1095,6 @@ class AwsProvider {
                 'sa-east-1',
               ],
             },
-            resourcePolicy: { $ref: '#/definitions/awsResourcePolicyStatements' },
             role: { $ref: '#/definitions/awsLambdaRole' },
             rolePermissionsBoundary: { $ref: '#/definitions/awsArnString' },
             rollbackConfiguration: {
@@ -1153,19 +1151,6 @@ class AwsProvider {
                 lambda: { $ref: '#/definitions/awsLambdaTracing' },
               },
               additionalProperties: false,
-            },
-            usagePlan: {
-              anyOf: [
-                apiGatewayUsagePlan,
-                {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    additionalProperties: apiGatewayUsagePlan,
-                    maxProperties: 1,
-                  },
-                },
-              ],
             },
             vpc: { $ref: '#/definitions/awsLambdaVpcConfig' },
             vpcEndpointIds: { $ref: '#/definitions/awsCfArrayInstruction' },


### PR DESCRIPTION
BREAKING CHANGE: Support for `usagePlan`, `resourcePolicy` and `apiKeys` on
`provider` level is removed. Use `provider.apiGateway` level instead to set
them.

