### PR TITLE
docs: Various updates for the v3 release

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -398,7 +398,7 @@ In context of v2 you may adapt old variables resolver so errors on unresolved va
 
 Deprecation code: `PROVIDER_IAM_SETTINGS`
 
-_Note: Originally support for old IAM settings was scheduled to be dropped with new major release. It's no longer the case. If you see this deprecation notice please upgrade to latest version of Serverless Framework_
+_Note: Originally, support for the legacy IAM settings format was scheduled to be dropped in v3. However, it's no longer the case. If you see this deprecation notice please upgrade to the latest version of Serverless Framework v2._
 
 All IAM-related settings of _provider_ including `iamRoleStatements`, `iamManagedPolicies`, `role` and `cfnRole` are also now supported at `iam` property. Refer to the [IAM Guide](/framework/docs/providers/aws/guide/iam.md).
 
@@ -568,7 +568,7 @@ Deprecation code: `AWS_FUNCTION_DESTINATIONS_ASYNC_CONFIG`
 
 Deprecation code: `AWS_HTTP_API_VERSION`
 
-Default HTTP API Payload version will be switched to 2.0 with next major release (For more details see [payload format documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format))
+Default HTTP API Payload version will be switched to 2.0 with v3 (For more details see [payload format documentation](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format)).
 
 Configure `httpApi.payload` explicitly to ensure seamless migration.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -6,13 +6,13 @@ layout: Doc
 
 # Resolution of environment variables
 
-To automatically load environment variables from `.env` files (with the help of [dotenv](https://www.npmjs.com/package/dotenv) package) please set `useDotenv` property in `serverless.yml` as below:
+To automatically load environment variables from `.env` files (with the help of the [dotenv](https://www.npmjs.com/package/dotenv) package), set `useDotenv: true` in `serverless.yml`:
 
 ```yaml
 useDotenv: true
 ```
 
-Having that `.env` files will also be excluded from the package in order to avoid uploading sensitive data as a part of a package by mistake. Starting with the next major version, `.env` files will be loaded by default and `useDotenv` setting will be ignored.
+With that option enabled, `.env` files will also be excluded from the package in order to avoid uploading sensitive data as a part of a package by mistake.
 
 ## Support for `.env` files
 

--- a/docs/providers/aws/events/event-bridge.md
+++ b/docs/providers/aws/events/event-bridge.md
@@ -16,7 +16,7 @@ layout: Doc
 
 The [EventBridge](https://aws.amazon.com/eventbridge/) makes it possible to connect applications using data from external sources (e.g. own applications, SaaS) or AWS services. The `eventBridge` event types helps setting up AWS Lambda functions to react to events coming in via the EventBridge.
 
-_Note_: Prior to `2.27.0` version of the Framework, `eventBridge` resources were provisioned with Custom Resources. With `2.27.0` an optional support for native CloudFormation was introduced and can be turned on by setting `provider.eventBridge.useCloudFormation` property to `true`. It is recommended to migrate to native CloudFormation as it will become a default with next major version. It also adds the ability to define `eventBus` with CF intrinsic functions as values.
+_Note_: Prior to `2.27.0` version of the Framework, `eventBridge` resources were provisioned with Custom Resources. With `2.27.0` an optional support for native CloudFormation was introduced and can be turned on by setting `provider.eventBridge.useCloudFormation: true`. It is recommended to migrate to native CloudFormation as it will become a default with v3. It also adds the ability to define `eventBus` with CF intrinsic functions as values.
 
 ## Setting up a scheduled event
 


### PR DESCRIPTION
I've gone over sentences like "next major version" or documentation for some deprecated features: the goal was to make it up to date for v3, and a bit less ambiguous ("next major version" will mean v4 next week, so it could be confusing).

There shouldn't be any conflicts with #10468 (which I'll rebase on v3 separately).