### PR TITLE
update log4j dependencies.

### DIFF
--- a/lib/plugins/create/templates/aws-kotlin-jvm-gradle/build.gradle
+++ b/lib/plugins/create/templates/aws-kotlin-jvm-gradle/build.gradle
@@ -35,9 +35,9 @@ dependencies {
   api (
       'org.jetbrains.kotlin:kotlin-stdlib:1.3.72',
       'com.amazonaws:aws-lambda-java-core:1.2.1',
-      'com.amazonaws:aws-lambda-java-log4j2:1.2.0',
-      'org.apache.logging.log4j:log4j-api:2.16.0',
-      'org.apache.logging.log4j:log4j-core:2.16.0',
+      'com.amazonaws:aws-lambda-java-log4j2:1.5.0',
+      'org.apache.logging.log4j:log4j-api:2.17.0',
+      'org.apache.logging.log4j:log4j-core:2.17.0',
       'com.fasterxml.jackson.core:jackson-core:2.11.0',
       'com.fasterxml.jackson.core:jackson-databind:2.11.0',
       'com.fasterxml.jackson.core:jackson-annotations:2.11.0'


### PR DESCRIPTION
Updated log4j-api, log4j-core to 2.17.0, aws-lambda-java-log4j2 to 1.5.0

  #10370 
Addresses: 10370 
