### PR TITLE
v3: Remove evaluation of deprecated lifecycle events

### DIFF
--- a/lib/classes/PluginManager.js
+++ b/lib/classes/PluginManager.js
@@ -324,17 +324,7 @@ class PluginManager {
     if (pluginInstance.commands) {
       Object.entries(pluginInstance.commands).forEach(([key, details]) => {
         const command = this.loadCommand(pluginName, details, key);
-        // Grab and extract deprecated events
-        command.lifecycleEvents = (command.lifecycleEvents || []).map((event) => {
-          if (event.startsWith('deprecated#')) {
-            // Extract event and optional redirect
-            const transformedEvent = /^deprecated#(.*?)(?:->(.*?))?$/.exec(event);
-            this.deprecatedEvents[`${command.key}:${transformedEvent[1]}`] =
-              transformedEvent[2] || null;
-            return transformedEvent[1];
-          }
-          return event;
-        });
+        if (!command.lifecycleEvents) command.lifecycleEvents = [];
         this.commands[key] = mergeCommands(
           this.commands[key],
           _.merge({}, command, {

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -36,16 +36,7 @@ commands.set('deploy', {
     },
   },
   // TODO: Remove deprecated events with v3
-  lifecycleEvents: [
-    'deprecated#cleanup->package:cleanup',
-    'deprecated#initialize->package:initialize',
-    'deprecated#setupProviderConfiguration->package:setupProviderConfiguration',
-    'deprecated#createDeploymentArtifacts->package:createDeploymentArtifacts',
-    'deprecated#compileFunctions->package:compileFunctions',
-    'deprecated#compileEvents->package:compileEvents',
-    'deploy',
-    'finalize',
-  ],
+  lifecycleEvents: ['deploy', 'finalize'],
 });
 
 commands.set('deploy function', {


### PR DESCRIPTION
Lifecycle events marked as deprecated (in context of v1) are no longer evaluated.

They were deprecated in the very early stage of v1, and no known plugins ever relied on them. Currently it's just noise in codebase, good to have cleaned up
