### PR TITLE
v3: Deprecate `deploy -f` 

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -36,6 +36,14 @@ Note:
 - In service configuration setting is ineffective for deprecations reported before service configuration is read.
 - `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
 
+<a name="CLI_DEPLOY_FUNCTION_OPTION_V3"><div>&nbsp;</div></a>
+
+## CLI `--function`/`-f` option for `deploy` command
+
+Deprecation code: `CLI_DEPLOY_FUNCTION_OPTION_V3`
+
+Starting with `v4.0.0`, `--function` or `-f` option for `deploy` command will no longer be supported. In order to deploy a single function, please use `deploy function` command instead.
+
 <a name="LAMBDA_HASHING_VERSION_PROPERTY"><div>&nbsp;</div></a>
 
 ## Property `provider.lambdaHashingVersion`

--- a/lib/cli/commands-schema/aws-service.js
+++ b/lib/cli/commands-schema/aws-service.js
@@ -21,10 +21,6 @@ commands.set('deploy', {
       usage: 'Forces a deployment to take place',
       type: 'boolean',
     },
-    'function': {
-      usage: "Function name. Deploys a single function. DEPRECATED: use 'deploy function' instead.",
-      shortcut: 'f',
-    },
     'aws-s3-accelerate': {
       usage: 'Enables S3 Transfer Acceleration making uploading artifacts much faster.',
       type: 'boolean',

--- a/lib/cli/param-reg-exp.js
+++ b/lib/cli/param-reg-exp.js
@@ -1,0 +1,4 @@
+'use strict';
+
+module.exports =
+  /^-(?:-(?<fullName>[a-zA-Z][A-Za-z0-9:_-]+)|(?<aliasNames>[a-z]+))(?:=(?<value>.*)|$)/;

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -3,10 +3,9 @@
 'use strict';
 
 const ServerlessError = require('../serverless-error');
+const paramRegExp = require('./param-reg-exp');
 
-const paramRe =
-  /^-(?:-(?<fullName>[a-zA-Z][A-Za-z0-9:_-]+)|(?<aliasNames>[a-z]+))(?:=(?<value>.*)|$)/;
-const isParamName = RegExp.prototype.test.bind(paramRe);
+const isParamName = RegExp.prototype.test.bind(paramRegExp);
 
 module.exports = (
   args,
@@ -19,7 +18,7 @@ module.exports = (
       result._.push(...args.slice(i + 1));
       break;
     }
-    const paramMatch = arg.match(paramRe);
+    const paramMatch = arg.match(paramRegExp);
     if (!paramMatch) {
       result._.push(arg);
       continue;

--- a/lib/cli/resolve-input.js
+++ b/lib/cli/resolve-input.js
@@ -7,9 +7,7 @@ const memoizee = require('memoizee');
 const parseArgs = require('./parse-args');
 const globalOptionsSchema = require('./commands-schema/common-options/global');
 
-const paramRe =
-  /^-(?:-(?<fullName>[a-zA-Z][A-Za-z0-9:_-]+)|(?<aliasNames>[a-z]+))(?:=(?<value>.*)|$)/;
-const isParamName = RegExp.prototype.test.bind(paramRe);
+const isParamName = RegExp.prototype.test.bind(require('./param-reg-exp'));
 
 const resolveArgsSchema = (commandOptionsSchema) => {
   const options = { boolean: new Set(), string: new Set(), alias: new Map(), multiple: new Set() };

--- a/lib/plugins/deploy.js
+++ b/lib/plugins/deploy.js
@@ -2,8 +2,6 @@
 
 const ServerlessError = require('../serverless-error');
 const cliCommandsSchema = require('../cli/commands-schema');
-const { logWarning } = require('../classes/Error');
-const { log } = require('@serverless/utils/log');
 
 class Deploy {
   constructor(serverless, options) {
@@ -31,34 +29,11 @@ class Deploy {
     };
 
     this.hooks = {
-      'initialize': () => {
-        if (
-          this.serverless.processedInput.commands.join(' ') === 'deploy' &&
-          this.options.function
-        ) {
-          logWarning(
-            'Please use "deploy function -f" command directly. Support for "deploy -f" alias is likely to be removed in the future.'
-          );
-          log.warning(
-            'Please use "deploy function -f" command directly. Support for "deploy -f" alias is likely to be removed in the future.'
-          );
-        }
-      },
       'before:deploy:deploy': async () => {
         const provider = this.serverless.service.provider.name;
         if (!this.serverless.getProvider(provider)) {
           const errorMessage = `The specified provider "${provider}" does not exist.`;
           throw new ServerlessError(errorMessage, 'INVALID_PROVIDER');
-        }
-
-        if (this.options.function) {
-          // If the user has given a function parameter, spawn a function deploy
-          // and terminate execution right afterwards. We did not enter the
-          // deploy lifecycle yet, so nothing has to be cleaned up.
-          await this.serverless.pluginManager.spawn('deploy:function', {
-            terminateLifecycleAfterExecution: true,
-          });
-          return;
         }
 
         if (!this.options.package && !this.serverless.service.package.path) {

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -108,10 +108,27 @@ const humanizePropertyPathKeys = require('../lib/configuration/variables/humaniz
 const processBackendNotificationRequest = require('../lib/utils/processBackendNotificationRequest');
 const logDeprecation = require('../lib/utils/logDeprecation');
 
+const rewriteDeployFunctionParam = () => {
+  const isParamName = RegExp.prototype.test.bind(require('../lib/cli/param-reg-exp'));
+
+  const args = process.argv.slice(2);
+  const firstParamIndex = args.findIndex(isParamName);
+  const commands = args.slice(0, firstParamIndex === -1 ? Infinity : firstParamIndex);
+  if (commands.join(' ') !== 'deploy') return;
+  if (!args.includes('-f') && !args.includes('--function')) return;
+  logDeprecation(
+    'CLI_DEPLOY_FUNCTION_OPTION_V3',
+    'Starting with v4.0.0, `--function` or `-f` option for `deploy` command will no longer be supported. In order to deploy a single function, please use `deploy function` command instead.'
+  );
+  process.argv.splice(3, 0, 'function');
+};
+
 const processSpanPromise = (async () => {
   try {
     const wait = require('timers-ext/promise/sleep');
     await wait(); // Ensure access to "processSpanPromise"
+
+    rewriteDeployFunctionParam();
 
     const resolveInput = require('../lib/cli/resolve-input');
 

--- a/test/unit/lib/plugins/deploy.test.js
+++ b/test/unit/lib/plugins/deploy.test.js
@@ -79,22 +79,6 @@ describe('Deploy', () => {
       );
     });
 
-    it('should execute deploy function if a function option is given', () => {
-      deploy.options.package = false;
-      deploy.options.function = 'myfunc';
-      deploy.serverless.service.package.path = false;
-
-      return expect(deploy.hooks['before:deploy:deploy']()).to.be.fulfilled.then(() =>
-        BbPromise.all([
-          expect(spawnPackageStub).to.not.be.called,
-          expect(spawnDeployFunctionStub).to.be.calledOnce,
-          expect(spawnDeployFunctionStub).to.be.calledWithExactly('deploy:function', {
-            terminateLifecycleAfterExecution: true,
-          }),
-        ])
-      );
-    });
-
     it('should throw an error if provider does not exist', () => {
       deploy.serverless.service.provider.name = 'nonExistentProvider';
 


### PR DESCRIPTION
Additionally, remove `--function` option documentation from `deploy` help