### PR TITLE
Variables: Ensure complete resolution of address and params values

### DIFF
--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -386,14 +386,8 @@ Object.defineProperties(
         const propertyPathKeys = propertyPath.split('\0');
         const { value, sourceValues } = valueMeta;
 
-        const valueEntries = (() => {
-          if (isPlainObject(value)) return Object.entries(value);
-          return Array.isArray(value) ? value.entries() : null;
-        })();
         let propertyVariablesMeta;
-        if (valueEntries) {
-          propertyVariablesMeta = parseEntries(valueEntries, propertyPathKeys, new Map());
-        } else if (typeof value === 'string') {
+        if (typeof value === 'string') {
           const valueVariables = (() => {
             const silentParse = (sourceValue) => {
               try {
@@ -443,6 +437,14 @@ Object.defineProperties(
             propertyVariablesMeta = new Map([[propertyPath, { value, variables: valueVariables }]]);
           } else if (valueMeta.error) {
             return;
+          }
+        } else {
+          const valueEntries = (() => {
+            if (isPlainObject(value)) return Object.entries(value);
+            return Array.isArray(value) ? value.entries() : null;
+          })();
+          if (valueEntries) {
+            propertyVariablesMeta = parseEntries(valueEntries, propertyPathKeys, new Map());
           }
         }
         if (propertyVariablesMeta && propertyVariablesMeta.size) {

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -27,6 +27,33 @@ const variableProcessingErrorNames = new Set(['ServerlessError', 'VariableSource
 
 let lastResolutionBatchId = 0;
 
+const resolveSourceValuesVariables = (sourceValues) => {
+  // Value is a result of concatenation of string values coming from multiple sources.
+  // Parse variables in each string part individually - it's to avoid accidental
+  // resolution of variable-like notation which may surface after joining two values.
+  // Also that way we do not accidentally re-parse an escaped variables notation
+  let baseIndex = 0;
+  let resolvedValueVariables = null;
+  for (const sourceValue of sourceValues) {
+    const sourceValueVariables = parse(sourceValue);
+    if (sourceValueVariables) {
+      for (const sourceValueVariable of sourceValueVariables) {
+        if (sourceValueVariable.end) {
+          sourceValueVariable.start += baseIndex;
+          sourceValueVariable.end += baseIndex;
+        } else {
+          sourceValueVariable.start = baseIndex;
+          sourceValueVariable.end = baseIndex + sourceValue.length;
+        }
+      }
+      if (!resolvedValueVariables) resolvedValueVariables = [];
+      resolvedValueVariables.push(...sourceValueVariables);
+    }
+    baseIndex += sourceValue.length;
+  }
+  return resolvedValueVariables;
+};
+
 class VariablesResolver {
   constructor({
     serviceDir,
@@ -389,48 +416,17 @@ Object.defineProperties(
         let propertyVariablesMeta;
         if (typeof value === 'string') {
           const valueVariables = (() => {
-            const silentParse = (sourceValue) => {
-              try {
-                return parse(sourceValue);
-              } catch (error) {
-                error.message = `Cannot resolve variable at "${humanizePropertyPath(
-                  propertyPathKeys
-                )}": Approached variable syntax error in resolved value "${value}": ${
-                  error.message
-                }`;
-                delete valueMeta.value;
-                valueMeta.error = error;
-                return null;
-              }
-            };
-            if (sourceValues) {
-              // Value is a result of concatenation of string values coming from multiple sources.
-              // Parse variables in each string part individually - it's to avoid accidental
-              // resolution of variable-like notation which may surface after joining two values.
-              // Also that way we do not accidentally re-parse an escaped variables notation
-              let baseIndex = 0;
-              let resolvedValueVariables = null;
-              for (const sourceValue of sourceValues) {
-                const sourceValueVariables = silentParse(sourceValue);
-                if (valueMeta.error) return null;
-                if (sourceValueVariables) {
-                  for (const sourceValueVariable of sourceValueVariables) {
-                    if (sourceValueVariable.end) {
-                      sourceValueVariable.start += baseIndex;
-                      sourceValueVariable.end += baseIndex;
-                    } else {
-                      sourceValueVariable.start = baseIndex;
-                      sourceValueVariable.end = baseIndex + sourceValue.length;
-                    }
-                  }
-                  if (!resolvedValueVariables) resolvedValueVariables = [];
-                  resolvedValueVariables.push(...sourceValueVariables);
-                }
-                baseIndex += sourceValue.length;
-              }
-              return resolvedValueVariables;
+            try {
+              if (sourceValues) return resolveSourceValuesVariables(sourceValues);
+              return parse(value);
+            } catch (error) {
+              error.message = `Cannot resolve variable at "${humanizePropertyPath(
+                propertyPathKeys
+              )}": Approached variable syntax error in resolved value "${value}": ${error.message}`;
+              delete valueMeta.value;
+              valueMeta.error = error;
+              return null;
             }
-            return silentParse(value);
           })();
 
           if (valueVariables) {

--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -256,20 +256,14 @@ class VariablesResolver {
         sourceData.params.map(async (param) => {
           if (!param.variables) return;
           await this.resolveVariables(resolutionBatchId, propertyPath, param);
-          if (param.error) throw param.error;
+          await this.resolveInternalResult(resolutionBatchId, propertyPath, param);
         })
       );
-      if (sourceData.params.some((param) => param.variables)) {
-        throw new ServerlessError('Cannot resolve variable', 'MISSING_VARIABLE_DEPENDENCY');
-      }
     }
     if (sourceData.address && sourceData.address.variables) {
       // Ensure to have all eventual variables in address resolved
       await this.resolveVariables(resolutionBatchId, propertyPath, sourceData.address);
-      if (sourceData.address.error) throw sourceData.address.error;
-      if (sourceData.address.variables) {
-        throw new ServerlessError('Cannot resolve variable', 'MISSING_VARIABLE_DEPENDENCY');
-      }
+      await this.resolveInternalResult(resolutionBatchId, propertyPath, sourceData.address);
     }
     return JSON.parse(
       JSON.stringify(
@@ -309,6 +303,68 @@ class VariablesResolver {
       )
     );
   }
+
+  async resolveInternalResult(resolutionBatchId, propertyPath, valueMeta, nestTracker = 10) {
+    if (valueMeta.error) throw valueMeta.error;
+    if (valueMeta.variables) {
+      throw new ServerlessError('Cannot resolve variable', 'MISSING_VARIABLE_DEPENDENCY');
+    }
+    if (!nestTracker) {
+      throw new ServerlessError(
+        `Cannot resolve variable at "${humanizePropertyPath(
+          propertyPath.split('\0')
+        )}": Excessive variables nest depth`,
+        'EXCESSIVE_RESOLVED_VARIABLES_NEST_DEPTH'
+      );
+    }
+    if (typeof valueMeta.value === 'string') {
+      const valueVariables = (() => {
+        try {
+          if (valueMeta.sourceValues) return resolveSourceValuesVariables(valueMeta.sourceValues);
+          return parse(valueMeta.value);
+        } catch (error) {
+          error.message = `Cannot resolve variable at "${humanizePropertyPath(
+            propertyPath.split('\0')
+          )}": Approached variable syntax error in resolved value "${valueMeta.value}": ${
+            error.message
+          }`;
+          delete valueMeta.value;
+          valueMeta.error = error;
+          throw error;
+        }
+      })();
+
+      if (!valueVariables) return;
+      valueMeta.variables = valueVariables;
+      delete valueMeta.sourceValues;
+      await this.resolveVariables(resolutionBatchId, propertyPath, valueMeta);
+      await this.resolveInternalResult(resolutionBatchId, propertyPath, valueMeta, --nestTracker);
+      return;
+    }
+    const valueEntries = (() => {
+      if (isPlainObject(valueMeta.value)) return Object.entries(valueMeta.value);
+      return Array.isArray(valueMeta.value) ? valueMeta.value.entries() : null;
+    })();
+    if (!valueEntries) return;
+    const propertyVariablesMeta = parseEntries(valueEntries, [], new Map());
+    for (const [propertyKeyPath, propertyValueMeta] of propertyVariablesMeta) {
+      await this.resolveVariables(resolutionBatchId, propertyPath, propertyValueMeta);
+      await this.resolveInternalResult(
+        resolutionBatchId,
+        propertyPath,
+        propertyValueMeta,
+        --nestTracker
+      );
+      const propertyKeyPathKeys = propertyKeyPath.split('\0');
+      const targetKey = propertyKeyPathKeys[propertyKeyPathKeys.length - 1];
+      let targetObject = valueMeta.value;
+      for (const parentKey of propertyKeyPathKeys.slice(0, -1)) {
+        targetObject = targetObject[parentKey];
+      }
+      targetObject[targetKey] = propertyValueMeta.value;
+    }
+  }
+
   validateCrossPropertyDependency(dependentPropertyPath, dependencyPropertyPath) {
     if (dependentPropertyPath === dependencyPropertyPath) {
       throw new ServerlessError(
@@ -531,10 +587,7 @@ Object.defineProperties(
               variables: variableData,
             };
             await this.resolveVariables(resolutionBatchId, propertyPath, meta);
-            if (meta.error) throw meta.error;
-            if (meta.variables) {
-              throw new ServerlessError('Cannot resolve variable', 'MISSING_VARIABLE_DEPENDENCY');
-            }
+            await this.resolveInternalResult(resolutionBatchId, propertyPath, meta);
             return meta.value;
           },
           resolveVariablesInString: async (stringValue) => {
@@ -550,10 +603,7 @@ Object.defineProperties(
               variables: variableData,
             };
             await this.resolveVariables(resolutionBatchId, propertyPath, meta);
-            if (meta.error) throw meta.error;
-            if (meta.variables) {
-              throw new ServerlessError('Cannot resolve variable', 'MISSING_VARIABLE_DEPENDENCY');
-            }
+            await this.resolveInternalResult(resolutionBatchId, propertyPath, meta);
             return meta.value;
           },
         });

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -79,7 +79,9 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
         resolve: ({ params }) => ({ value: params.join('|') }),
       },
       sourceAddress: {
-        resolve: ({ address }) => ({ value: address }),
+        resolve: ({ address }) => ({
+          value: typeof address === 'string' ? address.split('').reverse().join('') : address,
+        }),
       },
       sourceDirect: {
         resolve: () => ({ value: 234 }),
@@ -200,7 +202,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     });
 
     it('should pass address to source resolvers', () => {
-      expect(configuration.address).to.equal('fooaddress-result');
+      expect(configuration.address).to.equal('footluser-sserdda');
     });
 
     it('should resolve variables in params', () => {
@@ -223,7 +225,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
 
     it('should clear escapes', () => {
       expect(configuration.escape).to.equal(
-        'e${sourceDirect:}n\\$fooaddress-resultqe\\${sourceProperty(direct)}qn\\fooaddress-result'
+        'e${sourceDirect:}n\\$footluser-sserddaqe\\${sourceProperty(direct)}qn\\footluser-sserdda'
       );
     });
 

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -429,24 +429,22 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     });
 
     it('should correctly record encountered variable sources', () => {
-      expect(variableSourcesInConfig).to.deep.equal(
-        new Set([
-          'sourceParam',
-          'sourceDirect',
-          'sourceAddress',
-          'sourceProperty',
-          'sourceResultVariables',
-          'sourceResolveVariablesInString',
-          'sourceResolveVariable',
-          'sourceIncomplete',
-          'sourceMissing',
-          'sourceUnrecognized',
-          'sourceError',
-          'sourceInfinite',
-          'sourceShared',
-          'sourceSharedProperty',
-        ])
-      );
+      expect(Array.from(variableSourcesInConfig)).to.deep.equal([
+        'sourceParam',
+        'sourceDirect',
+        'sourceAddress',
+        'sourceProperty',
+        'sourceResultVariables',
+        'sourceResolveVariablesInString',
+        'sourceResolveVariable',
+        'sourceIncomplete',
+        'sourceMissing',
+        'sourceUnrecognized',
+        'sourceError',
+        'sourceInfinite',
+        'sourceShared',
+        'sourceSharedProperty',
+      ]);
     });
 
     describe('"resolveVariable" source util', () => {

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -76,7 +76,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     let variablesMeta;
     const sources = {
       sourceParam: {
-        resolve: ({ params }) => ({ value: params.join('|') }),
+        resolve: ({ params }) => ({ value: params.join('|').split('').reverse().join('') }),
       },
       sourceAddress: {
         resolve: ({ address }) => ({
@@ -198,7 +198,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     });
 
     it('should pass params to source resolvers', () => {
-      expect(configuration.foo.params).to.equal('param1|param2');
+      expect(configuration.foo.params).to.equal('2marap|1marap');
     });
 
     it('should pass address to source resolvers', () => {
@@ -206,7 +206,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
     });
 
     it('should resolve variables in params', () => {
-      expect(configuration.foo.varParam).to.equal('234');
+      expect(configuration.foo.varParam).to.equal('432');
     });
 
     it('should resolve variables in address', () => {
@@ -218,8 +218,8 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       expect(configuration.otherProperty).to.equal('foo234');
       expect(configuration.static).to.equal(true);
       expect(configuration.deepProperty).to.deep.equal({
-        params: 'param1|param2',
-        varParam: '234',
+        params: '2marap|1marap',
+        varParam: '432',
       });
     });
 
@@ -263,8 +263,8 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
 
     it('should provide working resolveVariablesInString util', () => {
       expect(configuration.resolveVariablesInString).to.deep.equal({
-        params: 'param1|param2',
-        varParam: '234',
+        params: '2marap|1marap',
+        varParam: '432',
       });
     });
 
@@ -451,7 +451,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
 
     describe('"resolveVariable" source util', () => {
       it('should resolve variable', () => {
-        expect(configuration.resolvesVariables).to.equal('234');
+        expect(configuration.resolvesVariables).to.equal('432');
       });
       it('should support multiple sources', () => {
         expect(configuration.resolvesVariablesFallback).to.equal(null);


### PR DESCRIPTION
Fixes: https://github.com/serverless/serverless/issues/10294

Addresses scenarios where _address_ or _param_ is constructed of variables, which resolve with strings that contain variables. Such case was handled properly for end property values (https://github.com/serverless/serverless/pull/9657), but remained not addressed for internal results that play part in variables resolution.