### PR TITLE
No longer set default `identitySource` for authorizer with `request` type and disabled caching 

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -3,7 +3,6 @@
 /* eslint-disable global-require */
 
 const BbPromise = require('bluebird');
-const _ = require('lodash');
 const memoize = require('memoizee');
 
 const validate = require('./lib/validate');
@@ -236,27 +235,6 @@ class AwsCompileApigEvents {
 
     this.hooks = {
       'initialize': () => {
-        if (
-          this.serverless.service.provider.name === 'aws' &&
-          Object.values(this.serverless.service.functions).some(({ events }) =>
-            events.some(({ http }) => {
-              return (
-                http &&
-                _.isObject(http.authorizer) &&
-                http.authorizer.type &&
-                http.authorizer.type.toUpperCase() === 'REQUEST' &&
-                http.authorizer.identitySource === undefined &&
-                http.authorizer.resultTtlInSeconds === 0
-              );
-            })
-          )
-        ) {
-          this.serverless._logDeprecation(
-            'AWS_API_GATEWAY_DEFAULT_IDENTITY_SOURCE',
-            'Starting with v3.0.0, "functions[].events[].http.authorizer.identitySource" will no longer be set to "method.request.header.Authorization" by default for authorizers of "request" type with caching disabled ("resultTtlInSeconds" set to "0").\nIf you want to keep this setting, please set it explicitly in your configuration. If you do not want this to be set, please set it explicitly to "null".'
-          );
-        }
-
         if (
           this.serverless.service.provider.name === 'aws' &&
           this.serverless.service.provider.apiGateway &&

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -289,7 +289,10 @@ module.exports = {
       managedExternally = false;
     }
 
-    if (typeof identitySource === 'undefined') {
+    if (
+      !identitySource &&
+      !(type && type.toUpperCase() === 'REQUEST' && resultTtlInSeconds === 0)
+    ) {
       identitySource = 'method.request.header.Authorization';
     }
 

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -1421,6 +1421,22 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/valida
       command: 'package',
       configExt: {
         functions: {
+          authorized: {
+            handler: 'index.handler',
+            events: [
+              {
+                http: {
+                  method: 'get',
+                  path: '/authorized',
+                  authorizer: {
+                    type: 'REQUEST',
+                    name: 'basic',
+                    resultTtlInSeconds: 0,
+                  },
+                },
+              },
+            ],
+          },
           corsDefault: {
             handler: 'index.handler',
             events: [
@@ -1470,5 +1486,10 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/valida
       getApiGatewayMethod('/cors-default-set-by-object', 'OPTIONS').Properties.Integration
         .IntegrationResponses[0].ResponseParameters
     ).to.deep.eq(expected);
+  });
+
+  it('Should not set default `identitySource` for `request` authorizers with caching disabled', async () => {
+    expect(cfResources[naming.getAuthorizerLogicalId('basic')].Properties.IdentitySource).to.be
+      .undefined;
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: For authorizers with `request` type and caching disabled
(`resultTtlInSeconds: 0`), the `identitySource` will no longer be set to
`method.request.header.Authorization` by default.

