### PR TITLE
v3: Fix detection of npm installed `serverless-tencent`

### DIFF
--- a/lib/cli/run-serverless-tencent.js
+++ b/lib/cli/run-serverless-tencent.js
@@ -16,7 +16,7 @@ const standaloneServerUrl = 'https://slt-binary-sv-1300963013.cos.accelerate.myq
 
 const resolveAbsoluteModulePath = (contextDirname, modulePath) => {
   try {
-    return createRequire(contextDirname).resolve(modulePath);
+    return createRequire(path.resolve(contextDirname, 'require-resolver')).resolve(modulePath);
   } catch {
     return null;
   }
@@ -25,7 +25,7 @@ const resolveAbsoluteModulePath = (contextDirname, modulePath) => {
 const resolveGlobalNpmPath = async () => {
   const npmNodeModulesPath = await (async () => {
     try {
-      return String((await spawn('npm', ['root', '-g'])).stdoutBuffer);
+      return String((await spawn('npm', ['root', '-g'])).stdoutBuffer).trim();
     } catch (error) {
       return null;
     }


### PR DESCRIPTION
Reported internally by @zongUMR 

Resolution of npm root folder worked ok with npm v6 but not npm v7 and v8. 
Resolution of local installation seemed to never been tested properly, this time I've confirmed that it works