### PR TITLE
refactor: Refactor direct use of `@serverless/utils/log`

### DIFF
--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -96,7 +96,8 @@ const shouldS3Accelerate = (method, params) => {
     params &&
     params.isS3TransferAccelerationEnabled
   ) {
-    log('Using S3 Transfer Acceleration Endpoint...');
+    legacy.log('Using S3 Transfer Acceleration Endpoint...');
+    log.notice('Using S3 Transfer Acceleration Endpoint...');
     return true;
   }
   return false;

--- a/lib/configuration/variables/eventually-report-resolution-errors.js
+++ b/lib/configuration/variables/eventually-report-resolution-errors.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const log = require('@serverless/utils/log');
+const { log, legacy } = require('@serverless/utils/log');
 const ServerlessError = require('../../serverless-error');
 const resolveCliInput = require('../../cli/resolve-input');
 const logDeprecation = require('../../utils/logDeprecation');
@@ -14,10 +14,14 @@ module.exports = (configurationPath, configuration, variablesMeta) => {
   if (!resolutionErrors.size) return false;
 
   if (resolveCliInput().isHelpRequest) {
-    log(
+    legacy.log(
       'Resolution of service configuration failed when resolving variables: ' +
         `${Array.from(resolutionErrors, (error) => `\n  - ${error.message}`)}\n`,
       { color: 'orange' }
+    );
+    log.warning(
+      'Resolution of service configuration failed when resolving variables: ' +
+        `${Array.from(resolutionErrors, (error) => `\n  - ${error.message}`)}\n`
     );
   } else {
     if (configuration.variablesResolutionMode) {

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -6,7 +6,6 @@ const crypto = require('crypto');
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
-const oldLog = require('@serverless/utils/log');
 const ServerlessError = require('../../../../serverless-error');
 const deepSortObjectByKey = require('../../../../utils/deepSortObjectByKey');
 const getHashForFilePath = require('../lib/getHashForFilePath');
@@ -755,8 +754,9 @@ function extractLayerConfigurationsFromFunction(functionProperties, cfTemplate) 
       const configuration = cfTemplate.Resources[potentialLocalLayerObject.Ref];
 
       if (!configuration) {
+        log.info(`Could not find reference to layer: ${potentialLocalLayerObject.Ref}.`);
         if (process.env.SLS_DEBUG) {
-          oldLog(`Could not find reference to layer: ${potentialLocalLayerObject.Ref}.`);
+          legacy.log(`Could not find reference to layer: ${potentialLocalLayerObject.Ref}.`);
         }
         return;
       }

--- a/lib/utils/npmPackage/isWritable.js
+++ b/lib/utils/npmPackage/isWritable.js
@@ -3,7 +3,7 @@
 const { format } = require('util');
 const path = require('path');
 const fsp = require('fs').promises;
-const log = require('@serverless/utils/log');
+const { log, legacy } = require('@serverless/utils/log');
 
 const npmPackageRoot = path.resolve(__dirname, '../../../');
 
@@ -13,7 +13,10 @@ module.exports = async () => {
     await fsp.utimes(npmPackageRoot, String(stats.atimeMs / 1000), String(stats.mtimeMs / 1000));
     return true;
   } catch (error) {
-    if (process.env.SLS_DEBUG) log(format('Auto update: file access error: %O', error));
+    if (process.env.SLS_DEBUG) {
+      legacy.log(format('Auto update: file access error: %O', error));
+    }
+    log.info('Auto update: file access error: %O', error);
     return false;
   }
 };


### PR DESCRIPTION
Reported internally, some of the logs haven't been refactored properly with modern implementation
