### PR TITLE
fix(AWS Deploy): Properly apply `stackPolicy` with changesets

### DIFF
--- a/lib/plugins/aws/lib/get-create-change-set-params.js
+++ b/lib/plugins/aws/lib/get-create-change-set-params.js
@@ -60,16 +60,6 @@ module.exports = {
       createChangeSetParams.Parameters = this.serverless.service.provider.stackParameters;
     }
 
-    // Policy must have at least one statement, otherwise no updates would be possible at all
-    if (
-      this.serverless.service.provider.stackPolicy &&
-      Object.keys(this.serverless.service.provider.stackPolicy).length
-    ) {
-      createChangeSetParams.StackPolicyBody = JSON.stringify({
-        Statement: this.serverless.service.provider.stackPolicy,
-      });
-    }
-
     if (this.serverless.service.provider.rollbackConfiguration) {
       createChangeSetParams.RollbackConfiguration =
         this.serverless.service.provider.rollbackConfiguration;

--- a/lib/plugins/aws/lib/update-stack.js
+++ b/lib/plugins/aws/lib/update-stack.js
@@ -91,6 +91,21 @@ module.exports = {
       return false;
     }
 
+    // Policy must have at least one statement, otherwise no updates would be possible at all
+    if (
+      this.serverless.service.provider.stackPolicy &&
+      Object.keys(this.serverless.service.provider.stackPolicy).length
+    ) {
+      log.info('Setting stack policy');
+      const stackPolicyBody = JSON.stringify({
+        Statement: this.serverless.service.provider.stackPolicy,
+      });
+      await this.provider.request('CloudFormation', 'setStackPolicy', {
+        StackName: stackName,
+        StackPolicyBody: stackPolicyBody,
+      });
+    }
+
     log.info('Executing created change set');
     await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
 

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -683,6 +683,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
   describe('custom deployment-related properties', () => {
     let createChangeSetStub;
     let executeChangeSetStub;
+    let setStackPolicyStub;
     const deploymentRole = 'arn:xxx';
     const notificationArns = ['arn:xxx', 'arn:yyy'];
     const stackParameters = [
@@ -724,6 +725,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
         .resolves({ Stacks: [{}] });
       createChangeSetStub = sinon.stub().resolves({});
       executeChangeSetStub = sinon.stub().resolves({});
+      setStackPolicyStub = sinon.stub().resolves({});
       const awsRequestStubMap = {
         ...baseAwsRequestStubMap,
         ECR: {
@@ -748,6 +750,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
             StackName: 'new-service-dev',
             Status: 'CREATE_COMPLETE',
           },
+          setStackPolicy: setStackPolicyStub,
           describeStackEvents: {
             StackEvents: [
               {
@@ -807,7 +810,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
     });
 
     it('should support `stackPolicy`', () => {
-      expect(createChangeSetStub.getCall(1).args[0].StackPolicyBody).to.deep.equal(
+      expect(setStackPolicyStub.getCall(0).args[0].StackPolicyBody).to.equal(
         JSON.stringify({ Statement: stackPolicy })
       );
     });


### PR DESCRIPTION
I've made a mistake during implementation of changeset-based deployments where I omitted that `StackBodyPolicy` is not supported on ChangeSet level directly - I've changed it here to be applied during deployment, after the change set is created (I've tested that it doesn't really have any influence on changeset creation, e.g. if policy prevents update that would be created as a part of changeset, the changeset will still be created and will only fail during execution) to apply it at last possible moment during the update. 

I've also investigated if it's possible to remove the `stackPolicy` during update, because I've noticed that in old logic we've never done it, e.g. if you set `stackPolicy`, deployed, removed `stackPolicy` setting and deployed again, stackPolicy was still left on the stack. Unfortunately, it's not possible to remove stackPolicy in any way - the only way to do it is to override it with a different one - it's a limitation of AWS at the moment.

Also for clarification - we don't set it on stack creation, because the stackPolicy is only effective during updates, not stack creation. 

Closes: #10606 