### PR TITLE
CLI: Ensure telemetry logs are issued at debug level

### DIFF
--- a/lib/utils/telemetry/index.js
+++ b/lib/utils/telemetry/index.js
@@ -12,7 +12,7 @@ const { legacy, log } = require('@serverless/utils/log');
 const isTelemetryDisabled = require('./areDisabled');
 const cacheDirPath = require('./cache-path');
 
-const debugLog = log.get('telemetry');
+const telemetryLog = log.get('telemetry');
 
 const timestampWeekBefore = Date.now() - 1000 * 60 * 60 * 24 * 7;
 
@@ -23,7 +23,7 @@ const isUuid = RegExp.prototype.test.bind(
 let serverlessRunEndTime;
 
 const logError = (type, error) => {
-  debugLog('User stats error: %s: %O', type, error);
+  telemetryLog.debug('User stats error: %s: %O', type, error);
   if (!process.env.SLS_STATS_DEBUG) return;
   legacy.log(format('User stats error: %s: %O', type, error));
 };
@@ -42,7 +42,7 @@ const processResponseBody = async (response, ids, startTime) => {
 
   const endTime = Date.now();
   if (serverlessRunEndTime) {
-    debugLog(
+    telemetryLog.debug(
       'Stats request prevented process from exiting for %dms (request time: %dms)',
       endTime - serverlessRunEndTime,
       endTime - startTime


### PR DESCRIPTION
By mistake they were issued at _notice_ level