### PR TITLE
CLI: Fix support for `-c` (`--config`) shortcut

### DIFF
--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -176,6 +176,13 @@ processSpanPromise = (async () => {
     if (!commandSchema || commandSchema.serviceDependencyMode) {
       // Command is potentially service specific, follow up with resolution of service config
 
+      // Parse args again, taking acounnt schema of service-specific flags
+      // as they may influence configuration resolution
+      resolveInput.clear();
+      ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
+        require('../lib/cli/commands-schema/service')
+      ));
+
       isInteractiveSetup = !isHelpRequest && command === '';
 
       const resolveConfigurationPath = require('../lib/cli/resolve-configuration-path');
@@ -202,14 +209,6 @@ processSpanPromise = (async () => {
 
       if (configuration) {
         serviceDir = process.cwd();
-        if (!commandSchema) {
-          // If command was not recognized in first resolution phase
-          // parse args again also against schemas of commands which require service context
-          resolveInput.clear();
-          ({ command, commands, options, isHelpRequest, commandSchema } = resolveInput(
-            require('../lib/cli/commands-schema/service')
-          ));
-        }
 
         // IIFE for maintenance convenience
         await (async () => {

--- a/test/fixtures/programmatic/custom-config-filename/serverless.custom.yml
+++ b/test/fixtures/programmatic/custom-config-filename/serverless.custom.yml
@@ -1,0 +1,10 @@
+service: service
+
+configValidationMode: error
+frameworkVersion: '*'
+
+custom:
+  looks: good
+
+provider:
+  name: aws

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -113,6 +113,18 @@ describe('test/unit/scripts/serverless.test.js', () => {
     ).to.include('self: bar');
   });
 
+  it('should support "-c" flag', async () => {
+    expect(
+      String(
+        (
+          await spawn('node', [serverlessPath, 'print', '-c', 'serverless.custom.yml'], {
+            cwd: path.resolve(programmaticFixturesPath, 'custom-config-filename'),
+          })
+        ).stdoutBuffer
+      )
+    ).to.include('looks: good');
+  });
+
   it('should rejected unresolved "provider" section', async () => {
     try {
       await spawn('node', [serverlessPath, 'print'], {


### PR DESCRIPTION
Regression was accidentally introduced with https://github.com/serverless/serverless/pull/10332.

Back in v2, the resolution of `-c/--config` was hardcoded into `lib/cli/resolve-input.js`. While in v3 it was generalized, and co-relies on schema, which defines this option only for _service specific_ commands.

Having that `-c` shortcut stopped being recognized on time, as initial CLI flags resolution (which precedes configuration file resolution), loads schema only for _non-service command flags_

This patch ensures that before we attempt to resolve configuration filename, we have flags common for _service specific_ commands also loaded from schema

Closes: #10601
