### PR TITLE
fix(AWS Deploy): Check for VPC config change in `deploy function`

### DIFF
--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -361,14 +361,16 @@ class AwsDeployFunction {
       const didVpcChange = () => {
         const remoteConfigToCompare = { SecurityGroupIds: [], SubnetIds: [] };
         if (remoteFunctionConfiguration.VpcConfig) {
-          remoteConfigToCompare.SecurityGroupIds =
-            remoteFunctionConfiguration.VpcConfig.SecurityGroupIds || [];
-          remoteConfigToCompare.SubnetIds = remoteFunctionConfiguration.VpcConfig.SubnetIds || [];
+          remoteConfigToCompare.SecurityGroupIds = new Set(
+            remoteFunctionConfiguration.VpcConfig.SecurityGroupIds || []
+          );
+          remoteConfigToCompare.SubnetIds = new Set(
+            remoteFunctionConfiguration.VpcConfig.SubnetIds || []
+          );
         }
         const localConfigToCompare = {
-          SecurityGroupIds: [],
-          SubnetIds: [],
-          ...params.VpcConfig,
+          SecurityGroupIds: new Set(params.VpcConfig.SecurityGroupIds || []),
+          SubnetIds: new Set(params.VpcConfig.SubnetIds || []),
         };
         return _.isEqual(remoteConfigToCompare, localConfigToCompare);
       };

--- a/test/unit/lib/plugins/aws/deployFunction.test.js
+++ b/test/unit/lib/plugins/aws/deployFunction.test.js
@@ -792,7 +792,7 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
               VpcConfig: {
                 VpcId: 'vpc-xxxx',
                 SecurityGroupIds: ['sg-111', 'sg-222'],
-                SubnetIds: ['subnet-111', 'subnet-222'],
+                SubnetIds: ['subnet-222', 'subnet-111'],
               },
             },
           },


### PR DESCRIPTION
Ensure that ordering does not matter when comparing VPC-related values. 
