### PR TITLE
fix: avoid fallBack to 'method.request.header.Authorization' for type=request

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -289,7 +289,7 @@ module.exports = {
       managedExternally = false;
     }
 
-    if (typeof identitySource === 'undefined') {
+    if (typeof identitySource === 'undefined' && (type || '').toUpperCase() !== 'REQUEST') {
       identitySource = 'method.request.header.Authorization';
     }
 


### PR DESCRIPTION
In case when authorizer uses `type` = `request`, it's redundant to make fallback to `method.request.header.Authorization`, cause it is a valid use case to have not `identitySource` in such case.

It is also not required by aws docs: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-api-lambdarequestauthorizer.html

There is already some [SO question](https://stackoverflow.com/questions/61326554/how-to-deploy-an-api-gateway-custom-authorizer-without-identity-sources-using-se), where  users forced to use empty string, as work around