### PR TITLE
Strip null values from CloudFormation template resource properties

### DIFF
--- a/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResources.js
+++ b/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResources.js
@@ -4,7 +4,7 @@ const stripNullPropsFromObj = (obj) => {
   Object.entries(obj).forEach(([propName, propVal]) => {
     if (propVal === null) {
       delete obj[propName];
-    } else if (propVal && typeof propVal === 'object') {
+    } else if (typeof propVal === 'object') {
       stripNullPropsFromObj(propVal);
     }
   });

--- a/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResources.js
+++ b/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResources.js
@@ -1,16 +1,22 @@
 'use strict';
 
+const stripNullPropsFromObj = (obj) => {
+  Object.entries(obj).forEach(([propName, propVal]) => {
+    if (propVal === null) {
+      delete obj[propName];
+    } else if (propVal && typeof propVal === 'object') {
+      stripNullPropsFromObj(propVal);
+    }
+  });
+};
+
 module.exports = {
   stripNullPropsFromTemplateResources() {
     const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
     for (const resource of Object.values(resources)) {
       if (resource.Properties) {
-        for (const [propName, propVal] of Object.entries(resource.Properties)) {
-          if (propVal === null) {
-            delete resource.Properties[propName];
-          }
-        }
+        stripNullPropsFromObj(resource.Properties);
       }
     }
   },

--- a/test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResources.test.js
@@ -28,6 +28,24 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
                 ObjectLockEnabled: false,
               },
             },
+            myLambdaFunction: {
+              Type: 'AWS::Lambda::Function',
+              Properties: {
+                Environment: {
+                  Variables: {
+                    MYNULLVAR: null,
+                  },
+                },
+                Handler: 'index.handler',
+                Role: {
+                  'Fn::GetAtt': ['MyLambdaRole', 'Arn'],
+                },
+                Code: {
+                  S3Bucket: 's3-containing-lambda',
+                },
+                Runtime: 'nodejs12.x',
+              },
+            },
           },
         },
       },
@@ -37,6 +55,12 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
 
   it('Should remove null properties from the final cloudformation template resources', async () => {
     expect(Object.keys(finalTemplate.Resources.myBucket.Properties).length).to.equal(0);
+  });
+
+  it('Should remove null values within nested objects in resource properties', async () => {
+    expect(
+      Object.keys(finalTemplate.Resources.myLambdaFunction.Properties.Environment.Variables).length
+    ).to.equal(0);
   });
 
   it('Should not affect resources without null props', async () => {


### PR DESCRIPTION
Previously, `stripNullPropsFromTemplateResources` stripped null from top-level resource properties in the compiled CFN template.

This PR:
- adds functionality to traverse the properties deeply, and strips null from nested objects within the properties
- allows for users to provide default value as null if they would like the variable to be removed from the template if the initial value is not available (see #10279)

Closes: #10279
