### PR TITLE
Use the configured function version or alias when referencing it

### DIFF
--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { addPermission, removePermission } = require('./lib/permissions');
+const { addPermission, removePermission, updatePermission } = require('./lib/permissions');
 const { updateConfiguration, removeConfiguration, findUserPoolByName } = require('./lib/userPool');
 const { getEnvironment, getLambdaArn, handlerWrapper } = require('../utils');
 
@@ -16,14 +16,15 @@ async function handler(event, context) {
 }
 
 async function create(event, context) {
-  const { FunctionName, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
+  const { FunctionName, FunctionVersion, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
   const { Partition, Region, AccountId } = getEnvironment(context);
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName, FunctionVersion);
 
   return findUserPoolByName({ userPoolName: UserPoolName, region: Region }).then((userPool) =>
     addPermission({
       functionName: FunctionName,
+      functionArn: lambdaArn,
       userPoolName: UserPoolName,
       partition: Partition,
       region: Region,
@@ -42,23 +43,35 @@ async function create(event, context) {
 
 async function update(event, context) {
   const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
+  const { FunctionName, FunctionVersion, UserPoolName, UserPoolConfigs } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName, FunctionVersion);
 
-  return updateConfiguration({
-    lambdaArn,
-    userPoolName: UserPoolName,
-    userPoolConfigs: UserPoolConfigs,
-    region: Region,
-  });
+  return findUserPoolByName({ userPoolName: UserPoolName, region: Region }).then((userPool) =>
+    updatePermission({
+      functionName: FunctionName,
+      functionArn: lambdaArn,
+      userPoolName: UserPoolName,
+      partition: Partition,
+      region: Region,
+      accountId: AccountId,
+      userPoolId: userPool.Id,
+    }).then(() =>
+      updateConfiguration({
+        lambdaArn,
+        userPoolName: UserPoolName,
+        userPoolConfigs: UserPoolConfigs,
+        region: Region,
+      })
+    )
+  );
 }
 
 async function remove(event, context) {
   const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, UserPoolName } = event.ResourceProperties;
+  const { FunctionName, FunctionVersion, UserPoolName } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName, FunctionVersion);
 
   return removePermission({
     functionName: FunctionName,

--- a/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/cognitoUserPool/lib/permissions.js
@@ -12,10 +12,11 @@ function getStatementId(functionName, userPoolName) {
 }
 
 async function addPermission(config) {
-  const { functionName, userPoolName, partition, region, accountId, userPoolId } = config;
+  const { functionName, functionArn, userPoolName, partition, region, accountId, userPoolId } =
+    config;
   const payload = {
     Action: 'lambda:InvokeFunction',
-    FunctionName: functionName,
+    FunctionName: functionArn,
     Principal: 'cognito-idp.amazonaws.com',
     StatementId: getStatementId(functionName, userPoolName),
     SourceArn: `arn:${partition}:cognito-idp:${region}:${accountId}:userpool/${userPoolId}`,
@@ -32,8 +33,22 @@ async function removePermission(config) {
   return awsRequest({ name: 'Lambda', params: { region } }, 'removePermission', payload);
 }
 
+async function updatePermission(config) {
+  try {
+    await removePermission(config);
+  } catch (err) {
+    // If this is just a "ResourceNotFoundException" this can be ignored, as the goal
+    // "no permission set" is achieved. Other errors need to be thrown for further investigation.
+    if (err.code !== 'ResourceNotFoundException') {
+      throw err;
+    }
+  }
+  await addPermission(config);
+}
+
 module.exports = {
   getStatementId,
   addPermission,
   removePermission,
+  updatePermission,
 };

--- a/lib/plugins/aws/customResources/resources/eventBridge/handler.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { addPermission, removePermission } = require('./lib/permissions');
+const { addPermission, removePermission, updatePermission } = require('./lib/permissions');
 const {
   createEventBus,
   deleteEventBus,
@@ -23,13 +23,14 @@ async function handler(event, context) {
 }
 
 async function create(event, context) {
-  const { FunctionName, EventBridgeConfig } = event.ResourceProperties;
+  const { FunctionName, FunctionVersion, EventBridgeConfig } = event.ResourceProperties;
   const { Partition, Region, AccountId } = getEnvironment(context);
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName, FunctionVersion);
 
   return addPermission({
     functionName: FunctionName,
+    functionArn: lambdaArn,
     partition: Partition,
     region: Region,
     accountId: AccountId,
@@ -67,29 +68,41 @@ async function create(event, context) {
 
 async function update(event, context) {
   const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, EventBridgeConfig } = event.ResourceProperties;
+  const { FunctionName, FunctionVersion, EventBridgeConfig } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName, FunctionVersion);
 
-  return updateRuleConfiguration({
+  return updatePermission({
+    functionName: FunctionName,
+    functionArn: lambdaArn,
+    partition: Partition,
     region: Region,
-    ruleName: EventBridgeConfig.RuleName,
+    accountId: AccountId,
     eventBus: EventBridgeConfig.EventBus,
-    pattern: EventBridgeConfig.Pattern,
-    schedule: EventBridgeConfig.Schedule,
-    state: EventBridgeConfig.State,
-  }).then(() =>
-    updateTargetConfiguration({
-      lambdaArn,
-      region: Region,
-      functionName: FunctionName,
-      ruleName: EventBridgeConfig.RuleName,
-      eventBus: EventBridgeConfig.EventBus,
-      input: EventBridgeConfig.Input,
-      inputPath: EventBridgeConfig.InputPath,
-      inputTransformer: EventBridgeConfig.InputTransformer,
-    })
-  );
+    ruleName: EventBridgeConfig.RuleName,
+  })
+    .then(() =>
+      updateRuleConfiguration({
+        region: Region,
+        ruleName: EventBridgeConfig.RuleName,
+        eventBus: EventBridgeConfig.EventBus,
+        pattern: EventBridgeConfig.Pattern,
+        schedule: EventBridgeConfig.Schedule,
+        state: EventBridgeConfig.State,
+      })
+    )
+    .then(() =>
+      updateTargetConfiguration({
+        lambdaArn,
+        region: Region,
+        functionName: FunctionName,
+        ruleName: EventBridgeConfig.RuleName,
+        eventBus: EventBridgeConfig.EventBus,
+        input: EventBridgeConfig.Input,
+        inputPath: EventBridgeConfig.InputPath,
+        inputTransformer: EventBridgeConfig.InputTransformer,
+      })
+    );
 }
 
 async function remove(event, context) {

--- a/lib/plugins/aws/customResources/resources/eventBridge/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/eventBridge/lib/permissions.js
@@ -13,7 +13,7 @@ function getStatementId(functionName, ruleName) {
 }
 
 async function addPermission(config) {
-  const { functionName, partition, region, accountId, eventBus, ruleName } = config;
+  const { functionName, functionArn, partition, region, accountId, eventBus, ruleName } = config;
   let SourceArn = `arn:${partition}:events:${region}:${accountId}:rule/${ruleName}`;
   if (eventBus) {
     const eventBusName = getEventBusName(eventBus);
@@ -21,7 +21,7 @@ async function addPermission(config) {
   }
   const payload = {
     Action: 'lambda:InvokeFunction',
-    FunctionName: functionName,
+    FunctionName: functionArn,
     Principal: 'events.amazonaws.com',
     StatementId: getStatementId(functionName, ruleName),
     SourceArn,
@@ -38,8 +38,22 @@ async function removePermission(config) {
   return awsRequest({ name: 'Lambda', params: { region } }, 'removePermission', payload);
 }
 
+async function updatePermission(config) {
+  try {
+    await removePermission(config);
+  } catch (err) {
+    // If this is just a "ResourceNotFoundException" this can be ignored, as the goal
+    // "no permission set" is achieved. Other errors need to be thrown for further investigation.
+    if (err.code !== 'ResourceNotFoundException') {
+      throw err;
+    }
+  }
+  await addPermission(config);
+}
+
 module.exports = {
   getStatementId,
   addPermission,
   removePermission,
+  updatePermission,
 };

--- a/lib/plugins/aws/customResources/resources/s3/handler.js
+++ b/lib/plugins/aws/customResources/resources/s3/handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { addPermission, removePermission } = require('./lib/permissions');
+const { addPermission, removePermission, updatePermission } = require('./lib/permissions');
 const { updateConfiguration, removeConfiguration } = require('./lib/bucket');
 const { getEnvironment, getLambdaArn, handlerWrapper } = require('../utils');
 
@@ -17,12 +17,13 @@ async function handler(event, context) {
 
 async function create(event, context) {
   const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
+  const { FunctionName, FunctionVersion, BucketName, BucketConfigs } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName, FunctionVersion);
 
   return addPermission({
     functionName: FunctionName,
+    functionArn: lambdaArn,
     bucketName: BucketName,
     partition: Partition,
     region: Region,
@@ -40,17 +41,26 @@ async function create(event, context) {
 
 async function update(event, context) {
   const { Partition, Region, AccountId } = getEnvironment(context);
-  const { FunctionName, BucketName, BucketConfigs } = event.ResourceProperties;
+  const { FunctionName, FunctionVersion, BucketName, BucketConfigs } = event.ResourceProperties;
 
-  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
+  const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName, FunctionVersion);
 
-  return updateConfiguration({
-    lambdaArn,
-    region: Region,
+  return updatePermission({
     functionName: FunctionName,
+    functionArn: lambdaArn,
     bucketName: BucketName,
-    bucketConfigs: BucketConfigs,
-  });
+    partition: Partition,
+    region: Region,
+    accountId: AccountId,
+  }).then(() =>
+    updateConfiguration({
+      lambdaArn,
+      region: Region,
+      functionName: FunctionName,
+      bucketName: BucketName,
+      bucketConfigs: BucketConfigs,
+    })
+  );
 }
 
 async function remove(event, context) {

--- a/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
+++ b/lib/plugins/aws/customResources/resources/s3/lib/permissions.js
@@ -12,10 +12,10 @@ function getStatementId(functionName, bucketName) {
 }
 
 async function addPermission(config) {
-  const { functionName, bucketName, partition, region, accountId } = config;
+  const { functionName, functionArn, bucketName, partition, region, accountId } = config;
   const payload = {
     Action: 'lambda:InvokeFunction',
-    FunctionName: functionName,
+    FunctionName: functionArn,
     Principal: 's3.amazonaws.com',
     StatementId: getStatementId(functionName, bucketName),
     SourceArn: `arn:${partition}:s3:::${bucketName}`,
@@ -33,8 +33,22 @@ async function removePermission(config) {
   return awsRequest({ name: 'Lambda', params: { region } }, 'removePermission', payload);
 }
 
+async function updatePermission(config) {
+  try {
+    await removePermission(config);
+  } catch (err) {
+    // If this is just a "ResourceNotFoundException" this can be ignored, as the goal
+    // "no permission set" is achieved. Other errors need to be thrown for further investigation.
+    if (err.code !== 'ResourceNotFoundException') {
+      throw err;
+    }
+  }
+  await addPermission(config);
+}
+
 module.exports = {
   getStatementId,
   addPermission,
   removePermission,
+  updatePermission,
 };

--- a/lib/plugins/aws/customResources/resources/utils.js
+++ b/lib/plugins/aws/customResources/resources/utils.js
@@ -56,8 +56,9 @@ async function response(event, context, status, data = {}, err) {
   });
 }
 
-function getLambdaArn(partition, region, accountId, functionName) {
-  return `arn:${partition}:lambda:${region}:${accountId}:function:${functionName}`;
+function getLambdaArn(partition, region, accountId, functionName, versionOrAlias) {
+  const suffix = versionOrAlias ? `:${versionOrAlias}` : '';
+  return `arn:${partition}:lambda:${region}:${accountId}:function:${functionName}${suffix}`;
 }
 
 function getEnvironment(context) {

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -167,6 +167,12 @@ module.exports = {
       ''
     )}`;
   },
+  getLambdaVersionLogicalIdRegex(functionName) {
+    return new RegExp(
+      `${this.getNormalizedFunctionName(functionName)}LambdaVersion[0-9a-z]+$`,
+      'i'
+    );
+  },
   getCodeDeployApplicationLogicalId() {
     return 'CodeDeployApplication';
   },

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool.js
@@ -137,6 +137,21 @@ class AwsCompileCognitoUserPoolEvents {
       const functionObj = service.getFunction(functionName);
       const FunctionName = functionObj.name;
 
+      const functionVersionDependsOn = [];
+      let maybeFunctionVersion;
+      if (functionObj.targetAlias) {
+        maybeFunctionVersion = { FunctionVersion: functionObj.targetAlias.name };
+        functionVersionDependsOn.push(functionObj.targetAlias.logicalId);
+      } else if (functionObj.versionLogicalId) {
+        maybeFunctionVersion = {
+          FunctionVersion: { 'Fn::GetAtt': [functionObj.versionLogicalId, 'Version'] },
+        };
+        // NB: This is also implied through the `Fn::GetAtt`
+        functionVersionDependsOn.push(functionObj.versionLogicalId);
+      } else {
+        maybeFunctionVersion = {};
+      }
+
       if (functionObj.events) {
         functionObj.events.forEach((event) => {
           if (event.cognitoUserPool && event.cognitoUserPool.existing) {
@@ -176,12 +191,17 @@ class AwsCompileCognitoUserPoolEvents {
                 [customPoolResourceLogicalId]: {
                   Type: 'Custom::CognitoUserPool',
                   Version: 1.0,
-                  DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
+                  DependsOn: [
+                    eventFunctionLogicalId,
+                    customResourceFunctionLogicalId,
+                    ...functionVersionDependsOn,
+                  ],
                   Properties: {
                     ServiceToken: {
                       'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
                     },
                     FunctionName,
+                    ...maybeFunctionVersion,
                     UserPoolName: pool,
                     UserPoolConfigs: [
                       {

--- a/lib/plugins/aws/package/compile/events/eventBridge/index.js
+++ b/lib/plugins/aws/package/compile/events/eventBridge/index.js
@@ -192,6 +192,17 @@ class AwsCompileEventBridgeEvents {
             const eventBusName = EventBus;
             // Custom resources will be deprecated in next major release
             if (!shouldUseCloudFormation) {
+              const functionVersionDependsOn = [];
+              let FunctionVersion;
+              if (functionObj.targetAlias) {
+                FunctionVersion = functionObj.targetAlias.name;
+                functionVersionDependsOn.push(functionObj.targetAlias.logicalId);
+              } else if (functionObj.versionLogicalId) {
+                FunctionVersion = { 'Fn::GetAtt': [functionObj.versionLogicalId, 'Version'] };
+                // NB: This is also implied through the `Fn::GetAtt`
+                functionVersionDependsOn.push(functionObj.versionLogicalId);
+              }
+
               const results = this.compileWithCustomResource({
                 eventBusName,
                 EventBus,
@@ -205,6 +216,8 @@ class AwsCompileEventBridgeEvents {
                 Pattern,
                 Schedule,
                 FunctionName,
+                FunctionVersion,
+                functionVersionDependsOn,
                 idx,
                 hasEventBusesIamRoleStatement,
                 iamRoleStatements,
@@ -213,6 +226,17 @@ class AwsCompileEventBridgeEvents {
               results.iamRoleStatements.forEach((statement) => iamRoleStatements.push(statement));
               hasEventBusesIamRoleStatement = results.hasEventBusesIamRoleStatement;
             } else {
+              let FunctionArn;
+              if (functionObj.targetAlias) {
+                FunctionArn = { Ref: functionObj.targetAlias.logicalId };
+              } else if (functionObj.versionLogicalId) {
+                FunctionArn = { Ref: functionObj.versionLogicalId };
+              } else {
+                FunctionArn = {
+                  'Fn::GetAtt': [this.provider.naming.getLambdaLogicalId(functionName), 'Arn'],
+                };
+              }
+
               this.compileWithCloudFormation({
                 eventBusName,
                 EventBus,
@@ -225,6 +249,7 @@ class AwsCompileEventBridgeEvents {
                 InputTransformer,
                 Pattern,
                 Schedule,
+                FunctionArn,
                 FunctionName,
                 idx,
                 hasEventBusesIamRoleStatement,
@@ -258,6 +283,8 @@ class AwsCompileEventBridgeEvents {
     Pattern,
     Schedule,
     FunctionName,
+    FunctionVersion,
+    functionVersionDependsOn,
     idx,
     hasEventBusesIamRoleStatement,
   }) {
@@ -280,15 +307,17 @@ class AwsCompileEventBridgeEvents {
     const customEventBridgeResourceLogicalId =
       this.provider.naming.getCustomResourceEventBridgeResourceLogicalId(functionName, idx);
 
+    const maybeFunctionVersion = FunctionVersion ? { FunctionVersion } : {};
     const customEventBridge = {
       Type: 'Custom::EventBridge',
       Version: 1.0,
-      DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
+      DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId, ...functionVersionDependsOn],
       Properties: {
         ServiceToken: {
           'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
         },
         FunctionName,
+        ...maybeFunctionVersion,
         EventBridgeConfig: {
           RuleName,
           State,
@@ -343,6 +372,7 @@ class AwsCompileEventBridgeEvents {
     InputTransformer,
     Pattern,
     Schedule,
+    FunctionArn,
     FunctionName,
     RetryPolicy,
     DeadLetterConfig,
@@ -379,9 +409,7 @@ class AwsCompileEventBridgeEvents {
     }
 
     const targetBase = {
-      Arn: {
-        'Fn::GetAtt': [this.provider.naming.getLambdaLogicalId(functionName), 'Arn'],
-      },
+      Arn: FunctionArn,
       Id: makeEventBusTargetId(RuleName),
     };
 
@@ -427,9 +455,7 @@ class AwsCompileEventBridgeEvents {
       Type: 'AWS::Lambda::Permission',
       Properties: {
         Action: 'lambda:InvokeFunction',
-        FunctionName: {
-          Ref: this.provider.naming.getLambdaLogicalId(functionName),
-        },
+        FunctionName: FunctionArn,
         Principal: 'events.amazonaws.com',
         SourceArn: {
           'Fn::Join': [

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -273,6 +273,21 @@ class AwsCompileS3Events {
       const functionObj = service.getFunction(functionName);
       const FunctionName = functionObj.name;
 
+      const functionVersionDependsOn = [];
+      let maybeFunctionVersion;
+      if (functionObj.targetAlias) {
+        maybeFunctionVersion = { FunctionVersion: functionObj.targetAlias.name };
+        functionVersionDependsOn.push(functionObj.targetAlias.logicalId);
+      } else if (functionObj.versionLogicalId) {
+        maybeFunctionVersion = {
+          FunctionVersion: { 'Fn::GetAtt': [functionObj.versionLogicalId, 'Version'] },
+        };
+        // NB: This is also implied through the `Fn::GetAtt`
+        functionVersionDependsOn.push(functionObj.versionLogicalId);
+      } else {
+        maybeFunctionVersion = {};
+      }
+
       if (functionObj.events) {
         functionObj.events.forEach((event) => {
           if (event.s3 && _.isObject(event.s3) && event.s3.existing) {
@@ -326,12 +341,17 @@ class AwsCompileS3Events {
                 [customS3ResourceLogicalId]: {
                   Type: 'Custom::S3',
                   Version: 1.0,
-                  DependsOn: [eventFunctionLogicalId, customResourceFunctionLogicalId],
+                  DependsOn: [
+                    eventFunctionLogicalId,
+                    customResourceFunctionLogicalId,
+                    ...functionVersionDependsOn,
+                  ],
                   Properties: {
                     ServiceToken: {
                       'Fn::GetAtt': [customResourceFunctionLogicalId, 'Arn'],
                     },
                     FunctionName,
+                    ...maybeFunctionVersion,
                     BucketName: bucket,
                     BucketConfigs: [
                       {

--- a/test/unit/lib/plugins/aws/customResources/test/utils.test.js
+++ b/test/unit/lib/plugins/aws/customResources/test/utils.test.js
@@ -6,51 +6,37 @@ const {
   getEnvironment,
 } = require('../../../../../../../lib/plugins/aws/customResources/resources/utils');
 
-describe('#getLambdaArn()', () => {
-  it('should return the Lambda arn', () => {
-    const partition = 'aws';
-    const region = 'us-east-1';
-    const accountId = '123456';
-    const functionName = 'some-function';
-    const arn = getLambdaArn(partition, region, accountId, functionName);
+[
+  { partition: 'aws', region: 'us-east-1' },
+  { partition: 'aws-us-gov', region: 'us-gov-west-1' },
+  { partition: 'aws-cn', region: 'cn-north-1' },
+].forEach(({ partition, region }) => {
+  describe(`#getLambdaArn() (${partition} ${region})`, () => {
+    it('should return the Lambda arn', () => {
+      const accountId = '123456';
+      const functionName = 'some-function';
+      const arn = getLambdaArn(partition, region, accountId, functionName);
 
-    expect(arn).to.equal('arn:aws:lambda:us-east-1:123456:function:some-function');
-  });
-});
+      expect(arn).to.equal(`arn:${partition}:lambda:${region}:123456:function:some-function`);
+    });
+    it('should return the Lambda arn for version', () => {
+      const accountId = '123456';
+      const functionName = 'some-function';
+      const functionVersion = '1';
+      const arn = getLambdaArn(partition, region, accountId, functionName, functionVersion);
 
-describe('#getLambdaArn() govloud west', () => {
-  it('should return the govcloud Lambda arn', () => {
-    const partition = 'aws-us-gov';
-    const region = 'us-gov-west-1';
-    const accountId = '123456';
-    const functionName = 'some-function';
-    const arn = getLambdaArn(partition, region, accountId, functionName);
+      expect(arn).to.equal(`arn:${partition}:lambda:${region}:123456:function:some-function:1`);
+    });
+    it('should return the Lambda arn for alias', () => {
+      const accountId = '123456';
+      const functionName = 'some-function';
+      const functionVersion = 'provisioned';
+      const arn = getLambdaArn(partition, region, accountId, functionName, functionVersion);
 
-    expect(arn).to.equal('arn:aws-us-gov:lambda:us-gov-west-1:123456:function:some-function');
-  });
-});
-
-describe('#getLambdaArn() govcloud east', () => {
-  it('should return the govcloud Lambda arn', () => {
-    const partition = 'aws-us-gov';
-    const region = 'us-gov-east-1';
-    const accountId = '123456';
-    const functionName = 'some-function';
-    const arn = getLambdaArn(partition, region, accountId, functionName);
-
-    expect(arn).to.equal('arn:aws-us-gov:lambda:us-gov-east-1:123456:function:some-function');
-  });
-});
-
-describe('#getLambdaArn() china region', () => {
-  it('should return the china Lambda arn', () => {
-    const partition = 'aws-cn';
-    const region = 'cn-north-1';
-    const accountId = '123456';
-    const functionName = 'some-function';
-    const arn = getLambdaArn(partition, region, accountId, functionName);
-
-    expect(arn).to.equal('arn:aws-cn:lambda:cn-north-1:123456:function:some-function');
+      expect(arn).to.equal(
+        `arn:${partition}:lambda:${region}:123456:function:some-function:provisioned`
+      );
+    });
   });
 });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/eventBridge/index.test.js
@@ -436,6 +436,68 @@ describe('EventBridgeEvents', () => {
             },
             functions: {
               basic: {
+                versionFunction: false,
+                events: [
+                  {
+                    eventBridge: {
+                      eventBus: eventBusName,
+                      schedule,
+                      pattern,
+                      input,
+                    },
+                  },
+                  {
+                    eventBridge: {
+                      eventBus: eventBusName,
+                      schedule,
+                      pattern,
+                      inputPath,
+                    },
+                  },
+                  {
+                    eventBridge: {
+                      eventBus: eventBusName,
+                      schedule,
+                      pattern,
+                      inputTransformer,
+                    },
+                  },
+                  {
+                    eventBridge: {
+                      eventBus: eventBusName,
+                      schedule,
+                      enabled: false,
+                      pattern,
+                    },
+                  },
+                  {
+                    eventBridge: {
+                      eventBus: eventBusName,
+                      schedule,
+                      enabled: true,
+                      pattern,
+                    },
+                  },
+                  {
+                    eventBridge: {
+                      eventBus: eventBusName,
+                      schedule,
+                      pattern,
+                      retryPolicy,
+                    },
+                  },
+                  {
+                    eventBridge: {
+                      eventBus: eventBusName,
+                      schedule,
+                      pattern,
+                      deadLetterQueueArn,
+                    },
+                  },
+                ],
+              },
+              other: {
+                versionFunction: true,
                 events: [
                   {
                     eventBridge: {
@@ -502,7 +564,7 @@ describe('EventBridgeEvents', () => {
         cfResources = cfTemplate.Resources;
         naming = awsNaming;
         eventBusLogicalId = naming.getEventBridgeEventBusLogicalId(eventBusName);
-        ruleResource = getRuleResourceEndingWith(cfResources, '1');
+        ruleResource = getRuleResourceEndingWith(cfResources, '-basic-rule-1');
         ruleTarget = ruleResource.Properties.Targets[0];
       });
 
@@ -574,6 +636,12 @@ describe('EventBridgeEvents', () => {
 
       it('should create a rule that references correct function in target', () => {
         expect(ruleTarget.Arn['Fn::GetAtt'][0]).to.equal(naming.getLambdaLogicalId('basic'));
+      });
+
+      it('should create a rule that references correct function version in target', () => {
+        const otherRuleResource = getRuleResourceEndingWith(cfResources, '-other-rule-1');
+        const otherRuleTarget = otherRuleResource.Properties.Targets[0];
+        expect(otherRuleTarget.Arn.Ref).to.match(naming.getLambdaVersionLogicalIdRegex('other'));
       });
 
       it('should create a lambda permission resource that correctly references event bus in SourceArn', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -842,6 +842,9 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
     const { cfTemplate, awsNaming, serverless } = await runServerless({
       fixture: 'function',
       configExt: {
+        provider: {
+          versionFunctions: false,
+        },
         functions: {
           basic: {
             events: [


### PR DESCRIPTION
When provisioning concurrency for a function the function must be referenced through the alias (see issue #10167)

Note that #10167 is about S3 events on existing buckets, but looking at the involved code I claim that the same fix is also needed for Cognito and eventbridge (i.e. all users of the modified function).

Open points:
* For consistency this PR also uses the version when versioning is enabled
* The event bridge logic is proposed to be removed, so this PR should maybe "queue behind" #10164 or maybe this should be split into per-type PRs (S3, cognito, eventbridge)?
* Integration tests: Waiting for CI :)