### PR TITLE
Separate internal and plugin output sections

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -462,6 +462,7 @@ class Serverless {
     }
 
     this.serviceOutputs = new Map();
+    this.servicePluginOutputs = new Map();
 
     // trigger the plugin lifecycle when there's something which should be processed
     await this.pluginManager.run(this.processedInput.commands);
@@ -478,10 +479,10 @@ class Serverless {
     } else if (!content) {
       throw new TypeError('Section content cannot be empty string');
     }
-    if (this.serviceOutputs.has(sectionName)) {
+    if (this.serviceOutputs.has(sectionName) || this.servicePluginOutputs.has(sectionName)) {
       throw new TypeError(`Section content for "${sectionName}" was already set`);
     }
-    this.serviceOutputs.set(sectionName, content);
+    this.servicePluginOutputs.set(sectionName, content);
   }
 
   setProvider(name, provider) {

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -191,6 +191,7 @@ class AwsDeploy {
         );
         writeText();
         writeServiceOutputs(this.serverless.serviceOutputs);
+        writeServiceOutputs(this.serverless.servicePluginOutputs);
       },
     };
   }

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -25,10 +25,10 @@ module.exports = {
 
     legacy.consoleLog(message);
     if (this.serverless.processedInput.commands.join(' ') === 'info') {
-      this.serverless.addServiceOutputSection('service', this.serverless.service.service);
-      this.serverless.addServiceOutputSection('stage', this.provider.getStage());
-      this.serverless.addServiceOutputSection('region', this.provider.getRegion());
-      this.serverless.addServiceOutputSection('stack', this.provider.naming.getStackName());
+      this.serverless.serviceOutputs.set('service', this.serverless.service.service);
+      this.serverless.serviceOutputs.set('stage', this.provider.getStage());
+      this.serverless.serviceOutputs.set('region', this.provider.getRegion());
+      this.serverless.serviceOutputs.set('stack', this.provider.naming.getStackName());
     }
 
     return message;
@@ -50,7 +50,7 @@ module.exports = {
         }
         outputSectionItems.push(`${apiKeyInfo.name}: ${apiKeyInfo.value}${description}`);
       });
-      this.serverless.addServiceOutputSection('api keys', outputSectionItems);
+      this.serverless.serviceOutputs.set('api keys', outputSectionItems);
     } else {
       apiKeysMessage += '\n  None';
     }
@@ -123,9 +123,9 @@ module.exports = {
     }
 
     if (outputSectionItems.length > 1) {
-      this.serverless.addServiceOutputSection('endpoints', outputSectionItems);
+      this.serverless.serviceOutputs.set('endpoints', outputSectionItems);
     } else if (outputSectionItems.length) {
-      this.serverless.addServiceOutputSection('endpoint', outputSectionItems[0]);
+      this.serverless.serviceOutputs.set('endpoint', outputSectionItems[0]);
     }
     legacy.consoleLog(endpointsMessage);
     return endpointsMessage;
@@ -145,7 +145,7 @@ module.exports = {
           }`
         );
       });
-      this.serverless.addServiceOutputSection('functions', outputSectionItems);
+      this.serverless.serviceOutputs.set('functions', outputSectionItems);
     } else {
       functionsMessage += '\n  None';
     }
@@ -164,7 +164,7 @@ module.exports = {
         layersMessage += `\n  ${l.name}: ${l.arn}`;
         outputSectionItems.push(`${l.name}: ${l.arn}`);
       });
-      this.serverless.addServiceOutputSection('layers', outputSectionItems);
+      this.serverless.serviceOutputs.set('layers', outputSectionItems);
     } else {
       layersMessage += '\n  None';
     }
@@ -190,7 +190,7 @@ module.exports = {
         outputSectionItems.push(`${output.OutputKey}: ${output.OutputValue}`);
       });
 
-      this.serverless.addServiceOutputSection('\nStack Outputs', outputSectionItems);
+      this.serverless.serviceOutputs.set('\nStack Outputs', outputSectionItems);
     }
 
     return message;

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -88,6 +88,7 @@ class AwsInfo {
       'finalize': () => {
         if (this.serverless.processedInput.commands.join(' ') !== 'info') return;
         writeServiceOutputs(this.serverless.serviceOutputs);
+        writeServiceOutputs(this.serverless.servicePluginOutputs);
       },
     };
   }


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Goal is to show sections as introduced by plugins after sections set in the core. For that we need to use different section collections.

This PR proposes so `serverless.addServiceOutputSection` is dedicated just for use within plugins, and internally we add sections directly into `serviceOutputs` collection.
