### PR TITLE
docs: Clarify that upgrading isn't required when getting started

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ choco install serverless
 
 ## Upgrade
 
-If `serverless` was installed via NPM, upgrade it via:
+If `serverless` was installed via NPM, you can upgrade it via:
 
 ```bash
 npm install -g serverless
@@ -73,7 +73,7 @@ If you installed `serverless` as a standalone binary, read the following section
 
 ### Standalone binary
 
-On MacOS/Linux, run:
+On MacOS/Linux, you can upgrade the standalone `serverless` binary by running:
 
 ```bash
 serverless upgrade


### PR DESCRIPTION
This is a follow-up of Steven's getting started run-through.

We can see in his recording that he:

- installs `serverless`
- then immediately updates it

This is because the "getting started" is structured like this:

- Install
- Upgrade
- Create a project & deploy

We could move "Upgrade" somewhere else, but I don't have a clear vision on that. Maybe a more ambitious solution would be to split into 2 pages:

- _Installation_ -> install & upgrade
- _Getting started_ -> more of a tutorial

However I'm not 100% sure about that yet so I'd rather ship a small improvement today instead of waiting forever for a better option.

So this change is very minimal, but the goal is to suggest that upgrading is **optional**: "you can upgrade" instead of just "upgrade".