### PR TITLE
refactor(Config Schema): Do not rely on `ajv-keywords`

### DIFF
--- a/lib/classes/ConfigSchemaHandler/regexpKeyword.js
+++ b/lib/classes/ConfigSchemaHandler/regexpKeyword.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Implementation has been heavily inspired by `ajv-keywords` implementation from:
+// https://github.com/ajv-validator/ajv-keywords/blob/9656614be0104fe71d229459a5217ccac11958a6/src/definitions/regexp.ts
+// The reason for that is the issue with `peerDependencies` of `ajv-keywords`, that causes the project to fail when other
+// dependency also relies on different `ajv` version and `npm@6` is used.
+// Related issue: https://github.com/ajv-validator/ajv-keywords/issues/170
+// After the issue is addressed, or if `npm@6` is no longer supported, this module can be removed
+// and we can go back to using `ajv-keywords` directly.
+
+const { _ } = require('ajv/dist/compile/codegen');
+
+const regexpMetaSchema = {
+  type: 'object',
+  properties: {
+    pattern: { type: 'string' },
+    flags: { type: 'string', nullable: true },
+  },
+  required: ['pattern'],
+  additionalProperties: false,
+};
+
+const metaRegexp = /^\/(.*)\/([gimuy]*)$/;
+
+const usePattern = ({ gen, it: { opts } }, pattern, flags = opts.unicodeRegExp ? 'u' : '') => {
+  const rx = new RegExp(pattern, flags);
+  return gen.scopeValue('pattern', {
+    key: rx.toString(),
+    ref: rx,
+    code: _`new RegExp(${pattern}, ${flags})`,
+  });
+};
+
+module.exports = {
+  keyword: 'regexp',
+  type: 'string',
+  schemaType: ['string', 'object'],
+  code(cxt) {
+    const { data, schema } = cxt;
+    const regx = getRegExp(schema);
+    cxt.pass(_`${regx}.test(${data})`);
+
+    function getRegExp(sch) {
+      if (typeof sch === 'object') return usePattern(cxt, sch.pattern, sch.flags);
+      const rx = metaRegexp.exec(sch);
+      if (rx) return usePattern(cxt, rx[1], rx[2]);
+      throw new Error('cannot parse string into RegExp');
+    }
+  },
+  metaSchema: {
+    anyOf: [{ type: 'string' }, regexpMetaSchema],
+  },
+};

--- a/lib/classes/ConfigSchemaHandler/resolveAjvValidate.js
+++ b/lib/classes/ConfigSchemaHandler/resolveAjvValidate.js
@@ -44,7 +44,7 @@ const getValidate = async (schema) => {
     // Ensure AJV related packages work well when there are mutliple AJV installations around
     // See: https://github.com/ajv-validator/ajv/issues/1390#issuecomment-763138202
     ajv.opts.code.formats = Ajv._`require("ajv-formats/dist/formats").fullFormats`;
-    require('ajv-keywords')(ajv, 'regexp');
+    ajv.addKeyword(require('./regexpKeyword'));
     const validate = ajv.compile(schema);
     const moduleCode = standaloneCode(ajv, validate);
     await fs.promises.writeFile(cachePath, moduleCode);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@serverless/utils": "pre-6",
     "ajv": "^8.8.2",
     "ajv-formats": "^2.1.1",
-    "ajv-keywords": "^5.1.0",
     "archiver": "^5.3.0",
     "aws-sdk": "^2.1053.0",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
Reported internally, `ajv-keywords` together with `npm@6` and dependencies that use different version of `ajv` cause an error due to a bug in how `npm` hoists dependencies: https://github.com/ajv-validator/ajv-keywords/issues/170

It will be added to original commit that upgrades `ajv` to `v8`