### PR TITLE
v3: CLI: Global `--verbose` and `--debug` flags

### DIFF
--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -17,10 +17,6 @@ commands.set('deploy', {
       usage: 'Path of the deployment package',
       shortcut: 'p',
     },
-    'verbose': {
-      usage: 'Show all stack events during deployment',
-      type: 'boolean',
-    },
     'force': {
       usage: 'Forces a deployment to take place',
       type: 'boolean',
@@ -89,10 +85,6 @@ commands.set('info', {
   options: {
     conceal: {
       usage: 'Hide secrets from the output (e.g. API Gateway key values)',
-      type: 'boolean',
-    },
-    verbose: {
-      usage: 'List stack outputs',
       type: 'boolean',
     },
   },
@@ -232,12 +224,6 @@ commands.set('metrics', {
 
 commands.set('remove', {
   usage: 'Remove Serverless service and all resources',
-  options: {
-    verbose: {
-      usage: 'Show all stack events during deployment',
-      type: 'boolean',
-    },
-  },
   lifecycleEvents: ['remove'],
 });
 
@@ -248,10 +234,6 @@ commands.set('rollback', {
       usage: 'Timestamp of the deployment (list deployments with `serverless deploy list`)',
       shortcut: 't',
       required: false,
-    },
-    verbose: {
-      usage: 'Show all stack events during deployment',
-      type: 'boolean',
     },
   },
   lifecycleEvents: ['initialize', 'rollback'],

--- a/lib/cli/commands-schema/common-options/global.js
+++ b/lib/cli/commands-schema/common-options/global.js
@@ -3,6 +3,7 @@
 module.exports = {
   help: { usage: 'Show this message', shortcut: 'h', type: 'boolean' },
   version: { usage: 'Show version info', type: 'boolean' },
+  verbose: { usage: 'Show verbose logs', type: 'boolean' },
 };
 
 for (const optionSchema of Object.values(module.exports)) {

--- a/lib/cli/commands-schema/common-options/global.js
+++ b/lib/cli/commands-schema/common-options/global.js
@@ -4,6 +4,7 @@ module.exports = {
   help: { usage: 'Show this message', shortcut: 'h', type: 'boolean' },
   version: { usage: 'Show version info', type: 'boolean' },
   verbose: { usage: 'Show verbose logs', type: 'boolean' },
+  debug: { usage: 'Namespace of debug logs to expose (use "*" to display all)', type: 'string' },
 };
 
 for (const optionSchema of Object.values(module.exports)) {

--- a/test/unit/lib/cli/filter-supported-options.test.js
+++ b/test/unit/lib/cli/filter-supported-options.test.js
@@ -57,6 +57,7 @@ describe('test/unit/lib/cli/filter-supported-options.test.js', () => {
       'app': null,
       'org': null,
       'use-local-credentials': null,
+      'verbose': null,
     });
   });
 
@@ -77,6 +78,7 @@ describe('test/unit/lib/cli/filter-supported-options.test.js', () => {
       version: null,
       config: null,
       stage: 'marko',
+      verbose: null,
     });
   });
 });

--- a/test/unit/lib/cli/filter-supported-options.test.js
+++ b/test/unit/lib/cli/filter-supported-options.test.js
@@ -58,6 +58,7 @@ describe('test/unit/lib/cli/filter-supported-options.test.js', () => {
       'org': null,
       'use-local-credentials': null,
       'verbose': null,
+      'debug': null,
     });
   });
 
@@ -79,6 +80,7 @@ describe('test/unit/lib/cli/filter-supported-options.test.js', () => {
       config: null,
       stage: 'marko',
       verbose: null,
+      debug: null,
     });
   });
 });


### PR DESCRIPTION
This PR just ensures that flags are recognized globally by schema.

Actual support is implemented at https://github.com/serverless/utils/pull/149