### PR TITLE
CLI: Do not crash on help request when invalid options

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -80,7 +80,7 @@ Starting with `v3.0.0`, it will not be possible to disable default export names 
 
 ## CLI `--function`/`-f` option for `deploy` command
 
-Deprecation code: `CLI_DEPLOY_FUNCTION_OPTION'`
+Deprecation code: `CLI_DEPLOY_FUNCTION_OPTION`
 
 _Note: We've resigned from this deprecation in the context of v2 (it'll be re-added in the context of v3). We continue to advise using `deploy function -f` command instead of `deploy -f`._
 
@@ -106,7 +106,7 @@ When external API Gateway resource is used and imported via `provider.apiGateway
 
 ## CLI Options extensions, `type` requirement
 
-Deprecation code: `CLI_OPTIONS_SCHEMA'`
+Deprecation code: `CLI_OPTIONS_SCHEMA`
 
 Internal handling of CLI arguments was improved with type awareness for options. Now each option definition is expected have `type` defined in its settings.
 

--- a/lib/cli/parse-args.js
+++ b/lib/cli/parse-args.js
@@ -14,6 +14,7 @@ module.exports = (
 ) => {
   const result = Object.create(null);
   result._ = [];
+  const isHelpRequest = args.includes('-h') || args.includes('--help');
   for (let i = 0, arg; (arg = args[i]); ++i) {
     if (arg === '--') {
       result._.push(...args.slice(i + 1));
@@ -32,6 +33,7 @@ module.exports = (
     if (aliasNames) {
       if (aliasNames.length > 1) {
         if (value != null) {
+          if (isHelpRequest) return result;
           throw new ServerlessError(
             `Unexpected value for "-${aliasNames}"`,
             'UNEXPECTED_CLI_PARAM_VALUE'
@@ -40,6 +42,7 @@ module.exports = (
         for (const aliasName of aliasNames) {
           paramName = alias.get(aliasName) || aliasName;
           if (result[paramName] != null) {
+            if (isHelpRequest) return result;
             throw new ServerlessError(
               `Unexpected multiple "--${paramName}" (aliased by "-${aliasName}") values`,
               'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'
@@ -56,6 +59,7 @@ module.exports = (
 
     if (string.has(paramName) || multiple.has(paramName)) {
       if (isBoolean) {
+        if (isHelpRequest) return result;
         throw new ServerlessError(`Unexpected boolean "--${paramName}"`, 'MISSING_CLI_PARAM_VALUE');
       }
       if (multiple.has(paramName)) {
@@ -64,6 +68,7 @@ module.exports = (
         continue;
       }
       if (result[paramName] !== undefined) {
+        if (isHelpRequest) return result;
         throw new ServerlessError(
           `Unexpected multiple "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'
@@ -76,12 +81,14 @@ module.exports = (
     if (paramName.startsWith('no-') && (boolean.has(paramName.slice(3)) || isBoolean)) {
       paramName = paramName.slice(3);
       if (value != null) {
+        if (isHelpRequest) return result;
         throw new ServerlessError(
           `Unexpected value for "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_VALUE'
         );
       }
       if (result[paramName] !== undefined) {
+        if (isHelpRequest) return result;
         throw new ServerlessError(
           `Unexpected multiple "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'
@@ -93,12 +100,14 @@ module.exports = (
 
     if (boolean.has(paramName) || isBoolean) {
       if (value != null) {
+        if (isHelpRequest) return result;
         throw new ServerlessError(
           `Unexpected value for "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_VALUE'
         );
       }
       if (result[paramName] !== undefined) {
+        if (isHelpRequest) return result;
         throw new ServerlessError(
           `Unexpected multiple "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'
@@ -112,6 +121,7 @@ module.exports = (
       if (Array.isArray(result[paramName])) {
         result[paramName].push(value == null ? args[++i] : value || null);
       } else if (typeof result[paramName] === 'boolean') {
+        if (isHelpRequest) return result;
         throw new ServerlessError(
           `Unexpected multiple "--${paramName}"`,
           'UNEXPECTED_CLI_PARAM_MULTIPLE_VALUE'

--- a/test/unit/lib/cli/parse-args.test.js
+++ b/test/unit/lib/cli/parse-args.test.js
@@ -139,6 +139,11 @@ describe('test/unit/lib/cli/parse-args.test.js', () => {
     expect(parsedArgs).to.deep.equal({});
   });
 
+  it('should not throw if -h or --help param', () => {
+    parseArgs(['-ab=foo', '--help'], {});
+    parseArgs(['--boolean=value', '-h'], { boolean: new Set(['boolean']) });
+  });
+
   it('should reject value for mutliple boolean properties alias', () =>
     expect(() => parseArgs(['-ab=foo'], {}))
       .to.throw(ServerlessError)


### PR DESCRIPTION
When `--help` or `-h` flag is passed, we should unconditionally show help