### PR TITLE
fix(AWS API Gateway): Ensure proper `apiId` resolution

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.js
@@ -150,7 +150,7 @@ async function resolveRestApiId() {
     }
     const apiName = apiGatewayResource
       ? apiGatewayResource.Properties.Name
-      : provider.naming.getApiGatewayName();
+      : this.provider.naming.getApiGatewayName();
     const resolveFromAws = (position) =>
       this.provider
         .request('APIGateway', 'getRestApis', { position, limit: 500 })

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -813,7 +813,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/u
     expect(untagResourceStub.args[0][0].tagKeys).to.deep.equal(['keytoremove']);
   });
 
-  it('should deploys shouldStartNameWithService without apiName', async () => {
+  it('should correctly resolve `apiId` during deployment', async () => {
     const { serviceConfig, servicePath, updateConfig } = await fixtures.setup('apiGateway');
     const getDeploymentsStub = sinon.stub().returns({ items: [{ id: 'deployment-id' }] });
     const stage = 'dev';


### PR DESCRIPTION
Closes: https://github.com/serverless/serverless/issues/10220

related: https://github.com/serverless/serverless/pull/10177

cc @vicary 