### PR TITLE
fix: nesting-tracking in resolver aborting too eagerly

### DIFF
--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -338,7 +338,7 @@ class VariablesResolver {
       valueMeta.variables = valueVariables;
       delete valueMeta.sourceValues;
       await this.resolveVariables(resolutionBatchId, propertyPath, valueMeta);
-      await this.resolveInternalResult(resolutionBatchId, propertyPath, valueMeta, --nestTracker);
+      await this.resolveInternalResult(resolutionBatchId, propertyPath, valueMeta, nestTracker - 1);
       return;
     }
     const valueEntries = (() => {
@@ -353,7 +353,7 @@ class VariablesResolver {
         resolutionBatchId,
         propertyPath,
         propertyValueMeta,
-        --nestTracker
+        nestTracker - 1
       );
       const propertyKeyPathKeys = propertyKeyPath.split('\0');
       const targetKey = propertyKeyPathKeys[propertyKeyPathKeys.length - 1];

--- a/test/unit/lib/configuration/variables/sources/file.test.js
+++ b/test/unit/lib/configuration/variables/sources/file.test.js
@@ -25,6 +25,7 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
       addressSupport: '${file(file.json):result}',
       jsFunctionResolveVariable: '${file(file-function-variable.js)}',
       jsFunctionResolveVariableMissingSource: '${file(file-function-variable-missing-source.js)}',
+      jsFunctionResolveManyVariables: '${file(file-function-many-variables.js)}',
       jsPropertyFunctionResolveVariable: '${file(file-property-function-variable.js):property}',
       jsPropertyFunctionResolveVariableMissingSource:
         '${file(file-property-function-variable-missing-source.js):property}',
@@ -100,6 +101,9 @@ describe('test/unit/lib/configuration/variables/sources/file.test.js', () => {
     });
     expect(configuration.jsPropertyFunctionResolveVariable).to.deep.equal({
       varResult: { result: 'json' },
+    });
+    expect(configuration.jsFunctionResolveManyVariables).to.deep.equal({
+      varResult: { result: ['yml', 'yml', 'yml', 'yml', 'yml', 'yml', 'yml', 'yml', 'yml', 'yml'] },
     });
   });
 

--- a/test/unit/lib/configuration/variables/sources/fixture/file-function-many-variables.js
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-function-many-variables.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async ({ resolveVariable }) => ({
+  varResult: await resolveVariable('file(file-function-many-variables.yaml)'),
+});

--- a/test/unit/lib/configuration/variables/sources/fixture/file-function-many-variables.yaml
+++ b/test/unit/lib/configuration/variables/sources/fixture/file-function-many-variables.yaml
@@ -1,0 +1,12 @@
+# The resolve nest depth is 10, so we have to resolve at least 10 files to ensure it's not being hit.
+result:
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}
+  - ${file(./file.yml):result}


### PR DESCRIPTION
Closes: #10549

This is a minor change to the resolver that removes a false-positive nesting depth error.

When importing a file from a js function (using `resolveVariable`), all variables in that file are resolved in a loop. The loop passes a nest depth of one lower, but did so by decrementing the loop counter on each iteration. This means that once you hit your 10th variable, it aborts because it thinks you've nested to deep (while in fact you're still only one level deep).

Effectively this changes `--nestTracker` to `nestTracker - 1`, so that the actual depth is kept, allowing for normal behavior.

I also added a test case for this particular use-case. Note that while the test case does file inclusion inside the file-included file, it affects any variable resolving, but I did not want to mess with the test file too much.