### PR TITLE
feat(AWS API Gateway): Error on tracing or logs set for external API

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/index.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/index.js
@@ -234,36 +234,6 @@ class AwsCompileApigEvents {
     this.createRequestValidator = memoize(this.createRequestValidator.bind(this));
 
     this.hooks = {
-      'initialize': () => {
-        if (
-          this.serverless.service.provider.name === 'aws' &&
-          this.serverless.service.provider.apiGateway &&
-          this.serverless.service.provider.apiGateway.restApiId &&
-          this.serverless.service.provider.tracing &&
-          this.serverless.service.provider.tracing.apiGateway != null
-        ) {
-          this.serverless._logDeprecation(
-            'AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS',
-            'When external API Gateway resource is imported via ' +
-              '`provider.apiGateway.restApiId`, property ' +
-              '"provider.tracing.apiGateway" will be ignored.'
-          );
-        }
-        if (
-          this.serverless.service.provider.name === 'aws' &&
-          this.serverless.service.provider.apiGateway &&
-          this.serverless.service.provider.apiGateway.restApiId &&
-          this.serverless.service.provider.logs &&
-          this.serverless.service.provider.logs.restApi != null
-        ) {
-          this.serverless._logDeprecation(
-            'AWS_API_GATEWAY_NON_APPLICABLE_SETTINGS',
-            'When external API Gateway resource is imported via ' +
-              '`provider.apiGateway.restApiId`, property ' +
-              '"provider.logs.restApi" will be ignored.'
-          );
-        }
-      },
       'package:compileEvents': async () => {
         this.validated = this.validate();
 

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -42,6 +42,30 @@ module.exports = {
     const events = [];
     const corsPreflight = {};
 
+    if (
+      this.serverless.service.provider.apiGateway &&
+      this.serverless.service.provider.apiGateway.restApiId &&
+      this.serverless.service.provider.tracing &&
+      this.serverless.service.provider.tracing.apiGateway != null
+    ) {
+      throw new ServerlessError(
+        'When external API Gateway resource is imported via "provider.apiGateway.restApiId", property "provider.tracing.apiGateway" is ineffective.',
+        'API_GATEWAY_EXTERNAL_API_TRACING'
+      );
+    }
+
+    if (
+      this.serverless.service.provider.apiGateway &&
+      this.serverless.service.provider.apiGateway.restApiId &&
+      this.serverless.service.provider.logs &&
+      this.serverless.service.provider.logs.restApi != null
+    ) {
+      throw new ServerlessError(
+        'When external API Gateway resource is imported via "provider.apiGateway.restApiId", property "provider.logs.restApi" is ineffective.',
+        'API_GATEWAY_EXTERNAL_API_LOGS'
+      );
+    }
+
     Object.entries(this.serverless.service.functions).forEach(([functionName, functionObject]) => {
       (functionObject.events || []).forEach((event) => {
         if (event.http) {


### PR DESCRIPTION
BREAKING CHANGE: Enabling logs or tracing for imported API Gateway will
now result in an error instead of warning

