### PR TITLE
feat: Allow `legacy` option for `lambdaHashingVersion` property

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -322,9 +322,11 @@ Org, app, service, stage, and region are required to resolve variables when logg
 
 Deprecation code: `LAMBDA_HASHING_VERSION_V2`
 
-Resolution of lambda version hashes was improved with better (fixed deterministism issues) algorithm, which will be used starting with v3.0.0
+Lambda version hashes were improved with a better algorithm (that fixed determinism issues). It will be used by default starting with v3.0.0.
 
-You can adapt your services to use it now, by setting `provider.lambdaHashingVersion` to `20201221`.
+You can adapt your services to use it now by setting `provider.lambdaHashingVersion` to `20201221`.
+
+While not recommended, you can keep using the old hashing algorithm by setting `provider.lambdaHashingVersion` to `20200924`. That will silence the deprecation and allow to upgrade to v3.
 
 **Notice:** If you apply this on already deployed service without any changes to lambda code, you might encounter an error similar to the one below:
 

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -62,7 +62,8 @@ class AwsCompileFunctions {
             'LAMBDA_HASHING_VERSION_V2',
             'Resolution of lambda version hashes was improved with better algorithm, ' +
               'which will be used in next major release.\n' +
-              'Switch to it now by setting "provider.lambdaHashingVersion" to "20201221"'
+              'Switch to it now by setting "provider.lambdaHashingVersion" to "20201221".\n' +
+              'While it is highly encouraged to upgrade to new algorithm, you can still use the old approach by setting "provider.lambdaHashingVersion" to "20200924".'
           );
         }
         if (
@@ -147,7 +148,7 @@ class AwsCompileFunctions {
 
   async addFileToHash(filePath, hash) {
     const lambdaHashingVersion = this.serverless.service.provider.lambdaHashingVersion;
-    if (lambdaHashingVersion) {
+    if (lambdaHashingVersion >= 20201221) {
       const filePathHash = await getHashForFilePath(filePath);
       hash.write(filePathHash);
     } else {
@@ -502,7 +503,7 @@ class AwsCompileFunctions {
       delete functionProperties.Tags;
 
       const lambdaHashingVersion = this.serverless.service.provider.lambdaHashingVersion;
-      if (lambdaHashingVersion) {
+      if (lambdaHashingVersion >= 20201221) {
         functionProperties.layerConfigurations = layerConfigurations;
         versionHash.write(JSON.stringify(deepSortObjectByKey(functionProperties)));
       } else {

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1010,7 +1010,7 @@ class AwsProvider {
             kmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
             lambdaHashingVersion: {
               type: 'string',
-              enum: ['20201221'],
+              enum: ['20200924', '20201221'],
             },
             layers: { $ref: '#/definitions/awsLambdaLayers' },
             logRetentionInDays: {


### PR DESCRIPTION
Allow to use `legacy` option for `lambdaHashingVersion` to keep using the old algorithm

Reported internally