### PR TITLE
Adjust install script for m1 macs & switch to Node 16

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -11,8 +11,8 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  linuxNode14:
-    name: '[Linux] Node.js 14: Publish canary, Unit & packaging tests '
+  linuxNode16:
+    name: '[Linux] Node.js 16: Publish canary, Unit & packaging tests '
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -21,7 +21,7 @@ jobs:
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: https://registry.npmjs.org
 
       - name: Publish canary
@@ -41,8 +41,8 @@ jobs:
           path: |
             ~/.npm
             node_modules
-          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
+          key: npm-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: npm-v16-${{ runner.os }}-${{ github.ref }}-
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
@@ -56,39 +56,9 @@ jobs:
       - name: Packaging tests
         run: npm run integration-test-run-package
 
-  windowsNode14:
-    name: '[Windows] Node.js v14: Unit tests'
+  windowsNode16:
+    name: '[Windows] Node.js v16: Unit tests'
     runs-on: windows-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Retrieve dependencies from cache
-        id: cacheNpm
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.npm
-            node_modules
-          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
-
-      - name: Install Node.js and npm
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Install dependencies
-        if: steps.cacheNpm.outputs.cache-hit != 'true'
-        run: |
-          npm update --no-save
-          npm update --save-dev --no-save
-      - name: Unit tests
-        run: npm test -- -b
-
-  linuxNode16:
-    name: '[Linux] Node.js 16: Isolated unit tests'
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -107,6 +77,36 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16.x
+
+      - name: Install dependencies
+        if: steps.cacheNpm.outputs.cache-hit != 'true'
+        run: |
+          npm update --no-save
+          npm update --save-dev --no-save
+      - name: Unit tests
+        run: npm test -- -b
+
+  linuxNode14:
+    name: '[Linux] Node.js 14: Isolated unit tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve dependencies from cache
+        id: cacheNpm
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: npm-v14-${{ runner.os }}-${{ github.ref }}-
+
+      - name: Install Node.js and npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
@@ -187,7 +187,7 @@ jobs:
   integrate:
     name: Integrate
     runs-on: ubuntu-latest
-    needs: [linuxNode14, windowsNode14, linuxNode16, linuxNode12, linuxNode10]
+    needs: [linuxNode16, windowsNode16, linuxNode14, linuxNode12, linuxNode10]
     timeout-minutes: 30 # Default is 360
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -211,7 +211,7 @@ jobs:
           path: |
             ~/.npm
             node_modules
-          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          key: npm-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
 
       # Potentially needed for test/integration/curated-plugins-python.test.js
       # (current GA runtime comes with Python 3.8 preinstalled, but that might be subject to changes)
@@ -222,7 +222,7 @@ jobs:
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       # Note: No need to install dependencies as we have retrieved cached `node_modules` for very
       #       same `package.json` as stored with previous job

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,12 +21,12 @@ jobs:
           path: |
             ~/.npm
             node_modules
-          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          key: npm-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -68,12 +68,12 @@ jobs:
           path: |
             ~/.npm
             node_modules
-          key: npm-v14-${{ runner.os }}-refs/heads/master-${{ hashFiles('package.json') }}
+          key: npm-v16-${{ runner.os }}-refs/heads/master-${{ hashFiles('package.json') }}
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: https://registry.npmjs.org
 
       # Normally we have a guarantee that deps are already there, still it may not be the case when:
@@ -126,12 +126,12 @@ jobs:
           path: |
             ~/.npm
             node_modules
-          key: npm-v14-${{ runner.os }}-refs/heads/master-${{ hashFiles('package.json') }}
+          key: npm-v16-${{ runner.os }}-refs/heads/master-${{ hashFiles('package.json') }}
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
           registry-url: https://registry.npmjs.org
 
       # Note: No need to install dependencies as we have retrieved cached `node_modules` for very

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,8 +11,8 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  linuxNode14:
-    name: '[Linux] Node.js 14: Lint, Formatting, Eventual Commitlint, Eventual Changelog, Unit & packaging tests'
+  linuxNode16:
+    name: '[Linux] Node.js 16: Lint, Formatting, Eventual Commitlint, Eventual Changelog, Unit & packaging tests'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -36,15 +36,15 @@ jobs:
           path: |
             ~/.npm
             node_modules
-          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          key: npm-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
           restore-keys: |
-            npm-v14-${{ runner.os }}-${{ github.ref }}-
-            npm-v14-${{ runner.os }}-refs/heads/master-
+            npm-v16-${{ runner.os }}-${{ github.ref }}-
+            npm-v16-${{ runner.os }}-refs/heads/master-
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'
@@ -72,41 +72,9 @@ jobs:
       - name: Packaging tests
         run: npm run integration-test-run-package
 
-  windowsNode14:
-    name: '[Windows] Node.js v14: Unit tests'
+  windowsNode16:
+    name: '[Windows] Node.js v16: Unit tests'
     runs-on: windows-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Retrieve dependencies from cache
-        id: cacheNpm
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.npm
-            node_modules
-          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
-          restore-keys: |
-            npm-v14-${{ runner.os }}-${{ github.ref }}-
-            npm-v14-${{ runner.os }}-refs/heads/master-
-
-      - name: Install Node.js and npm
-        uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-
-      - name: Install dependencies
-        if: steps.cacheNpm.outputs.cache-hit != 'true'
-        run: |
-          npm update --no-save
-          npm update --save-dev --no-save
-      - name: Unit tests
-        run: npm test -- -b
-
-  linuxNode16:
-    name: '[Linux] Node.js 16: Isolated unit tests'
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -127,6 +95,38 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16.x
+
+      - name: Install dependencies
+        if: steps.cacheNpm.outputs.cache-hit != 'true'
+        run: |
+          npm update --no-save
+          npm update --save-dev --no-save
+      - name: Unit tests
+        run: npm test -- -b
+
+  linuxNode14:
+    name: '[Linux] Node.js 14: Isolated unit tests'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Retrieve dependencies from cache
+        id: cacheNpm
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: npm-v14-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
+          restore-keys: |
+            npm-v14-${{ runner.os }}-${{ github.ref }}-
+            npm-v14-${{ runner.os }}-refs/heads/master-
+
+      - name: Install Node.js and npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
 
       - name: Install dependencies
         if: steps.cacheNpm.outputs.cache-hit != 'true'

--- a/lib/utils/standalone.js
+++ b/lib/utils/standalone.js
@@ -17,7 +17,12 @@ const arch = (() => {
     case 'x32':
       return 'x86';
     case 'arm':
+      return 'armv6';
     case 'arm64':
+      if (process.platform === 'darwin') {
+        // Handle case of M1 Macs that are using x64 binary via Rosetta
+        return 'x64';
+      }
       return 'armv6';
     default:
       return process.arch;

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "mocha": "^8.4.0",
     "mock-require": "^3.0.3",
     "nyc": "^15.1.0",
-    "pkg": "^4.5.1",
+    "pkg": "^5.5.1",
     "prettier": "^2.5.0",
     "proxyquire": "^2.1.3",
     "semver-regex": "^3.1.3",

--- a/scripts/pkg/build.js
+++ b/scripts/pkg/build.js
@@ -31,7 +31,7 @@ const spawnOptions = { cwd: serverlessPath, stdio: 'inherit' };
         '-c',
         'scripts/pkg/config.js',
         '--targets',
-        'node14-linux-x64,node14-mac-x64,node14-win-x64',
+        'node16-linux-x64,node16-mac-x64,node16-win-x64',
         '--out-path',
         'dist',
         'bin/serverless.js',

--- a/scripts/pkg/install.sh
+++ b/scripts/pkg/install.sh
@@ -30,6 +30,9 @@ fi
 MACHINE_TYPE=`uname -m`
 if [[ $MACHINE_TYPE == "x86_64" ]]; then
   ARCH='x64'
+elif [[ $OSTYPE == "darwin"* ]] && [[ $MACHINE_TYPE == "arm64" ]]; then
+  ARCH='x64'
+  echo "There is no native binary installer available for $MACHINE_TYPE architecture. Version for x86_64 architecture will be installed instead. In order to use it, you need to have Rosetta installed."
 else
   echo "$red Sorry, there's no serverless binary installer available for $MACHINE_TYPE architecture. Please open request for it at https://github.com/serverless/serverless/issues.$reset"
   exit 1


### PR DESCRIPTION
Scope:
- support for binary installation for M1 Macs (still using x86 binary)
- Switch to Node 16 for standalone binaries
- Use Node 16 as main in CI