### PR TITLE
Variables: Resign from `projectDir` concept

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -21,8 +21,6 @@ Here is a list of all available properties in `serverless.yml` when the provider
 
 service: myService
 
-projectDir: ./ # Boundary of a project in which service is configured. Influences file resolution
-
 frameworkVersion: '2'
 configValidationMode: warn # Modes for config validation. `error` throws an exception, `warn` logs error to console, `off` disables validation at all. The default is warn.
 enableLocalInstallationFallback: false # If set to 'true', guarantees that it's a locally (for service, in its node_modules) installed framework which processes the command

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -411,8 +411,6 @@ custom:
 
 You can reference properties in other YAML or JSON files. To reference properties in other YAML files use the `${file(./myFile.yml):someProperty}` syntax in your `serverless.yml` configuration file.
 
-Files need to be referenced by relative paths, which should not reach out beyond project directory (by default service directory). If you work with multi-service project, you can change project directory boundary with `projectDir` setting (e.g. set `projectDir: ../` if you're service is nested in top level _service-x_ directory)
-
 To reference properties in other JSON files use the `${file(./myFile.json):someProperty}` syntax. It is important that the file you are referencing has the correct suffix, or file extension, for its file type (`.yml` for YAML or `.json` for JSON) in order for it to be interpreted correctly.
 
 Here's an example:

--- a/lib/configuration/variables/sources/file.js
+++ b/lib/configuration/variables/sources/file.js
@@ -44,17 +44,6 @@ module.exports = {
         errorCode: 'INVALID_FILE_SOURCE_PATH_ARGUMENT',
       })
     );
-    const projectDir = path.resolve(
-      serviceDir,
-      (await resolveConfigurationProperty(['projectDir'])) || '.'
-    );
-    if (!filePath.startsWith(`${projectDir}${path.sep}`)) {
-      throw new ServerlessError(
-        'Cannot load file from outside of a project directory ' +
-          '(configure "projectDir" to extend project boundary)',
-        'FILE_SOURCE_PATH_OUTSIDE_OF_PROJECT'
-      );
-    }
     if (address != null) {
       address = ensureString(address, {
         Error: ServerlessError,

--- a/test/fixtures/programmatic/multiService/serviceA/serverless.yml
+++ b/test/fixtures/programmatic/multiService/serviceA/serverless.yml
@@ -3,8 +3,6 @@ service: service
 configValidationMode: error
 frameworkVersion: '*'
 
-projectDir: ../
-
 provider:
   name: aws
   runtime: nodejs12.x

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -49,7 +49,6 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       notFile: '${file(dir.yaml)}',
       noParams: '${file:}',
       noParams2: '${file():}',
-      external: '${file(../file.test.js)}',
       invalidYaml: '${file(invalid.yml)}',
       invalidJson: '${file(invalid.json)}',
       invalidJs: '${file(invalid.js)}',
@@ -178,9 +177,6 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     expect(variablesMeta.get('noParams2').error.code).to.equal('VARIABLE_RESOLUTION_ERROR');
   });
 
-  it('should report with an error attempt to access external path', () =>
-    expect(variablesMeta.get('external').error.code).to.equal('VARIABLE_RESOLUTION_ERROR'));
-
   it('should report with an error an invalid YAML file', () =>
     expect(variablesMeta.get('invalidYaml').error.code).to.equal('VARIABLE_RESOLUTION_ERROR'));
 
@@ -222,9 +218,8 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     );
   });
 
-  it('should support "projectDir"', async () => {
+  it('should support reaching out beyond service directory', async () => {
     configuration = {
-      projectDir: '..',
       yml: '${file(../file.yml)}',
     };
     variablesMeta = resolveMeta(configuration);


### PR DESCRIPTION
As decided internally, resign from `projectDir` concept.

After that change, files in variables can be resolved from any system path