### PR TITLE
v3: Remove `cli.suppressLogIfPrintCommand` internal method

### DIFF
--- a/lib/Serverless.js
+++ b/lib/Serverless.js
@@ -143,7 +143,6 @@ class Serverless {
   async run() {
     if (this.configurationInput) this.service.reloadServiceFileParam();
 
-    this.cli.suppressLogIfPrintCommand(this.processedInput);
     // make sure the command exists before doing anything else
     this.pluginManager.validateCommand(this.processedInput.commands);
 

--- a/lib/classes/CLI.js
+++ b/lib/classes/CLI.js
@@ -24,27 +24,6 @@ class CLI {
     this.loadedCommands = commands;
   }
 
-  suppressLogIfPrintCommand(processedInput) {
-    const commands = processedInput.commands;
-
-    // if "-help" or "-h" was entered
-    if (resolveCliInput().isHelpRequest) return;
-
-    // if "print" was NOT entered
-    if (commands.indexOf('print') === -1) {
-      return;
-    }
-
-    // if other command was combined with "print"
-    if (commands.length !== 1) {
-      return;
-    }
-
-    // Make "log" no-op to suppress warnings.
-    // But preserve "consoleLog" which "print" command use to print config.
-    this.log = function () {};
-  }
-
   displayHelp() {
     if (!resolveCliInput().isHelpRequest) return false;
     renderHelp(this.serverless.pluginManager.externalPlugins);

--- a/test/unit/lib/classes/CLI.test.js
+++ b/test/unit/lib/classes/CLI.test.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const chai = require('chai');
-const sinon = require('sinon');
 const CLI = require('../../../../lib/classes/CLI');
-const overrideArgv = require('process-utils/override-argv');
 const Serverless = require('../../../../lib/Serverless');
-const resolveInput = require('../../../../lib/cli/resolve-input');
 
 const { expect } = chai;
 chai.use(require('sinon-chai'));
@@ -42,75 +39,6 @@ describe('CLI', () => {
       cli.setLoadedPlugins(plugins);
 
       expect(cli.loadedPlugins[0]).to.equal(pluginMock);
-    });
-  });
-
-  describe('#suppressLogIfPrintCommand()', () => {
-    let logStub;
-    let consoleLogStub;
-
-    beforeEach(() => {
-      logStub = sinon.stub();
-      consoleLogStub = sinon.stub();
-    });
-
-    it('should do nothing when no command is given', () => {
-      cli = new CLI(serverless);
-      cli.log = logStub;
-      cli.consoleLog = consoleLogStub;
-
-      cli.suppressLogIfPrintCommand({ commands: [], options: {} });
-      cli.log('logged');
-      cli.consoleLog('logged');
-
-      expect(logStub.calledOnce).to.equal(true);
-      expect(consoleLogStub.calledOnce).to.equal(true);
-    });
-
-    it('should do nothing when "print" is given with "--help"', () => {
-      cli = new CLI(serverless);
-      cli.log = logStub;
-      cli.consoleLog = consoleLogStub;
-
-      resolveInput.clear();
-      overrideArgv({ args: ['serverless', '--help'] }, () =>
-        cli.suppressLogIfPrintCommand({
-          commands: ['print'],
-          options: { help: true },
-        })
-      );
-      resolveInput.clear();
-      cli.log('logged');
-      cli.consoleLog('logged');
-
-      expect(logStub.calledOnce).to.equal(true);
-      expect(consoleLogStub.calledOnce).to.equal(true);
-    });
-
-    it('should do nothing when "print" is combined with other command.', () => {
-      cli = new CLI(serverless);
-      cli.log = logStub;
-      cli.consoleLog = consoleLogStub;
-
-      cli.suppressLogIfPrintCommand({ commands: ['other', 'print'], options: {} });
-      cli.log('logged');
-      cli.consoleLog('logged');
-
-      expect(logStub.calledOnce).to.equal(true);
-      expect(consoleLogStub.calledOnce).to.equal(true);
-    });
-
-    it('should suppress log when "print" is given', () => {
-      cli = new CLI(serverless);
-      cli.log = logStub;
-      cli.consoleLog = consoleLogStub;
-
-      cli.suppressLogIfPrintCommand({ commands: ['print'], options: {} });
-      cli.log('NOT LOGGED');
-      cli.consoleLog('logged');
-
-      expect(logStub.calledOnce).to.equal(false);
-      expect(consoleLogStub.calledOnce).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
After we've moved logging to `stderr`, and relying on different logging interfaces this method is obsolete.