### PR TITLE
docs: Update PR template to mention Node 12 requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
 https://github.com/serverless/serverless/blob/main/test/README.md
 --
 
-<!-- ⚠️⚠️ Ensure that support for Node.js v10 is maintained. -->
+<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->
 
 <!--
 ⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:


### PR DESCRIPTION
Framework Version 3 require Node 12 but the PR template still mention the v10.