### PR TITLE
feat: Make configuration mandatory for `Serverless` constructor

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -21,13 +21,11 @@ const ConfigSchemaHandler = require('./classes/ConfigSchemaHandler');
 const ServerlessError = require('./serverless-error');
 const version = require('./../package.json').version;
 const isStandaloneExecutable = require('./utils/isStandaloneExecutable');
-const resolveConfigurationPath = require('./cli/resolve-configuration-path');
 const logDeprecation = require('./utils/logDeprecation');
 const eventuallyUpdate = require('./utils/eventuallyUpdate');
 const resolveLocalServerlessPath = require('./cli/resolve-local-serverless-path');
 const commmandsSchema = require('./cli/commands-schema');
 const resolveCliInput = require('./cli/resolve-input');
-const readConfiguration = require('./configuration/read');
 const conditionallyLoadDotenv = require('./cli/conditionally-load-dotenv');
 
 const serverlessPath = path.resolve(__dirname, '..');
@@ -37,9 +35,7 @@ class Serverless {
     let configObject = config;
     configObject = configObject || {};
     this._isInvokedByGlobalInstallation = Boolean(configObject._isInvokedByGlobalInstallation);
-
     if (configObject.serviceDir != null) {
-      // Modern intialization way, to be the only supported way with v3
       this.serviceDir = path.resolve(
         ensureString(configObject.serviceDir, {
           name: 'config.serviceDir',
@@ -63,36 +59,9 @@ class Serverless {
         Error: ServerlessError,
         errorCode: 'INVALID_NON_OBJECT_CONFIGURATION',
       });
-      this.isConfigurationInputResolved = Boolean(configObject.isConfigurationResolved);
-    } else if (configObject.configurationPath != null) {
-      // Semi-modern initialization way, mid-step introduced over the course of v2 refactor
-      const configurationPath = path.resolve(
-        ensureString(configObject.configurationPath, {
-          name: 'config.configurationPath',
-          Error: ServerlessError,
-          errorCode: 'INVALID_NON_STRING_CONFIGURATION_PATH',
-        })
-      );
-      this.serviceDir = process.cwd();
-      this.configurationFilename = configurationPath.slice(this.serviceDir.length + 1);
-      this.configurationInput = ensurePlainObject(configObject.configuration, {
-        isOptional: true,
-        name: 'config.configuration',
-        Error: ServerlessError,
-        errorCode: 'INVALID_NON_OBJECT_CONFIGURATION',
-      });
-      if (this.configurationInput) {
-        this.isConfigurationInputResolved = Boolean(configObject.isConfigurationResolved);
-      }
-      this._shouldReportMissingServiceDeprecation = true;
-    } else if (
-      configObject.configurationPath === undefined &&
-      configObject.serviceDir === undefined
-    ) {
-      // Old intialization way
-      this._shouldResolveConfigurationInternally = true;
-      this._shouldReportMissingServiceDeprecation = true;
     }
+    this.isConfigurationInputResolved = true;
+
     const commands = ensureArray(configObject.commands);
     let options = ensurePlainObject(configObject.options);
     // This is a temporary workaround to ensure that original `options` are not mutated
@@ -152,29 +121,6 @@ class Serverless {
     if (this._isInvokedByGlobalInstallation) {
       logDeprecation.defaultMode = 'warn';
       logDeprecation.flushBuffered();
-    } else if (this._shouldReportMissingServiceDeprecation) {
-      this._logDeprecation(
-        'MISSING_SERVICE_CONFIGURATION',
-        'Serverless constructor expects service configuration details to be provided.\n' +
-          'Starting from next major Serverless will no longer auto resolve it internally.'
-      );
-    }
-    if (this._shouldResolveConfigurationInternally) {
-      const configurationPath = await resolveConfigurationPath();
-      if (configurationPath) {
-        this.serviceDir = process.cwd();
-        this.configurationFilename = configurationPath.slice(this.serviceDir.length + 1);
-      }
-    }
-    if (this.configurationFilename && !this.configurationInput) {
-      this.configurationInput = await (async () => {
-        try {
-          return await readConfiguration(path.resolve(this.serviceDir, this.configurationFilename));
-        } catch (error) {
-          if (resolveCliInput().isHelpRequest) return null;
-          throw error;
-        }
-      })();
     }
 
     // create an instanceId (can be e.g. used when a predictable random value is needed)

--- a/test/unit/lib/Serverless.test.js
+++ b/test/unit/lib/Serverless.test.js
@@ -28,12 +28,27 @@ describe('Serverless', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
   });
 
   describe('#constructor()', () => {
     it('should set the correct config if a config object is passed', () => {
-      const configObj = { some: 'config', commands: [], options: {} };
+      const configObj = {
+        some: 'config',
+        commands: [],
+        options: {},
+        serviceDir: process.cwd(),
+        configurationFilename: 'serverless.yml',
+        configuration: {},
+        isConfigurationResovled: true,
+      };
       const serverlessWithConfig = new Serverless(configObj);
 
       expect(serverlessWithConfig.config.some).to.equal('config');

--- a/test/unit/lib/classes/CLI.test.js
+++ b/test/unit/lib/classes/CLI.test.js
@@ -15,7 +15,14 @@ describe('CLI', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
   });
 
   describe('#constructor()', () => {

--- a/test/unit/lib/classes/Config.test.js
+++ b/test/unit/lib/classes/Config.test.js
@@ -4,7 +4,14 @@ const expect = require('chai').expect;
 const Config = require('../../../../lib/classes/Config');
 const Serverless = require('../../../../lib/Serverless');
 
-const serverless = new Serverless({ commands: [], options: {} });
+const serverless = new Serverless({
+  commands: [],
+  options: {},
+  serviceDir: process.cwd(),
+  configurationFilename: 'serverless.yml',
+  configuration: {},
+  isConfigurationResovled: true,
+});
 
 describe('Config', () => {
   describe('#constructor()', () => {

--- a/test/unit/lib/classes/PluginManager.test.js
+++ b/test/unit/lib/classes/PluginManager.test.js
@@ -422,7 +422,14 @@ describe('PluginManager', () => {
 
   beforeEach(() => {
     ({ restoreEnv } = overrideEnv({ whitelist: ['APPDATA', 'PATH'] }));
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new CLI();
     serverless.processedInput = { commands: ['print'], options: {} };
     pluginManager = new PluginManager(serverless);
@@ -1257,7 +1264,14 @@ describe('PluginManager', () => {
     let pluginManagerInstance;
 
     beforeEach(() => {
-      serverlessInstance = new Serverless({ commands: [], options: {} });
+      serverlessInstance = new Serverless({
+        commands: [],
+        options: {},
+        serviceDir: process.cwd(),
+        configurationFilename: 'serverless.yml',
+        configuration: {},
+        isConfigurationResovled: true,
+      });
       serverlessInstance.configurationInput = null;
       serverlessInstance.serviceDir = 'my-service';
       pluginManagerInstance = new PluginManager(serverlessInstance);
@@ -1283,34 +1297,6 @@ describe('PluginManager', () => {
       const foo = pluginManagerInstance.commands.foo;
 
       expect(pluginManagerInstance.validateServerlessConfigDependency(foo)).to.be.undefined;
-    });
-
-    it('should throw an error if configDependent is true and no config is found', () => {
-      pluginManagerInstance.commands = {
-        foo: {
-          configDependent: true,
-        },
-      };
-
-      const foo = pluginManagerInstance.commands.foo;
-
-      expect(() => {
-        pluginManager.validateServerlessConfigDependency(foo);
-      }).to.throw(Error);
-    });
-
-    it('should throw an error if configDependent is true and config is an empty string', () => {
-      pluginManagerInstance.commands = {
-        foo: {
-          configDependent: true,
-        },
-      };
-
-      const foo = pluginManagerInstance.commands.foo;
-
-      expect(() => {
-        pluginManager.validateServerlessConfigDependency(foo);
-      }).to.throw(Error);
     });
 
     it('should load if the configDependent property is true and config exists', () => {
@@ -1887,7 +1873,14 @@ describe('PluginManager', () => {
     });
 
     beforeEach(() => {
-      serverlessInstance = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+      serverlessInstance = new Serverless({
+        commands: ['print'],
+        options: {},
+        serviceDir: process.cwd(),
+        configurationFilename: 'serverless.yml',
+        configuration: {},
+        isConfigurationResovled: true,
+      });
       return serverlessInstance.init().then(() => {
         // Cannot rely on shebang in severless.js to invoke script using NodeJS on Windows.
         const tmpDir = getTmpDirPath();

--- a/test/unit/lib/classes/Utils.test.js
+++ b/test/unit/lib/classes/Utils.test.js
@@ -16,7 +16,14 @@ describe('Utils', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     utils = new Utils(serverless);
   });
 

--- a/test/unit/lib/classes/YamlParser.test.js
+++ b/test/unit/lib/classes/YamlParser.test.js
@@ -14,7 +14,14 @@ const { getTmpFilePath, getTmpDirPath } = require('../../../utils/fs');
 chai.use(require('chai-as-promised'));
 const expect = require('chai').expect;
 
-const serverless = new Serverless({ commands: [], options: {} });
+const serverless = new Serverless({
+  commands: [],
+  options: {},
+  serviceDir: process.cwd(),
+  configurationFilename: 'serverless.yml',
+  configuration: {},
+  isConfigurationResovled: true,
+});
 
 describe('YamlParser', () => {
   describe('#parse()', () => {

--- a/test/unit/lib/plugins/aws/common/index.test.js
+++ b/test/unit/lib/plugins/aws/common/index.test.js
@@ -9,7 +9,14 @@ const sinon = require('sinon');
 describe('AwsCommon', () => {
   let awsCommon;
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     const options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
@@ -14,7 +14,14 @@ describe('#moveArtifactsToPackage()', () => {
   const moveServerlessPath = path.join(moveBasePath, '.serverless');
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     awsCommon = new AWSCommon(serverless, {});
 
     serverless.serviceDir = moveBasePath;
@@ -104,7 +111,14 @@ describe('#moveArtifactsToTemp()', () => {
   const moveTargetPath = path.join(moveBasePath, 'target');
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     awsCommon = new AWSCommon(serverless, {});
 
     serverless.serviceDir = moveBasePath;

--- a/test/unit/lib/plugins/aws/common/lib/cleanupTempDir.test.js
+++ b/test/unit/lib/plugins/aws/common/lib/cleanupTempDir.test.js
@@ -11,7 +11,14 @@ describe('#cleanupTempDir()', () => {
   let packageService;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     packageService = new Package(serverless);
 
     serverless.serviceDir = getTmpDirPath();

--- a/test/unit/lib/plugins/aws/configCredentials.test.js
+++ b/test/unit/lib/plugins/aws/configCredentials.test.js
@@ -42,7 +42,14 @@ describe('AwsConfigCredentials', () => {
   });
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     return serverless.init().then(() => {
       const options = {
         provider: 'aws',

--- a/test/unit/lib/plugins/aws/customResources/index.test.js
+++ b/test/unit/lib/plugins/aws/customResources/index.test.js
@@ -36,7 +36,14 @@ describe('#addCustomResourceToService()', () => {
       region: 'us-east-1',
     };
     tmpDirPath = createTmpDir();
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new CLI();
     serverless.pluginManager.cliOptions = options;
     provider = new AwsProvider(serverless, options);

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -22,7 +22,14 @@ describe('AwsDeploy', () => {
   let options;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/checkForChanges.test.js
@@ -33,7 +33,14 @@ describe('checkForChanges', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.serviceDir = 'my-service';
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);

--- a/test/unit/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/cleanupS3Bucket.test.js
@@ -24,7 +24,14 @@ describe('cleanupS3Bucket', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.serviceDir = 'foo';
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);

--- a/test/unit/lib/plugins/aws/deploy/lib/createStack.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/createStack.test.js
@@ -30,7 +30,14 @@ describe('createStack', () => {
   };
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, {}));
     serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
     serverless.serviceDir = tmpDirPath;

--- a/test/unit/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/existsDeploymentBucket.test.js
@@ -18,7 +18,14 @@ describe('#existsDeploymentBucket()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     awsPlugin.serverless = serverless;
     awsPlugin.provider = new AwsProvider(serverless, options);
 

--- a/test/unit/lib/plugins/aws/deploy/lib/extendedValidate.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/extendedValidate.test.js
@@ -41,7 +41,14 @@ describe('extendedValidate', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.utils.writeFileSync(serverlessYmlPath, serverlessYml);
     serverless.serviceDir = tmpDirPath;

--- a/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/uploadArtifacts.test.js
@@ -25,7 +25,14 @@ describe('uploadArtifacts', () => {
   let cryptoStub;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, {}));
     const options = {

--- a/test/unit/lib/plugins/aws/deploy/lib/validateTemplate.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/validateTemplate.test.js
@@ -23,7 +23,14 @@ describe('validateTemplate', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);

--- a/test/unit/lib/plugins/aws/deployFunction.test.js
+++ b/test/unit/lib/plugins/aws/deployFunction.test.js
@@ -22,7 +22,14 @@ describe('AwsDeployFunction', () => {
   let cryptoStub;
 
   beforeEach(async () => {
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.servicePath = true;
     serverless.service.environment = {
       vars: {},

--- a/test/unit/lib/plugins/aws/deployList.test.js
+++ b/test/unit/lib/plugins/aws/deployList.test.js
@@ -17,7 +17,14 @@ describe('AwsDeployList', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'listDeployments';

--- a/test/unit/lib/plugins/aws/info/getApiKeyValues.test.js
+++ b/test/unit/lib/plugins/aws/info/getApiKeyValues.test.js
@@ -16,7 +16,14 @@ describe('#getApiKeyValues()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'my-service';
     awsInfo = new AwsInfo(serverless, options);

--- a/test/unit/lib/plugins/aws/info/getResourceCount.test.js
+++ b/test/unit/lib/plugins/aws/info/getResourceCount.test.js
@@ -18,7 +18,14 @@ describe('#getResourceCount()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'my-service';
     serverless.service.functions = {

--- a/test/unit/lib/plugins/aws/info/getStackInfo.test.js
+++ b/test/unit/lib/plugins/aws/info/getStackInfo.test.js
@@ -16,7 +16,14 @@ describe('#getStackInfo()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'my-service';
     serverless.service.functions = {

--- a/test/unit/lib/plugins/aws/info/index.test.js
+++ b/test/unit/lib/plugins/aws/info/index.test.js
@@ -25,7 +25,14 @@ describe('AwsInfo', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.cli = {
       log: sinon.stub().returns(),

--- a/test/unit/lib/plugins/aws/invokeLocal/index.test.js
+++ b/test/unit/lib/plugins/aws/invokeLocal/index.test.js
@@ -64,7 +64,14 @@ describe('AwsInvokeLocal', () => {
       'get-stdin': stdinStub,
       'child-process-ext/spawn': spawnExtStub,
     });
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.serviceDir = 'servicePath';
     serverless.cli = new CLI(serverless);
     serverless.processedInput = { commands: ['invoke'] };

--- a/test/unit/lib/plugins/aws/lib/getServiceState.test.js
+++ b/test/unit/lib/plugins/aws/lib/getServiceState.test.js
@@ -17,7 +17,14 @@ describe('#getServiceState()', () => {
   const awsPlugin = {};
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.serviceDir = 'my-service';
     awsPlugin.serverless = serverless;
     awsPlugin.provider = new AwsProvider(serverless, options);

--- a/test/unit/lib/plugins/aws/lib/monitorStack.test.js
+++ b/test/unit/lib/plugins/aws/lib/monitorStack.test.js
@@ -12,7 +12,14 @@ chai.use(require('chai-as-promised'));
 const { expect } = chai;
 
 describe('monitorStack', () => {
-  const serverless = new Serverless({ commands: [], options: {} });
+  const serverless = new Serverless({
+    commands: [],
+    options: {},
+    serviceDir: process.cwd(),
+    configurationFilename: 'serverless.yml',
+    configuration: {},
+    isConfigurationResovled: true,
+  });
   const awsPlugin = {};
 
   beforeEach(() => {

--- a/test/unit/lib/plugins/aws/lib/setBucketName.test.js
+++ b/test/unit/lib/plugins/aws/lib/setBucketName.test.js
@@ -12,7 +12,14 @@ describe('#setBucketName()', () => {
   let getServerlessDeploymentBucketNameStub;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.serviceDir = 'foo';
     const options = {
       stage: 'dev',

--- a/test/unit/lib/plugins/aws/lib/updateStack.test.js
+++ b/test/unit/lib/plugins/aws/lib/updateStack.test.js
@@ -17,7 +17,14 @@ describe('updateStack', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.serviceDir = 'foo';
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsDeploy = new AwsDeploy(serverless, options);

--- a/test/unit/lib/plugins/aws/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/lib/validate.test.js
@@ -11,7 +11,14 @@ chai.use(require('chai-as-promised'));
 const expect = chai.expect;
 
 describe('#validate', () => {
-  const serverless = new Serverless({ commands: [], options: {} });
+  const serverless = new Serverless({
+    commands: [],
+    options: {},
+    serviceDir: process.cwd(),
+    configurationFilename: 'serverless.yml',
+    configuration: {},
+    isConfigurationResovled: true,
+  });
   let provider;
   const awsPlugin = {};
 

--- a/test/unit/lib/plugins/aws/logs.test.js
+++ b/test/unit/lib/plugins/aws/logs.test.js
@@ -21,7 +21,14 @@ describe('AwsLogs', () => {
       region: 'us-east-1',
       function: 'first',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     const provider = new AwsProvider(serverless, options);
     provider.cachedCredentials = {
       credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },
@@ -335,7 +342,14 @@ describe('AwsLogs', () => {
         region: 'us-east-1',
         function: 'first',
       };
-      serverless = new Serverless({ commands: [], options: {} });
+      serverless = new Serverless({
+        commands: [],
+        options: {},
+        serviceDir: process.cwd(),
+        configurationFilename: 'serverless.yml',
+        configuration: {},
+        isConfigurationResovled: true,
+      });
       const provider = new AwsProvider(serverless, options);
       provider.cachedCredentials = {
         credentials: { accessKeyId: 'foo', secretAccessKey: 'bar' },

--- a/test/unit/lib/plugins/aws/metrics.test.js
+++ b/test/unit/lib/plugins/aws/metrics.test.js
@@ -17,7 +17,14 @@ describe('AwsMetrics', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new CLI(serverless);
     const options = {
       stage: 'dev',

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/listenerRules.test.js
@@ -9,7 +9,14 @@ describe('#compileListenerRules()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'some-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/permissions.test.js
@@ -9,7 +9,14 @@ describe('#compilePermissions()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'some-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/targetGroups.test.js
@@ -9,7 +9,14 @@ describe('#compileTargetGroups()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'some-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -9,7 +9,14 @@ describe('#validate()', () => {
   let awsCompileAlbEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'some-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/alexaSkill.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alexaSkill.test.js
@@ -12,7 +12,14 @@ describe('AwsCompileAlexaSkillEvents', () => {
   let awsCompileAlexaSkillEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileAlexaSkillEvents = new AwsCompileAlexaSkillEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/alexaSmartHome.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alexaSmartHome.test.js
@@ -10,7 +10,14 @@ describe('AwsCompileAlexaSmartHomeEvents', () => {
   let awsCompileAlexaSmartHomeEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileAlexaSmartHomeEvents = new AwsCompileAlexaSmartHomeEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/index.test.js
@@ -14,7 +14,14 @@ describe('AwsCompileApigEvents', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.environment = {
       vars: {},
       stages: {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/apiKeys.test.js
@@ -15,7 +15,14 @@ describe('#compileApiKeys()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/authorizers.test.js
@@ -11,7 +11,14 @@ describe('#compileAuthorizers()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/cors.test.js
@@ -14,7 +14,14 @@ describe('#compileCors()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/deployment.test.js
@@ -15,7 +15,14 @@ describe('#compileDeployment()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.provider.compiledCloudFormationTemplate = {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/disassociateUsagePlan.test.js
@@ -13,7 +13,14 @@ describe('#disassociateUsagePlan()', () => {
   let providerRequestStub;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.service = 'my-service';
     serverless.cli = {
       log: sinon.spy(),

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/updateStage.test.js
@@ -29,7 +29,14 @@ describe('#updateStage()', () => {
   let context;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.service = 'my-service';
     options = { stage: 'dev', region: 'us-east-1' };
     awsProvider = new AwsProvider(serverless, options);

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/method/index.test.js
@@ -15,7 +15,14 @@ describe('#compileMethods()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/permissions.test.js
@@ -9,7 +9,14 @@ describe('#awsCompilePermissions()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/resources.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/resources.test.js
@@ -10,7 +10,14 @@ describe('#compileResources()', () => {
   let awsCompileApigEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -18,7 +18,14 @@ describe('#compileRestApi()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/stage/index.test.js
@@ -24,7 +24,14 @@ describe('#compileStage()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'my-service';

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlan.test.js
@@ -15,7 +15,14 @@ describe('#compileUsagePlan()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/usagePlanKeys.test.js
@@ -15,7 +15,14 @@ describe('#compileUsagePlanKeys()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     serverless.service.service = 'first-service';
     serverless.service.provider.compiledCloudFormationTemplate = {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -22,7 +22,14 @@ describe('#validate()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsCompileApigEvents = new AwsCompileApigEvents(serverless, options);
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js
@@ -21,7 +21,14 @@ describe('AwsCompileCloudFrontEvents', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.processedInput = {
       commands: [],
     };

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudWatchEvent.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudWatchEvent.test.js
@@ -10,7 +10,14 @@ describe('awsCompileCloudWatchEventEvents', () => {
   let awsCompileCloudWatchEventEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileCloudWatchEventEvents = new AwsCompileCloudWatchEventEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/cloudWatchLog.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloudWatchLog.test.js
@@ -10,7 +10,14 @@ describe('AwsCompileCloudWatchLogEvents', () => {
   let awsCompileCloudWatchLogEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileCloudWatchLogEvents = new AwsCompileCloudWatchLogEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/cognitoUserPool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognitoUserPool.test.js
@@ -27,7 +27,14 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
         },
       }
     );
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileCognitoUserPoolEvents = new AwsCompileCognitoUserPoolEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
@@ -10,7 +10,14 @@ describe('AwsCompileIoTEvents', () => {
   let awsCompileIoTEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileIoTEvents = new AwsCompileIoTEvents(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -28,7 +28,14 @@ describe('AwsCompileS3Events', () => {
         },
       }
     );
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
     serverless.setProvider('aws', new AwsProvider(serverless));
     awsCompileS3Events = new AwsCompileS3Events(serverless);

--- a/test/unit/lib/plugins/aws/package/compile/events/sns.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/sns.test.js
@@ -10,7 +10,14 @@ describe('AwsCompileSNSEvents', () => {
   let awsCompileSNSEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     const options = {
       region: 'some-region',
     };

--- a/test/unit/lib/plugins/aws/package/compile/events/sqs.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/sqs.test.js
@@ -11,7 +11,14 @@ describe('AwsCompileSQSEvents', () => {
   let awsCompileSQSEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {
         IamRoleLambdaExecution: {

--- a/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
@@ -11,7 +11,14 @@ describe('AwsCompileStreamEvents', () => {
   let awsCompileStreamEvents;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {
         IamRoleLambdaExecution: {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -10,7 +10,14 @@ describe('AwsCompileWebsocketsEvents', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.environment = {
       vars: {},
       stages: {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/api.test.js
@@ -10,7 +10,14 @@ describe('#compileApi()', () => {
   let roleLogicalId;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'my-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
@@ -10,7 +10,14 @@ describe('#compileAuthorizers()', () => {
 
   describe('for routes with authorizer definition', () => {
     beforeEach(() => {
-      const serverless = new Serverless({ commands: [], options: {} });
+      const serverless = new Serverless({
+        commands: [],
+        options: {},
+        serviceDir: process.cwd(),
+        configurationFilename: 'serverless.yml',
+        configuration: {},
+        isConfigurationResovled: true,
+      });
       serverless.setProvider('aws', new AwsProvider(serverless));
       serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 
@@ -106,7 +113,14 @@ describe('#compileAuthorizers()', () => {
 
   describe('for routes without authorizer definition', () => {
     beforeEach(() => {
-      const serverless = new Serverless({ commands: [], options: {} });
+      const serverless = new Serverless({
+        commands: [],
+        options: {},
+        serviceDir: process.cwd(),
+        configurationFilename: 'serverless.yml',
+        configuration: {},
+        isConfigurationResovled: true,
+      });
       serverless.setProvider('aws', new AwsProvider(serverless));
       serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/deployment.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/deployment.test.js
@@ -13,7 +13,14 @@ describe('#compileDeployment()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = {
       Resources: {},

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
@@ -9,7 +9,14 @@ describe('#compileIntegrations()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
@@ -9,7 +9,14 @@ describe('#compilePermissions()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routeResponses.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routeResponses.test.js
@@ -9,7 +9,14 @@ describe('#compileRouteResponses()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routes.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/routes.test.js
@@ -9,7 +9,14 @@ describe('#compileRoutes()', () => {
   let awsCompileWebsocketsEvents;
 
   beforeEach(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -24,7 +24,14 @@ describe('#compileStage()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.service = 'my-service';
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
@@ -15,7 +15,14 @@ describe('#validate()', () => {
       stage: 'dev',
       region: 'us-east-1',
     };
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless, options);
   });

--- a/test/unit/lib/plugins/aws/package/index.test.js
+++ b/test/unit/lib/plugins/aws/package/index.test.js
@@ -14,7 +14,14 @@ describe('AwsPackage', () => {
   let options;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/package/lib/generateArtifactDirectoryName.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/generateArtifactDirectoryName.test.js
@@ -10,7 +10,14 @@ describe('#generateArtifactDirectoryName()', () => {
   let awsPackage;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     const options = {
       stage: 'dev',
       region: 'us-east-1',

--- a/test/unit/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/mergeCustomProviderResources.test.js
@@ -12,7 +12,14 @@ describe('mergeCustomProviderResources', () => {
   let coreCloudFormationTemplate;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     awsPackage = new AwsPackage(serverless, {});
 
     coreCloudFormationTemplate = awsPackage.serverless.utils.readFileSync(

--- a/test/unit/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/saveCompiledTemplate.test.js
@@ -15,7 +15,14 @@ describe('#saveCompiledTemplate()', () => {
 
   beforeEach(() => {
     const options = {};
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsPackage = new AwsPackage(serverless, options);
     serverless.serviceDir = 'my-service';

--- a/test/unit/lib/plugins/aws/package/lib/saveServiceState.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/saveServiceState.test.js
@@ -15,7 +15,14 @@ describe('#saveServiceState()', () => {
 
   beforeEach(() => {
     const options = {};
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.setProvider('aws', new AwsProvider(serverless, options));
     awsPackage = new AwsPackage(serverless, options);
     serverless.serviceDir = 'my-service';

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -31,7 +31,15 @@ describe('AwsProvider', () => {
 
   beforeEach(() => {
     ({ restoreEnv } = overrideEnv());
-    serverless = new Serverless({ ...options, commands: [], options: {} });
+    serverless = new Serverless({
+      ...options,
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new serverless.classes.CLI();
     awsProvider = new AwsProvider(serverless, options);
   });

--- a/test/unit/lib/plugins/aws/remove/lib/bucket.test.js
+++ b/test/unit/lib/plugins/aws/remove/lib/bucket.test.js
@@ -14,7 +14,14 @@ describe('emptyS3Bucket', () => {
     stage: 'dev',
     region: 'us-east-1',
   };
-  const serverless = new Serverless({ commands: [], options: {} });
+  const serverless = new Serverless({
+    commands: [],
+    options: {},
+    serviceDir: process.cwd(),
+    configurationFilename: 'serverless.yml',
+    configuration: {},
+    isConfigurationResovled: true,
+  });
   serverless.service.service = 'emptyS3Bucket';
   serverless.setProvider('aws', new AwsProvider(serverless, options));
 

--- a/test/unit/lib/plugins/aws/remove/lib/stack.test.js
+++ b/test/unit/lib/plugins/aws/remove/lib/stack.test.js
@@ -11,7 +11,14 @@ describe('removeStack', () => {
     stage: 'dev',
     region: 'us-east-1',
   };
-  const serverless = new Serverless({ commands: [], options: {} });
+  const serverless = new Serverless({
+    commands: [],
+    options: {},
+    serviceDir: process.cwd(),
+    configurationFilename: 'serverless.yml',
+    configuration: {},
+    isConfigurationResovled: true,
+  });
   serverless.service.service = 'removeStack';
   serverless.setProvider('aws', new AwsProvider(serverless, options));
 

--- a/test/unit/lib/plugins/aws/rollback.test.js
+++ b/test/unit/lib/plugins/aws/rollback.test.js
@@ -15,7 +15,14 @@ describe('AwsRollback', () => {
   let provider;
 
   const createInstance = (options) => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     provider = new AwsProvider(serverless, options);
     serverless.setProvider('aws', provider);
     serverless.service.service = 'rollback';

--- a/test/unit/lib/plugins/aws/rollbackFunction.test.js
+++ b/test/unit/lib/plugins/aws/rollbackFunction.test.js
@@ -18,7 +18,14 @@ describe('AwsRollbackFunction', () => {
     AwsRollbackFunction = proxyquire('../../../../../lib/plugins/aws/rollbackFunction.js', {
       'node-fetch': fetchStub,
     });
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.functions = {
       hello: {
         handler: true,

--- a/test/unit/lib/plugins/create/create.test.js
+++ b/test/unit/lib/plugins/create/create.test.js
@@ -21,7 +21,14 @@ describe('Create', () => {
   let create;
 
   before(() => {
-    const serverless = new Serverless({ commands: [], options: {} });
+    const serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     const options = {};
     create = new Create(serverless, options);
     create.serverless.cli = new serverless.classes.CLI();

--- a/test/unit/lib/plugins/deploy.test.js
+++ b/test/unit/lib/plugins/deploy.test.js
@@ -17,7 +17,14 @@ describe('Deploy', () => {
   let options;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     options = {};
     deploy = new Deploy(serverless, options);
     deploy.serverless.providers = { validProvider: true };

--- a/test/unit/lib/plugins/info.test.js
+++ b/test/unit/lib/plugins/info.test.js
@@ -13,7 +13,14 @@ describe('Info', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     info = new Info(serverless);
   });
 

--- a/test/unit/lib/plugins/install.test.js
+++ b/test/unit/lib/plugins/install.test.js
@@ -28,7 +28,14 @@ describe('Install', () => {
 
     serviceDir = tmpDir;
 
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     install = new Install(serverless);
     return serverless.init().then(() => {
       install.serverless.cli = new serverless.classes.CLI();

--- a/test/unit/lib/plugins/invoke.test.js
+++ b/test/unit/lib/plugins/invoke.test.js
@@ -16,7 +16,14 @@ describe('Invoke', () => {
 
   beforeEach(() => {
     ({ restoreEnv } = overrideEnv());
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     invoke = new Invoke(serverless);
   });
 

--- a/test/unit/lib/plugins/metrics.test.js
+++ b/test/unit/lib/plugins/metrics.test.js
@@ -9,7 +9,14 @@ describe('Metrics', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     const options = {};
     metrics = new Metrics(serverless, options);
   });

--- a/test/unit/lib/plugins/package/lib/zipService.test.js
+++ b/test/unit/lib/plugins/package/lib/zipService.test.js
@@ -29,7 +29,14 @@ describe('zipService', () => {
 
   beforeEach(() => {
     tmpDirPath = getTmpDirPath();
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.service.service = 'first-service';
     serverless.serviceDir = tmpDirPath;
     packagePlugin = new Package(serverless, {});

--- a/test/unit/lib/plugins/package/package.test.js
+++ b/test/unit/lib/plugins/package/package.test.js
@@ -16,7 +16,14 @@ describe('Package', () => {
   let pkg;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     return serverless.init().then(() => {
       options = {
         stage: 'dev',

--- a/test/unit/lib/plugins/plugin/install.test.js
+++ b/test/unit/lib/plugins/plugin/install.test.js
@@ -44,7 +44,14 @@ describe('PluginInstall', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginInstall = new PluginInstall(serverless, options);

--- a/test/unit/lib/plugins/plugin/lib/utils.test.js
+++ b/test/unit/lib/plugins/plugin/lib/utils.test.js
@@ -34,7 +34,14 @@ describe('PluginUtils', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginUtils = new PluginInstall(serverless, options);

--- a/test/unit/lib/plugins/plugin/list.test.js
+++ b/test/unit/lib/plugins/plugin/list.test.js
@@ -14,7 +14,14 @@ describe('PluginList', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginList = new PluginList(serverless, options);

--- a/test/unit/lib/plugins/plugin/search.test.js
+++ b/test/unit/lib/plugins/plugin/search.test.js
@@ -32,7 +32,14 @@ describe('PluginSearch', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginSearch = new PluginSearch(serverless, options);

--- a/test/unit/lib/plugins/plugin/uninstall.test.js
+++ b/test/unit/lib/plugins/plugin/uninstall.test.js
@@ -39,7 +39,14 @@ describe('PluginUninstall', () => {
   ];
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     serverless.cli = new CLI(serverless);
     const options = {};
     pluginUninstall = new PluginUninstall(serverless, options);

--- a/test/unit/lib/plugins/remove.test.js
+++ b/test/unit/lib/plugins/remove.test.js
@@ -11,7 +11,14 @@ describe('Remove', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     remove = new Remove(serverless);
   });
 

--- a/test/unit/lib/plugins/rollback.test.js
+++ b/test/unit/lib/plugins/rollback.test.js
@@ -9,7 +9,14 @@ describe('Rollback', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     rollback = new Rollback(serverless);
   });
 

--- a/test/unit/lib/plugins/slstats.test.js
+++ b/test/unit/lib/plugins/slstats.test.js
@@ -11,7 +11,14 @@ describe('SlStats', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     return serverless.init().then(() => {
       slStats = new SlStats(serverless);
     });

--- a/test/unit/lib/utils/fs/writeFile.test.js
+++ b/test/unit/lib/utils/fs/writeFile.test.js
@@ -17,7 +17,14 @@ describe('#writeFile()', function () {
   this.timeout(0);
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
   });
 
   it('should write a .json file asynchronously', () => {

--- a/test/unit/lib/utils/fs/writeFileSync.test.js
+++ b/test/unit/lib/utils/fs/writeFileSync.test.js
@@ -11,7 +11,14 @@ describe('#writeFileSync()', () => {
   let serverless;
 
   beforeEach(() => {
-    serverless = new Serverless({ commands: [], options: {} });
+    serverless = new Serverless({
+      commands: [],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
   });
 
   it('should write a .json file synchronously', () => {

--- a/test/unit/lib/utils/getCommandSuggestion.test.js
+++ b/test/unit/lib/utils/getCommandSuggestion.test.js
@@ -8,7 +8,14 @@ describe('#getCommandSuggestion', () => {
   let serverless;
 
   before(() => {
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     return serverless.init();
   });
 

--- a/test/unit/lib/utils/renameService.test.js
+++ b/test/unit/lib/utils/renameService.test.js
@@ -23,7 +23,14 @@ describe('renameService', () => {
 
     serviceDir = tmpDir;
 
-    serverless = new Serverless({ commands: ['print'], options: {}, serviceDir: null });
+    serverless = new Serverless({
+      commands: ['print'],
+      options: {},
+      serviceDir: process.cwd(),
+      configurationFilename: 'serverless.yml',
+      configuration: {},
+      isConfigurationResovled: true,
+    });
     return serverless.init();
   });
 


### PR DESCRIPTION
BREAKING CHANGE: `Serverless` constructor depends on service configuration
resolved externally and now requires following options in the constructor:
`configuration`, `serviceDir` and `configurationFilename`. It applies only
to programmatic use of the framework.


