### PR TITLE
v3: CLI:  Deprecate missing options schema

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -36,6 +36,20 @@ Note:
 - In service configuration setting is ineffective for deprecations reported before service configuration is read.
 - `SLS_DEPRECATION_DISABLE` env var and `disabledDeprecations` configuration setting remain respected, and no errors will be thrown for mentioned deprecation coodes.
 
+<a name="CLI_OPTIONS_SCHEMA_V3"><div>&nbsp;</div></a>
+
+## CLI Options extensions, `type` requirement
+
+Deprecation code: `CLI_OPTIONS_SCHEMA_V3`
+
+Internal handling of CLI arguments was improved with type awareness for options. Now each option definition is expected have `type` defined in its settings.
+
+Possible values are `string`, `boolean` and `multiple`. Check [Defining options](/framework/docs/providers/aws/guide/plugins#defining-options) documentation for more info.
+
+If you rely on a plugin which does not set types (yet) please report the issue at its issue tracker.
+
+Starting with v4.0.0 any option extensions which does not have `type` defined will be communicated with a thrown error
+
 <a name="PROVIDER_IAM_SETTINGS_V3"><div>&nbsp;</div></a>
 
 ## Grouping IAM settings under `provider.iam`

--- a/lib/cli/commands-schema/resolve-final.js
+++ b/lib/cli/commands-schema/resolve-final.js
@@ -8,10 +8,9 @@ const serviceCommands = require('./service');
 const awsServiceCommands = require('./aws-service');
 const serviceOptions = require('./common-options/service');
 const awsServiceOptions = require('./common-options/aws-service');
-const { logWarning } = require('../../classes/Error');
-const { log } = require('@serverless/utils/log');
+const logDeprecation = require('../../utils/logDeprecation');
 
-module.exports = (loadedPlugins, { providerName }) => {
+module.exports = (loadedPlugins, { providerName, configuration }) => {
   const commands = new Map(providerName === 'aws' ? awsServiceCommands : serviceCommands);
 
   if (providerName !== 'aws') {
@@ -108,25 +107,18 @@ module.exports = (loadedPlugins, { providerName }) => {
   for (const loadedPlugin of loadedPlugins) resolveCommands(loadedPlugin, loadedPlugin);
 
   if (missingOptionTypes.size) {
-    logWarning(
+    logDeprecation(
+      'CLI_OPTIONS_SCHEMA_V3',
       'CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). ' +
         'Below listed plugins do not predefine type for introduced options:\n' +
         ` - ${Array.from(
           missingOptionTypes,
           ([plugin, optionNames]) =>
             `${plugin.constructor.name} for "${Array.from(optionNames).join('", "')}"`
-        ).join('\n - ')}\n\n` +
-        'Please report this issue in plugin issue tracker.'
-    );
-    log.warning(
-      'CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). ' +
-        'Plugins listed below do not predefine type for introduced options:\n' +
-        ` - ${Array.from(
-          missingOptionTypes,
-          ([plugin, optionNames]) =>
-            `${plugin.constructor.name} for "${Array.from(optionNames).join('", "')}"`
-        ).join('\n - ')}\n\n` +
-        'Please report this issue in issue tracker of the corresponding plugin.\n'
+        ).join('\n - ')}\n` +
+        'Please report this issue in plugin issue tracker.\n' +
+        'Starting with next major release, this will be communicated with a thrown error.',
+      { serviceConfig: configuration }
     );
   }
 


### PR DESCRIPTION
Bring back deprecation removed in context of v2 

(Complement to: #10348)