### PR TITLE
Ask docker build to print all logs immediately

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -2001,6 +2001,7 @@ Object.defineProperties(
           localTag,
           '-f',
           pathToDockerfile,
+          '--progress=plain',
           ...buildArgsArr,
           ...cacheFromArr,
           imagePath,

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -1287,6 +1287,7 @@ aws_secret_access_key = CUSTOMSECRET
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
           path.join(serviceDir, 'Dockerfile'),
+          '--progress=plain',
           './',
         ]);
         expect(spawnExtStub).to.be.calledWith('docker', [
@@ -1420,6 +1421,7 @@ aws_secret_access_key = CUSTOMSECRET
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
           path.join(serviceDir, 'Dockerfile'),
+          '--progress=plain',
           './',
         ]);
         expect(innerSpawnExtStub).to.be.calledWith('docker', [
@@ -1576,6 +1578,7 @@ aws_secret_access_key = CUSTOMSECRET
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
           path.join(serviceDir, 'Dockerfile.dev'),
+          '--progress=plain',
           './',
         ]);
       });
@@ -1633,6 +1636,7 @@ aws_secret_access_key = CUSTOMSECRET
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
           path.join(serviceDir, 'Dockerfile.dev'),
+          '--progress=plain',
           '--cache-from',
           'my-image:latest',
           './',
@@ -1694,6 +1698,7 @@ aws_secret_access_key = CUSTOMSECRET
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
           path.join(serviceDir, 'Dockerfile.dev'),
+          '--progress=plain',
           '--build-arg',
           'TESTKEY=TESTVAL',
           './',
@@ -1753,6 +1758,7 @@ aws_secret_access_key = CUSTOMSECRET
           `${awsNaming.getEcrRepositoryName()}:baseimage`,
           '-f',
           path.join(serviceDir, 'Dockerfile.dev'),
+          '--progress=plain',
           './',
           '--platform=TESTVAL',
         ]);


### PR DESCRIPTION
Currently docker build logs are only printed to the terminal at the end the build. This makes following progress problematic, when not using an interactive terminal.

The added progress option asks docker to print lines to STOUT without buffering
