### PR TITLE
fix: use new Tencent CLI standalone on windows

### DIFF
--- a/lib/cli/run-serverless-tencent.js
+++ b/lib/cli/run-serverless-tencent.js
@@ -40,6 +40,20 @@ const resolveGlobalNpmPath = async () => {
 };
 
 const isStandaloneInstalled = async () => {
+  if (process.platform === 'win32') {
+    const standaloneNewFilename = path.resolve(
+      os.homedir(),
+      `.serverless-tencent/bin/serverless-tencent${process.platform === 'win32' ? '-new.exe' : ''}`
+    );
+
+    try {
+      await fsp.access(standaloneNewFilename);
+      await fsp.rename(standaloneNewFilename, standaloneFilename);
+    } catch {
+      // no new win standalone downloaded, no nothing
+    }
+  }
+
   try {
     await fsp.access(standaloneFilename);
     return true;


### PR DESCRIPTION
cli will use new standalone to replace the old one before call the it on windows system.