### PR TITLE
docs: Fix long lines in code examples

### DIFF
--- a/docs/providers/aws/cli-reference/config-credentials.md
+++ b/docs/providers/aws/cli-reference/config-credentials.md
@@ -43,7 +43,11 @@ This example will configure the `default` profile with the `aws_access_key_id` o
 ### Configure a custom profile
 
 ```bash
-serverless config credentials --provider aws --key 1234 --secret 5678 --profile custom-profile
+serverless config credentials \
+  --provider aws \
+  --key 1234 \
+  --secret 5678 \
+  --profile custom-profile
 ```
 
 This example create and configure a `custom-profile` profile with the `aws_access_key_id` of `1234` and the `aws_secret_access_key` of `5678`.
@@ -51,7 +55,12 @@ This example create and configure a `custom-profile` profile with the `aws_acces
 ### Update an existing profile
 
 ```bash
-serverless config credentials --provider aws --key 1234 --secret 5678 --profile custom-profile --overwrite
+serverless config credentials \
+  --provider aws \
+  --key 1234 \
+  --secret 5678 \
+  --profile custom-profile \
+  --overwrite
 ```
 
 This example overwrite `custom-profile` profile with the `aws_access_key_id` of `1234` and the `aws_secret_access_key` of `5678`.

--- a/docs/providers/aws/cli-reference/config.md
+++ b/docs/providers/aws/cli-reference/config.md
@@ -29,12 +29,12 @@ The purpose of `serverless config` is to allow to enable or disable automatic up
 
 ### Turn on auto update mechanism
 
-```
+```bash
 serverless config --autoupdate
 ```
 
 ### Turn off auto update mechanism
 
-```
+```bash
 serverless config --no-autoupdate
 ```

--- a/docs/providers/aws/cli-reference/create.md
+++ b/docs/providers/aws/cli-reference/create.md
@@ -16,22 +16,24 @@ layout: Doc
 
 Creates a new service in the current working directory based on the provided template.
 
-**Create service in current working directory:**
+**Create a service in the current working directory:**
 
 ```bash
 serverless create --template aws-nodejs
 ```
 
-**Create service in new folder:**
+**Create a service in a new folder:**
 
 ```bash
 serverless create --template aws-nodejs --path myService
 ```
 
-**Create service in new folder using a custom template:**
+**Create a service in a new folder using a custom template:**
 
 ```bash
-serverless create --template-url https://github.com/serverless/serverless/tree/master/lib/plugins/create/templates/aws-nodejs --path myService
+serverless create \
+  --template-url https://github.com/serverless/serverless/tree/master/lib/plugins/create/templates/aws-nodejs \
+  --path myService
 ```
 
 ## Options
@@ -106,7 +108,10 @@ renamed to `my-new-service`.
 ### Creating a new service using a local template
 
 ```bash
-serverless create --template-path path/to/my/template/folder --path path/to/my/service --name my-new-service
+serverless create \
+  --template-path path/to/my/template/folder \
+  --path path/to/my/service \
+  --name my-new-service
 ```
 
 This will copy the `path/to/my/template/folder` folder into `path/to/my/service` and rename the service to `my-new-service`.

--- a/docs/providers/aws/cli-reference/deploy-function.md
+++ b/docs/providers/aws/cli-reference/deploy-function.md
@@ -43,7 +43,9 @@ serverless deploy function --function helloWorld
 ### Deployment with stage and region options
 
 ```bash
-serverless deploy function --function helloWorld --stage dev --region us-east-1
+serverless deploy function --function helloWorld \
+  --stage dev \
+  --region us-east-1
 ```
 
 ### Deploy only configuration changes

--- a/docs/providers/aws/cli-reference/invoke-local.md
+++ b/docs/providers/aws/cli-reference/invoke-local.md
@@ -98,7 +98,8 @@ serverless invoke local --function functionName --context "hello world"
 ### Local function invocation with context passing
 
 ```bash
-serverless invoke local --function functionName --contextPath lib/context.json
+serverless invoke local --function functionName \
+  --contextPath lib/context.json
 ```
 
 This example will pass the json context in the `lib/context.json` file (relative to the root of the service) while invoking the specified/deployed function.
@@ -110,7 +111,9 @@ serverless invoke local -f functionName -e VAR1=value1
 
 # Or more than one variable
 
-serverless invoke local -f functionName -e VAR1=value1 -e VAR2=value2
+serverless invoke local -f functionName \
+  -e VAR1=value1 \
+  -e VAR2=value2
 ```
 
 When using [AWS CloudFormation intrinsic functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html) as environment variables value, **only Fn::ImportValue and Ref** will be automatically resolved for function invocation. Other intrinsic functions use will result in the corresponding configuration object passed in the function as environment variable.

--- a/docs/providers/aws/cli-reference/invoke.md
+++ b/docs/providers/aws/cli-reference/invoke.md
@@ -72,19 +72,19 @@ output the result of the invocation in your terminal.
 #### Function invocation with data
 
 ```bash
-serverless invoke --function functionName --stage dev --region us-east-1 --data "hello world"
+serverless invoke --function functionName --data "hello world"
 ```
 
 #### Function invocation with custom context
 
 ```bash
-serverless invoke --function functionName --stage dev --region us-east-1 --context "hello world"
+serverless invoke --function functionName --context "hello world"
 ```
 
 #### Function invocation with context passing
 
 ```bash
-serverless invoke --function functionName --stage dev --region us-east-1 --contextPath lib/context.json
+serverless invoke --function functionName --contextPath lib/context.json
 ```
 
 This example will pass the json context in the `lib/context.json` file (relative to the root of the service) while invoking the specified/deployed function.
@@ -92,13 +92,13 @@ This example will pass the json context in the `lib/context.json` file (relative
 #### Function invocation with data from standard input
 
 ```bash
-node dataGenerator.js | serverless invoke --function functionName --stage dev --region us-east-1
+node dataGenerator.js | serverless invoke --function functionName
 ```
 
 #### Function invocation with logging
 
 ```bash
-serverless invoke --function functionName --stage dev --region us-east-1 --log
+serverless invoke --function functionName --log
 ```
 
 Just like the first example, but will also outputs logging information about your invocation.
@@ -106,7 +106,7 @@ Just like the first example, but will also outputs logging information about you
 #### Function invocation with data passing
 
 ```bash
-serverless invoke --function functionName --stage dev --region us-east-1 --path lib/data.json
+serverless invoke --function functionName --path lib/data.json
 ```
 
 This example will pass the json data in the `lib/data.json` file (relative to the root of the service) while invoking
@@ -132,7 +132,8 @@ serverless invoke local --function functionName --context "hello world"
 ### Local function invocation with context passing
 
 ```bash
-serverless invoke local --function functionName --contextPath lib/context.json
+serverless invoke local --function functionName \
+  --contextPath lib/context.json
 ```
 
 This example will pass the json context in the `lib/context.json` file (relative to the root of the service) while invoking the specified/deployed function.

--- a/docs/providers/aws/cli-reference/login.md
+++ b/docs/providers/aws/cli-reference/login.md
@@ -20,7 +20,4 @@ It will create a new serverless platform account if one doesn't already exist.
 
 ```bash
 serverless login
-
-# Shorthand
-sls login
 ```

--- a/docs/providers/aws/cli-reference/logs.md
+++ b/docs/providers/aws/cli-reference/logs.md
@@ -19,7 +19,7 @@ Lets you watch the logs of a specific function.
 ```bash
 serverless logs -f hello
 
-# Optionally tail the logs with -t
+# Optionally tail the logs with --tail or -t
 serverless logs -f hello -t
 ```
 

--- a/docs/providers/aws/cli-reference/metrics.md
+++ b/docs/providers/aws/cli-reference/metrics.md
@@ -59,7 +59,9 @@ Displays all `hello` function metrics for the last 24h.
 ### See metrics for the function `hello` of a specific timespan
 
 ```bash
-serverless metrics --function hello --startTime 2016-01-01 --endTime 2016-01-02
+serverless metrics --function hello \
+  --startTime 2016-01-01 \
+  --endTime 2016-01-02
 ```
 
 Displays all `hello` function metrics for the time between January 1, 2016 and January 2, 2016.

--- a/docs/providers/aws/cli-reference/rollback-function.md
+++ b/docs/providers/aws/cli-reference/rollback-function.md
@@ -17,7 +17,8 @@ layout: Doc
 Rollback a function service to a specific version.
 
 ```bash
-serverless rollback function --function <name> --function-version <version>
+serverless rollback function --function <name> \
+  --function-version <version>
 ```
 
 **Note:** You can only rollback a function which was previously deployed through `serverless deploy`. Functions are not versioned when running `serverless deploy function`.

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -339,7 +339,8 @@ functions:
               - X-Amz-Security-Token
               - X-Amz-User-Agent
             allowCredentials: false
-            cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate' # Caches on browser and proxy for 10 minutes and doesnt allow proxy to serve out of date content
+            # Caches on browser and proxy for 10 minutes and doesnt allow proxy to serve out of date content
+            cacheControl: 'max-age=600, s-maxage=600, proxy-revalidate'
 ```
 
 CORS header accepts single value too
@@ -367,8 +368,10 @@ module.exports.hello = function (event, context, callback) {
   const response = {
     statusCode: 200,
     headers: {
-      'Access-Control-Allow-Origin': '*', // Required for CORS support to work
-      'Access-Control-Allow-Credentials': true, // Required for cookies, authorization headers with HTTPS
+      // Required for CORS support to work
+      'Access-Control-Allow-Origin': '*',
+      // Required for cookies, authorization headers with HTTPS
+      'Access-Control-Allow-Credentials': true,
     },
     body: JSON.stringify({ message: 'Hello World!' }),
   };
@@ -636,10 +639,12 @@ provider:
     apiKeys:
       - myFirstKey
       - ${opt:stage}-myFirstKey
-      - ${env:MY_API_KEY} # you can hide it in a serverless variable
+      # you can hide it in a serverless variable
+      - ${env:MY_API_KEY}
       - name: myThirdKey
         value: myThirdKeyValue
-      - value: myFourthKeyValue # let cloudformation name the key (recommended when setting api key value)
+      # let cloudformation name the key (recommended when setting api key value)
+      - value: myFourthKeyValue
         description: Api key description # Optional
         customerId: A string that will be set as the customerID for the key # Optional
     usagePlan:

--- a/docs/providers/aws/examples/hello-world/csharp/README.md
+++ b/docs/providers/aws/examples/hello-world/csharp/README.md
@@ -31,7 +31,7 @@ Commands
 
 ## 1. Create a service
 
-```
+```bash
 sls create --template aws-csharp --path myService
 ```
 
@@ -41,19 +41,19 @@ The `--path` or shorthand `-p` is the location to be created with the template s
 
 ## 2. Build using .NET Core 3.1 CLI tools and create zip package
 
-```
+```bash
 # Linux or Mac OS
 ./build.sh
 ```
 
-```
+```bash
 # Windows PowerShell
 .\build.cmd
 ```
 
 ## 3. Deploy
 
-```
+```bash
 sls deploy
 ```
 
@@ -61,7 +61,7 @@ This will deploy your function to AWS Lambda based on the settings in `serverles
 
 ## 4. Invoke deployed function
 
-```
+```bash
 sls invoke -f hello
 ```
 
@@ -69,14 +69,14 @@ Invoke deployed function with command `invoke` and `--function` or shorthand `-f
 
 In your terminal window you should see the response from AWS Lambda.
 
-```bash
+```json
 {
-    "Message": "Go Serverless v1.0! Your function executed successfully!",
-    "Request": {
-        "Key1": null,
-        "Key2": null,
-        "Key3": null
-    }
+  "Message": "Go Serverless v1.0! Your function executed successfully!",
+  "Request": {
+    "Key1": null,
+    "Key2": null,
+    "Key3": null
+  }
 }
 ```
 

--- a/docs/providers/aws/examples/hello-world/fsharp/README.md
+++ b/docs/providers/aws/examples/hello-world/fsharp/README.md
@@ -29,7 +29,7 @@ Commands
 
 ## 1. Create a service
 
-```
+```bash
 sls create --template aws-fsharp --path myService
 ```
 
@@ -39,19 +39,19 @@ The `--path` or shorthand `-p` is the location to be created with the template s
 
 ## 2. Build using .NET Core 3.1.x CLI tools and create zip package
 
-```
+```bash
 # Linux or Mac OS
 ./build.sh
 ```
 
-```
+```bash
 # Windows PowerShell
 ./build.cmd
 ```
 
 ## 3. Deploy
 
-```
+```bash
 sls deploy
 ```
 
@@ -59,7 +59,7 @@ This will deploy your function to AWS Lambda based on the settings in `serverles
 
 ## 4. Invoke deployed function
 
-```
+```bash
 sls invoke -f hello
 ```
 
@@ -67,14 +67,14 @@ Invoke deployed function with command `invoke` and `--function` or shorthand `-f
 
 In your terminal window you should see the response from AWS Lambda.
 
-```bash
+```json
 {
-    "Message": "Go Serverless v1.0! Your function executed successfully!",
-    "Request": {
-        "Key1": null,
-        "Key2": null,
-        "Key3": null
-    }
+  "Message": "Go Serverless v1.0! Your function executed successfully!",
+  "Request": {
+    "Key1": null,
+    "Key2": null,
+    "Key3": null
+  }
 }
 ```
 

--- a/docs/providers/aws/examples/hello-world/go/README.md
+++ b/docs/providers/aws/examples/hello-world/go/README.md
@@ -39,7 +39,7 @@ The Serverless Framework includes starter templates for various languages and pr
 
 `aws-go` fetches dependencies using standard `go get`.
 
-```
+```bash
 sls create --template aws-go --path myService
 ```
 
@@ -47,7 +47,7 @@ sls create --template aws-go --path myService
 
 `aws-go-dep` uses [go dep](https://github.com/golang/dep) and requires your project to be in `$GOPATH/src`.
 
-```
+```bash
 sls create --template aws-go-dep --path myService
 ```
 
@@ -55,7 +55,7 @@ sls create --template aws-go-dep --path myService
 
 `aws-go-mod` uses standard [Go modules] and requires your project to be **outside** `$GOPATH` and to use Go 1.13+.
 
-```
+```bash
 sls create --template aws-go-mod --path myService
 ```
 
@@ -88,7 +88,7 @@ Run `make build` to build both functions. Successful build should generate the f
 
 ## 3. Deploy
 
-```
+```bash
 sls deploy
 ```
 
@@ -96,11 +96,11 @@ This will deploy your function to AWS Lambda based on the settings in `serverles
 
 ## 4. Invoke deployed function
 
-```
+```bash
 sls invoke -f hello
 ```
 
-```
+```bash
 sls invoke -f world
 ```
 

--- a/docs/providers/aws/examples/hello-world/node/README.md
+++ b/docs/providers/aws/examples/hello-world/node/README.md
@@ -29,7 +29,7 @@ Commands
 
 ## 1. Create a service
 
-```
+```bash
 sls create --template aws-nodejs --path myService
 ```
 
@@ -39,7 +39,7 @@ The `--path` or shorthand `-p` is the location to be created with the template s
 
 ## 2. Deploy
 
-```
+```bash
 sls deploy
 ```
 
@@ -47,7 +47,7 @@ This will deploy your function to AWS Lambda based on the settings in `serverles
 
 ## 3. Invoke deployed function
 
-```
+```bash
 sls invoke -f hello
 ```
 
@@ -55,10 +55,10 @@ Invoke deployed function with command `invoke` and `--function` or shorthand `-f
 
 In your terminal window you should see the response from AWS Lambda.
 
-```bash
+```json
 {
-    "statusCode": 200,
-    "body": "{\"message\":\"Go Serverless v1.0! Your function executed successfully!\",\"input\":{}}"
+  "statusCode": 200,
+  "body": "{\"message\":\"Go Serverless v1.0! Your function executed successfully!\",\"input\":{}}"
 }
 ```
 

--- a/docs/providers/aws/examples/hello-world/python/README.md
+++ b/docs/providers/aws/examples/hello-world/python/README.md
@@ -29,7 +29,7 @@ Commands
 
 ## 1. Create a service
 
-```
+```bash
 sls create --template aws-python3 --path myService
 ```
 
@@ -39,7 +39,7 @@ The `--path` or shorthand `-p` is the location to be created with the template s
 
 ## 2. Deploy
 
-```
+```bash
 sls deploy
 ```
 
@@ -47,7 +47,7 @@ This will deploy your function to AWS Lambda based on the settings in `serverles
 
 ## 3. Invoke deployed function
 
-```
+```bash
 sls invoke -f hello
 ```
 
@@ -55,10 +55,10 @@ Invoke deployed function with command `invoke` and `--function` or shorthand `-f
 
 In your terminal window you should see the response from AWS Lambda.
 
-```bash
+```json
 {
-    "statusCode": 200,
-    "body": "{\"message\":\"Go Serverless v1.0! Your function executed successfully!\",\"input\":{}}"
+  "statusCode": 200,
+  "body": "{\"message\":\"Go Serverless v1.0! Your function executed successfully!\",\"input\":{}}"
 }
 ```
 

--- a/docs/providers/aws/examples/hello-world/ruby/README.md
+++ b/docs/providers/aws/examples/hello-world/ruby/README.md
@@ -29,7 +29,7 @@ Commands
 
 ## 1. Create a service
 
-```
+```bash
 sls create --template aws-ruby --path myService
 ```
 
@@ -39,7 +39,7 @@ The `--path` or shorthand `-p` is the location to be created with the template s
 
 ## 2. Deploy
 
-```
+```bash
 sls deploy
 ```
 
@@ -47,7 +47,7 @@ This will deploy your function to AWS Lambda based on the settings in `serverles
 
 ## 3. Invoke deployed function
 
-```
+```bash
 sls invoke -f hello
 ```
 

--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -91,7 +91,8 @@ export AWS_SECRET_ACCESS_KEY=<your-secret-key-here>
 # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are now available for serverless to use
 serverless deploy
 
-# 'export' command is valid only for unix shells. In Windows - use 'set' instead of 'export'
+# 'export' command is valid only for unix shells
+# In Windows use 'set' instead of 'export'
 ```
 
 **Please note:** _If you are using a self-signed certificate you'll need to do one of the following:_
@@ -109,8 +110,8 @@ export cafile="/path/to/cafile.pem"
 # or multiple, comma separated
 export cafile="/path/to/cafile1.pem,/path/to/cafile2.pem"
 
-
-# 'export' command is valid only for unix shells. In Windows - use 'set' instead of 'export'
+# 'export' command is valid only for unix shells
+# In Windows use 'set' instead of 'export'
 ```
 
 #### Using AWS Profiles
@@ -124,7 +125,10 @@ Serverless provides a convenient way to configure AWS profiles with the help of 
 Here's an example how you can configure the `default` AWS profile:
 
 ```bash
-serverless config credentials --provider aws --key AKIAIOSFODNN7EXAMPLE --secret wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+serverless config credentials \
+  --provider aws \
+  --key AKIAIOSFODNN7EXAMPLE \
+  --secret wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
 Take a look at the [`config` CLI reference](../cli-reference/config-credentials.md) for more information about credential configuration.

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -24,18 +24,22 @@ In the beginning of an application, many people use a single Service to define a
 
 ```bash
 myService/
-  serverless.yml  # Contains all functions and infrastructure resources
+  # Contains all functions and infrastructure resources
+  serverless.yml
 ```
 
 However, as your application grows, you can break it out into multiple services. A lot of people organize their services by workflows or data models, and group the functions related to those workflows and data models together in the service.
 
 ```bash
 users/
-  serverless.yml # Contains 4 functions that do Users CRUD operations and the Users database
+  # Contains 4 functions that do Users CRUD operations and the Users database
+  serverless.yml
 posts/
-  serverless.yml # Contains 4 functions that do Posts CRUD operations and the Posts database
+  # Contains 4 functions that do Posts CRUD operations and the Posts database
+  serverless.yml
 comments/
-  serverless.yml # Contains 4 functions that do Comments CRUD operations and the Comments database
+  # Contains 4 functions that do Comments CRUD operations and the Comments database
+  serverless.yml
 ```
 
 This makes sense since related functions usually use common infrastructure resources, and you want to keep those functions and resources together as a single unit of deployment, for better organization and separation of concerns.

--- a/docs/providers/aws/guide/workflow.md
+++ b/docs/providers/aws/guide/workflow.md
@@ -45,7 +45,7 @@ A handy list of commands to use when developing with the Serverless Framework.
 
 Creates a new Service
 
-```
+```bash
 serverless create -p [SERVICE NAME] -t aws-nodejs
 ```
 
@@ -53,7 +53,7 @@ serverless create -p [SERVICE NAME] -t aws-nodejs
 
 This is a convenience method to install a pre-made Serverless Service locally by downloading the Github repo and unzipping it.
 
-```
+```bash
 serverless install -u [GITHUB URL OF SERVICE]
 ```
 
@@ -61,7 +61,7 @@ serverless install -u [GITHUB URL OF SERVICE]
 
 Use this when you have made changes to your Functions, Events or Resources in `serverless.yml` or you simply want to deploy all changes within your Service at the same time.
 
-```
+```bash
 serverless deploy -s [STAGE NAME] -r [REGION NAME] -v
 ```
 
@@ -69,7 +69,7 @@ serverless deploy -s [STAGE NAME] -r [REGION NAME] -v
 
 Use this to quickly overwrite your AWS Lambda code on AWS, allowing you to develop faster.
 
-```
+```bash
 serverless deploy function -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME]
 ```
 
@@ -77,14 +77,17 @@ serverless deploy function -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME]
 
 Invokes an AWS Lambda Function on AWS and returns logs.
 
-```
-serverless invoke -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME] -l
+```bash
+serverless invoke -f [FUNCTION NAME] \
+  -s [STAGE NAME] \
+  -r [REGION NAME] \
+  -l
 ```
 
 ##### Streaming Logs
 
 Open up a separate tab in your console and stream all logs for a specific Function using this command.
 
-```
+```bash
 serverless logs -f [FUNCTION NAME] -s [STAGE NAME] -r [REGION NAME]
 ```


### PR DESCRIPTION
As discussed internally, there are some code examples (especially CLI snippets) that don't render well. For example:

<img width="698" alt="image" src="https://user-images.githubusercontent.com/720328/147250986-c27dc86b-3877-439b-a279-8499e65f2dce.png">

I tried to go over the main ones (AWS docs, CLI snippets mostly, I avoided the huge YAML code examples for now) and make these multi-line.