### PR TITLE
fix(Plugins): Upgrade log4j to version 2.16.0

### DIFF
--- a/lib/plugins/create/templates/aws-java-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-java-maven/pom.xml
@@ -22,12 +22,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.15.0</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.15.0</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-maven/pom.xml
@@ -46,12 +46,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Additional fixes had to be introduced to log4j to address the zero day attack vulnerability.  Hopefully this will be the end of it.

Closes: https://github.com/serverless/serverless/issues/10337
