### PR TITLE
CLI: Improve timestamp visiblity in `deploy list` output

### DIFF
--- a/lib/plugins/aws/deployList.js
+++ b/lib/plugins/aws/deployList.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { legacy, log, writeText, style } = require('@serverless/utils/log');
+const { legacy, log, writeText } = require('@serverless/utils/log');
 const validate = require('./lib/validate');
 const findAndGroupDeployments = require('./utils/findAndGroupDeployments');
 const setBucketName = require('./lib/setBucketName');
@@ -61,8 +61,8 @@ class AwsDeployList {
           `${String(date.getUTCHours()).padStart(2, 0)}:${String(date.getUTCMinutes()).padStart(
             2,
             0
-          )}:${String(date.getUTCSeconds()).padStart(2, 0)} UTC ` +
-          `${style.aside(`(${match[1]})`)}`,
+          )}:${String(date.getUTCSeconds()).padStart(2, 0)} UTC`,
+        `Timestamp: ${match[1]}`,
         'Files:'
       );
       legacy.log(`Timestamp: ${match[1]}`);


### PR DESCRIPTION
Deployment timestamp serves as an identifier which is used e.g. in `rollback -t <timestamp>` command.
Therefore we improve its visibility in `deploy list` command

Changes output of `deploy list` from:
<img width="274" alt="Screenshot 2021-11-09 at 12 10 20" src="https://user-images.githubusercontent.com/122434/140913791-56590c41-d512-4068-b9f6-f12c503a0c1b.png">

Into:

<img width="260" alt="Screenshot 2021-11-09 at 12 12 11" src="https://user-images.githubusercontent.com/122434/140913990-9e22839d-15c5-4701-9f93-9a8a5ddc3685.png">


