### PR TITLE
CLI: Ensure to pass through `serverless-tencent` exit code

### DIFF
--- a/lib/cli/run-serverless-tencent.js
+++ b/lib/cli/run-serverless-tencent.js
@@ -145,5 +145,9 @@ module.exports = async () => {
     }
   }
 
-  childProcess.spawn(standaloneFilename, process.argv.slice(2), { stdio: 'inherit' });
+  childProcess
+    .spawn(standaloneFilename, process.argv.slice(2), { stdio: 'inherit' })
+    .on('close', (code) => {
+      process.exitCode = code;
+    });
 };


### PR DESCRIPTION
Reported internally by @zongUMR 

It appears that in case of falling back to _binary_ `serverless-tencent` we never exposed it's exit code, and `sls` CLI always exited with `0`, which definitely should not be the case.

This patch fixes that