### PR TITLE
Remove support for unrecognized CLI options

### DIFF
--- a/lib/cli/ensure-supported-command.js
+++ b/lib/cli/ensure-supported-command.js
@@ -3,7 +3,6 @@
 const { distance: getDistance } = require('fastest-levenshtein');
 const resolveInput = require('./resolve-input');
 const ServerlessError = require('../serverless-error');
-const logDeprecation = require('../utils/logDeprecation');
 
 const getCommandSuggestion = (command, commandsSchema) => {
   let suggestion;
@@ -42,11 +41,9 @@ module.exports = (configuration = null) => {
     (optionName) => !supportedOptions.has(optionName)
   );
   if (unrecognizedOptions.length) {
-    logDeprecation(
-      'UNSUPPORTED_CLI_OPTIONS',
-      `Detected unrecognized CLI options: "--${unrecognizedOptions.join('", "--')}".\n` +
-        'Starting with the next major, Serverless Framework will report them with a thrown error',
-      { serviceConfig: configuration }
+    throw new ServerlessError(
+      `Detected unrecognized CLI options: "--${unrecognizedOptions.join('", "--')}".\n`,
+      'UNSUPPORTED_CLI_OPTIONS'
     );
   }
   if (isContainerCommand) return;

--- a/test/unit/commands/doctor.test.js
+++ b/test/unit/commands/doctor.test.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 const path = require('path');
 const spawn = require('child-process-ext/spawn');
 const { expect } = require('chai');
+const fixturesEngine = require('../../fixtures/programmatic');
 
 chai.use(require('chai-as-promised'));
 
@@ -16,8 +17,17 @@ describe('test/unit/commands/doctor.test.js', async () => {
   });
 
   it('should print health status after command which triggered deprecation', async () => {
+    const { servicePath: serviceDir } = await fixturesEngine.setup('httpApi', {
+      configExt: {
+        provider: {
+          httpApi: {
+            useProviderTags: true,
+          },
+        },
+      },
+    });
     // Trigger deprecation
-    await spawn('node', [serverlessPath, 'config', '--foo']);
+    await spawn('node', [serverlessPath, 'print'], { cwd: serviceDir });
 
     // Gather Health status
     expect(String((await spawn('node', [serverlessPath, 'doctor'])).stdoutBuffer)).to.include(

--- a/test/unit/lib/cli/ensure-supported-command.test.js
+++ b/test/unit/lib/cli/ensure-supported-command.test.js
@@ -18,7 +18,6 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
       () => resolveInput()
     );
     ensureSupportedCommand();
-    expect(triggeredDeprecations.has('UNSUPPORTED_CLI_OPTIONS')).to.be.false;
   });
 
   it('should do nothing on container commmand', async () => {
@@ -31,7 +30,6 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
       () => resolveInput()
     );
     ensureSupportedCommand();
-    expect(triggeredDeprecations.has('UNSUPPORTED_CLI_OPTIONS')).to.be.false;
   });
 
   it('should reject invalid command', async () => {
@@ -59,7 +57,7 @@ describe('test/unit/lib/cli/ensure-supported-command.test.js', () => {
     );
     expect(() => ensureSupportedCommand())
       .to.throw(ServerlessError)
-      .with.property('code', 'REJECTED_DEPRECATION_UNSUPPORTED_CLI_OPTIONS');
+      .with.property('code', 'UNSUPPORTED_CLI_OPTIONS');
   });
 
   it('should reject missing options', async () => {


### PR DESCRIPTION
BREAKING CHANGE: Unrecognized CLI options will no longer be supported and
will result in an error.

