### PR TITLE
test(Config Schema): Improve caching of Ajv validator

### DIFF
--- a/lib/classes/ConfigSchemaHandler/resolveAjvValidate.js
+++ b/lib/classes/ConfigSchemaHandler/resolveAjvValidate.js
@@ -17,8 +17,17 @@ const getCacheDir = () => {
   );
 };
 
+// Validators are cached by schema hash for the purpose
+// of speeding up tests and reducing their memory footprint.
+// If that solution proves to not be enough, we can improve it
+// with `uni-global` package.
+const cachedValidatorsBySchemaHash = {};
+
 const getValidate = async (schema) => {
   const schemaHash = objectHash(deepSortObjectByKey(schema));
+  if (cachedValidatorsBySchemaHash[schemaHash]) {
+    return cachedValidatorsBySchemaHash[schemaHash];
+  }
   const filename = `${schemaHash}.js`;
   const cachePath = path.resolve(getCacheDir(), filename);
 
@@ -38,10 +47,12 @@ const getValidate = async (schema) => {
   };
   await ensureExists(cachePath, generate);
   const loadedModuleCode = await fs.promises.readFile(cachePath, 'utf-8');
-  return requireFromString(
+  const validator = requireFromString(
     loadedModuleCode,
     path.resolve(__dirname, `[generated-ajv-validate]${filename}`)
   );
+  cachedValidatorsBySchemaHash[schemaHash] = validator;
+  return validator;
 };
 
 module.exports = getValidate;


### PR DESCRIPTION
Reported internally, to avoid memory leaks in tests