### PR TITLE
feat: Simplify `logs` command output

### DIFF
--- a/lib/plugins/aws/invoke.js
+++ b/lib/plugins/aws/invoke.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const chalk = require('chalk');
 const path = require('path');
 const validate = require('./lib/validate');
 const stdin = require('get-stdin');
 const formatLambdaLogEvent = require('./utils/formatLambdaLogEvent');
 const ServerlessError = require('../../serverless-error');
-const { legacy, writeText, style } = require('@serverless/utils/log');
+const { writeText, style } = require('@serverless/utils/log');
 
 class AwsInvoke {
   constructor(serverless, options) {
@@ -102,26 +101,19 @@ class AwsInvoke {
   }
 
   log(invocationReply) {
-    const color = !invocationReply.FunctionError ? (x) => x : chalk.red;
-
     if (invocationReply.Payload) {
       const response = JSON.parse(invocationReply.Payload);
 
-      legacy.consoleLog(color(JSON.stringify(response, null, 4)));
       writeText(JSON.stringify(response, null, 4));
     }
 
     if (invocationReply.LogResult) {
-      legacy.consoleLog(
-        chalk.gray('--------------------------------------------------------------------')
-      );
       writeText(
         style.aside('--------------------------------------------------------------------')
       );
       const logResult = Buffer.from(invocationReply.LogResult, 'base64').toString();
       logResult.split('\n').forEach((line) => {
-        legacy.consoleLog(formatLambdaLogEvent(line));
-        writeText(formatLambdaLogEvent(line, { isModern: true }));
+        writeText(formatLambdaLogEvent(line));
       });
     }
 

--- a/lib/plugins/aws/logs.js
+++ b/lib/plugins/aws/logs.js
@@ -95,6 +95,9 @@ class AwsLogs {
     const results = await this.provider.request('CloudWatchLogs', 'filterLogEvents', params);
     if (results.events) {
       results.events.forEach((e) => {
+        if (e.message.includes('SERVERLESS_ENTERPRISE') || e.message.startsWith('END')) {
+          return;
+        }
         writeText(formatLambdaLogEvent(e.message));
       });
     }

--- a/lib/plugins/aws/logs.js
+++ b/lib/plugins/aws/logs.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const dayjs = require('dayjs');
 const utc = require('dayjs/plugin/utc');
 const wait = require('timers-ext/promise/sleep');
-const { legacy, writeText } = require('@serverless/utils/log');
+const { writeText } = require('@serverless/utils/log');
 const validate = require('./lib/validate');
 const formatLambdaLogEvent = require('./utils/formatLambdaLogEvent');
 const ServerlessError = require('../../serverless-error');
@@ -95,8 +95,7 @@ class AwsLogs {
     const results = await this.provider.request('CloudWatchLogs', 'filterLogEvents', params);
     if (results.events) {
       results.events.forEach((e) => {
-        legacy.write(formatLambdaLogEvent(e.message));
-        writeText(formatLambdaLogEvent(e.message, { isModern: true }));
+        writeText(formatLambdaLogEvent(e.message));
       });
     }
 

--- a/lib/plugins/aws/utils/formatLambdaLogEvent.js
+++ b/lib/plugins/aws/utils/formatLambdaLogEvent.js
@@ -1,25 +1,18 @@
 'use strict';
 
 const dayjs = require('dayjs');
-const chalk = require('chalk');
-const os = require('os');
 const { style } = require('@serverless/utils/log');
 
-module.exports = (msgParam, options = {}) => {
-  const { isModern } = options;
+module.exports = (msgParam) => {
   let msg = msgParam;
   const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS (Z)';
 
-  if (isModern) {
-    if (!msg.startsWith('REPORT')) msg = msg.trimRight();
-  } else if (msg.startsWith('REPORT')) {
-    msg += os.EOL;
-  }
+  if (!msg.startsWith('REPORT')) msg = msg.trimRight();
 
   if (msg.startsWith('START') || msg.startsWith('END') || msg.startsWith('REPORT')) {
-    return isModern ? style.aside(msg) : chalk.gray(msg);
+    return style.aside(msg);
   } else if (msg.trim() === 'Process exited before completing request') {
-    return isModern ? style.error(msg) : chalk.red(msg);
+    return style.error(msg);
   }
 
   const splitted = msg.split('\t');
@@ -44,6 +37,5 @@ module.exports = (msgParam, options = {}) => {
   const text = msg.split(`${reqId}\t`)[1];
   const time = dayjs(date).format(dateFormat);
 
-  if (isModern) return `${style.aside(`${time}\t${reqId}`)}\t${level}${text}`;
-  return `${chalk.green(time)}\t${chalk.yellow(reqId)}\t${level}${text}`;
+  return `${style.aside(`${time}\t${reqId}`)}\t${level}${text}`;
 };

--- a/lib/plugins/aws/utils/formatLambdaLogEvent.js
+++ b/lib/plugins/aws/utils/formatLambdaLogEvent.js
@@ -5,13 +5,23 @@ const { style } = require('@serverless/utils/log');
 
 module.exports = (msgParam) => {
   let msg = msgParam;
-  const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS (Z)';
+  const dateFormat = 'YYYY-MM-DD HH:mm:ss.SSS';
 
   if (!msg.startsWith('REPORT')) msg = msg.trimRight();
 
-  if (msg.startsWith('START') || msg.startsWith('END') || msg.startsWith('REPORT')) {
+  if (msg.startsWith('START')) {
+    msg = 'START';
     return style.aside(msg);
-  } else if (msg.trim() === 'Process exited before completing request') {
+  }
+
+  if (msg.startsWith('REPORT')) {
+    const splitted = msg.split('\t');
+    // Replace REPORT with END and filter out RequestId
+    msg = `END ${splitted.slice(1).join('\t')}`;
+    return style.aside(msg);
+  }
+
+  if (msg.trim() === 'Process exited before completing request') {
     return style.error(msg);
   }
 
@@ -37,5 +47,5 @@ module.exports = (msgParam) => {
   const text = msg.split(`${reqId}\t`)[1];
   const time = dayjs(date).format(dateFormat);
 
-  return `${style.aside(`${time}\t${reqId}`)}\t${level}${text}`;
+  return `${style.aside(`${time}\t`)}${level}${text}`;
 };

--- a/test/unit/lib/plugins/aws/utils/formatLambdaLogEvent.test.js
+++ b/test/unit/lib/plugins/aws/utils/formatLambdaLogEvent.test.js
@@ -2,8 +2,7 @@
 
 const expect = require('chai').expect;
 const dayjs = require('dayjs');
-const chalk = require('chalk');
-const os = require('os');
+const { style } = require('@serverless/utils/log');
 const formatLambdaLogEvent = require('../../../../../../lib/plugins/aws/utils/formatLambdaLogEvent');
 
 describe('#formatLambdaLogEvent()', () => {
@@ -11,12 +10,12 @@ describe('#formatLambdaLogEvent()', () => {
     const msg =
       'REPORT\tRequestId: 99c30000-b01a-11e5-93f7-b8e85631a00e\tDuration: 0.40 ms\tBilled Duration: 100 ms\tMemory Size: 512 MB\tMax Memory Used: 30 MB';
 
-    expect(formatLambdaLogEvent(msg)).to.equal(chalk.grey(msg + os.EOL));
+    expect(formatLambdaLogEvent(msg)).to.deep.equal(style.aside(msg));
   });
 
   it('should format invocation failures', () => {
     const msg = 'Process exited before completing request';
-    expect(formatLambdaLogEvent(msg)).to.equal(chalk.red(msg));
+    expect(formatLambdaLogEvent(msg)).to.deep.equal(style.error(msg));
   });
 
   it('should format lambda console.log lines', () => {
@@ -24,8 +23,8 @@ describe('#formatLambdaLogEvent()', () => {
 
     let expectedLogMessage = '';
     const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS (Z)');
-    expectedLogMessage += `${chalk.green(date)}\t`;
-    expectedLogMessage += `${chalk.yellow('99c30000-b01a-11e5-93f7-b8e85631a00e')}\t`;
+    expectedLogMessage += `${style.aside(date)}\t`;
+    expectedLogMessage += `${style.aside('99c30000-b01a-11e5-93f7-b8e85631a00e')}\t`;
     expectedLogMessage += 'test';
 
     expect(formatLambdaLogEvent(nodeLogLine)).to.equal(expectedLogMessage);
@@ -37,8 +36,8 @@ describe('#formatLambdaLogEvent()', () => {
 
     let expectedLogMessage = '';
     const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS (Z)');
-    expectedLogMessage += `${chalk.green(date)}\t`;
-    expectedLogMessage += `${chalk.yellow('99c30000-b01a-11e5-93f7-b8e85631a00e')}\t`;
+    expectedLogMessage += `${style.aside(date)}\t`;
+    expectedLogMessage += `${style.aside('99c30000-b01a-11e5-93f7-b8e85631a00e')}\t`;
     expectedLogMessage += `${'[INFO]'}\t`;
     expectedLogMessage += 'test';
 

--- a/test/unit/lib/plugins/aws/utils/formatLambdaLogEvent.test.js
+++ b/test/unit/lib/plugins/aws/utils/formatLambdaLogEvent.test.js
@@ -8,9 +8,12 @@ const formatLambdaLogEvent = require('../../../../../../lib/plugins/aws/utils/fo
 describe('#formatLambdaLogEvent()', () => {
   it('should format invocation report', () => {
     const msg =
-      'REPORT\tRequestId: 99c30000-b01a-11e5-93f7-b8e85631a00e\tDuration: 0.40 ms\tBilled Duration: 100 ms\tMemory Size: 512 MB\tMax Memory Used: 30 MB';
+      'REPORT RequestId: 99c30000-b01a-11e5-93f7-b8e85631a00e\tDuration: 0.40 ms\tBilled Duration: 100 ms\tMemory Size: 512 MB\tMax Memory Used: 30 MB';
+    const expectedMsg = style.aside(
+      'END Duration: 0.40 ms\tBilled Duration: 100 ms\tMemory Size: 512 MB\tMax Memory Used: 30 MB'
+    );
 
-    expect(formatLambdaLogEvent(msg)).to.deep.equal(style.aside(msg));
+    expect(formatLambdaLogEvent(msg)).to.deep.equal(expectedMsg);
   });
 
   it('should format invocation failures', () => {
@@ -19,12 +22,12 @@ describe('#formatLambdaLogEvent()', () => {
   });
 
   it('should format lambda console.log lines', () => {
-    const nodeLogLine = '2016-01-01T12:00:00Z\t99c30000-b01a-11e5-93f7-b8e85631a00e\ttest';
+    const nodeLogLine = '2016-01-01T12:00:00Z\t99c30000-b01a-11e5-93f7-b8e85631a00e\tINFO\ttest';
 
     let expectedLogMessage = '';
-    const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS (Z)');
+    const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS');
     expectedLogMessage += `${style.aside(date)}\t`;
-    expectedLogMessage += `${style.aside('99c30000-b01a-11e5-93f7-b8e85631a00e')}\t`;
+    expectedLogMessage += 'INFO\t';
     expectedLogMessage += 'test';
 
     expect(formatLambdaLogEvent(nodeLogLine)).to.equal(expectedLogMessage);
@@ -35,9 +38,8 @@ describe('#formatLambdaLogEvent()', () => {
       '[INFO]\t2016-01-01T12:00:00Z\t99c30000-b01a-11e5-93f7-b8e85631a00e\ttest';
 
     let expectedLogMessage = '';
-    const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS (Z)');
+    const date = dayjs('2016-01-01T12:00:00Z').format('YYYY-MM-DD HH:mm:ss.SSS');
     expectedLogMessage += `${style.aside(date)}\t`;
-    expectedLogMessage += `${style.aside('99c30000-b01a-11e5-93f7-b8e85631a00e')}\t`;
     expectedLogMessage += `${'[INFO]'}\t`;
     expectedLogMessage += 'test';
 


### PR DESCRIPTION
BREAKING CHANGE: Output from `logs` is simplified and no longer follows
standard CloudWatch formatting

Reported internally
![logsoutput](https://user-images.githubusercontent.com/17499590/140514286-4dba3236-f630-4d15-b701-c2a2ef0df77b.png)

