### PR TITLE
Only check for layer changes when actually deploying

### DIFF
--- a/lib/plugins/aws/package/compile/layers.js
+++ b/lib/plugins/aws/package/compile/layers.js
@@ -20,6 +20,7 @@ class AwsCompileLayers {
 
     this.hooks = {
       'package:compileLayers': async () => BbPromise.bind(this).then(this.compileLayers),
+      'aws:deploy:checkForChanges': async () => BbPromise.bind(this).then(this.checkForChanges),
     };
   }
 
@@ -166,11 +167,12 @@ class AwsCompileLayers {
 
   async compileLayers() {
     const allLayers = this.serverless.service.getAllLayers();
-    return Promise.all(
-      allLayers.map((layerName) =>
-        this.compileLayer(layerName).then(() => this.compareWithLastLayer(layerName))
-      )
-    );
+    return Promise.all(allLayers.map((layerName) => this.compileLayer(layerName)));
+  }
+
+  checkForChanges() {
+    const allLayers = this.serverless.service.getAllLayers();
+    return Promise.all(allLayers.map((layerName) => this.compareWithLastLayer(layerName)));
   }
 
   cfLambdaLayerTemplate() {


### PR DESCRIPTION
Addresses: #8187

---
The discussion in #8187 seems to be stuck, and proposes quite some changes. I think it would be beneficial to unbreak `serverless package` using this trivial change, and then look into the bigger picture (see also #8499 and #8666, for example.)

The layers part is clearly depending on the `aws` provider, and so (IMHO) should be free to hook into the `aws:deploy:checkForChanges`.

Practical reasons for this change for us: We're using `package` to produce the cloudformation template (for various combinations of parameters), which we then run through cfn-lint as a first step in sanity-checking before deploying.