### PR TITLE
feat: Disallow custom nested configuration path

### DIFF
--- a/lib/cli/resolve-configuration-path.js
+++ b/lib/cli/resolve-configuration-path.js
@@ -6,7 +6,6 @@ const path = require('path');
 const fsp = require('fs').promises;
 const ServerlessError = require('../serverless-error');
 const fileExists = require('../utils/fs/fileExists');
-const logDeprecation = require('../utils/logDeprecation');
 const resolveInput = require('./resolve-input');
 
 const supportedExtensions = new Set(['yml', 'yaml', 'json', 'js', 'ts']);
@@ -50,10 +49,9 @@ module.exports = async (options = {}) => {
       );
     }
     if (cwd !== path.dirname(customConfigPath)) {
-      logDeprecation(
-        'NESTED_CUSTOM_CONFIGURATION_PATH',
-        'Service configuration is expected to be placed in a root of a service (working directory). All paths, function handlers in a configuration are resolved against service directory".\n' +
-          'Starting from next major Serverless will no longer permit configurations nested in sub directories.'
+      throw new ServerlessError(
+        'Service configuration is expected to be placed in a root of a service (working directory). All paths, function handlers in a configuration are resolved against service directory.\n',
+        'NESTED_CUSTOM_CONFIGURATION_PATH'
       );
     }
     return customConfigPath;

--- a/test/unit/lib/cli/resolve-configuration-path.test.js
+++ b/test/unit/lib/cli/resolve-configuration-path.test.js
@@ -86,19 +86,18 @@ describe('test/unit/lib/cli/resolve-configuration-path.test.js', () => {
         process.env.SLS_DEPRECATION_NOTIFICATION_MODE = 'warn';
         const uncached = requireUncached(() => ({
           resolveServerlessConfigPath: require('../../../../lib/cli/resolve-configuration-path'),
-          triggeredDeprecations: require('../../../../lib/utils/logDeprecation')
-            .triggeredDeprecations,
         }));
         await overrideArgv(
           {
             args: ['serverless', '--config', 'nested/custom.yml'],
           },
           async () => {
-            expect(await uncached.resolveServerlessConfigPath()).to.equal(
-              path.resolve('nested/custom.yml')
+            await expect(
+              uncached.resolveServerlessConfigPath()
+            ).to.eventually.be.rejected.and.have.property(
+              'code',
+              'NESTED_CUSTOM_CONFIGURATION_PATH'
             );
-            expect(uncached.triggeredDeprecations.has('NESTED_CUSTOM_CONFIGURATION_PATH')).to.be
-              .true;
           }
         );
       });


### PR DESCRIPTION
BREAKING CHANGE: Custom nested configuration paths will no longer be
supported and such usage will result in an error.

