### PR TITLE
v3: Expose `sls doctor` command and cleanup

### DIFF
--- a/lib/classes/ConfigSchemaHandler/index.js
+++ b/lib/classes/ConfigSchemaHandler/index.js
@@ -65,8 +65,7 @@ class ConfigSchemaHandler {
     this.serverless = serverless;
     this.schema = _.cloneDeep(schema);
 
-    // TODO: Switch back to deepFreeze(this.schema.properties.service) once awsKmsKeyArn property is removed, see https://github.com/serverless/serverless/issues/8261
-    Object.freeze(this.schema.properties.service.name);
+    deepFreeze(this.schema.properties.service);
     deepFreeze(this.schema.properties.plugins);
     deepFreeze(this.schema.properties.package);
   }

--- a/lib/cli/commands-schema/no-service.js
+++ b/lib/cli/commands-schema/no-service.js
@@ -107,8 +107,6 @@ commands.set('dashboard', {
 
 commands.set('doctor', {
   usage: 'Print status on reported deprecations triggered in the last command run',
-  // TODO: Expose in v3
-  isHidden: true,
 });
 
 commands.set('generate-event', {

--- a/lib/configSchema.js
+++ b/lib/configSchema.js
@@ -132,11 +132,6 @@ const schema = {
   additionalProperties: false,
   required: ['provider', 'service'],
   definitions: {
-    // TODO: awsKmsArn definition to be moved to lib/plugins/aws/provider/awsProvider.js once service.awsKmsKeyArn removed with v3.0.0, see https://github.com/serverless/serverless/issues/8261
-    // TODO: awsKmsArn to include #/definitions/awsCfFunction instead of type: object as one of the possible definition, see https://github.com/serverless/serverless/issues/8261
-    awsKmsArn: {
-      anyOf: [{ type: 'object' }, { type: 'string', pattern: '^arn:aws[a-z-]*:kms' }],
-    },
     errorCode: {
       type: 'string',
       pattern: '^[A-Z0-9_]+$',

--- a/lib/plugins/aws/deployFunction.js
+++ b/lib/plugins/aws/deployFunction.js
@@ -29,10 +29,7 @@ class AwsDeployFunction {
     this.hooks = {
       'initialize': () => {
         const commandName = this.serverless.processedInput.commands.join(' ');
-        // TODO: Remove second part of condition with v3
-        if (commandName !== 'deploy function' && !(commandName === 'deploy' && options.function)) {
-          return;
-        }
+        if (commandName !== 'deploy function') return;
         log.notice();
         log.notice(
           `Deploying function ${this.options.function} to stage ${this.serverless

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -516,6 +516,12 @@ class AwsProvider {
               ],
             },
           },
+          awsKmsArn: {
+            anyOf: [
+              { $ref: '#/definitions/awsCfFunction' },
+              { type: 'string', pattern: '^arn:aws[a-z-]*:kms' },
+            ],
+          },
           awsLambdaArchitecture: { enum: ['arm64', 'x86_64'] },
           awsLambdaEnvironment: {
             type: 'object',


### PR DESCRIPTION
- Expose `sls doctor` command
- Cleanup left overs of `awsKmsKey` and `deploy function` handling (will be added to their commits)
