### PR TITLE
docs: Switch to `npm i` instead of broken `npm update`

### DIFF
--- a/docs/cn/getting-started.md
+++ b/docs/cn/getting-started.md
@@ -60,7 +60,7 @@ $ choco upgrade serverless
 npm install -g serverless
 
 # 或者更新 serverless cli 到最新版本
-npm update -g serverless
+npm install -g serverless
 ```
 
 如果你的环境中还没有安装 Node 8 或者更高的版本，那么你需要首先安装 [Node.js](https://nodejs.org/zh-cn/download/)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,10 +42,10 @@ To install the latest version, run this command in your terminal:
 curl -o- -L https://slss.io/install | bash
 ```
 
-To install an specific version you may set a VERSION variable, for example:
+To install a specific version, you may set a VERSION variable, for example:
 
 ```bash
-curl -o- -L https://slss.io/install | VERSION=2.21.1 bash
+curl -o- -L https://slss.io/install | VERSION=2.72.2 bash
 ```
 
 Then, open another terminal window to run the `serverless` program.
@@ -63,7 +63,10 @@ choco install serverless
 If `serverless` was installed via NPM, upgrade it via:
 
 ```bash
-npm update -g serverless
+npm install -g serverless
+
+# You can also specify a major version:
+npm install -g serverless@2
 ```
 
 If you installed `serverless` as a standalone binary, read the following section instead.
@@ -74,6 +77,9 @@ On MacOS/Linux, run:
 
 ```bash
 serverless upgrade
+
+# You can also restrict the upgrade to the latest v2 version:
+curl -o- -L https://slss.io/install | VERSION=2.72.2 bash
 ```
 
 On Windows, run:

--- a/docs/guides/upgrading-v3.md
+++ b/docs/guides/upgrading-v3.md
@@ -17,13 +17,11 @@ Serverless Framework v3 contains a few breaking changes that may impact some pro
 
 This guide helps users upgrade from Serverless Framework v2 to v3.
 
-**Note:** Serverless Framework v3 isn't released yet. However, this guide helps to prepare to v3, or upgrade to the [v3 beta version](https://www.serverless.com/blog/serverless-framework-v3-beta).
-
 ## Am I impacted by breaking changes?
 
 Serverless Framework v2 signals any deprecated feature via a deprecation warning. The simplest way to upgrade to v3 is to:
 
-1. Upgrade Serverless Framework to the latest v2 version
+1. [Upgrade Serverless Framework](../getting-started.md#upgrade) to the latest v2 version
 2. Run `serverless` commands in the project to see if there are any deprecation warnings
 
 Projects that do not have any deprecations can be immediately upgraded to v3. Projects that have deprecation warnings should first solve these deprecations, then upgrade to v3.
@@ -36,15 +34,13 @@ That being said, some plugins need to be updated to be installable with v3. In m
 
 ## Upgrading to v3
 
-First, upgrade to the latest v2 version and make sure that you do not see any deprecation warning.
+First, [upgrade to the latest v2 version](../getting-started.md#upgrade) and make sure that you do not get any deprecation warning when running `serverless` commands.
 
 Then, to upgrade to Serverless Framework v3, run:
 
 ```bash
-npm update -g serverless
+npm install -g serverless
 ```
-
-**Note:** v3 is currently available as beta version. [Read the blog post](https://www.serverless.com/blog/serverless-framework-v3-beta) to upgrade to v3 beta until the stable version is released.
 
 If you [installed `serverless` as a standalone binary](../getting-started.md#install-as-a-standalone-binary), run the following command instead:
 


### PR DESCRIPTION
See https://github.com/npm/cli/issues/3175 why `npm update -g` is broken.

I targeted v3 to avoid unnecessary rebase. ATM we don't document the command with a version number, so the risk of keeping that around 1 more week is low I think.