### PR TITLE
fix(aws apiGateway): restApiRootResourceId is required when restApId is configured

### DIFF
--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.js
@@ -41,6 +41,14 @@ module.exports = {
   validate() {
     const events = [];
     const corsPreflight = {};
+    const apiGateway = this.serverless.service.provider.apiGateway;
+
+    if (apiGateway && apiGateway.restApiId && !apiGateway.restApiRootResourceId) {
+      throw new ServerlessError(
+        'Missing required "provider.apiGateway.restApiRootResourceId" property (needed if "provider.apiGateway.restApiId" is provided)',
+        'API_GATEWAY_MISSING_REST_API_ROOT_RESOURCE_ID'
+      );
+    }
 
     Object.entries(this.serverless.service.functions).forEach(([functionName, functionObject]) => {
       (functionObject.events || []).forEach((event) => {

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -8,6 +8,9 @@ const Serverless = require('../../../../../../../../../../lib/Serverless');
 const AwsProvider = require('../../../../../../../../../../lib/plugins/aws/provider');
 const ServerlessError = require('../../../../../../../../../../lib/serverless-error');
 
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+
 describe('#validate()', () => {
   let serverless;
   let awsCompileApigEvents;
@@ -1470,5 +1473,37 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/valida
       getApiGatewayMethod('/cors-default-set-by-object', 'OPTIONS').Properties.Integration
         .IntegrationResponses[0].ResponseParameters
     ).to.deep.eq(expected);
+  });
+
+  it('should throw an error when restApiRootResourceId is not provided with restApiId', async () => {
+    await expect(
+      runServerless({
+        fixture: 'function',
+        command: 'package',
+        configExt: {
+          provider: {
+            apiGateway: {
+              restApiId: 'ivrcdpj7y2'
+            },
+          },
+          functions: {
+            first: {
+              handler: 'index.handler',
+              events: [
+                {
+                  http: {
+                    method: 'GET',
+                    path: 'foo/bar',
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    ).to.be.eventually.rejected.and.have.property(
+      'code',
+      'API_GATEWAY_MISSING_REST_API_ROOT_RESOURCE_ID'
+    );
   });
 });

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/validate.test.js
@@ -1483,7 +1483,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/valida
         configExt: {
           provider: {
             apiGateway: {
-              restApiId: 'ivrcdpj7y2'
+              restApiId: 'ivrcdpj7y2',
             },
           },
           functions: {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/master/test/README.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/master/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #8515 
