### PR TITLE
Add forceDeploy property in Cognito User Pools

### DIFF
--- a/docs/providers/aws/events/cognito-user-pool.md
+++ b/docs/providers/aws/events/cognito-user-pool.md
@@ -134,5 +134,21 @@ resources:
       Type: AWS::Cognito::UserPool
 ```
 
+## Forcing deploying of triggers
+
+A Cognito User Pool with triggers attached may not be correctly updated by AWS Cloudformation on subsequent deployments. To circumvent this issue you can use the `forceDeploy` flag which will try to force Cloudformation to update the triggers no matter what. This flag has to be used in conjuction with the `existing: true` flag.
+
+```yml
+functions:
+  preSignUp:
+    handler: preSignUp.handler
+    events:
+      - cognitoUserPool:
+          pool: MyUserPool1
+          trigger: PreSignUp
+          existing: true
+          forceDeploy: true
+```
+
 [aws-triggers-guide]: http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html
 [aws-triggers-list]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -509,6 +509,7 @@ functions:
           pool: MyUserPool
           trigger: PreSignUp
           existing: true # optional, if you're referencing an existing User Pool
+          forceDeploy: true # optional, for forcing deployment of triggers on existing User Pools
       - alb:
           listenerArn: arn:aws:elasticloadbalancing:us-east-1:12345:listener/app/my-load-balancer/50dc6c495c0c9188/
           priority: 1

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool.js
@@ -172,7 +172,7 @@ class AwsCompileCognitoUserPoolEvents {
             }
 
             let customCognitoUserPoolResource;
-            const forceDeployProperty = forceDeploy ? Math.random() * 10 : 0;
+            const forceDeployProperty = forceDeploy ? Date.now() : undefined;
             if (numEventsForFunc === 1) {
               customCognitoUserPoolResource = {
                 [customPoolResourceLogicalId]: {

--- a/lib/plugins/aws/package/compile/events/cognitoUserPool.js
+++ b/lib/plugins/aws/package/compile/events/cognitoUserPool.js
@@ -39,6 +39,7 @@ class AwsCompileCognitoUserPoolEvents {
         pool: { type: 'string', maxLength: 128, pattern: '^[\\w\\s+=,.@-]+$' },
         trigger: { enum: validTriggerSources },
         existing: { type: 'boolean' },
+        forceDeploy: { type: 'boolean' },
       },
       required: ['pool', 'trigger'],
       additionalProperties: false,
@@ -141,7 +142,7 @@ class AwsCompileCognitoUserPoolEvents {
         functionObj.events.forEach((event) => {
           if (event.cognitoUserPool && event.cognitoUserPool.existing) {
             numEventsForFunc++;
-            const { pool, trigger } = event.cognitoUserPool;
+            const { pool, trigger, forceDeploy } = event.cognitoUserPool;
             usesExistingCognitoUserPool = funcUsesExistingCognitoUserPool = true;
 
             if (!currentPoolName) {
@@ -171,6 +172,7 @@ class AwsCompileCognitoUserPoolEvents {
             }
 
             let customCognitoUserPoolResource;
+            const forceDeployProperty = forceDeploy ? Math.random() * 10 : 0;
             if (numEventsForFunc === 1) {
               customCognitoUserPoolResource = {
                 [customPoolResourceLogicalId]: {
@@ -188,6 +190,7 @@ class AwsCompileCognitoUserPoolEvents {
                         Trigger: trigger,
                       },
                     ],
+                    ForceDeploy: forceDeployProperty,
                   },
                 },
               };

--- a/test/unit/lib/plugins/aws/package/compile/events/cognitoUserPool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognitoUserPool.test.js
@@ -346,7 +346,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
       });
     });
 
-    it('should create the necessary resources for the most minimal configuration with forceDeploy', async () => {
+    it('should support `forceDeploy` setting', async () => {
       const result = await runServerless({
         fixture: 'cognitoUserPool',
         configExt: {
@@ -371,8 +371,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
       const customResource =
         Resources[awsNaming.getCustomResourceCognitoUserPoolResourceLogicalId('existingSimple')];
 
-      expect(customResource.Properties.ForceDeploy).to.not.deep.equal(undefined);
-      expect(customResource.Properties.ForceDeploy).to.be.below(Date.now()).and.to.be.above(0);
+      expect(typeof customResource.Properties.ForceDeploy).to.equal('number');
     });
 
     it('should create the necessary resources for a service using multiple event definitions', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/cognitoUserPool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognitoUserPool.test.js
@@ -339,7 +339,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
                 Trigger: 'CustomMessage',
               },
             ],
-            ForceDeploy: 0,
+            ForceDeploy: undefined,
           },
         });
       });
@@ -409,7 +409,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
                 Trigger: 'CustomMessage',
               },
             ],
-            ForceDeploy: 0,
+            ForceDeploy: undefined,
           },
         });
       });
@@ -498,7 +498,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
                 Trigger: 'DefineAuthChallenge',
               },
             ],
-            ForceDeploy: 0,
+            ForceDeploy: undefined,
           },
         });
       });
@@ -628,7 +628,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
                 Trigger: 'DefineAuthChallenge',
               },
             ],
-            ForceDeploy: 0,
+            ForceDeploy: undefined,
           },
         });
         expect(Resources.SecondCustomCognitoUserPool1).to.deep.equal({
@@ -656,7 +656,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
                 Trigger: 'PostAuthentication',
               },
             ],
-            ForceDeploy: 0,
+            ForceDeploy: undefined,
           },
         });
       });


### PR DESCRIPTION
I tried to implement the proposed solution which can be found [here](https://github.com/serverless/serverless/issues/9635#issuecomment-874320921). I added a `forceDeploy` flag that once set will set a random property in the custom resource that is used to attach triggers - if the flag is set to false then it sets the property to `0`. I updated tests as well, and made sure the linter is happy.


Addresses: #9635
