### PR TITLE
feat: Remove `studio` command schema

### DIFF
--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -268,18 +268,6 @@ commands.set('rollback function', {
   lifecycleEvents: ['rollback'],
 });
 
-commands.set('studio', {
-  usage: 'Develop a Serverless application in the cloud.',
-  options: {
-    autoStage: {
-      usage: 'If specified, generate a random stage. This stage will be removed on exit.',
-      shortcut: 'a',
-      type: 'boolean',
-    },
-  },
-  lifecycleEvents: ['studio'],
-});
-
 commands.set('test', {
   usage: 'Run HTTP tests',
   options: {


### PR DESCRIPTION
BREAKING CHANGE: Remove `studio` command schema

Related PR: https://github.com/serverless/dashboard-plugin/pull/638