### PR TITLE
chore: Add log statements for ajv validation debugging

### DIFF
--- a/lib/classes/config-schema-handler/resolve-ajv-validate.js
+++ b/lib/classes/config-schema-handler/resolve-ajv-validate.js
@@ -5,6 +5,7 @@ const objectHash = require('object-hash');
 const path = require('path');
 const os = require('os');
 const standaloneCode = require('ajv/dist/standalone').default;
+const { log } = require('@serverless/utils/log');
 const fs = require('fs');
 const requireFromString = require('require-from-string');
 const deepSortObjectByKey = require('../../utils/deep-sort-object-by-key');
@@ -67,6 +68,12 @@ const getValidate = async (schema) => {
     loadedModuleCode,
     path.resolve(__dirname, `[generated-ajv-validate]${filename}`)
   );
+  if (typeof validator !== 'function') {
+    log.error('Unexpected validator %o, resolved from source %s', validator, loadedModuleCode);
+    throw new Error(
+      'Unexpected non-function AJV validator type. Please report at https://github.com/serverless/serverless including all the logs output'
+    );
+  }
   cachedValidatorsBySchemaHash[schemaHash] = validator;
   return validator;
 };


### PR DESCRIPTION
Happens from time to time in CI: https://github.com/serverless/serverless/runs/5022323764?check_suite_focus=true

Also reported on our forum: https://forum.serverless.com/t/error-on-deploy-after-upgrading-to-v3-typeerror-validate-is-not-a-function/16626/4

I'm not throwing more meaningful error yet because I'm not sure what we should even throw to users as they cannot really act on it in any way