### PR TITLE
test: Ensure we tests against unached version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash": "^4.17.21",
     "memoizee": "^0.4.15",
     "micromatch": "^4.0.4",
-    "ncjsm": "^4.2.0",
+    "ncjsm": "^4.3.0",
     "node-fetch": "^2.6.7",
     "open": "^7.4.2",
     "path2": "^0.1.0",

--- a/test/unit/lib/plugins/aws/customResources/generateZip.test.js
+++ b/test/unit/lib/plugins/aws/customResources/generateZip.test.js
@@ -2,9 +2,9 @@
 
 const path = require('path');
 const globby = require('globby');
+const requireUncached = require('ncjsm/require-uncached');
 const { listZipFiles } = require('../../../../../utils/fs');
 const { expect } = require('chai');
-const generateZip = require('../../../../../../lib/plugins/aws/customResources/generateZip');
 
 // The directory that holds the files that generateZip zips up
 const resourcesDir = path.resolve(
@@ -15,7 +15,9 @@ const resourcesDir = path.resolve(
 describe('test/unit/lib/plugins/aws/customResources/generateZip.test.js', () => {
   describe('when generating a zip file', () => {
     it('should generate a zip file with the contents of the resources directory', async () => {
-      const zipFilePath = await generateZip();
+      const zipFilePath = await requireUncached(async () =>
+        require('../../../../../../lib/plugins/aws/customResources/generateZip')()
+      );
 
       // List the files in the zip to make sure it is valid
       const filesInZip = await listZipFiles(zipFilePath);


### PR DESCRIPTION
I've got false failures locally, due to `generateZip` being resolved against my local home dir. This fixes that.

While we consider `master` frozen. It's fine to take this in (so it also serves later v2 branch), as it doesn't touch any functionality
