### PR TITLE
CLI: Do not recomment `frameworkVersion` when running pre release

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -145,7 +145,7 @@ class Service {
       );
       ymlVersion = null;
     }
-    if (!this.isLocallyInstalled && !ymlVersion) {
+    if (!this.isLocallyInstalled && !ymlVersion && !semver.parse(version).prerelease.length) {
       log.info(
         'To ensure safe major version upgrades ensure "frameworkVersion" setting in ' +
           'service configuration ' +


### PR DESCRIPTION
When playing with v3 pre-release spotted the following log, I think we should not recommend setting `frameworkVersion` when pre-release is run:

```
To ensure safe major version upgrades ensure "frameworkVersion" setting in service configuration (recommended setup: "frameworkVersion: ^3.0.0-pre")
```
