### PR TITLE
AWS Deploy: Handle gently missing template body

### DIFF
--- a/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
+++ b/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
@@ -75,7 +75,9 @@ module.exports = {
       TemplateStage: 'Original',
     });
 
-    const templateBody = JSON.parse(getTemplateResult.TemplateBody);
+    const templateBody = getTemplateResult.TemplateBody
+      ? JSON.parse(getTemplateResult.TemplateBody)
+      : {};
     if (!templateBody.Resources) {
       templateBody.Resources = {};
     }

--- a/test/integration-package/lambda-files.tests.js
+++ b/test/integration-package/lambda-files.tests.js
@@ -14,8 +14,7 @@ const fixturePaths = {
   individuallyFunction: path.join(__dirname, 'fixtures/individually-function'),
 };
 
-describe('Integration test - Packaging - Lambda Files', function () {
-  this.timeout(15000);
+describe('Integration test - Packaging - Lambda Files', () => {
   let cwd;
   beforeEach(() => {
     cwd = getTmpDirPath();


### PR DESCRIPTION
In #10619 report, we can see that AWS SDK's `CloudFormation.getTempalte` can return empty string for `TemplateBody`, we do not handle such scenario well, and that triggers the programmer error. This patch fixes that

--- 

In CI packaging test timed out, most likely due to some npm service issue. I've increased test timeout to follow one set as default