### PR TITLE
Docs: Remove `tenant` wording

### DIFF
--- a/docs/guides/cicd/running-in-your-own-cicd.md
+++ b/docs/guides/cicd/running-in-your-own-cicd.md
@@ -48,7 +48,7 @@ Follow these steps to create an access token:
 5. Provide a name and press “Create”
 6. You will be presented with the access key on the new page.
 
-**Note**: The access token has permission to the tenant; however, it is associated with your account. If your account is deleted, then the access token will be revoked too.
+**Note**: The access token has permission to the org; however, it is associated with your account. If your account is deleted, then the access token will be revoked too.
 
 ### Configure environment variables
 

--- a/docs/providers/aws/cli-reference/slstats.md
+++ b/docs/providers/aws/cli-reference/slstats.md
@@ -55,6 +55,6 @@ The following is a list of the events that we collect:
 
 ## Signed in to the Dashboard
 
-If you are signed in to the [Serverless Dashboard](https://app.serverless.com), we do receive your userId as part of the event payloads. We can use this information to understand your tenant and users interactions with the CLI and building services.
+If you are signed in to the [Serverless Dashboard](https://app.serverless.com), we do receive your userId as part of the event payloads. We can use this information to understand your org and users interactions with the CLI and building services.
 
 If you are not signed in, we do not send any identifying information, such as an userId, within any of the event payloads.


### PR DESCRIPTION
It's a long time `tenant` concept was renamed to `org`. Yet few occurrences can still be found in the docs