### PR TITLE
feat(AWS MSK): Support `maximumBatchingWindow`

### DIFF
--- a/docs/providers/aws/events/msk.md
+++ b/docs/providers/aws/events/msk.md
@@ -43,13 +43,13 @@ functions:
           topic: mytopic
 ```
 
-## Setting the BatchSize and StartingPosition
+## Setting the BatchSize, MaximumBatchingWindow and StartingPosition
 
 For the MSK event integration, you can set the `batchSize`, which effects how many messages can be processed in a single Lambda invocation. The default `batchSize` is 100, and the max `batchSize` is 10000.
-Likewise `maximumBatchingWindowInSeconds` can be set to determine the amount of time the Lambda spends gathering records before invoking the function. The default is 0, but **if you set `batchSize` to more than 10, you must set `maximumBatchingWindowInSeconds` to at least 1**. The maximum is 300.
+Likewise `maximumBatchingWindow` can be set to determine the amount of time the Lambda spends gathering records before invoking the function. The default is 0, but **if you set `batchSize` to more than 10, you must set `maximumBatchingWindow` to at least 1**. The maximum is 300.
 In addition, you can also configure `startingPosition`, which controls the position at which Lambda should start consuming messages from MSK topic. It supports two possible values, `TRIM_HORIZON` and `LATEST`, with `TRIM_HORIZON` being the default.
 
-In the following example, we specify that the `compute` function should have an `msk` event configured with `batchSize` of 1000 and `startingPosition` equal to `LATEST`.
+In the following example, we specify that the `compute` function should have an `msk` event configured with `batchSize` of 1000, `maximumBatchingWindow` to 30 seconds and `startingPosition` equal to `LATEST`.
 
 ```yml
 functions:
@@ -60,6 +60,7 @@ functions:
           arn: arn:aws:kafka:region:XXXXXX:cluster/MyCluster/xxxx-xxxxx-xxxx
           topic: mytopic
           batchSize: 1000
+          maximumBatchingWindow: 30
           startingPosition: LATEST
 ```
 

--- a/docs/providers/aws/events/msk.md
+++ b/docs/providers/aws/events/msk.md
@@ -46,6 +46,7 @@ functions:
 ## Setting the BatchSize and StartingPosition
 
 For the MSK event integration, you can set the `batchSize`, which effects how many messages can be processed in a single Lambda invocation. The default `batchSize` is 100, and the max `batchSize` is 10000.
+Likewise `maximumBatchingWindowInSeconds` can be set to determine the amount of time the Lambda spends gathering records before invoking the function. The default is 0, but **if you set `batchSize` to more than 10, you must set `maximumBatchingWindowInSeconds` to at least 1**. The maximum is 300.
 In addition, you can also configure `startingPosition`, which controls the position at which Lambda should start consuming messages from MSK topic. It supports two possible values, `TRIM_HORIZON` and `LATEST`, with `TRIM_HORIZON` being the default.
 
 In the following example, we specify that the `compute` function should have an `msk` event configured with `batchSize` of 1000 and `startingPosition` equal to `LATEST`.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -920,6 +920,8 @@ functions:
           topic: kafkaTopic
           # Optional, must be in 1-10000 range
           batchSize: 100
+          # Optional, minimum is 0 and the maximum is 300 (seconds)
+          maximumBatchingWindowInSeconds: 30
           # Optional, can be set to LATEST or TRIM_HORIZON
           startingPosition: LATEST
           # (default: true)

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -921,7 +921,7 @@ functions:
           # Optional, must be in 1-10000 range
           batchSize: 100
           # Optional, minimum is 0 and the maximum is 300 (seconds)
-          maximumBatchingWindowInSeconds: 30
+          maximumBatchingWindow: 30
           # Optional, can be set to LATEST or TRIM_HORIZON
           startingPosition: LATEST
           # (default: true)

--- a/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/lib/plugins/aws/package/compile/events/msk/index.js
@@ -26,7 +26,7 @@ class AwsCompileMSKEvents {
           minimum: 1,
           maximum: 10000,
         },
-        maximumBatchingWindowInSeconds: {
+        maximumBatchingWindow: {
           type: 'number',
           minimum: 0,
           maximum: 300,
@@ -76,7 +76,7 @@ class AwsCompileMSKEvents {
           const eventSourceArn = event.msk.arn;
           const topic = event.msk.topic;
           const batchSize = event.msk.batchSize;
-          const maximumBatchingWindowInSeconds = event.msk.maximumBatchingWindowInSeconds;
+          const maximumBatchingWindow = event.msk.maximumBatchingWindow;
           const enabled = event.msk.enabled;
           const startingPosition = event.msk.startingPosition || 'TRIM_HORIZON';
 
@@ -108,8 +108,8 @@ class AwsCompileMSKEvents {
             mskResource.Properties.BatchSize = batchSize;
           }
 
-          if (maximumBatchingWindowInSeconds) {
-            mskResource.Properties.MaximumBatchingWindowInSeconds = maximumBatchingWindowInSeconds;
+          if (maximumBatchingWindow) {
+            mskResource.Properties.MaximumBatchingWindowInSeconds = maximumBatchingWindow;
           }
 
           if (enabled != null) {

--- a/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/lib/plugins/aws/package/compile/events/msk/index.js
@@ -26,6 +26,11 @@ class AwsCompileMSKEvents {
           minimum: 1,
           maximum: 10000,
         },
+        maximumBatchingWindowInSeconds: {
+          type: 'number',
+          minimum: 0,
+          maximum: 300,
+        },
         enabled: {
           type: 'boolean',
         },
@@ -71,6 +76,7 @@ class AwsCompileMSKEvents {
           const eventSourceArn = event.msk.arn;
           const topic = event.msk.topic;
           const batchSize = event.msk.batchSize;
+          const maximumBatchingWindowInSeconds = event.msk.maximumBatchingWindowInSeconds;
           const enabled = event.msk.enabled;
           const startingPosition = event.msk.startingPosition || 'TRIM_HORIZON';
 
@@ -100,6 +106,10 @@ class AwsCompileMSKEvents {
 
           if (batchSize) {
             mskResource.Properties.BatchSize = batchSize;
+          }
+
+          if (maximumBatchingWindowInSeconds) {
+            mskResource.Properties.MaximumBatchingWindowInSeconds = maximumBatchingWindowInSeconds;
           }
 
           if (enabled != null) {

--- a/test/integration/aws/infra-dependent/msk.test.js
+++ b/test/integration/aws/infra-dependent/msk.test.js
@@ -54,6 +54,8 @@ describe('AWS - MSK Integration Test', function () {
                 msk: {
                   arn: outputMap.get('MSKCluster'),
                   topic: topicName,
+                  batchSize: 100,
+                  maximumBatchWindowingInSeconds: 3,
                 },
               },
             ],

--- a/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
@@ -13,7 +13,7 @@ describe('AwsCompileMSKEvents', () => {
   const enabled = false;
   const startingPosition = 'LATEST';
   const batchSize = 5000;
-  const maximumBatchingWindowInSeconds = 10;
+  const maximumBatchingWindow = 10;
 
   describe('when there are msk events defined', () => {
     let minimalEventSourceMappingResource;
@@ -43,7 +43,7 @@ describe('AwsCompileMSKEvents', () => {
                     topic,
                     arn,
                     batchSize,
-                    maximumBatchingWindowInSeconds,
+                    maximumBatchingWindow,
                     enabled,
                     startingPosition,
                   },
@@ -104,7 +104,7 @@ describe('AwsCompileMSKEvents', () => {
     it('should correctly complie EventSourceMapping resource with all parameters', () => {
       expect(allParamsEventSourceMappingResource.Properties).to.deep.equal({
         BatchSize: batchSize,
-        MaximumBatchingWindowInSeconds: maximumBatchingWindowInSeconds,
+        MaximumBatchingWindowInSeconds: maximumBatchingWindow,
         Enabled: enabled,
         EventSourceArn: arn,
         StartingPosition: startingPosition,

--- a/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
@@ -13,6 +13,7 @@ describe('AwsCompileMSKEvents', () => {
   const enabled = false;
   const startingPosition = 'LATEST';
   const batchSize = 5000;
+  const maximumBatchingWindowInSeconds = 10;
 
   describe('when there are msk events defined', () => {
     let minimalEventSourceMappingResource;
@@ -42,6 +43,7 @@ describe('AwsCompileMSKEvents', () => {
                     topic,
                     arn,
                     batchSize,
+                    maximumBatchingWindowInSeconds,
                     enabled,
                     startingPosition,
                   },
@@ -102,6 +104,7 @@ describe('AwsCompileMSKEvents', () => {
     it('should correctly complie EventSourceMapping resource with all parameters', () => {
       expect(allParamsEventSourceMappingResource.Properties).to.deep.equal({
         BatchSize: batchSize,
+        MaximumBatchingWindowInSeconds: maximumBatchingWindowInSeconds,
         Enabled: enabled,
         EventSourceArn: arn,
         StartingPosition: startingPosition,


### PR DESCRIPTION
### bugfix(AWS MSK): Support MaximumBatchingWindowInSeconds property in event source mapping config

Looking at the AWS docs for [EventSourceMappingConfig](https://docs.aws.amazon.com/lambda/latest/dg/API_EventSourceMappingConfiguration.html), it says:

> When you set `BatchSize` to a value greater than 10, you must set `MaximumBatchingWindowInSeconds` to at least 1.

This (bug fix :grimacing:) PR adds the `maximumBatchingWindow` property to serverless.yaml + updates the existing unit test + have updated the integration test, but unable to get the integration test setup working properly.

[new PR after attempting to rebase #10579 failed]