### PR TITLE
Variables: Improve resolution queuing and related cleanup

### DIFF
--- a/lib/classes/plugin-manager.js
+++ b/lib/classes/plugin-manager.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const config = require('@serverless/utils/config');
 const _ = require('lodash');
 const ServerlessError = require('../serverless-error');
 const resolveCliInput = require('../cli/resolve-input');
@@ -134,7 +133,7 @@ class PluginManager {
       .filter(Boolean)
       .forEach((Plugin) => this.addPlugin(Plugin));
     isRegisteringExternalPlugins = false;
-    if (EnterprisePlugin) this.dashboardPlugin = this.addPlugin(EnterprisePlugin);
+    this.dashboardPlugin = this.addPlugin(EnterprisePlugin);
     isRegisteringExternalPlugins = true;
     return this.asyncPluginInit();
   }
@@ -255,7 +254,6 @@ class PluginManager {
   }
 
   resolveEnterprisePlugin() {
-    if (config.getConfig().enterpriseDisabled) return null;
     this.pluginIndependentCommands.add('login').add('logout').add('dashboard');
     return require('@serverless/dashboard-plugin');
   }

--- a/lib/cli/conditionally-load-dotenv.js
+++ b/lib/cli/conditionally-load-dotenv.js
@@ -4,8 +4,7 @@ const _ = require('lodash');
 
 module.exports = async (options, configuration) => {
   const stage = options.stage || _.get(configuration, 'provider.stage', 'dev');
-  if (configuration.useDotenv) {
-    require('./load-dotenv')(stage);
-    return;
-  }
+  if (!configuration.useDotenv) return false;
+  require('./load-dotenv')(stage);
+  return true;
 };

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -565,7 +565,20 @@ processSpanPromise = (async () => {
         if (isHelpRequest) return;
         if (!_.get(variablesMeta, 'size')) return;
 
-        // Resolve remaininig service configuration variables
+        if (commandSchema) {
+          resolverConfiguration.options = filterSupportedOptions(options, {
+            commandSchema,
+            providerName,
+          });
+        }
+        resolverConfiguration.fulfilledSources.add('opt');
+
+        // Register serverless instance specific variable sources
+        resolverConfiguration.sources.sls =
+          require('../lib/configuration/variables/sources/instance-dependent/get-sls')(serverless);
+        resolverConfiguration.fulfilledSources.add('sls');
+
+        // Register AWS provider specific variable sources
         if (providerName === 'aws') {
           // Ensure properties which are crucial to some variable source resolvers
           // are actually resolved.
@@ -577,21 +590,6 @@ processSpanPromise = (async () => {
           ) {
             return;
           }
-        }
-        if (commandSchema) {
-          resolverConfiguration.options = filterSupportedOptions(options, {
-            commandSchema,
-            providerName,
-          });
-        }
-        resolverConfiguration.fulfilledSources.add('opt');
-
-        // Register serverless instance and AWS provider specific variable sources
-        resolverConfiguration.sources.sls =
-          require('../lib/configuration/variables/sources/instance-dependent/get-sls')(serverless);
-        resolverConfiguration.fulfilledSources.add('sls');
-
-        if (providerName === 'aws') {
           Object.assign(resolverConfiguration.sources, {
             cf: require('../lib/configuration/variables/sources/instance-dependent/get-cf')(
               serverless

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -604,7 +604,7 @@ processSpanPromise = (async () => {
               serverless
             ),
           });
-          resolverConfiguration.fulfilledSources.add('cf').add('s3').add('ssm');
+          resolverConfiguration.fulfilledSources.add('cf').add('s3').add('ssm').add('aws');
         }
 
         // Register dashboard specific variable source resolvers

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -680,9 +680,7 @@ processSpanPromise = (async () => {
       }
     } catch (error) {
       // If Dashboard Plugin, capture error
-      const dashboardPlugin =
-        serverless.pluginManager.dashboardPlugin ||
-        serverless.pluginManager.plugins.find((p) => p.enterprise);
+      const dashboardPlugin = serverless.pluginManager.dashboardPlugin;
       const dashboardErrorHandler = _.get(dashboardPlugin, 'enterprise.errorHandler');
       if (!dashboardErrorHandler) throw error;
       try {

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -362,17 +362,17 @@ processSpanPromise = (async () => {
           }
 
           // Load eventual environment variables from .env files
-          await require('../lib/cli/conditionally-load-dotenv')(options, configuration);
-
-          if (envVarNamesNeededForDotenvResolution) {
-            for (const envVarName of envVarNamesNeededForDotenvResolution) {
-              if (process.env[envVarName]) {
-                throw new ServerlessError(
-                  'Cannot reliably resolve "env" variables due to resolution conflict.\n' +
-                    `Environment variable "${envVarName}" which influences resolution of ` +
-                    '".env" file were found to be defined in resolved ".env" file.' +
-                    'DOTENV_ENV_VAR_RESOLUTION_CONFLICT'
-                );
+          if (await require('../lib/cli/conditionally-load-dotenv')(options, configuration)) {
+            if (envVarNamesNeededForDotenvResolution) {
+              for (const envVarName of envVarNamesNeededForDotenvResolution) {
+                if (process.env[envVarName]) {
+                  throw new ServerlessError(
+                    'Cannot reliably resolve "env" variables due to resolution conflict.\n' +
+                      `Environment variable "${envVarName}" which influences resolution of ` +
+                      '".env" file were found to be defined in resolved ".env" file.' +
+                      'DOTENV_ENV_VAR_RESOLUTION_CONFLICT'
+                  );
+                }
               }
             }
           }

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -608,19 +608,17 @@ processSpanPromise = (async () => {
         }
 
         // Register dashboard specific variable source resolvers
-        if (serverless.pluginManager.dashboardPlugin) {
-          if (configuration.org) {
-            for (const [sourceName, sourceConfig] of Object.entries(
-              serverless.pluginManager.dashboardPlugin.configurationVariablesSources
-            )) {
-              resolverConfiguration.sources[sourceName] = sourceConfig;
-              resolverConfiguration.fulfilledSources.add(sourceName);
-            }
-          } else {
-            resolverConfiguration.sources.param =
-              serverless.pluginManager.dashboardPlugin.configurationVariablesSources.param;
-            resolverConfiguration.fulfilledSources.add('param');
+        if (configuration.org) {
+          for (const [sourceName, sourceConfig] of Object.entries(
+            serverless.pluginManager.dashboardPlugin.configurationVariablesSources
+          )) {
+            resolverConfiguration.sources[sourceName] = sourceConfig;
+            resolverConfiguration.fulfilledSources.add(sourceName);
           }
+        } else {
+          resolverConfiguration.sources.param =
+            serverless.pluginManager.dashboardPlugin.configurationVariablesSources.param;
+          resolverConfiguration.fulfilledSources.add('param');
         }
 
         // Register variable source resolvers provided by external plugins


### PR DESCRIPTION
Improve variable resolution queuing logic.

It also fixes one shortcoming, where after registering all non-AWS specific sources, logic immediately moved to validation on whether properties that influence AWS authentication logic are resolved.
This patch ensure that we attempt to re-resolve those properties having additional information, before validating them. This e.g. allows to configure `provider.profile` with `param` variable sources.

Fixes https://github.com/serverless/serverless/issues/10642

---

Additionally dropped support for `enterpriseDisabled` user configuration property, which didn't seem to be documented anywhere, and if used it prevented to use `param` variables, even with no dashboard enabled in service config.
