### PR TITLE
Cleanup obsolete TODO comments

### DIFF
--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -7,7 +7,6 @@ const log = require('@serverless/utils/log');
 const resolveCliInput = require('../cli/resolve-input');
 const renderHelp = require('../cli/render-help');
 
-// TODO: Remove this class with next major
 class CLI {
   constructor(serverless) {
     this.serverless = serverless;

--- a/lib/configuration/variables/index.js
+++ b/lib/configuration/variables/index.js
@@ -34,7 +34,6 @@ const reportEventualErrors = (variablesMeta) => {
 };
 
 module.exports = async ({ serviceDir, servicePath, configuration, options, sources = null }) => {
-  // TODO: Remove support for `servicePath` with next major
   serviceDir = ensureString(serviceDir || servicePath);
   ensurePlainObject(configuration);
   options = ensurePlainObject(options, { default: {} });

--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -10,9 +10,8 @@ const generateZip = require('./generateZip');
 const ServerlessError = require('../../../serverless-error');
 
 const prepareCustomResourcePackage = _.memoize(async (zipFilePath) => {
-  // TODO: check every once in a while if external packages are still necessary
-  legacy.log('Installing dependencies for custom CloudFormation resources...');
-  log.info('Installing dependencies for custom CloudFormation resources');
+  legacy.log('Generating custom CloudFormation resources...');
+  log.info('Generating custom CloudFormation resources');
   return BbPromise.all([generateZip(), fse.mkdirs(path.dirname(zipFilePath))])
     .then(([cachedZipFilePath]) => fse.copy(cachedZipFilePath, zipFilePath))
     .then(() => path.basename(zipFilePath));

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -236,7 +236,6 @@ class AwsProvider {
       // Below ideally should be in hooks.intialize, but variables resolution depend on this
       this.serverless.service.provider.region = this.getRegion();
       require('../../utils/awsSdkPatch');
-      // TODO: Complete schema, see https://github.com/serverless/serverless/issues/8016
       serverless.configSchemaHandler.defineProvider('aws', {
         definitions: {
           awsAccountId: {

--- a/test/integration/aws/httpApi.test.js
+++ b/test/integration/aws/httpApi.test.js
@@ -255,8 +255,6 @@ describe('HTTP API Integration Test', function () {
     });
 
     after(async function () {
-      // Added temporarily to inspect random fails
-      // TODO: Remove once properly diagnosed
       if (this.test.parent.tests.some((test) => test.state === 'failed')) return;
       log.notice('Removing service...');
       await removeService(serviceDir);

--- a/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -107,7 +107,6 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
     });
   });
 
-  // TODO: VERIFY THESE CLEANUPS
   after(() => {
     sinon.restore();
   });


### PR DESCRIPTION
TODO comments in most cases indicate changes proposed for the next major (so they're not lost).

Some of them are no longer actual, or were left over by mistake. This PR cleans that up.

Additionally improved log on custom resource building. It's a long time it doesn't involve `npm install` and yet log messages suggested that)
