### PR TITLE
fix: Improve validation of min supported Node version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ Read the [**complete v3 Upgrade Guide**](https://www.serverless.com/framework/do
 - Duplicate plugin definition in configuration will now result in an error instead of a warning.
 - Using `--aws-s3-accelerate` flag will result in an error instead of deprecation when custom S3 bucket is used.
 - Removed support for `provider.disableDefaultOutputExportNames`
-- Node.js versions lower than 12 is no longer supported
+- Node.js versions lower than v12.13.0 (LTS) is no longer supported
 - Lifecycle events marked as deprecated (in context of v1) are no longer evaluated
 
 ### Features

--- a/bin/serverless.js
+++ b/bin/serverless.js
@@ -11,15 +11,21 @@
 const isMainModule = !EvalError.$serverlessCommandStartTime;
 if (isMainModule) EvalError.$serverlessCommandStartTime = process.hrtime();
 
-const nodeVersion = Number(process.version.split('.')[0].slice(1));
-const minimumSupportedVersion = 12;
+const nodeVersionMajor = Number(process.version.split('.')[0].slice(1));
+const nodeVersionMinor = Number(process.version.split('.')[1]);
+const minimumSupportedVersionMajor = 12;
+const minimumSupportedVersionMinor = 13;
 
-if (nodeVersion < minimumSupportedVersion) {
+if (
+  nodeVersionMajor < minimumSupportedVersionMajor ||
+  (nodeVersionMajor === minimumSupportedVersionMajor &&
+    nodeVersionMinor < minimumSupportedVersionMinor)
+) {
   const serverlessVersion = Number(require('../package.json').version.split('.')[0]);
   process.stderr.write(
     `\x1b[91mError: Serverless Framework v${serverlessVersion} does not support ` +
-      `Node.js v${nodeVersion}. Please upgrade Node.js to the latest ` +
-      `LTS version (v${minimumSupportedVersion} is a minimum supported version)\x1b[39m\n`
+      `Node.js ${process.version}. Please upgrade Node.js to the latest ` +
+      `LTS version (v${minimumSupportedVersionMajor}.${minimumSupportedVersionMinor}.0 is a minimum supported version)\x1b[39m\n`
   );
   process.exit(1);
 }

--- a/docs/guides/upgrading-v3.md
+++ b/docs/guides/upgrading-v3.md
@@ -75,7 +75,7 @@ You will find below a complete list of all breaking changes. All those breaking 
 
 ### CLI commands and options
 
-The `serverless` CLI no longer runs on Node v10 because [that version is obsolete](https://endoflife.date/nodejs): upgrade to v12 or greater to run `serverless` on your machine.
+The `serverless` CLI no longer runs on Node v10 because [that version is obsolete](https://endoflife.date/nodejs): upgrade to v12.13.0 (LTS) or greater to run `serverless` on your machine.
 
 The `serverless` CLI used to accept free-form CLI options. This feature was deprecated and has been removed. The main reason is that this prevented us from detecting typos in options, which sometimes created unexpected situations and overall a bad user experience. [Learn more about this change](../deprecations.md#handling-of-unrecognized-cli-options).
 


### PR DESCRIPTION
Reported internally

I propose to validate versions against first Node 12 LTS as @medikoo suggested. Please let me know what do you think @mnapoli 