### PR TITLE
CLI: Remove obsolete `v` postfix when listing global version

### DIFF
--- a/lib/cli/render-version.js
+++ b/lib/cli/render-version.js
@@ -70,7 +70,7 @@ module.exports = async () => {
 
   const globalInstallationPostfix = (() => {
     if (EvalError.$serverlessInitInstallationVersion) {
-      return ` ${EvalError.$serverlessInitInstallationVersion}v (global)`;
+      return ` ${EvalError.$serverlessInitInstallationVersion} (global)`;
     }
     return '';
   })();


### PR DESCRIPTION
Noticed in bug reports, that version prints as:

```
Running "serverless" from node_modules
Framework Core: 3.2.0 (local) 3.2.1v (global)
Plugin: 6.0.0
SDK: 4.3.1
```

`v` postfix should not be there
