### PR TITLE
refactor(CLI Onboarding): Download templates from v3 examples branch

### DIFF
--- a/lib/cli/interactive-setup/service.js
+++ b/lib/cli/interactive-setup/service.js
@@ -203,7 +203,7 @@ module.exports = {
         stepHistory: context.stepHistory,
       });
       projectDir = join(workingDir, projectName);
-      const templateUrl = `https://github.com/serverless/examples/tree/v2/${projectType}`;
+      const templateUrl = `https://github.com/serverless/examples/tree/v3/${projectType}`;
       legacy.write(`\nDownloading "${projectType}" template...\n`);
       const downloadProgress = progress.get('template-download');
       downloadProgress.notice(`Downloading "${projectType}" template`);

--- a/test/unit/lib/cli/interactive-setup/service.test.js
+++ b/test/unit/lib/cli/interactive-setup/service.test.js
@@ -103,7 +103,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       const stats = await fsp.lstat('test-project/serverless.yml');
       expect(stats.isFile()).to.be.true;
       expect(downloadTemplateFromRepoStub).to.have.been.calledWith(
-        'https://github.com/serverless/examples/tree/v2/aws-nodejs',
+        'https://github.com/serverless/examples/tree/v3/aws-nodejs',
         'aws-nodejs',
         'test-project'
       );
@@ -144,7 +144,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       const stats = await fsp.lstat('test-project-template/serverless.yml');
       expect(stats.isFile()).to.be.true;
       expect(downloadTemplateFromRepoStub).to.have.been.calledWith(
-        'https://github.com/serverless/examples/tree/v2/aws-nodejs',
+        'https://github.com/serverless/examples/tree/v3/aws-nodejs',
         'aws-nodejs',
         'test-project-template'
       );
@@ -191,7 +191,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       const stats = await fsp.lstat('test-project-package-json/serverless.yml');
       expect(stats.isFile()).to.be.true;
       expect(downloadTemplateFromRepoStub).to.have.been.calledWith(
-        'https://github.com/serverless/examples/tree/v2/aws-nodejs',
+        'https://github.com/serverless/examples/tree/v3/aws-nodejs',
         'aws-nodejs',
         'test-project-package-json'
       );
@@ -322,7 +322,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
       const stats = await fsp.lstat('test-project-from-provided-template/serverless.yml');
       expect(stats.isFile()).to.be.true;
       expect(downloadTemplateFromRepoStub).to.have.been.calledWith(
-        'https://github.com/serverless/examples/tree/v2/test-template',
+        'https://github.com/serverless/examples/tree/v3/test-template',
         'test-template',
         'test-project-from-provided-template'
       );
@@ -333,7 +333,7 @@ describe('test/unit/lib/cli/interactive-setup/service.test.js', () => {
     });
 
     it('Should create project at not existing directory with provided `template-url`', async () => {
-      const providedTemplateUrl = 'https://github.com/serverless/examples/tree/v2/test-template';
+      const providedTemplateUrl = 'https://github.com/serverless/examples/tree/v3/test-template';
       const downloadTemplateFromRepoStub = sinon.stub();
       const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/service', {
         '../../utils/downloadTemplateFromRepo': {


### PR DESCRIPTION
Reported internally, switch to `v3` branch in `examples` for onboarding templates