### PR TITLE
fix(Config Schema): Recognize `provider.websocketsDescription`

### DIFF
--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -78,6 +78,7 @@ provider:
   runtime: nodejs12.x
   websocketsApiName: custom-websockets-api-name
   websocketsApiRouteSelectionExpression: $request.body.action # custom routes are selected by the value of the action property in the body
+  websocketsDescription: Custom Serverless Websockets
 
 functions:
   connectionHandler:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -241,6 +241,8 @@ provider:
   websocketsApiName: custom-websockets-api-name
   # custom route selection expression
   websocketsApiRouteSelectionExpression: $request.body.route
+  # Use a custom description for the websockets API
+  websocketsDescription: Custom Serverless Websockets
   # Optional API Gateway REST API global config
   apiGateway:
     # Attach to an externally created REST API via its ID:

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1183,6 +1183,7 @@ class AwsProvider {
             versionFunctions: { $ref: '#/definitions/awsLambdaVersioning' },
             websocketsApiName: { type: 'string' },
             websocketsApiRouteSelectionExpression: { type: 'string' },
+            websocketsDescription: { type: 'string' },
           },
         },
         function: {


### PR DESCRIPTION
I used it back with the v1 version, and now on v2 (at least) I got a _Configuration warning_ when defining that value:

```
Serverless: Configuration warning at 'provider': unrecognized property 'websocketsDescription'
```

The value is used in different places but is missing in the config schema.
I've also updated the doc about it.

Simple schema to reproduce the warning:

```yaml
service: serverless-ws-test

provider:
  name: aws
  runtime: nodejs12.x
  websocketsApiRouteSelectionExpression: $request.body.route
  websocketsDescription: Hi, I'm here to trigger a warning!

functions:
  wsHandler:
    handler: handler.wsHandler
    events:
      - websocket:
          route: $connect
      - websocket:
          route: $disconnect
      - websocket:
          route: $default
```