### PR TITLE
CLI: Improve Node.js version resolution error message

### DIFF
--- a/.github/workflows/integrate-v3.yml
+++ b/.github/workflows/integrate-v3.yml
@@ -170,7 +170,7 @@ jobs:
           node-version: 4.x
 
       - name: Node version validation test
-        run: ./bin/serverless.js | grep -q "Initialization error"
+        run: ./bin/serverless.js 2>&1 | grep -q "does not support"
 
   integrate:
     name: Integrate

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -166,7 +166,7 @@ jobs:
           node-version: 4.x
 
       - name: Node version validation test
-        run: ./bin/serverless.js | grep -q "Initialization error"
+        run: ./bin/serverless.js 2>&1 | grep -q "does not support"
 
   integrate:
     name: Integrate

--- a/.github/workflows/validate-v3.yml
+++ b/.github/workflows/validate-v3.yml
@@ -185,4 +185,4 @@ jobs:
           node-version: 4.x
 
       - name: Node version validation test
-        run: ./bin/serverless.js | grep -q "Initialization error"
+        run: ./bin/serverless.js 2>&1 | grep -q "does not support"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -188,4 +188,4 @@ jobs:
           node-version: 4.x
 
       - name: Node version validation test
-        run: ./bin/serverless.js | grep -q "Initialization error"
+        run: ./bin/serverless.js 2>&1 | grep -q "does not support"

--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -10,12 +10,14 @@
 EvalError.$serverlessCommandStartTime = process.hrtime();
 
 const nodeVersion = Number(process.version.split('.')[0].slice(1));
+const minimumSupportedVersion = 12;
 
-if (nodeVersion < 12) {
+if (nodeVersion < minimumSupportedVersion) {
   const serverlessVersion = Number(require('../package.json').version.split('.')[0]);
-  process.stdout.write(
-    `Serverless: \x1b[91mInitialization error: Node.js v${nodeVersion} is not supported by ` +
-      `Serverless Framework v${serverlessVersion}. Please upgrade\x1b[39m\n`
+  process.stderr.write(
+    `\x1b[91mError: Serverless Framework v${serverlessVersion} does not support ` +
+      `Node.js v${nodeVersion}. Please upgrade Node.js to the latest ` +
+      `LTS version (v${minimumSupportedVersion} is a minimum supported version)\x1b[39m\n`
   );
   process.exit(1);
 }


### PR DESCRIPTION
In v2 error message that states that given Node.js version is not supported is prefixed with `Serverless:`, in v3 to adhere to new logs look I believe it should not be the case.

I've updated it, so it looks as:

<img width="845" alt="Screenshot 2022-01-13 at 13 20 22" src="https://user-images.githubusercontent.com/122434/149329527-dff5de72-224b-4166-ad2d-a7135c08912c.png">

@mnapoli if you have any further improvement suggestions, let me know

_(It'll be integrated into commit with which we dropped support for Node.js v10)_
