### PR TITLE
CLI: Get `serverless-tencent` version from all supported locations

### DIFF
--- a/lib/cli/render-version.js
+++ b/lib/cli/render-version.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const os = require('os');
+const { createRequire } = require('module');
 const { version } = require('../../package');
 const spawn = require('child-process-ext/spawn');
 const { version: dashboardPluginVersion } = require('@serverless/dashboard-plugin/package');
@@ -12,7 +13,34 @@ const { writeText } = require('@serverless/utils/log');
 
 const serverlessPath = path.resolve(__dirname, '../..');
 
-const resolveTencentCliVersion = async () => {
+const resolveTencentCliNpmLocalVersion = () => {
+  try {
+    return createRequire(path.resolve(process.cwd(), 'require-resolver'))(
+      'serverless-tencent/package'
+    ).version;
+  } catch {
+    return null;
+  }
+};
+
+const resolveTencentCliNpmGlobalVersion = async () => {
+  const npmNodeModulesPath = await (async () => {
+    try {
+      return String((await spawn('npm', ['root', '-g'])).stdoutBuffer).trim();
+    } catch {
+      return null;
+    }
+  })();
+
+  if (!npmNodeModulesPath) return null;
+  try {
+    return require(`${npmNodeModulesPath}/serverless-tencent/package`).version;
+  } catch {
+    return null;
+  }
+};
+
+const resolveTencentCliStandaloneVersion = async () => {
   try {
     return String(
       (
@@ -46,7 +74,11 @@ module.exports = async () => {
     return '';
   })();
 
-  const tencentCliVersion = await resolveTencentCliVersion();
+  const tencentCliVersion =
+    resolveTencentCliNpmLocalVersion() ||
+    (await resolveTencentCliNpmGlobalVersion()) ||
+    (await resolveTencentCliStandaloneVersion());
+
   writeText(
     `Framework Core: ${version}${installationModePostfix}${globalInstallationPostfix}`,
     `Plugin: ${dashboardPluginVersion}`,


### PR DESCRIPTION
While we support falling back to `serverless-tencent` CLI being installed in three different locations (npm local, npm global, standalone), on printing version info we took into account only the last one. This PR fixes that, so all supported locations are taken into account.

This, unfortunately, slows down `sls -v` output by 200ms (on a fast machine), and it's not much we can do about it

/cc @zongUMR 
