### PR TITLE
Test: Ensure to fully cleanup `serverless` installation when testing plugins

### DIFF
--- a/test/fixtures/programmatic/curated-plugins/_setup.js
+++ b/test/fixtures/programmatic/curated-plugins/_setup.js
@@ -3,7 +3,12 @@
 const path = require('path');
 const fsp = require('fs').promises;
 
-const slsDependencyDir = path.resolve(__dirname, 'node_modules/serverless');
+const nodeModulesDir = path.resolve(__dirname, 'node_modules');
 
 // Ensure to remove "serverless" installed as peer-dependency to avoid local fallback
-module.exports = async () => fsp.rm(slsDependencyDir, { recursive: true, force: true });
+module.exports = async () =>
+  Promise.all([
+    fsp.rm(path.resolve(nodeModulesDir, 'serverless'), { recursive: true, force: true }),
+    fsp.unlink(path.resolve(nodeModulesDir, '.bin/serverless')).catch(() => {}),
+    fsp.unlink(path.resolve(nodeModulesDir, '.bin/sls')).catch(() => {}),
+  ]);


### PR DESCRIPTION
Otherwise it leaves a broken symlinks of which copying crashes `fse.copy` https://github.com/jprichardson/node-fs-extra/issues/765 (observable in v9 of `fs-extra` we're still relying on).

This issue was responsible for tests not passing in v3 branch once switching to Node.js v16
