### PR TITLE
fix(AWS Deploy): Ensure to clear `notificationArns` if needed

### DIFF
--- a/lib/plugins/aws/lib/get-create-change-set-params.js
+++ b/lib/plugins/aws/lib/get-create-change-set-params.js
@@ -54,6 +54,8 @@ module.exports = {
 
     if (this.serverless.service.provider.notificationArns) {
       createChangeSetParams.NotificationARNs = this.serverless.service.provider.notificationArns;
+    } else {
+      createChangeSetParams.NotificationARNs = [];
     }
 
     if (this.serverless.service.provider.stackParameters) {

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -668,6 +668,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
       ChangeSetType: 'UPDATE',
       Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
       Parameters: [],
+      NotificationARNs: [],
       Tags: [{ Key: 'STAGE', Value: 'dev' }],
       TemplateBody: JSON.stringify({
         Resources: serverless.service.provider.coreCloudFormationTemplate.Resources,


### PR DESCRIPTION
It fixes a long-standing bug that is still present on `v2` branch, but due to some internal AWS quirks never surfaced as an error during deployment when `createStack` and `updateStack` operations were used instead of changesets. 

The root of the problem was that when `notificationArns` were specified during deployment and in subsequent deployment they were removed from configuration, they still stayed configured for stack on CloudFormation level. Suprisingly, if the topic was removed and configured ARN pointed to nonexistent topic, the CF updates still happened normally - that changed with ChangeSets, where an attempt to execute ChangeSet results in an error with missing topic. Logic in this PR ensures to explicitly pass empty list to clear any previously set and uncleared notification arns.

One caveat - it might remove notificationArns that were set outside of Serverless configuration, but I don't think we should worry about it as doing any side changes can introduce unexpected behavior.

Closes: #10600 