### PR TITLE
bugfix(AWS RabbitMQ): Support MaximumBatchingWindowInSeconds property in event source mapping config

### DIFF
--- a/docs/providers/aws/events/rabbitmq.md
+++ b/docs/providers/aws/events/rabbitmq.md
@@ -54,9 +54,10 @@ functions:
           basicAuthArn: arn:aws:secretsmanager:us-east-1:01234567890:secret:MySecret
 ```
 
-## Specifying batch size
+## Specifying batch size and batch window
 
 You can also specify `batchSize` of number of items to retrieve in a single batch. If not specified, this will default to `100`.
+Likewise `maximumBatchingWindow` can be set to determine the amount of time the Lambda spends gathering records before invoking the function. The default is 0, but **if you set `batchSize` to more than 10, you must set `maximumBatchingWindow` to at least 1**. The maximum is 300.
 
 ```yml
 functions:
@@ -67,6 +68,7 @@ functions:
           arn: arn:aws:mq:us-east-1:0000:broker:ExampleMQBroker:b-xxx-xxx
           queue: queue-name
           batchSize: 5000
+          maximumBatchingWindow: 30
           basicAuthArn: arn:aws:secretsmanager:us-east-1:01234567890:secret:MySecret
 ```
 

--- a/lib/plugins/aws/package/compile/events/rabbitmq.js
+++ b/lib/plugins/aws/package/compile/events/rabbitmq.js
@@ -34,6 +34,11 @@ class AwsCompileRabbitMQEvents {
           minimum: 1,
           maximum: 10000,
         },
+        maximumBatchingWindow: {
+          type: 'number',
+          minimum: 0,
+          maximum: 300,
+        },
         enabled: {
           type: 'boolean',
         },
@@ -86,7 +91,8 @@ class AwsCompileRabbitMQEvents {
         if (!event.rabbitmq) return;
 
         hasMQEvent = true;
-        const { basicAuthArn, arn, batchSize, enabled, queue } = event.rabbitmq;
+        const { basicAuthArn, arn, batchSize, maximumBatchingWindow, enabled, queue } =
+          event.rabbitmq;
 
         const mqEventLogicalId = this.provider.naming.getRabbitMQEventLogicalId(
           functionName,
@@ -115,6 +121,10 @@ class AwsCompileRabbitMQEvents {
 
         if (batchSize) {
           mqResource.Properties.BatchSize = batchSize;
+        }
+
+        if (maximumBatchingWindow) {
+          mqResource.Properties.MaximumBatchingWindowInSeconds = maximumBatchingWindow;
         }
 
         if (enabled != null) {

--- a/test/unit/lib/plugins/aws/package/compile/events/rabbitmq.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/rabbitmq.test.js
@@ -13,6 +13,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/rabbitmq.test.js', ()
   const queue = 'TestingQueue';
   const enabled = false;
   const batchSize = 5000;
+  const maximumBatchingWindow = 20;
 
   describe('when there are rabbitmq events defined', () => {
     let minimalEventSourceMappingResource;
@@ -44,6 +45,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/rabbitmq.test.js', ()
                     arn: brokerArn,
                     basicAuthArn,
                     batchSize,
+                    maximumBatchingWindow,
                     enabled,
                   },
                 },
@@ -102,6 +104,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/rabbitmq.test.js', ()
       expect(allParamsEventSourceMappingResource.Properties).to.deep.equal({
         EventSourceArn: brokerArn,
         BatchSize: batchSize,
+        MaximumBatchingWindowInSeconds: maximumBatchingWindow,
         Enabled: enabled,
         SourceAccessConfigurations: [
           {


### PR DESCRIPTION
As per #10580, this PR adds `maximumBatchingWindow` property to serverless.yaml for RabbitMQ event sources