### PR TITLE
CLI: Respect old Node.js versions in version detection

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -184,10 +184,25 @@ jobs:
         # Workaround taken from https://github.com/actions/runner/issues/241#issuecomment-577360161
         run: script -e -c "npm test -- -b"
 
+  linuxNode4:
+    name: '[Linux] Node.js v4: Node version validation test'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Node.js and npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: 4.x
+
+      - name: Node version validation test
+        run: ./bin/serverless.js | grep -q "Initialization error"
+
   integrate:
     name: Integrate
     runs-on: ubuntu-latest
-    needs: [linuxNode16, windowsNode16, linuxNode14, linuxNode12, linuxNode10]
+    needs: [linuxNode16, windowsNode16, linuxNode14, linuxNode12, linuxNode10, linuxNode4]
     timeout-minutes: 30 # Default is 360
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -207,3 +207,18 @@ jobs:
         # Some tests depend on TTY support, which is missing in GA runner
         # Workaround taken from https://github.com/actions/runner/issues/241#issuecomment-577360161
         run: script -e -c "npm test -- -b"
+
+  linuxNode4:
+    name: '[Linux] Node.js v4: Node version validation test'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Node.js and npm
+        uses: actions/setup-node@v1
+        with:
+          node-version: 4.x
+
+      - name: Node version validation test
+        run: ./bin/serverless.js | grep -q "Initialization error"

--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// WARNING: Do not use syntax not supported by old Node.js versions (v4 lowest)
+// It's to ensure that users running those versions, see properly the error message
+// (as constructed below) instead of the syntax error
+
 'use strict';
 
 // `EvalError` is used to not pollute global namespace but still have the value accessible globally
@@ -31,9 +35,7 @@ if (require('../lib/utils/isStandaloneExecutable')) {
   }
 }
 
-(async () => {
-  const cliName = await require('../lib/cli/triage')();
-
+require('../lib/cli/triage')().then((cliName) => {
   switch (cliName) {
     case 'serverless':
       require('../scripts/serverless');
@@ -47,4 +49,4 @@ if (require('../lib/utils/isStandaloneExecutable')) {
     default:
       throw new Error(`Unrecognized CLI name "${cliName}"`);
   }
-})();
+});


### PR DESCRIPTION
When working on local fallback updates, I've realized our Node.js version detection works well only in recent versions of Node.js

e.g. if someone attempts to run Framework with Node.js v6 will see an ugly syntax error. This patch fixes that, and configures test to prevent further regression in that area.