### PR TITLE
docs(AWS Local Invocation): Update supported runtimes

### DIFF
--- a/docs/providers/aws/cli-reference/invoke.md
+++ b/docs/providers/aws/cli-reference/invoke.md
@@ -139,7 +139,7 @@ This example will pass the json context in the `lib/context.json` file (relative
 
 ### Limitations
 
-Currently, `invoke local` only supports the NodeJs and Python runtimes.
+Currently, `invoke local` only supports the Node.js, Python, Java and Ruby runtimes.
 
 ## Resource permissions
 


### PR DESCRIPTION
Updated the list of supported runtimes for 
 `invoke local` to match the actual [supported runtimes](https://github.com/serverless/serverless/blob/4da08996736c9a8f2b0a0193f7cca4b24f3fc6f1/lib/plugins/aws/invokeLocal/index.js#L266-L294).