### PR TITLE
feat(AWS ActiveMQ): Support `maximumBatchingWindow`

### DIFF
--- a/docs/providers/aws/events/activemq.md
+++ b/docs/providers/aws/events/activemq.md
@@ -54,9 +54,10 @@ functions:
           basicAuthArn: arn:aws:secretsmanager:us-east-1:01234567890:secret:MySecret
 ```
 
-## Specifying batch size
+## Specifying batch size and batch window
 
 You can also specify `batchSize` of number of items to retrieve in a single batch. If not specified, this will default to `100`.
+Likewise `maximumBatchingWindow` can be set to determine the amount of time the Lambda spends gathering records before invoking the function. The default is 0, but **if you set `batchSize` to more than 10, you must set `maximumBatchingWindow` to at least 1**. The maximum is 300.
 
 ```yml
 functions:
@@ -67,6 +68,7 @@ functions:
           arn: arn:aws:mq:us-east-1:0000:broker:ExampleMQBroker:b-xxx-xxx
           queue: queue-name
           batchSize: 5000
+          maximumBatchingWindow: 30
           basicAuthArn: arn:aws:secretsmanager:us-east-1:01234567890:secret:MySecret
 ```
 

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -928,6 +928,30 @@ functions:
           enabled: false
 ```
 
+[ActiveMQ events](../events/activemq.md):
+
+```yaml
+functions:
+  hello:
+    # ...
+    events:
+      - activemq:
+          # ARN of ActiveMQ Broker
+          arn: arn:aws:mq:us-east-1:0000:broker:ExampleMQBroker:b-xxx-xxx
+          # name of ActiveMQ queue consume from
+          queue: queue-name
+          # Secrets Manager ARN for credentials required to do basic auth
+          basicAuthArn: arn:aws:secretsmanager:us-east-1:01234567890:secret:MySecret
+          # Optional, must be in 1-10000 range
+          batchSize: 100
+          # Optional, minimum is 0 and the maximum is 300 (seconds)
+          maximumBatchingWindow: 30
+          # Optional, can be set to LATEST or TRIM_HORIZON
+          startingPosition: LATEST
+          # (default: true)
+          enabled: false
+```
+
 ### Alexa
 
 [Alexa Skill events](../events/alexa-skill.md) and [Alexa Smart Home events](../events/alexa-smart-home.md):

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -920,7 +920,7 @@ functions:
           topic: kafkaTopic
           # Optional, must be in 1-10000 range
           batchSize: 100
-          # Optional, minimum is 0 and the maximum is 300 (seconds)
+          # Optional, must be in 0-300 range (seconds)
           maximumBatchingWindow: 30
           # Optional, can be set to LATEST or TRIM_HORIZON
           startingPosition: LATEST

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -928,6 +928,8 @@ functions:
           enabled: false
 ```
 
+### ActiveMQ
+
 [ActiveMQ events](../events/activemq.md):
 
 ```yaml

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -940,13 +940,13 @@ functions:
       - activemq:
           # ARN of ActiveMQ Broker
           arn: arn:aws:mq:us-east-1:0000:broker:ExampleMQBroker:b-xxx-xxx
-          # name of ActiveMQ queue consume from
+          # Name of ActiveMQ queue consume from
           queue: queue-name
-          # Secrets Manager ARN for credentials required to do basic auth
+          # Secrets Manager ARN for basic auth credentials
           basicAuthArn: arn:aws:secretsmanager:us-east-1:01234567890:secret:MySecret
           # Optional, must be in 1-10000 range
           batchSize: 100
-          # Optional, minimum is 0 and the maximum is 300 (seconds)
+          # Optional, must be in 0-300 range (seconds)
           maximumBatchingWindow: 30
           # Optional, can be set to LATEST or TRIM_HORIZON
           startingPosition: LATEST

--- a/lib/plugins/aws/package/compile/events/activemq.js
+++ b/lib/plugins/aws/package/compile/events/activemq.js
@@ -34,6 +34,11 @@ class AwsCompileActiveMQEvents {
           minimum: 1,
           maximum: 10000,
         },
+        maximumBatchingWindow: {
+          type: 'number',
+          minimum: 0,
+          maximum: 300,
+        },
         enabled: {
           type: 'boolean',
         },
@@ -86,7 +91,8 @@ class AwsCompileActiveMQEvents {
         if (!event.activemq) return;
 
         hasMQEvent = true;
-        const { basicAuthArn, arn, batchSize, enabled, queue } = event.activemq;
+        const { basicAuthArn, arn, batchSize, maximumBatchingWindow, enabled, queue } =
+          event.activemq;
 
         const mqEventLogicalId = this.provider.naming.getActiveMQEventLogicalId(
           functionName,
@@ -115,6 +121,10 @@ class AwsCompileActiveMQEvents {
 
         if (batchSize) {
           mqResource.Properties.BatchSize = batchSize;
+        }
+
+        if (maximumBatchingWindow) {
+          mqResource.Properties.MaximumBatchingWindowInSeconds = maximumBatchingWindow;
         }
 
         if (enabled != null) {

--- a/test/unit/lib/plugins/aws/package/compile/events/activemq.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/activemq.test.js
@@ -13,6 +13,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/activemq.test.js', ()
   const queue = 'TestingQueue';
   const enabled = false;
   const batchSize = 5000;
+  const maximumBatchingWindow = 20;
 
   describe('when there are activemq events defined', () => {
     let minimalEventSourceMappingResource;
@@ -44,6 +45,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/activemq.test.js', ()
                     arn: brokerArn,
                     basicAuthArn,
                     batchSize,
+                    maximumBatchingWindow,
                     enabled,
                   },
                 },
@@ -102,6 +104,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/activemq.test.js', ()
       expect(allParamsEventSourceMappingResource.Properties).to.deep.equal({
         EventSourceArn: brokerArn,
         BatchSize: batchSize,
+        MaximumBatchingWindowInSeconds: maximumBatchingWindow,
         Enabled: enabled,
         SourceAccessConfigurations: [
           {


### PR DESCRIPTION
As per #10580, this PR adds `maximumBatchingWindow` property to serverless.yaml for ActiveMQ event sources