### PR TITLE
fix: Report more meaningful strict schema mode error

### DIFF
--- a/lib/classes/config-schema-handler/resolve-ajv-validate.js
+++ b/lib/classes/config-schema-handler/resolve-ajv-validate.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const requireFromString = require('require-from-string');
 const deepSortObjectByKey = require('../../utils/deep-sort-object-by-key');
 const ensureExists = require('../../utils/ensure-exists');
+const ServerlessError = require('../../serverless-error');
 
 const getCacheDir = () => {
   return path.resolve(
@@ -45,7 +46,18 @@ const getValidate = async (schema) => {
     // See: https://github.com/ajv-validator/ajv/issues/1390#issuecomment-763138202
     ajv.opts.code.formats = Ajv._`require("ajv-formats/dist/formats").fullFormats`;
     ajv.addKeyword(require('./regexp-keyword'));
-    const validate = ajv.compile(schema);
+    let validate;
+    try {
+      validate = ajv.compile(schema);
+    } catch (err) {
+      if (err.message && err.message.includes('strict mode')) {
+        throw new ServerlessError(
+          'At least one of the plugins defines a validation schema that is invalid. Try disabling plugins one by one to identify the problematic plugin and report it to the plugin maintainers.',
+          'SCHEMA_FAILS_STRICT_MODE'
+        );
+      }
+      throw err;
+    }
     const moduleCode = standaloneCode(ajv, validate);
     await fs.promises.writeFile(cachePath, moduleCode);
   };


### PR DESCRIPTION
Reported internally, improve the error message a bit when plugin does not conform to strict schema validation