### PR TITLE
refactor: Remove leftover `SLS_DEBUG` references

### DIFF
--- a/lib/aws/request.js
+++ b/lib/aws/request.js
@@ -212,9 +212,12 @@ async function awsRequest(service, method, ...args) {
           if (typeof err.code === 'number') return `HTTP_${err.code}_ERROR`;
           return normalizeErrorCodePostfix(err.code);
         })();
+        if (err.stack) {
+          log.debug(`${err.stack}\n${'-'.repeat(100)}`);
+        }
         throw Object.assign(
           new ServerlessError(
-            process.env.SLS_DEBUG && err.stack ? `${err.stack}\n${'-'.repeat(100)}` : message,
+            message,
             `AWS_${normalizeErrorCodePostfix(service.name)}_${normalizeErrorCodePostfix(
               method
             )}_${providerErrorCodeExtension}`

--- a/test/unit/lib/aws/request.test.js
+++ b/test/unit/lib/aws/request.test.js
@@ -14,7 +14,6 @@ describe('#request', () => {
   it('should enable aws logging when debug log is enabled', () => {
     const configStub = sinon.stub();
     overrideEnv(() => {
-      process.env.SLS_DEBUG = true;
       proxyquire('../../../../lib/aws/request', {
         'aws-sdk': { config: configStub },
       });
@@ -40,7 +39,6 @@ describe('#request', () => {
     });
 
     it('should produce a meaningful error when no supported credentials are provided', async () => {
-      process.env.SLS_DEBUG = true;
       const awsRequest = require('../../../../lib/aws/request');
       return expect(
         awsRequest(

--- a/test/utils/integration.js
+++ b/test/utils/integration.js
@@ -14,7 +14,6 @@ const { load: loadYaml } = require('js-yaml');
 const serverlessExec = require('../serverlessBinary');
 
 const env = resolveAwsEnv();
-env.SLS_DEBUG = '1';
 
 async function resolveServiceName(cwd) {
   const configContent = await (async () => {


### PR DESCRIPTION
I did not submit the log change to current `master` as I don't want to release yet another v2 release before v3 major