### PR TITLE
v3: Improve post install log to reflect modern style

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "archiver": "^5.3.0",
     "aws-sdk": "^2.1046.0",
     "bluebird": "^3.7.2",
-    "boxen": "^5.1.2",
     "cachedir": "^2.3.0",
     "chalk": "^4.1.2",
     "child-process-ext": "^2.1.1",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const boxen = require('boxen');
 const chalk = require('chalk');
 const isStandaloneExecutable = require('../lib/utils/isStandaloneExecutable');
 
@@ -29,16 +28,5 @@ if (!truthyStr(CI) && !truthyStr(ADBLOCK) && !truthyStr(SILENT)) {
     messageTokens.push('Uninstall at any time by running “serverless uninstall”.');
   }
 
-  const message = messageTokens.join('\n\n');
-  process.stdout.write(
-    `${
-      isStandaloneExecutable && isWindows
-        ? message
-        : boxen(chalk.yellow(message), {
-            padding: 1,
-            margin: 1,
-            borderColor: 'yellow',
-          })
-    }\n`
-  );
+  process.stdout.write(`${chalk.grey(messageTokens.join('\n\n'))}\n`);
 }


### PR DESCRIPTION
At same time drop `boxen` dependency, which takes one step forward, towards addressing #10182