### PR TITLE
Change default deployment method of EventBridge to use native CloudFormation

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -36,6 +36,16 @@ Note:
 - In service configuration setting is ineffective for deprecations reported before service configuration is read.
 - `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
 
+<a name="AwS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN"><div>&nbsp;</div></a>
+
+## AWS EventBridge lambda event triggers based on Custom Resources
+
+Deprecation code: `AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN`
+
+Support for provisioning AWS EventBridge resources without native CloudFormation resources is deprecated and will no longer be maintained. If you want to upgrade to native CloudFormation, remove "eventBridge.useCloudFormation" setting from your configuration. If you are currently using "eventBridge.useCloudFormation" set to `true` to enable native CloudFormation, you can safely remove this setting from your configuration.
+
+Note that to migrate away from the legacy behavior, you will need to remove (or comment) EventBridge triggers, deploy, re-add them and re-deploy in order to migrate from the legacy behavior.
+
 <a name="AWS_HTTP_API_USE_PROVIDER_TAGS_PROPERTY"><div>&nbsp;</div></a>
 
 ## Ineffective property `provider.httpApi.useProviderTags`

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -13,16 +13,31 @@ class AwsCompileEventBridgeEvents {
 
     this.hooks = {
       'initialize': () => {
-        if (_.get(this.serverless.service.provider, 'eventBridge.useCloudFormation') == null) {
-          const hasFunctionsWithEventBridgeTrigger = Object.values(
-            this.serverless.service.functions
-          ).some(({ events }) => events.some(({ eventBridge }) => eventBridge));
-          if (hasFunctionsWithEventBridgeTrigger) {
+        const useCloudFormation = _.get(
+          this.serverless.service.provider,
+          'eventBridge.useCloudFormation'
+        );
+        const hasFunctionsWithEventBridgeTrigger = Object.values(
+          this.serverless.service.functions
+        ).some(({ events }) => events.some(({ eventBridge }) => eventBridge));
+
+        if (hasFunctionsWithEventBridgeTrigger) {
+          if (useCloudFormation === false) {
             this.serverless._logDeprecation(
-              'AWS_EVENT_BRIDGE_CUSTOM_RESOURCE',
-              'Starting with "v3.0.0", AWS EventBridge resources will be created using native CloudFormation resources by default. It is possible to use that functionality now by setting "eventBridge.useCloudFormation: true" as provider property in your configuration. If you want to keep using the old creation method, set that property to "false" to hide this deprecation message.'
+              'AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN',
+              'Support for provisioning AWS EventBridge resources without native CloudFormation resources is deprecated and will no longer be maintained. If you want to upgrade to native CloudFormation, remove "eventBridge.useCloudFormation" setting from your configuration.'
+            );
+          } else if (useCloudFormation === true) {
+            this.serverless._logDeprecation(
+              'AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN',
+              'Provisioning AWS EventBridge resources with native CloudFormation is now enabled by default. Please remove "eventBridge.useCloudFormation" from your configuration as this setting will not be recognized in next major release.'
             );
           }
+        } else if (useCloudFormation != null) {
+          this.serverless._logDeprecation(
+            'AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN',
+            'Your service does not configure any "eventBridge" events. Please remove "eventBridge.useCloudFormation" from your configuration as this setting will not be recognized in next major release.'
+          );
         }
       },
       'package:compileEvents': this.compileEventBridgeEvents.bind(this),
@@ -114,7 +129,7 @@ class AwsCompileEventBridgeEvents {
     const { compiledCloudFormationTemplate } = provider;
     const iamRoleStatements = [];
     const { eventBridge: options } = provider;
-    const shouldUseCloudFormation = options ? options.useCloudFormation : false;
+    const shouldUseCloudFormation = options ? options.useCloudFormation : true;
     let hasEventBusesIamRoleStatement = false;
     let anyFuncUsesEventBridge = false;
 

--- a/test/integration/aws/eventBridge.test.js
+++ b/test/integration/aws/eventBridge.test.js
@@ -50,7 +50,12 @@ describe('AWS - Event Bridge Integration Test', () => {
       arnEventBusArn = (await createEventBus(arnEventBusName)).EventBusArn;
       // update the YAML file with the arn
       await serviceData.updateConfig({
-        disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'],
+        disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN'],
+        provider: {
+          eventBridge: {
+            useCloudFormation: false,
+          },
+        },
         functions: {
           eventBusDefaultArn: {
             events: [
@@ -183,11 +188,6 @@ describe('AWS - Event Bridge Integration Test', () => {
       // NOTE: deployment can only be done once the Event Bus is created
       arnEventBusArn = (await createEventBus(arnEventBusName)).EventBusArn;
       await serviceData.updateConfig({
-        provider: {
-          eventBridge: {
-            useCloudFormation: true,
-          },
-        },
         functions: {
           eventBusDefaultArn: {
             events: [

--- a/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -164,6 +164,7 @@ describe('EventBridgeEvents', () => {
         fixture: 'function',
         configExt: {
           ...serverlessConfigurationExtension,
+          disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN'],
           provider: {
             eventBridge: {
               useCloudFormation: false,
@@ -284,7 +285,12 @@ describe('EventBridgeEvents', () => {
         runServerless({
           fixture: 'function',
           configExt: {
-            disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'],
+            disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN'],
+            provider: {
+              eventBridge: {
+                useCloudFormation: false,
+              },
+            },
             functions: {
               basic: {
                 events: [
@@ -316,7 +322,12 @@ describe('EventBridgeEvents', () => {
         runServerless({
           fixture: 'function',
           configExt: {
-            disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'],
+            disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN'],
+            provider: {
+              eventBridge: {
+                useCloudFormation: false,
+              },
+            },
             functions: {
               basic: {
                 events: [
@@ -347,7 +358,12 @@ describe('EventBridgeEvents', () => {
         runServerless({
           fixture: 'function',
           configExt: {
-            disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'],
+            disabledDeprecations: ['AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN'],
+            provider: {
+              eventBridge: {
+                useCloudFormation: false,
+              },
+            },
             functions: {
               basic: {
                 events: [
@@ -366,21 +382,6 @@ describe('EventBridgeEvents', () => {
       ).to.be.eventually.rejected.and.have.property(
         'code',
         'ERROR_INVALID_REFERENCE_TO_EVENT_BUS_CUSTOM_RESOURCE'
-      );
-    });
-
-    it('should emit deprecation when `eventBridge.useCloudFormation` is not explicitly set', async () => {
-      await expect(
-        runServerless({
-          fixture: 'function',
-          configExt: {
-            ...serverlessConfigurationExtension,
-          },
-          command: 'package',
-        })
-      ).to.be.eventually.rejected.and.have.property(
-        'code',
-        'REJECTED_DEPRECATION_AWS_EVENT_BRIDGE_CUSTOM_RESOURCE'
       );
     });
   });
@@ -429,11 +430,6 @@ describe('EventBridgeEvents', () => {
         const { cfTemplate, awsNaming } = await runServerless({
           fixture: 'function',
           configExt: {
-            provider: {
-              eventBridge: {
-                useCloudFormation: true,
-              },
-            },
             functions: {
               basic: {
                 events: [
@@ -595,11 +591,6 @@ describe('EventBridgeEvents', () => {
           fixture: 'function',
           command: 'package',
           configExt: {
-            provider: {
-              eventBridge: {
-                useCloudFormation: true,
-              },
-            },
             functions: {
               basic: {
                 events: [
@@ -676,5 +667,24 @@ describe('EventBridgeEvents', () => {
         ).not.to.include('default');
       });
     });
+  });
+
+  it('should trigger deprecation when `useCloudFormation` is set without any `eventBridge` events', async () => {
+    await expect(
+      runServerless({
+        fixture: 'function',
+        command: 'package',
+        configExt: {
+          provider: {
+            eventBridge: {
+              useCloudFormation: true,
+            },
+          },
+        },
+      })
+    ).to.be.eventually.rejected.and.have.property(
+      'code',
+      'REJECTED_DEPRECATION_AWS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN'
+    );
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: By default, EventBridge resources now will be deployed using
native CloudFormation resources instead of Custom Resources.

