### PR TITLE
v3: CLI: Remove `@serverless/cli` CLI integration 

### DIFF
--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -56,7 +56,20 @@ if (require('../lib/utils/isStandaloneExecutable')) {
       }
       return;
     case '@serverless/cli':
-      require('@serverless/cli').runComponents();
+      {
+        const chalk = require('chalk');
+        process.stdout.write(
+          `${[
+            'Serverless Components CLI v1 is no longer bundled with Serverless Framework CLI',
+            '',
+            "To run it, ensure it's installed:",
+            chalk.bold('npm install -g @serverless/cli'),
+            '',
+            'Then run:',
+            chalk.bold('components-v1 <command> <options>'),
+          ].join('\n')}\n`
+        );
+      }
       return;
     default:
       throw new Error(`Unrecognized CLI name "${cliName}"`);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "sls": "./bin/serverless.js"
   },
   "dependencies": {
-    "@serverless/cli": "^1.5.3",
     "@serverless/dashboard-plugin": "pre-6",
     "@serverless/platform-client": "^4.3.0",
     "@serverless/utils": "pre-6",


### PR DESCRIPTION
Depends on: https://github.com/serverless/cli/pull/23 being published