### PR TITLE
v3: CLI: Do not decorate `cli.log` logs

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -3,9 +3,11 @@
 const version = require('../../package.json').version;
 const os = require('os');
 const chalk = require('chalk');
-const log = require('@serverless/utils/log');
+const { log } = require('@serverless/utils/log');
 const resolveCliInput = require('../cli/resolve-input');
 const renderHelp = require('../cli/render-help');
+
+const legacyPluginLog = log.get('plugin-legacy');
 
 // TODO: Remove this class with next major
 class CLI {
@@ -69,7 +71,15 @@ class CLI {
   }
 
   log(message, entity, opts) {
-    log(message, { ...opts, entity: entity || 'Serverless' });
+    const { underline = false, bold = false, color = null } = opts || {};
+
+    let print = chalk;
+
+    if (color) print = chalk.keyword(color);
+    if (underline) print = print.underline;
+    if (bold) print = print.bold;
+
+    legacyPluginLog.notice(entity ? `${entity}: ${print(message)}` : print(message));
   }
 
   consoleLog(message) {


### PR DESCRIPTION
We agreed to remove any default decoration for logs written via `serverless.cli.log`.

This will make the logs appear closer to the new logs design