### PR TITLE
fix(AWS Local Invocation): Improve `ruby` context

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -741,7 +741,22 @@ class AwsInvokeLocal {
   async invokeLocalRuby(runtime, handlerPath, handlerName, event, context) {
     const input = JSON.stringify({
       event: event || {},
-      context,
+      context: Object.assign(
+        {
+          function_name: this.options.functionObj.name,
+          version: 'LATEST',
+          log_group_name: this.provider.naming.getLogGroupName(this.options.functionObj.name),
+          memory_limit_in_mb:
+            Number(this.options.functionObj.memorySize) ||
+            Number(this.serverless.service.provider.memorySize) ||
+            1024,
+          timeout:
+            Number(this.options.functionObj.timeout) ||
+            Number(this.serverless.service.provider.timeout) ||
+            6,
+        },
+        context
+      ),
     });
 
     const wrapperPath = await this.resolveRuntimeWrapperPath('invoke.rb');

--- a/lib/plugins/aws/invoke-local/runtime-wrappers/invoke.rb
+++ b/lib/plugins/aws/invoke-local/runtime-wrappers/invoke.rb
@@ -1,44 +1,32 @@
 require 'json'
+require 'securerandom'
 
 class FakeLambdaContext
-  attr_reader :function_name, :function_version
+  attr_reader :function_name, :function_version, :aws_request_id, :log_stream_name, :memory_limit_in_mb,
+    :invoked_function_arn, :log_group_name, :deadline_ms
 
-  def initialize(name: 'Fake', version: 'LATEST', timeout: 6, **options)
-    @function_name = name
+  def initialize(function_name: 'Fake', version: 'LATEST', timeout: 6, **options)
+    @function_name = function_name
     @function_version = version
-    @created_time = Time.now()
+    @memory_limit_in_mb = 1024
     @timeout = timeout
-    options.each {|k,v|
-      send(k, v)
-    }
+
+    # Allow overriding defaults
+    options.each do |k,v|
+      instance_variable_set("@#{k}", v)
+    end
+
+    @aws_request_id = SecureRandom.uuid
+    @invoked_function_arn = "arn:aws:lambda:aws-region:acct-id:function:#{@function_name}"
+    @log_group_name = "/aws/lambda/#{@function_name}"
+    @log_stream_name = Time.now.strftime('%Y/%m/%d') +'/[$' + @function_version + ']58419525dade4d17a495dceeeed44708'
+
+    @created_time = Time.now
+    @deadline_ms = (@created_time + @timeout).to_i * 1000
   end
 
   def get_remaining_time_in_millis
-    [@timeout*1000 - ((Time.now() - @created_time)*1000).round, 0].max
-  end
-
-  def invoked_function_arn
-    "arn:aws:lambda:serverless:#{function_name}"
-  end
-
-  def memory_limit_in_mb
-    return '1024'
-  end
-
-  def aws_request_id
-    return '1234567890'
-  end
-
-  def log_group_name
-    return "/aws/lambda/#{function_name}"
-  end
-
-  def log_stream_name
-    return Time.now.strftime('%Y/%m/%d') +'/[$' + function_version + ']58419525dade4d17a495dceeeed44708'
-  end
-
-  def deadline_ms
-    (@created_time + @timeout).to_i * 1000
+    [@timeout * 1000 - ((Time.now - @created_time) * 1000).round, 0].max
   end
 
   def log(message)
@@ -61,8 +49,7 @@ if __FILE__ == $0
     exit 1
   end
 
-  handler_path = ARGV[0]
-  handler_name = ARGV[1]
+  handler_path, handler_name = ARGV
 
   input = JSON.load($stdin) || {}
 

--- a/lib/plugins/aws/invoke-local/runtime-wrappers/invoke.rb
+++ b/lib/plugins/aws/invoke-local/runtime-wrappers/invoke.rb
@@ -62,7 +62,7 @@ if __FILE__ == $0
 
   attach_tty
 
-  context = FakeLambdaContext.new(**input.fetch('context', {}))
+  context = FakeLambdaContext.new(**input.fetch('context', {}).transform_keys(&:to_sym))
   result = Object.const_get(handler_class).send(handler_method, event: input['event'], context: context)
 
   puts result.to_json


### PR DESCRIPTION
This PR improves the quality of the `invoke local` integration for Ruby (specifically the fake context), bringing it closer to par with the Node.js and Python ones:

- Fixes bug that made `FakeLambdaContext` crash when extra options were supplied. The existing code `send(k, v)` calls nonexistent methods.
- Fixes bug that makes `invoke local` crash on Ruby 2.5 if a context is passed by the user
- Randomizes the `aws_request_id`, so each request has a different ID (something tracing code often depends on)
- Sets the function name correctly (which makes the invoked_function_arn, log group and log stream name more correct)
- Sets the memory limit as specified in `serverless.yml`
- Allows for the user to correctly override the defaults (though they shouldn't need to)
- Cleaned up the code so it's more idiomatic Ruby

I've verified these improvements locally.