### PR TITLE
fix(AWS EventBridge): Addres typos in error messages

### DIFF
--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -166,7 +166,7 @@ class AwsCompileEventBridgeEvents {
             if (RetryPolicy) {
               if (!shouldUseCloudFormation) {
                 throw new ServerlessError(
-                  'Configuring RetryPolicy is not supported for EventBrigde integration backed by Custom Resources. Please use "provider.eventBridge.useCloudFormation" setting to use native CloudFormation support for EventBridge.',
+                  'Configuring RetryPolicy is not supported for EventBridge integration backed by Custom Resources. Please use "provider.eventBridge.useCloudFormation" setting to use native CloudFormation support for EventBridge.',
                   'ERROR_INVALID_RETRY_POLICY_TO_EVENT_BUS_CUSTOM_RESOURCE'
                 );
               }
@@ -180,7 +180,7 @@ class AwsCompileEventBridgeEvents {
             if (event.eventBridge.deadLetterQueueArn) {
               if (!shouldUseCloudFormation) {
                 throw new ServerlessError(
-                  'Configuring DeadLetterConfig is not supported for EventBrigde integration backed by Custom Resources. Please use "provider.eventBridge.useCloudFormation" setting to use native CloudFormation support for EventBridge.',
+                  'Configuring DeadLetterConfig is not supported for EventBridge integration backed by Custom Resources. Please use "provider.eventBridge.useCloudFormation" setting to use native CloudFormation support for EventBridge.',
                   'ERROR_INVALID_DEAD_LETTER_CONFIG_TO_EVENT_BUS_CUSTOM_RESOURCE'
                 );
               }
@@ -263,7 +263,7 @@ class AwsCompileEventBridgeEvents {
   }) {
     if (_.isObject(eventBusName)) {
       throw new ServerlessError(
-        'Referencing event bus with CloudFormation intrinsic functions is not supported for EventBrigde integration backed by Custom Resources. Please use `provider.eventBridge.useCloudFormation` setting to use native CloudFormation support for EventBridge.',
+        'Referencing event bus with CloudFormation intrinsic functions is not supported for EventBridge integration backed by Custom Resources. Please use `provider.eventBridge.useCloudFormation` setting to use native CloudFormation support for EventBridge.',
         'ERROR_INVALID_REFERENCE_TO_EVENT_BUS_CUSTOM_RESOURCE'
       );
     }


### PR DESCRIPTION
This fixes a bunch of similar typos in error messages.
