### PR TITLE
docs: Fix typo in deprecations

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -246,7 +246,7 @@ Check [Packaging Patterns](/framework/docs/providers/aws/guide/packaging/#patter
 
 Deprecation code: `UNSUPPORTED_CLI_OPTIONS`
 
-Framework was upgraded with extensive CLI options validation and that required dropping support for _free form_ CLI options (keeping that in will make not possible to reliably detect accidental typos in option names).
+Framework was upgraded with extensive CLI options validation and that required dropping support for _free form_ CLI options (keeping that in will make it not possible to reliably detect accidental typos in option names).
 
 For _free form_ process configuration options it is advised to rely on environment variables instead, as e.g.:
 


### PR DESCRIPTION
Fix a small typo in the documentation.

BTW, the link at the end of each documentation page is dead since your renamed `master` into `main`: https://github.com/serverless/serverless/edit/master/docs/deprecations.md