### PR TITLE
fix(AWS API Gateway): Ensure `shouldStartNameWithService` support

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -150,9 +150,7 @@ async function resolveRestApiId() {
     }
     const apiName = apiGatewayResource
       ? apiGatewayResource.Properties.Name
-      : provider.apiName || (provider.apiGateway && provider.apiGateway.shouldStartNameWithService)
-        ? `${this.state.service.service}-${this.options.stage}`
-        : `${this.options.stage}-${this.state.service.service}`;
+      : provider.apiName || provider.naming.getApiGatewayName();
     const resolveFromAws = (position) =>
       this.provider
         .request('APIGateway', 'getRestApis', { position, limit: 500 })

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -150,7 +150,9 @@ async function resolveRestApiId() {
     }
     const apiName = apiGatewayResource
       ? apiGatewayResource.Properties.Name
-      : provider.apiName || `${this.options.stage}-${this.state.service.service}`;
+      : provider.apiName || (provider.apiGateway && provider.apiGateway.shouldStartNameWithService)
+        ? `${this.state.service.service}-${this.options.stage}`
+        : `${this.options.stage}-${this.state.service.service}`;
     const resolveFromAws = (position) =>
       this.provider
         .request('APIGateway', 'getRestApis', { position, limit: 500 })

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -150,7 +150,7 @@ async function resolveRestApiId() {
     }
     const apiName = apiGatewayResource
       ? apiGatewayResource.Properties.Name
-      : provider.apiName || provider.naming.getApiGatewayName();
+      : provider.naming.getApiGatewayName();
     const resolveFromAws = (position) =>
       this.provider
         .request('APIGateway', 'getRestApis', { position, limit: 500 })

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -811,7 +811,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/u
     expect(untagResourceStub.args[0][0].tagKeys).to.deep.equal(['keytoremove']);
   });
 
-  it.only('should deploys shouldStartNameWithService without apiName', async () => {
+  it('should deploys shouldStartNameWithService without apiName', async () => {
     const { serviceConfig, servicePath, updateConfig } = await fixtures.setup('apiGateway');
     const getDeploymentsStub = sinon.stub().returns({ items: [{ id: 'deployment-id' }] });
     const stage = 'dev';

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -13,6 +13,7 @@ const {
   defaultApiGatewayLogLevel,
 } = require('../../../../../../../../../../../lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage');
 const runServerless = require('../../../../../../../../../../utils/run-serverless');
+const fixtures = require('../../../../../../../../../../fixtures/programmatic');
 
 chai.use(require('sinon-chai'));
 chai.use(require('chai-as-promised'));
@@ -810,30 +811,30 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/u
     expect(untagResourceStub.args[0][0].tagKeys).to.deep.equal(['keytoremove']);
   });
 
-  it('should deploys shouldStartNameWithService without apiName', async () => {
+  it.only('should deploys shouldStartNameWithService without apiName', async () => {
+    const { serviceConfig, servicePath, updateConfig } = await fixtures.setup('apiGateway');
     const getDeploymentsStub = sinon.stub().returns({ items: [{ id: 'deployment-id' }] });
-    const service = 'test-service';
     const stage = 'dev';
 
-    await runServerless({
-      fixture: 'apiGateway',
-      command: 'deploy',
-      configExt: {
-        service,
-        provider: {
-          apiGateway: {
-            shouldStartNameWithService: true,
-          },
-          stackTags: { key: 'value' },
+    await updateConfig({
+      provider: {
+        apiGateway: {
+          shouldStartNameWithService: true,
         },
+        stackTags: { key: 'value' },
       },
+    });
+
+    await runServerless({
+      command: 'deploy',
+      cwd: servicePath,
       options: { stage },
       lastLifecycleHookName: 'after:deploy:deploy',
       awsRequestStubMap: {
         APIGateway: {
           createStage: {},
           getDeployments: getDeploymentsStub,
-          getRestApis: { items: [{ id: 'api-id', name: `${service}-${stage}` }] },
+          getRestApis: { items: [{ id: 'api-id', name: `${serviceConfig.service}-${stage}` }] },
           tagResource: {},
         },
         CloudFormation: {


### PR DESCRIPTION
The closing of #8720 was a workaround by supplying an optional option `apiName`.

In a perfect world it should correctly deploy with the recommended `provider.apiGateway.shouldStartNameWithService` without having to provide a custom `apiName`. But the workaround in the issue make it a required option, otherwise the script exits with code 1, and my CI environment is not happy about it.

This PR is a continuation of the discussion I started after the closing of the issue.

For more context please see https://github.com/serverless/serverless/issues/8720#issuecomment-955037755