### PR TITLE
v3: Drop support for placing CLI params (options) before command tokens

### DIFF
--- a/lib/cli/commands-schema/common-options/global.js
+++ b/lib/cli/commands-schema/common-options/global.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   help: { usage: 'Show this message', shortcut: 'h', type: 'boolean' },
-  version: { usage: 'Show version info', type: 'boolean' },
+  version: { usage: 'Show version info', shortcut: 'v', type: 'boolean' },
   verbose: { usage: 'Show verbose logs', type: 'boolean' },
   debug: { usage: 'Namespace of debug logs to expose (use "*" to display all)', type: 'string' },
 };

--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -5,15 +5,11 @@
 const ensureMap = require('type/map/ensure');
 const memoizee = require('memoizee');
 const parseArgs = require('./parse-args');
+const globalOptionsSchema = require('./commands-schema/common-options/global');
 
-const baseArgsSchema = {
-  boolean: new Set(['help', 'help-interactive', 'use-local-credentials', 'v', 'version']),
-  string: new Set(['app', 'config', 'org', 'stage']),
-  alias: new Map([
-    ['c', 'config'],
-    ['h', 'help'],
-  ]),
-};
+const paramRe =
+  /^-(?:-(?<fullName>[a-zA-Z][A-Za-z0-9:_-]+)|(?<aliasNames>[a-z]+))(?:=(?<value>.*)|$)/;
+const isParamName = RegExp.prototype.test.bind(paramRe);
 
 const resolveArgsSchema = (commandOptionsSchema) => {
   const options = { boolean: new Set(), string: new Set(), alias: new Map(), multiple: new Set() };
@@ -38,35 +34,16 @@ const resolveArgsSchema = (commandOptionsSchema) => {
 module.exports = memoizee((commandsSchema = require('./commands-schema')) => {
   commandsSchema = ensureMap(commandsSchema);
   const args = process.argv.slice(2);
+  const firstParamIndex = args.findIndex(isParamName);
 
-  // Ideally no options should be passed before command (to know what options are supported,
-  // and whether they're boolean or not, we need to know command name upfront).
-  // Still so far we (kind of) supported such notation and we need to maintain it in current major.
-  // Thefore at first resolution stage we use schema that recognizes just some popular options
-  let options = parseArgs(args, baseArgsSchema);
-  let commands = options._;
+  const commands = args.slice(0, firstParamIndex === -1 ? Infinity : firstParamIndex);
+  const command = commands.join(' ');
+  const commandSchema = commandsSchema.get(command);
+  const options = parseArgs(
+    args.slice(firstParamIndex === -1 ? Infinity : firstParamIndex),
+    resolveArgsSchema(commandSchema ? commandSchema.options : globalOptionsSchema)
+  );
   delete options._;
-
-  let command = commands.join(' ');
-
-  // Having command potentially resolved, resolve options again with help of the command schema
-  let commandSchema = commandsSchema.get(command);
-  while (commandSchema) {
-    const resolvedOptions = parseArgs(args, resolveArgsSchema(commandSchema.options));
-    const resolvedCommand = resolvedOptions._.join(' ');
-    if (resolvedCommand === command) {
-      options = resolvedOptions;
-      commands = options._;
-      delete options._;
-      break;
-    }
-    // Unlikely scenario, where after applying the command schema different command resolves
-    // It can happen only in cases where e.g. for "sls deploy --force  function -f foo"
-    // we initially assume "deploy" command, while after applying "deploy" command schema it's
-    // actually a "deploy function" command that resolves
-    command = resolvedCommand;
-    commandSchema = commandsSchema.get(resolvedCommand);
-  }
 
   const result = { commands, options, command, commandSchema, commandsSchema };
   if (!commandSchema) {
@@ -86,17 +63,6 @@ module.exports = memoizee((commandsSchema = require('./commands-schema')) => {
     command === 'help'
   ) {
     result.isHelpRequest = true;
-    return result;
-  }
-
-  const argsString = args.join(' ');
-  if (command && argsString !== command && !argsString.startsWith(`${command} `)) {
-    // Some options were passed before command name (e.g. "sls -v deploy"), deprecate such usage
-    require('../utils/logDeprecation')(
-      'CLI_OPTIONS_BEFORE_COMMAND',
-      '"serverless" command options are expected to follow command and not be put before the command.\n' +
-        'Starting from next major Serverless will no longer support the latter form.'
-    );
   }
 
   return result;

--- a/test/unit/lib/cli/resolve-input.test.js
+++ b/test/unit/lib/cli/resolve-input.test.js
@@ -33,7 +33,7 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
     });
 
     it('should resolve commands', async () => {
-      expect(data.commands).to.deep.equal(['cmd1', 'cmd2', 'ver', 'h', 'elo', 'other']);
+      expect(data.commands).to.deep.equal(['cmd1', 'cmd2']);
     });
 
     it('should recognize --version as boolean', async () => {
@@ -46,46 +46,6 @@ describe('test/unit/lib/cli/resolve-input.test.js', () => {
 
     it('should recognize --config', async () => {
       expect(data.options.config).to.equal('conf');
-    });
-
-    describe('"-v" handling', () => {
-      before(() => {
-        resolveInput.clear();
-        data = overrideArgv(
-          {
-            args: ['serverless', 'cmd1', 'cmd2', '-v', 'ver', 'other'],
-          },
-          () => resolveInput()
-        );
-      });
-      it('should not recognize as version alias', async () => {
-        expect(data.options).to.not.have.property('version');
-      });
-      it('should recognize as boolean', async () => {
-        expect(data.options.v).to.equal(true);
-      });
-    });
-
-    describe('Command with initially not recognized boolean', () => {
-      before(() => {
-        resolveInput.clear();
-        data = overrideArgv(
-          {
-            args: ['serverless', 'deploy', '--force', 'function', '-f', 'foo'],
-          },
-          () => resolveInput()
-        );
-      });
-
-      it('should recognize target command', async () => {
-        expect(data).to.deep.equal({
-          commandSchema: commandsSchema.get('deploy function'),
-          command: 'deploy function',
-          commands: ['deploy', 'function'],
-          options: { force: true, function: 'foo' },
-          commandsSchema,
-        });
-      });
     });
   });
 


### PR DESCRIPTION
Supporting options at every point lead to ambiguous results and made parsing logic more convoluted.

This patch improves the CLI parsing landscape