### PR TITLE
v3: Support `params` configuration

### DIFF
--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -86,6 +86,14 @@ const schema = {
       },
       additionalProperties: false,
     },
+    params: {
+      patternProperties: {
+        [stagePattern]: {
+          type: 'object',
+        },
+      },
+      additionalProperties: false,
+    },
     plugins: {
       anyOf: [
         {

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const functionNamePattern = '^[a-zA-Z0-9-_]+$';
+const stagePattern = '^[a-zA-Z0-9-]+$';
 
 const schema = {
   type: 'object',
@@ -149,6 +150,7 @@ const schema = {
       pattern: functionNamePattern,
     },
     serviceName: { type: 'string', pattern: '^[a-zA-Z][0-9a-zA-Z-]+$' },
+    stage: { type: 'string', pattern: stagePattern },
   },
 };
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1141,7 +1141,7 @@ class AwsProvider {
               type: 'object',
               additionalProperties: require('./package/compile/events/s3/configSchema'),
             },
-            stage: { type: 'string' },
+            stage: { $ref: '#/definitions/stage' },
             stackName: {
               type: 'string',
               pattern: '^[a-zA-Z][a-zA-Z0-9-]*$',


### PR DESCRIPTION
The actual implementation is placed at https://github.com/serverless/dashboard-plugin/pull/648 here we just need to recognize the `params` property in the configuration schema.

Additionally restricted `stage` with pattern validation. Not setting this was overlooked in the context of v2, hence it's now better to add it in v3 (it's a safe change, I've browsed stage values in mixpanel and all I've scrolled through fit the proposed pattern, also stage name as used in stack name and resource names is already restricted by AWS naming rules)

