### PR TITLE
feat(AWS Deploy): Ensure consistent function state in `deploy function`

### DIFF
--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -22,6 +22,8 @@ class AwsDeployFunction {
       path.join(this.serverless.serviceDir || '.', '.serverless');
     this.provider = this.serverless.getProvider('aws');
 
+    this.shouldEnsureFunctionState = false;
+
     Object.assign(this, validate);
 
     this.hooks = {
@@ -76,6 +78,9 @@ class AwsDeployFunction {
           await this.deployFunction();
         }
         await this.updateFunctionConfiguration();
+        if (this.shouldEnsureFunctionState) {
+          await this.ensureFunctionState();
+        }
         await this.serverless.pluginManager.spawn('aws:common:cleanupTempDir');
       },
     };
@@ -161,6 +166,38 @@ class AwsDeployFunction {
       RoleName: role['Fn::GetAtt'][0],
     });
     return data.Arn;
+  }
+
+  async ensureFunctionState() {
+    this.options.functionObj = this.serverless.service.getFunction(this.options.function);
+    const params = {
+      FunctionName: this.options.functionObj.name,
+    };
+    const startTime = Date.now();
+
+    const callWithRetry = async () => {
+      const result = await this.provider.request('Lambda', 'getFunction', params);
+      if (
+        result &&
+        result.Configuration.State === 'Active' &&
+        result.Configuration.LastUpdateStatus === 'Successful'
+      ) {
+        return;
+      }
+      const didOneMinutePass = Date.now() - startTime > 60 * 1000;
+      if (didOneMinutePass) {
+        throw new ServerlessError(
+          'Ensuring function state timed out. Please try to deploy your function once again.',
+          'DEPLOY_FUNCTION_ENSURE_STATE_TIMED_OUT'
+        );
+      }
+      legacy.log(`Retrying ensure function state for function: ${this.options.function}.`);
+      log.info(`Retrying ensure function state for function: ${this.options.function}.`);
+      await wait(500);
+      await callWithRetry();
+    };
+
+    await callWithRetry();
   }
 
   async callUpdateFunctionConfiguration(params) {
@@ -389,6 +426,7 @@ class AwsDeployFunction {
 
     mainProgress.notice('Updating function configuration', { isMainEvent: true });
     await this.callUpdateFunctionConfiguration(params);
+    this.shouldEnsureFunctionState = true;
     if (this.options['update-config']) log.notice();
     log.notice.success(
       `Function configuration updated ${style.aside(
@@ -461,6 +499,7 @@ class AwsDeployFunction {
 
     mainProgress.notice('Deploying', { isMainEvent: true });
     await this.provider.request('Lambda', 'updateFunctionCode', params);
+    this.shouldEnsureFunctionState = true;
     legacy.log(`Successfully deployed function: ${this.options.function}`);
     log.notice();
     log.notice.success(

--- a/test/unit/lib/plugins/package/lib/packageService.test.js
+++ b/test/unit/lib/plugins/package/lib/packageService.test.js
@@ -359,6 +359,8 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
           getFunction: {
             Configuration: {
               LastModified: '2020-05-20T15:34:16.494+0000',
+              State: 'Active',
+              LastUpdateStatus: 'Successful',
             },
           },
           updateFunctionCode: updateFunctionCodeStub,


### PR DESCRIPTION
After doing a bit of more research I've noticed that at the moment, `updateFunctionConfiguration` is already resilient and does retries in situations where function is still being updated, so I've decided to stick to only ensuring that function is in updated state at the end of `deploy function`. 