### PR TITLE
fix(aws): allow false values in aws provider configuration

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -736,7 +736,7 @@ class AwsProvider {
                   },
                   additionalProperties: false,
                 },
-                shouldStartNameWithService: { const: true },
+                shouldStartNameWithService: { type: 'boolean' },
                 usagePlan: {
                   anyOf: [
                     apiGatewayUsagePlan,
@@ -850,7 +850,7 @@ class AwsProvider {
             },
             deploymentPrefix: { type: 'string' },
             disableDefaultOutputExportNames: { const: true },
-            disableRollback: { const: true },
+            disableRollback: { type: 'boolean' },
             endpointType: {
               anyOf: ['REGIONAL', 'EDGE', 'PRIVATE'].map(caseInsensitive),
             },
@@ -943,7 +943,7 @@ class AwsProvider {
                 metrics: { type: 'boolean' },
                 useProviderTags: { const: true },
                 disableDefaultEndpoint: { type: 'boolean' },
-                shouldStartNameWithService: { const: true },
+                shouldStartNameWithService: { type: 'boolean' },
               },
               additionalProperties: false,
             },


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->
Hello ! Thanks for the hard work.

In aws provider, is currently not possible to put falsy values for some configuration keys. This PR will enable per-stage configuration that is currently not possible 
