### PR TITLE
fix(CLI): help command usage "undefined"

### DIFF
--- a/lib/cli/commands-schema/no-service.js
+++ b/lib/cli/commands-schema/no-service.js
@@ -161,7 +161,7 @@ commands.set('generate-event', {
 });
 
 commands.set('help', {
-  // Shows general "help", so has no specific usage info
+  usage: 'Show this help',
   serviceDependencyMode: 'optional',
 });
 


### PR DESCRIPTION
The "help" command currently shows "undefined" in the usage. This PR adds a simple description that it'll just show the help that the user is currently seeing

![2021-10-29_10-39-18](https://user-images.githubusercontent.com/5831347/139404212-7b3dee50-e16c-4065-adca-9e4107907232.png)
 