### PR TITLE
docs: Add visual example of success message

### DIFF
--- a/docs/guides/plugins/cli-output.md
+++ b/docs/guides/plugins/cli-output.md
@@ -61,6 +61,10 @@ To write a formatted "success" message, use the following helper:
 log.success('The task executed with success');
 ```
 
+Success messages render with the checkmark, like the "Service deployed" success message:
+
+![](https://uploads-ssl.webflow.com/60acbb950c4d6606963e1fed/618259092410635f822c71af_framework-plugin-api-success-message.png)
+
 Log methods also support the printf format:
 
 ```js


### PR DESCRIPTION
Follow-up of #10155.

Here is a preview of the GitHub rendering:

<img width="748" alt="image" src="https://user-images.githubusercontent.com/720328/140038475-80899469-ba67-435b-a59b-fdafb89de301.png">

(I hosted the image on the website webflow)