### PR TITLE
v3: Adapt to renames in `@serverless/dashboard-plugin`

### DIFF
--- a/lib/cli/interactive-setup/aws-credentials.js
+++ b/lib/cli/interactive-setup/aws-credentials.js
@@ -16,8 +16,8 @@ const resolveRegion = require('../../utils/resolve-region');
 
 const isValidAwsAccessKeyId = RegExp.prototype.test.bind(/^[A-Z0-9]{10,}$/);
 const isValidAwsSecretAccessKey = RegExp.prototype.test.bind(/^[a-zA-Z0-9/+]{10,}$/);
-const { getPlatformClientWithAccessKey } = require('@serverless/dashboard-plugin/lib/clientUtils');
-const isAuthenticated = require('@serverless/dashboard-plugin/lib/isAuthenticated');
+const { getPlatformClientWithAccessKey } = require('@serverless/dashboard-plugin/lib/client-utils');
+const isAuthenticated = require('@serverless/dashboard-plugin/lib/is-authenticated');
 
 const CREDENTIALS_SETUP_CHOICE = {
   LOCAL: '_local_',

--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -11,7 +11,7 @@ const { writeOrgAndApp, showOnboardingWelcome } = require('./utils');
 const {
   getPlatformClientWithAccessKey,
   getOrCreateAccessKeyForOrg,
-} = require('@serverless/dashboard-plugin/lib/clientUtils');
+} = require('@serverless/dashboard-plugin/lib/client-utils');
 
 const isValidAppName = RegExp.prototype.test.bind(/^[a-z0-9](?:[a-z0-9-]{0,126}[a-z0-9])?$/);
 

--- a/lib/cli/interactive-setup/deploy.js
+++ b/lib/cli/interactive-setup/deploy.js
@@ -6,7 +6,7 @@ const promptWithHistory = require('@serverless/utils/inquirer/prompt-with-histor
 const { doesServiceInstanceHaveLinkedProvider } = require('./utils');
 const _ = require('lodash');
 const AWS = require('aws-sdk');
-const isAuthenticated = require('@serverless/dashboard-plugin/lib/isAuthenticated');
+const isAuthenticated = require('@serverless/dashboard-plugin/lib/is-authenticated');
 
 const printMessage = () => {
   writeText(

--- a/lib/cli/interactive-setup/utils.js
+++ b/lib/cli/interactive-setup/utils.js
@@ -4,8 +4,8 @@ const path = require('path');
 const memoizee = require('memoizee');
 const inquirer = require('@serverless/utils/inquirer');
 const { log } = require('@serverless/utils/log');
-const resolveProviderCredentials = require('@serverless/dashboard-plugin/lib/resolveProviderCredentials');
-const isAuthenticated = require('@serverless/dashboard-plugin/lib/isAuthenticated');
+const resolveProviderCredentials = require('@serverless/dashboard-plugin/lib/resolve-provider-credentials');
+const isAuthenticated = require('@serverless/dashboard-plugin/lib/is-authenticated');
 const hasLocalCredentials = require('../../aws/has-local-credentials');
 
 const fsp = require('fs').promises;

--- a/test/unit/lib/cli/interactive-setup/aws-credentials.test.js
+++ b/test/unit/lib/cli/interactive-setup/aws-credentials.test.js
@@ -34,7 +34,7 @@ const step = proxyquire('../../../../../lib/cli/interactive-setup/aws-credential
   '../../utils/openBrowser': async (url) => {
     openBrowserUrls.push(url);
   },
-  '@serverless/dashboard-plugin/lib/clientUtils': {
+  '@serverless/dashboard-plugin/lib/client-utils': {
     getPlatformClientWithAccessKey: async () => mockedSdk,
   },
 });
@@ -90,10 +90,10 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       },
     };
     const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-      '@serverless/dashboard-plugin/lib/clientUtils': {
+      '@serverless/dashboard-plugin/lib/client-utils': {
         getPlatformClientWithAccessKey: async () => internalMockedSdk,
       },
-      '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+      '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
     });
 
     const context = {
@@ -126,10 +126,10 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       },
     };
     const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-      '@serverless/dashboard-plugin/lib/clientUtils': {
+      '@serverless/dashboard-plugin/lib/client-utils': {
         getPlatformClientWithAccessKey: async () => internalMockedSdk,
       },
-      '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+      '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
       './utils': {
         doesServiceInstanceHaveLinkedProvider: () => true,
       },
@@ -172,10 +172,10 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       },
     };
     const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-      '@serverless/dashboard-plugin/lib/clientUtils': {
+      '@serverless/dashboard-plugin/lib/client-utils': {
         getPlatformClientWithAccessKey: async () => internalMockedSdk,
       },
-      '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+      '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
       './utils': {
         doesServiceInstanceHaveLinkedProvider: () => false,
       },
@@ -207,10 +207,10 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
       },
     };
     const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-      '@serverless/dashboard-plugin/lib/clientUtils': {
+      '@serverless/dashboard-plugin/lib/client-utils': {
         getPlatformClientWithAccessKey: async () => internalMockedSdk,
       },
-      '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+      '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
     });
 
     expect(
@@ -445,11 +445,11 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
         createProviderLink: mockedCreateProviderLink,
       };
       const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-        '@serverless/dashboard-plugin/lib/clientUtils': {
+        '@serverless/dashboard-plugin/lib/client-utils': {
           getPlatformClientWithAccessKey: async () => internalMockedSdk,
         },
         '../../utils/openBrowser': mockedOpenBrowser,
-        '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+        '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
       });
 
       configureInquirerStub(inquirer, {
@@ -515,11 +515,11 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
         createProviderLink: mockedCreateProviderLink,
       };
       const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-        '@serverless/dashboard-plugin/lib/clientUtils': {
+        '@serverless/dashboard-plugin/lib/client-utils': {
           getPlatformClientWithAccessKey: async () => internalMockedSdk,
         },
         '../../utils/openBrowser': mockedOpenBrowser,
-        '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+        '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
       });
 
       configureInquirerStub(inquirer, {
@@ -566,7 +566,7 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
         },
       };
       const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-        '@serverless/dashboard-plugin/lib/clientUtils': {
+        '@serverless/dashboard-plugin/lib/client-utils': {
           getPlatformClientWithAccessKey: async () => internalMockedSdk,
         },
         '../../utils/openBrowser': mockedOpenBrowser,
@@ -620,7 +620,7 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
         createProviderLink: mockedCreateProviderLink,
       };
       const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-        '@serverless/dashboard-plugin/lib/clientUtils': {
+        '@serverless/dashboard-plugin/lib/client-utils': {
           getPlatformClientWithAccessKey: async () => internalMockedSdk,
         },
       });
@@ -681,7 +681,7 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
         createProviderLink: mockedCreateProviderLink,
       };
       const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-        '@serverless/dashboard-plugin/lib/clientUtils': {
+        '@serverless/dashboard-plugin/lib/client-utils': {
           getPlatformClientWithAccessKey: async () => internalMockedSdk,
         },
       });
@@ -725,10 +725,10 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
         },
       };
       const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/aws-credentials', {
-        '@serverless/dashboard-plugin/lib/clientUtils': {
+        '@serverless/dashboard-plugin/lib/client-utils': {
           getPlatformClientWithAccessKey: async () => internalMockedSdk,
         },
-        '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+        '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
       });
 
       await mockedStep.run({

--- a/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -98,7 +98,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       '@serverless/platform-client': {
         ServerlessSDK: ServerlessSDKMock,
       },
-      '@serverless/dashboard-plugin/lib/clientUtils': {
+      '@serverless/dashboard-plugin/lib/client-utils': {
         getPlatformClientWithAccessKey: async () => new ServerlessSDKMock(),
         getOrCreateAccessKeyForOrg: async () => 'accessKey',
       },

--- a/test/unit/lib/cli/interactive-setup/deploy.test.js
+++ b/test/unit/lib/cli/interactive-setup/deploy.test.js
@@ -53,7 +53,7 @@ describe('test/unit/lib/cli/interactive-setup/deploy.test.js', () => {
 
   it('Should be applied if service instance has a linked provider', async () => {
     const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/deploy', {
-      '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+      '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
       './utils': {
         doesServiceInstanceHaveLinkedProvider: () => true,
       },

--- a/test/unit/lib/cli/interactive-setup/utils.test.js
+++ b/test/unit/lib/cli/interactive-setup/utils.test.js
@@ -21,7 +21,7 @@ describe('test/unit/lib/cli/interactive-setup/utils.test.js', () => {
       const { doesServiceInstanceHaveLinkedProvider } = proxyquire(
         '../../../../../lib/cli/interactive-setup/utils',
         {
-          '@serverless/dashboard-plugin/lib/resolveProviderCredentials': () => {
+          '@serverless/dashboard-plugin/lib/resolve-provider-credentials': () => {
             return {
               accessKeyId: 'someaccess',
               secretAccessKey: 'somesecret',
@@ -37,7 +37,7 @@ describe('test/unit/lib/cli/interactive-setup/utils.test.js', () => {
       const { doesServiceInstanceHaveLinkedProvider } = proxyquire(
         '../../../../../lib/cli/interactive-setup/utils',
         {
-          '@serverless/dashboard-plugin/lib/resolveProviderCredentials': () => {
+          '@serverless/dashboard-plugin/lib/resolve-provider-credentials': () => {
             return null;
           },
         }
@@ -49,7 +49,7 @@ describe('test/unit/lib/cli/interactive-setup/utils.test.js', () => {
       const { doesServiceInstanceHaveLinkedProvider } = proxyquire(
         '../../../../../lib/cli/interactive-setup/utils',
         {
-          '@serverless/dashboard-plugin/lib/resolveProviderCredentials': () => {
+          '@serverless/dashboard-plugin/lib/resolve-provider-credentials': () => {
             const err = new Error('Error');
             err.statusCode = 500;
             throw err;
@@ -73,7 +73,7 @@ describe('test/unit/lib/cli/interactive-setup/utils.test.js', () => {
       const { resolveInitialContext } = proxyquire(
         '../../../../../lib/cli/interactive-setup/utils',
         {
-          '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+          '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
           '../../aws/has-local-credentials': () => true,
         }
       );
@@ -91,7 +91,7 @@ describe('test/unit/lib/cli/interactive-setup/utils.test.js', () => {
       const { resolveInitialContext } = proxyquire(
         '../../../../../lib/cli/interactive-setup/utils',
         {
-          '@serverless/dashboard-plugin/lib/isAuthenticated': () => true,
+          '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
           '../../aws/has-local-credentials': () => true,
         }
       );


### PR DESCRIPTION
Follows https://github.com/serverless/dashboard-plugin/pull/661, tests won't pass until PR on `@serverless/dashboard-plugin` side is merged