### PR TITLE
v3: Dashboard: Drop support for `tenant`

### DIFF
--- a/lib/classes/Service.js
+++ b/lib/classes/Service.js
@@ -103,7 +103,6 @@ class Service {
 
     // (dashboard plugin)
     this.app = configurationInput.app;
-    this.tenant = configurationInput.tenant;
     this.org = configurationInput.org;
 
     this.plugins = configurationInput.plugins;

--- a/lib/cli/interactive-setup/utils.js
+++ b/lib/cli/interactive-setup/utils.js
@@ -13,7 +13,7 @@ const fsp = require('fs').promises;
 const yamlExtensions = new Set(['.yml', '.yaml']);
 
 const appPattern = /^(?:#\s*)?app\s*:.+/m;
-const orgPattern = /^(?:#\s*)?(?:tenant|org)\s*:.+/m;
+const orgPattern = /^(?:#\s*)?(?:org)\s*:.+/m;
 
 const ServerlessError = require('../../serverless-error');
 const resolveStage = require('../../utils/resolve-stage');

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -445,7 +445,6 @@ const processSpanPromise = (async () => {
           if (!ensureResolvedProperty('frameworkVersion')) return;
           if (!ensureResolvedProperty('app')) return;
           if (!ensureResolvedProperty('org')) return;
-          if (!ensureResolvedProperty('tenant')) return;
           if (!ensureResolvedProperty('service')) return;
           if (configuration.org) {
             // Dashboard requires AWS region to be resolved upfront


### PR DESCRIPTION
This property is a long time not used by users. v3 is a good time to also drop support for it in a codebase.

Accompanied by https://github.com/serverless/dashboard-plugin/pull/656