### PR TITLE
Packaging: Revert exclusion of local plugins from a bundle

### DIFF
--- a/lib/plugins/package/lib/packageService.js
+++ b/lib/plugins/package/lib/packageService.js
@@ -39,7 +39,7 @@ module.exports = {
     const pluginsLocalPath = this.serverless.pluginManager.parsePluginsObject(
       this.serverless.service.plugins
     ).localPath;
-    const localPathExcludes = this.serverless.pluginManager.getLocalPluginsPathPatterns();
+    const localPathExcludes = [];
     if (pluginsLocalPath) {
       localPathExcludes.push(pluginsLocalPath);
     }

--- a/test/unit/lib/plugins/package/lib/packageService.test.js
+++ b/test/unit/lib/plugins/package/lib/packageService.test.js
@@ -229,38 +229,6 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
     });
   });
 
-  describe('with local plugins', async () => {
-    it('should exclude local plugins with relative paths', async () => {
-      const {
-        fixtureData: {
-          servicePath: serviceDir,
-          serviceConfig: { service: serviceName },
-        },
-      } = await runServerless({
-        fixture: 'packaging',
-        command: 'package',
-        awsRequestStubMap,
-        configExt: {
-          plugins: [
-            './custom-plugins/index.js',
-            './custom-plugins/plugin-2/index',
-            './custom-plugins/plugin-3',
-            './custom-plugins/plugin-4/',
-          ],
-        },
-      });
-
-      const zippedFiles = await listZipFiles(
-        path.join(serviceDir, '.serverless', `${serviceName}.zip`)
-      );
-
-      expect(zippedFiles).to.not.include('custom-plugins/index.js');
-      expect(zippedFiles).to.not.include('custom-plugins/plugin-2/index.js');
-      expect(zippedFiles).to.not.include('custom-plugins/plugin-3/src/main.js');
-      expect(zippedFiles).to.not.include('custom-plugins/plugin-4/index.js');
-    });
-  });
-
   describe('pre-prepared artifact', () => {
     let serverless;
     before(async () => {


### PR DESCRIPTION
Reverts serverless/serverless#10259 as it was detected that it breaks some projects that rely on local plugins

More context: https://github.com/serverless/serverless/pull/10259#issuecomment-1008771301

I've decided to keep most of the work from the PR, as it's highly likely we will need a resolution of local plugins, and cleanup of the tests improved maintenance