### PR TITLE
Remove deprecation for missing "options" or "commands" in `Serverless` contructor config 

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -93,17 +93,12 @@ class Serverless {
       this._shouldResolveConfigurationInternally = true;
       this._shouldReportMissingServiceDeprecation = true;
     }
-    const commands = ensureArray(configObject.commands, { isOptional: true });
-    let options = ensurePlainObject(configObject.options, { isOptional: true });
+    const commands = ensureArray(configObject.commands);
+    let options = ensurePlainObject(configObject.options);
     // This is a temporary workaround to ensure that original `options` are not mutated
     // Should be removed after addressing: https://github.com/serverless/serverless/issues/2582
     if (options) options = { ...options };
-    if (!commands || !options) {
-      this._shouldReportCommandsDeprecation = true;
-      this.processedInput = resolveCliInput();
-    } else {
-      this.processedInput = { commands, options };
-    }
+    this.processedInput = { commands, options };
     this.hasResolvedCommandsExternally = Boolean(configObject.hasResolvedCommandsExternally);
     this.isTelemetryReportedExternally = Boolean(configObject.isTelemetryReportedExternally);
 
@@ -157,22 +152,12 @@ class Serverless {
     if (this._isInvokedByGlobalInstallation) {
       logDeprecation.defaultMode = 'warn';
       logDeprecation.flushBuffered();
-    } else {
-      if (this._shouldReportMissingServiceDeprecation) {
-        this._logDeprecation(
-          'MISSING_SERVICE_CONFIGURATION',
-          'Serverless constructor expects service configuration details to be provided.\n' +
-            'Starting from next major Serverless will no longer auto resolve it internally.'
-        );
-      }
-      if (this._shouldReportCommandsDeprecation) {
-        this._logDeprecation(
-          'MISSING_COMMANDS_OR_OPTIONS_AT_CONSTRUCTION',
-          'Serverless constructor expects resolved CLI commands and options to be provided ' +
-            'via "config.commands" and "config.options".\n' +
-            'Starting from next major Serverless will no longer auto resolve CLI arguments internally.'
-        );
-      }
+    } else if (this._shouldReportMissingServiceDeprecation) {
+      this._logDeprecation(
+        'MISSING_SERVICE_CONFIGURATION',
+        'Serverless constructor expects service configuration details to be provided.\n' +
+          'Starting from next major Serverless will no longer auto resolve it internally.'
+      );
     }
     if (this._shouldResolveConfigurationInternally) {
       const configurationPath = await resolveConfigurationPath();

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -33,7 +33,7 @@ describe('Serverless', () => {
 
   describe('#constructor()', () => {
     it('should set the correct config if a config object is passed', () => {
-      const configObj = { some: 'config' };
+      const configObj = { some: 'config', commands: [], options: {} };
       const serverlessWithConfig = new Serverless(configObj);
 
       expect(serverlessWithConfig.config.some).to.equal('config');

--- a/test/unit/lib/classes/CLI.test.js
+++ b/test/unit/lib/classes/CLI.test.js
@@ -15,7 +15,7 @@ describe('CLI', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({});
+    serverless = new Serverless({ commands: [], options: {} });
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/classes/Config.test.js
+++ b/test/unit/lib/classes/Config.test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const Config = require('../../../../lib/classes/Config');
 const Serverless = require('../../../../lib/Serverless');
 
-const serverless = new Serverless();
+const serverless = new Serverless({ commands: [], options: {} });
 
 describe('Config', () => {
   describe('#constructor()', () => {

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -418,7 +418,7 @@ describe('PluginManager', () => {
 
   beforeEach(() => {
     ({ restoreEnv } = overrideEnv({ whitelist: ['APPDATA', 'PATH'] }));
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.cli = new CLI();
     serverless.processedInput = { commands: ['print'], options: {} };
     pluginManager = new PluginManager(serverless);
@@ -1253,7 +1253,7 @@ describe('PluginManager', () => {
     let pluginManagerInstance;
 
     beforeEach(() => {
-      serverlessInstance = new Serverless();
+      serverlessInstance = new Serverless({ commands: [], options: {} });
       serverlessInstance.configurationInput = null;
       serverlessInstance.serviceDir = 'my-service';
       pluginManagerInstance = new PluginManager(serverlessInstance);

--- a/test/unit/lib/classes/Utils.test.js
+++ b/test/unit/lib/classes/Utils.test.js
@@ -16,7 +16,7 @@ describe('Utils', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     utils = new Utils(serverless);
   });
 

--- a/test/unit/lib/classes/YamlParser.test.js
+++ b/test/unit/lib/classes/YamlParser.test.js
@@ -14,7 +14,7 @@ const { getTmpFilePath, getTmpDirPath } = require('../../../utils/fs');
 chai.use(require('chai-as-promised'));
 const expect = require('chai').expect;
 
-const serverless = new Serverless();
+const serverless = new Serverless({ commands: [], options: {} });
 
 describe('YamlParser', () => {
   describe('#parse()', () => {

--- a/test/unit/lib/plugins/aws/common/index.test.js
+++ b/test/unit/lib/plugins/aws/common/index.test.js
@@ -9,7 +9,7 @@ const sinon = require('sinon');
 describe('AwsCommon', () => {
   let awsCommon;
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     const options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
@@ -14,7 +14,7 @@ describe('#moveArtifactsToPackage()', () => {
   const moveServerlessPath = path.join(moveBasePath, '.serverless');
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     awsCommon = new AWSCommon(serverless, {});
 
     serverless.serviceDir = moveBasePath;
@@ -104,7 +104,7 @@ describe('#moveArtifactsToTemp()', () => {
   const moveTargetPath = path.join(moveBasePath, 'target');
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     awsCommon = new AWSCommon(serverless, {});
 
     serverless.serviceDir = moveBasePath;

--- a/test/unit/lib/plugins/aws/common/lib/cleanupTempDir.test.js
+++ b/test/unit/lib/plugins/aws/common/lib/cleanupTempDir.test.js
@@ -11,7 +11,7 @@ describe('#cleanupTempDir()', () => {
   let packageService;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     packageService = new Package(serverless);
 
     serverless.serviceDir = getTmpDirPath();

--- a/test/unit/lib/plugins/aws/customResources/index.test.js
+++ b/test/unit/lib/plugins/aws/customResources/index.test.js
@@ -36,7 +36,7 @@ describe('#addCustomResourceToService()', () => {
       region: 'us-east-1',
     };
     tmpDirPath = createTmpDir();
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.cli = new CLI();
     serverless.pluginManager.cliOptions = options;
     provider = new AwsProvider(serverless, options);

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -22,7 +22,7 @@ describe('AwsDeploy', () => {
   let options;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -33,7 +33,7 @@ describe('checkForChanges', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.serviceDir = 'my-service';
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);

--- a/test/unit/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
@@ -24,7 +24,7 @@ describe('cleanupS3Bucket', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.serviceDir = 'foo';
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);

--- a/test/unit/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -30,7 +30,7 @@ describe('createStack', () => {
   };
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, {}));
     serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
     serverless.serviceDir = tmpDirPath;

--- a/test/unit/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
@@ -18,7 +18,7 @@ describe('#existsDeploymentBucket()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     awsPlugin.serverless = serverless;
     awsPlugin.provider = new AwsProvider(serverless, options);
 

--- a/test/unit/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -41,7 +41,7 @@ describe('extendedValidate', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
     serverless.serviceDir = tmpDirPath;

--- a/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -25,7 +25,7 @@ describe('uploadArtifacts', () => {
   let cryptoStub;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, {}));
     const options = {

--- a/test/unit/lib/plugins/aws/deploy/lib/validateTemplate.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/validateTemplate.test.js
@@ -23,7 +23,7 @@ describe('validateTemplate', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);

--- a/test/unit/lib/plugins/aws/deployList.test.js
+++ b/test/unit/lib/plugins/aws/deployList.test.js
@@ -17,7 +17,7 @@ describe('AwsDeployList', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'listDeployments';

--- a/test/unit/lib/plugins/aws/info/getApiKeyValues.test.js
+++ b/test/unit/lib/plugins/aws/info/getApiKeyValues.test.js
@@ -16,7 +16,7 @@ describe('#getApiKeyValues()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'my-service';
     awsInfo = new AwsInfo(serverless, options);

--- a/test/unit/lib/plugins/aws/info/getResourceCount.test.js
+++ b/test/unit/lib/plugins/aws/info/getResourceCount.test.js
@@ -18,7 +18,7 @@ describe('#getResourceCount()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'my-service';
     serverless.service.functions = {

--- a/test/unit/lib/plugins/aws/info/getStackInfo.test.js
+++ b/test/unit/lib/plugins/aws/info/getStackInfo.test.js
@@ -16,7 +16,7 @@ describe('#getStackInfo()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'my-service';
     serverless.service.functions = {

--- a/test/unit/lib/plugins/aws/info/index.test.js
+++ b/test/unit/lib/plugins/aws/info/index.test.js
@@ -25,7 +25,7 @@ describe('AwsInfo', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.cli = {
       log: sinon.stub().returns(),

--- a/test/unit/lib/plugins/aws/invokeLocal/index.test.js
+++ b/test/unit/lib/plugins/aws/invokeLocal/index.test.js
@@ -64,7 +64,7 @@ describe('AwsInvokeLocal', () => {
       'get-stdin': stdinStub,
       'child-process-ext/spawn': spawnExtStub,
     });
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.serviceDir = 'servicePath';
     serverless.cli = new CLI(serverless);
     serverless.processedInput = { commands: ['invoke'] };

--- a/test/unit/lib/plugins/aws/lib/getServiceState.test.js
+++ b/test/unit/lib/plugins/aws/lib/getServiceState.test.js
@@ -17,7 +17,7 @@ describe('#getServiceState()', () => {
   const awsPlugin = {};
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.serviceDir = 'my-service';
     awsPlugin.serverless = serverless;
     awsPlugin.provider = new AwsProvider(serverless, options);

--- a/test/unit/lib/plugins/aws/lib/monitorStack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitorStack.test.js
@@ -12,7 +12,7 @@ chai.use(require('chai-as-promised'));
 const { expect } = chai;
 
 describe('monitorStack', () => {
-  const serverless = new Serverless();
+  const serverless = new Serverless({ commands: [], options: {} });
   const awsPlugin = {};
 
   beforeEach(() => {

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -15,6 +15,8 @@ describe('#naming()', () => {
     options = {
       stage: 'dev',
       region: 'us-east-1',
+      commands: [],
+      options: {},
     };
     serverless = new Serverless(options);
     sdk = new SDK(serverless, options);

--- a/test/unit/lib/plugins/aws/lib/setBucketName.test.js
+++ b/test/unit/lib/plugins/aws/lib/setBucketName.test.js
@@ -12,7 +12,7 @@ describe('#setBucketName()', () => {
   let getServerlessDeploymentBucketNameStub;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.serviceDir = 'foo';
     const options = {
       stage: 'dev',

--- a/test/unit/lib/plugins/aws/lib/updateStack.test.js
+++ b/test/unit/lib/plugins/aws/lib/updateStack.test.js
@@ -17,7 +17,7 @@ describe('updateStack', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);

--- a/test/unit/lib/plugins/aws/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/lib/validate.test.js
@@ -11,7 +11,7 @@ chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 describe('#validate', () => {
-  const serverless = new Serverless();
+  const serverless = new Serverless({ commands: [], options: {} });
   let provider;
   const awsPlugin = {};
 

--- a/test/unit/lib/plugins/aws/logs.test.js
+++ b/test/unit/lib/plugins/aws/logs.test.js
@@ -21,7 +21,7 @@ describe('AwsLogs', () => {
       region: 'us-east-1',
       function: 'first',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     const provider = new AwsProvider(serverless, options);
     provider.cachedCredentials = {
       credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },
@@ -335,7 +335,7 @@ describe('AwsLogs', () => {
         region: 'us-east-1',
         function: 'first',
       };
-      serverless = new Serverless();
+      serverless = new Serverless({ commands: [], options: {} });
       const provider = new AwsProvider(serverless, options);
       provider.cachedCredentials = {
         credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },

--- a/test/unit/lib/plugins/aws/metrics.test.js
+++ b/test/unit/lib/plugins/aws/metrics.test.js
@@ -17,7 +17,7 @@ describe('AwsMetrics', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.cli = new CLI(serverless);
     const options = {
       stage: 'dev',

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
@@ -9,7 +9,7 @@ describe('#compileListenerRules()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'some-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/permissions.test.js
@@ -9,7 +9,7 @@ describe('#compilePermissions()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'some-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -9,7 +9,7 @@ describe('#compileTargetGroups()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'some-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -9,7 +9,7 @@ describe('#validate()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'some-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/alexaSkill.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alexaSkill.test.js
@@ -12,7 +12,7 @@ describe('AwsCompileAlexaSkillEvents', () => {
   let awsCompileAlexaSkillEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileAlexaSkillEvents = new AwsCompileAlexaSkillEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/alexaSmartHome.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alexaSmartHome.test.js
@@ -10,7 +10,7 @@ describe('AwsCompileAlexaSmartHomeEvents', () => {
   let awsCompileAlexaSmartHomeEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileAlexaSmartHomeEvents = new AwsCompileAlexaSmartHomeEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -14,7 +14,7 @@ describe('AwsCompileApigEvents', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.service.environment = {
       vars: {},
       stages: {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
@@ -15,7 +15,7 @@ describe('#compileApiKeys()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
@@ -11,7 +11,7 @@ describe('#compileAuthorizers()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -14,7 +14,7 @@ describe('#compileCors()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
@@ -15,7 +15,7 @@ describe('#compileDeployment()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.provider.compiledCloudFormationTemplate = {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.test.js
@@ -13,7 +13,7 @@ describe('#disassociateUsagePlan()', () => {
   let providerRequestStub;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.service = 'my-service';
     serverless.cli = {
       log: sinon.spy(),

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -28,7 +28,7 @@ describe('#updateStage()', () => {
   let context;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.service = 'my-service';
     options = { stage: 'dev', region: 'us-east-1' };
     awsProvider = new AwsProvider(serverless, options);

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -15,7 +15,7 @@ describe('#compileMethods()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
@@ -9,7 +9,7 @@ describe('#awsCompilePermissions()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/resources.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/resources.test.js
@@ -10,7 +10,7 @@ describe('#compileResources()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -18,7 +18,7 @@ describe('#compileRestApi()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
@@ -24,7 +24,7 @@ describe('#compileStage()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'my-service';

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -15,7 +15,7 @@ describe('#compileUsagePlan()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.test.js
@@ -15,7 +15,7 @@ describe('#compileUsagePlanKeys()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = {

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
@@ -21,7 +21,7 @@ describe('AwsCompileCloudFrontEvents', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.processedInput = {
       commands: [],
     };

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudWatchEvent.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudWatchEvent.test.js
@@ -10,7 +10,7 @@ describe('awsCompileCloudWatchEventEvents', () => {
   let awsCompileCloudWatchEventEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileCloudWatchEventEvents = new AwsCompileCloudWatchEventEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudWatchLog.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudWatchLog.test.js
@@ -10,7 +10,7 @@ describe('AwsCompileCloudWatchLogEvents', () => {
   let awsCompileCloudWatchLogEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileCloudWatchLogEvents = new AwsCompileCloudWatchLogEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/cognitoUserPool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognitoUserPool.test.js
@@ -27,7 +27,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
         },
       }
     );
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileCognitoUserPoolEvents = new AwsCompileCognitoUserPoolEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
@@ -10,7 +10,7 @@ describe('AwsCompileIoTEvents', () => {
   let awsCompileIoTEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileIoTEvents = new AwsCompileIoTEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -28,7 +28,7 @@ describe('AwsCompileS3Events', () => {
         },
       }
     );
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileS3Events = new AwsCompileS3Events(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/sns.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/sns.test.js
@@ -10,7 +10,7 @@ describe('AwsCompileSNSEvents', () => {
   let awsCompileSNSEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     const options = {
       region: 'some-region',
     };

--- a/test/unit/lib/plugins/aws/package/compile/events/sqs.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/sqs.test.js
@@ -11,7 +11,7 @@ describe('AwsCompileSQSEvents', () => {
   let awsCompileSQSEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {
         IamRoleLambdaExecution: {

--- a/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
@@ -11,7 +11,7 @@ describe('AwsCompileStreamEvents', () => {
   let awsCompileStreamEvents;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {
         IamRoleLambdaExecution: {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -10,7 +10,7 @@ describe('AwsCompileWebsocketsEvents', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.service.environment = {
       vars: {},
       stages: {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
@@ -10,7 +10,7 @@ describe('#compileApi()', () => {
   let roleLogicalId;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'my-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
@@ -10,7 +10,7 @@ describe('#compileAuthorizers()', () => {
 
   describe('for routes with authorizer definition', () => {
     beforeEach(() => {
-      const serverless = new Serverless();
+      const serverless = new Serverless({ commands: [], options: {} });
       serverless.setProvider('aws', new AwsProvider(serverless));
       serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 
@@ -106,7 +106,7 @@ describe('#compileAuthorizers()', () => {
 
   describe('for routes without authorizer definition', () => {
     beforeEach(() => {
-      const serverless = new Serverless();
+      const serverless = new Serverless({ commands: [], options: {} });
       serverless.setProvider('aws', new AwsProvider(serverless));
       serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/deployment.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/deployment.test.js
@@ -13,7 +13,7 @@ describe('#compileDeployment()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
@@ -9,7 +9,7 @@ describe('#compileIntegrations()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
@@ -9,7 +9,7 @@ describe('#compilePermissions()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routeResponses.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routeResponses.test.js
@@ -9,7 +9,7 @@ describe('#compileRouteResponses()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routes.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routes.test.js
@@ -9,7 +9,7 @@ describe('#compileRoutes()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -24,7 +24,7 @@ describe('#compileStage()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'my-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
@@ -15,7 +15,7 @@ describe('#validate()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);
   });

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -32,6 +32,8 @@ describe('AwsCompileFunctions', () => {
     const options = {
       stage: 'dev',
       region: 'us-east-1',
+      commands: [],
+      options: {},
     };
     serverless = new Serverless(options);
     awsProvider = new AwsProvider(serverless, options);

--- a/test/unit/lib/plugins/aws/package/index.test.js
+++ b/test/unit/lib/plugins/aws/package/index.test.js
@@ -14,7 +14,7 @@ describe('AwsPackage', () => {
   let options;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/package/lib/generateArtifactDirectoryName.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/generateArtifactDirectoryName.test.js
@@ -10,7 +10,7 @@ describe('#generateArtifactDirectoryName()', () => {
   let awsPackage;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     const options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
@@ -12,7 +12,7 @@ describe('mergeCustomProviderResources', () => {
   let coreCloudFormationTemplate;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     awsPackage = new AwsPackage(serverless, {});
 
     coreCloudFormationTemplate = awsPackage.serverless.utils.readFileSync(

--- a/test/unit/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
@@ -15,7 +15,7 @@ describe('#saveCompiledTemplate()', () => {
 
   beforeEach(() => {
     const options = {};
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsPackage = new AwsPackage(serverless, options);
     serverless.serviceDir = 'my-service';

--- a/test/unit/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -15,7 +15,7 @@ describe('#saveServiceState()', () => {
 
   beforeEach(() => {
     const options = {};
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsPackage = new AwsPackage(serverless, options);
     serverless.serviceDir = 'my-service';

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -31,7 +31,7 @@ describe('AwsProvider', () => {
 
   beforeEach(() => {
     ({ restoreEnv } = overrideEnv());
-    serverless = new Serverless(options);
+    serverless = new Serverless({ ...options, commands: [], options: {} });
     serverless.cli = new serverless.classes.CLI();
     awsProvider = new AwsProvider(serverless, options);
   });
@@ -53,6 +53,8 @@ describe('AwsProvider', () => {
             even if http event is present and stage is ${stage}`, () => {
           const config = {
             stage,
+            commands: [],
+            options: {},
           };
           serverless = new Serverless(config);
 

--- a/test/unit/lib/plugins/aws/remove/lib/bucket.test.js
+++ b/test/unit/lib/plugins/aws/remove/lib/bucket.test.js
@@ -14,7 +14,7 @@ describe('emptyS3Bucket', () => {
     stage: 'dev',
     region: 'us-east-1',
   };
-  const serverless = new Serverless();
+  const serverless = new Serverless({ commands: [], options: {} });
   serverless.service.service = 'emptyS3Bucket';
   serverless.setProvider('aws', new AwsProvider(serverless, options));
 

--- a/test/unit/lib/plugins/aws/remove/lib/stack.test.js
+++ b/test/unit/lib/plugins/aws/remove/lib/stack.test.js
@@ -11,7 +11,7 @@ describe('removeStack', () => {
     stage: 'dev',
     region: 'us-east-1',
   };
-  const serverless = new Serverless();
+  const serverless = new Serverless({ commands: [], options: {} });
   serverless.service.service = 'removeStack';
   serverless.setProvider('aws', new AwsProvider(serverless, options));
 

--- a/test/unit/lib/plugins/aws/rollback.test.js
+++ b/test/unit/lib/plugins/aws/rollback.test.js
@@ -15,7 +15,7 @@ describe('AwsRollback', () => {
   let provider;
 
   const createInstance = (options) => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'rollback';

--- a/test/unit/lib/plugins/aws/rollbackFunction.test.js
+++ b/test/unit/lib/plugins/aws/rollbackFunction.test.js
@@ -18,7 +18,7 @@ describe('AwsRollbackFunction', () => {
     AwsRollbackFunction = proxyquire('../../../../../lib/plugins/aws/rollbackFunction.js', {
       'node-fetch': fetchStub,
     });
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.functions = {
       hello: {
         handler: true,

--- a/test/unit/lib/plugins/create/create.test.js
+++ b/test/unit/lib/plugins/create/create.test.js
@@ -21,7 +21,7 @@ describe('Create', () => {
   let create;
 
   before(() => {
-    const serverless = new Serverless();
+    const serverless = new Serverless({ commands: [], options: {} });
     const options = {};
     create = new Create(serverless, options);
     create.serverless.cli = new serverless.classes.CLI();

--- a/test/unit/lib/plugins/deploy.test.js
+++ b/test/unit/lib/plugins/deploy.test.js
@@ -17,7 +17,7 @@ describe('Deploy', () => {
   let options;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     options = {};
     deploy = new Deploy(serverless, options);
     deploy.serverless.providers = { validProvider: true };

--- a/test/unit/lib/plugins/info.test.js
+++ b/test/unit/lib/plugins/info.test.js
@@ -13,7 +13,7 @@ describe('Info', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     info = new Info(serverless);
   });
 

--- a/test/unit/lib/plugins/invoke.test.js
+++ b/test/unit/lib/plugins/invoke.test.js
@@ -16,7 +16,7 @@ describe('Invoke', () => {
 
   beforeEach(() => {
     ({ restoreEnv } = overrideEnv());
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     invoke = new Invoke(serverless);
   });
 

--- a/test/unit/lib/plugins/metrics.test.js
+++ b/test/unit/lib/plugins/metrics.test.js
@@ -9,7 +9,7 @@ describe('Metrics', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     const options = {};
     metrics = new Metrics(serverless, options);
   });

--- a/test/unit/lib/plugins/package/lib/zipService.test.js
+++ b/test/unit/lib/plugins/package/lib/zipService.test.js
@@ -29,7 +29,7 @@ describe('zipService', () => {
 
   beforeEach(() => {
     tmpDirPath = getTmpDirPath();
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.service.service = 'first-service';
     serverless.serviceDir = tmpDirPath;
     packagePlugin = new Package(serverless, {});

--- a/test/unit/lib/plugins/plugin/install.test.js
+++ b/test/unit/lib/plugins/plugin/install.test.js
@@ -44,7 +44,7 @@ describe('PluginInstall', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginInstall = new PluginInstall(serverless, options);

--- a/test/unit/lib/plugins/plugin/lib/utils.test.js
+++ b/test/unit/lib/plugins/plugin/lib/utils.test.js
@@ -34,7 +34,7 @@ describe('PluginUtils', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginUtils = new PluginInstall(serverless, options);

--- a/test/unit/lib/plugins/plugin/list.test.js
+++ b/test/unit/lib/plugins/plugin/list.test.js
@@ -14,7 +14,7 @@ describe('PluginList', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginList = new PluginList(serverless, options);

--- a/test/unit/lib/plugins/plugin/search.test.js
+++ b/test/unit/lib/plugins/plugin/search.test.js
@@ -32,7 +32,7 @@ describe('PluginSearch', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginSearch = new PluginSearch(serverless, options);

--- a/test/unit/lib/plugins/plugin/uninstall.test.js
+++ b/test/unit/lib/plugins/plugin/uninstall.test.js
@@ -39,7 +39,7 @@ describe('PluginUninstall', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginUninstall = new PluginUninstall(serverless, options);

--- a/test/unit/lib/plugins/remove.test.js
+++ b/test/unit/lib/plugins/remove.test.js
@@ -11,7 +11,7 @@ describe('Remove', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     remove = new Remove(serverless);
   });
 

--- a/test/unit/lib/plugins/rollback.test.js
+++ b/test/unit/lib/plugins/rollback.test.js
@@ -9,7 +9,7 @@ describe('Rollback', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
     rollback = new Rollback(serverless);
   });
 

--- a/test/unit/lib/utils/fs/writeFile.test.js
+++ b/test/unit/lib/utils/fs/writeFile.test.js
@@ -17,7 +17,7 @@ describe('#writeFile()', function () {
   this.timeout(0);
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
   });
 
   it('should write a .json file asynchronously', () => {

--- a/test/unit/lib/utils/fs/writeFileSync.test.js
+++ b/test/unit/lib/utils/fs/writeFileSync.test.js
@@ -11,7 +11,7 @@ describe('#writeFileSync()', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless();
+    serverless = new Serverless({ commands: [], options: {} });
   });
 
   it('should write a .json file synchronously', () => {


### PR DESCRIPTION
Adjusting all tests would be really time taking so I've decided to just alter how `Serverless` is instantiated. 