### PR TITLE
docs: Remove reference to `-v` as shortcut for `--verbose`

### DIFF
--- a/docs/providers/aws/cli-reference/deploy.md
+++ b/docs/providers/aws/cli-reference/deploy.md
@@ -26,7 +26,7 @@ serverless deploy
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.
-- `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
+- `--verbose` Shows all stack events during deployment, and display any Stack Output.
 - `--force` Forces a deployment to take place.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.
 - `--conceal` Hides secrets from the output (e.g. API Gateway key values).

--- a/docs/providers/aws/cli-reference/info.md
+++ b/docs/providers/aws/cli-reference/info.md
@@ -24,7 +24,7 @@ serverless info
 
 - `--stage` or `-s` The stage in your service you want to display information about.
 - `--region` or `-r` The region in your stage that you want to display information about.
-- `--verbose` or `-v` Shows displays any Stack Output.
+- `--verbose` Shows displays any Stack Output.
 
 ## Provided lifecycle events
 

--- a/docs/providers/aws/cli-reference/remove.md
+++ b/docs/providers/aws/cli-reference/remove.md
@@ -24,7 +24,7 @@ serverless remove
 
 - `--stage` or `-s` The name of the stage in service.
 - `--region` or `-r` The name of the region in stage.
-- `--verbose` or `-v` Shows all stack events during deployment.
+- `--verbose` Shows all stack events during deployment.
 
 ## Provided lifecycle events
 

--- a/docs/providers/aws/cli-reference/rollback.md
+++ b/docs/providers/aws/cli-reference/rollback.md
@@ -25,7 +25,7 @@ If `timestamp` is not specified, Framework will show your existing deployments.
 ## Options
 
 - `--timestamp` or `-t` The deployment you want to rollback to.
-- `--verbose` or `-v` Shows any Stack Output.
+- `--verbose` Shows any Stack Output.
 
 ## Provided lifecycle events
 

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -209,7 +209,7 @@ Check out the [deployment guide](https://serverless.com/framework/docs/providers
 
 To easily remove your Service from your AWS account, you can use the `remove` command.
 
-Run `serverless remove -v` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
+Run `serverless remove --verbose` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
 
 Serverless will start the removal and informs you about its process on the console. A success message is printed once the whole service is removed.
 

--- a/docs/providers/azure/cli-reference/deploy.md
+++ b/docs/providers/azure/cli-reference/deploy.md
@@ -29,7 +29,7 @@ The `sls deploy apim` command will deploy API management as configured within `s
 - `--region` or `-r` - Specify region name
 - `--subscriptionId` or `-i` - Specify subscription ID
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
-- `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
+- `--verbose` Shows all stack events during deployment, and display any Stack Output.
 
 ## Artifacts
 

--- a/docs/providers/azure/cli-reference/rollback.md
+++ b/docs/providers/azure/cli-reference/rollback.md
@@ -27,7 +27,7 @@ serverless rollback --timestamp timestamp
 - `--region` or `-r` - Specify region name
 - `--subscriptionId` or `-i` - Specify subscription ID
 - `--timestamp` or `-t` The deployment you want to rollback to.
-- `--verbose` or `-v` Shows any Stack Output.
+- `--verbose` Shows any Stack Output.
 
 ## Provided lifecycle events
 

--- a/docs/providers/azure/guide/function-apps.md
+++ b/docs/providers/azure/guide/function-apps.md
@@ -127,7 +127,7 @@ Check out the [deployment guide](https://serverless.com/framework/docs/providers
 
 To easily remove your function app from your Azure Functions account, you can use the `remove` command.
 
-Run `serverless remove -v` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
+Run `serverless remove --verbose` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
 
 Serverless will start the removal and informs you about it's process on the console. A success message is printed once the whole function app is removed.
 

--- a/docs/providers/cloudflare/cli-reference/deploy.md
+++ b/docs/providers/cloudflare/cli-reference/deploy.md
@@ -46,7 +46,7 @@ This is the simplest deployment usage possible. With this command, Serverless wi
 ## Options
 
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
-- `--verbose` or `-v`: Shows all stack events during deployment, and display any Stack Output.
+- `--verbose`: Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f`: Invokes `deploy function` (see above). Convenience shortcut
 
 ## Provided lifecycle events

--- a/docs/providers/fn/cli-reference/deploy.md
+++ b/docs/providers/fn/cli-reference/deploy.md
@@ -27,7 +27,7 @@ This is the simplest deployment usage possible. With this command Serverless wil
 ## Options
 
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
-- `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
+- `--verbose` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut
 
 ## Provided lifecycle events

--- a/docs/providers/kubeless/cli-reference/deploy.md
+++ b/docs/providers/kubeless/cli-reference/deploy.md
@@ -27,7 +27,7 @@ This is the simplest deployment usage possible. With this command Serverless wil
 ## Options
 
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
-- `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
+- `--verbose` Shows all stack events during deployment, and display any Stack Output.
 - `--package` or `-p` The path of a previously packaged deployment to get deployed (skips packaging step).
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.
 

--- a/docs/providers/kubeless/cli-reference/info.md
+++ b/docs/providers/kubeless/cli-reference/info.md
@@ -22,7 +22,7 @@ serverless info
 
 ## Options
 
-- `--verbose` or `-v` Shows the metadata of the Kubernetes objects.
+- `--verbose` Shows the metadata of the Kubernetes objects.
 
 ## Provided lifecycle events
 

--- a/docs/providers/kubeless/cli-reference/remove.md
+++ b/docs/providers/kubeless/cli-reference/remove.md
@@ -24,7 +24,7 @@ It will remove the Kubeless Function objects from your Kubernetes cluster, the K
 
 ## Options
 
-- `--verbose` or `-v` Shows additional information during the removal.
+- `--verbose` Shows additional information during the removal.
 
 ## Provided lifecycle events
 

--- a/docs/providers/kubeless/guide/services.md
+++ b/docs/providers/kubeless/guide/services.md
@@ -122,7 +122,7 @@ Check out the [deployment guide](https://serverless.com/framework/docs/providers
 
 To easily remove your Service from your Kubernetes cluster, you can use the `remove` command.
 
-Run `serverless remove -v` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
+Run `serverless remove --verbose` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
 
 Serverless will start the removal and informs you about it's process on the console. A success message is printed once the whole service is removed.
 

--- a/docs/providers/openwhisk/cli-reference/deploy.md
+++ b/docs/providers/openwhisk/cli-reference/deploy.md
@@ -24,7 +24,7 @@ serverless deploy
 
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--noDeploy` or `-n` Skips the deployment steps and leaves artifacts in the `.serverless` directory
-- `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
+- `--verbose` Shows all stack events during deployment, and display any Stack Output.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.
 
 ## Artifacts

--- a/docs/providers/openwhisk/cli-reference/info.md
+++ b/docs/providers/openwhisk/cli-reference/info.md
@@ -22,7 +22,7 @@ serverless info
 
 ## Options
 
-- `--verbose` or `-v` Shows displays any Stack Output.
+- `--verbose` Shows displays any Stack Output.
 
 ## Provided lifecycle events
 

--- a/docs/providers/openwhisk/guide/services.md
+++ b/docs/providers/openwhisk/guide/services.md
@@ -133,7 +133,7 @@ Check out the [deployment guide](https://serverless.com/framework/docs/providers
 
 To easily remove your Service from your Apache OpenWhisk account, you can use the `remove` command.
 
-Run `serverless remove -v` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
+Run `serverless remove --verbose` to trigger the removal process. As in the deploy step we're also running in the `verbose` mode so you can see all details of the remove process.
 
 Serverless will start the removal and informs you about it's process on the console. A success message is printed once the whole service is removed.
 

--- a/docs/providers/spotinst/cli-reference/deploy.md
+++ b/docs/providers/spotinst/cli-reference/deploy.md
@@ -24,4 +24,4 @@ serverless deploy -v
 
 - `--config` or `-c` Name of your configuration file, if other than `serverless.yml|.yaml|.js|.json`.
 - `--package` or `-p` path to a pre-packaged directory and skip packaging step.
-- `--verbose` or `-v` Shows all stack events during deployment, and display any Stack Output.
+- `--verbose` Shows all stack events during deployment, and display any Stack Output.

--- a/docs/providers/spotinst/cli-reference/info.md
+++ b/docs/providers/spotinst/cli-reference/info.md
@@ -23,4 +23,4 @@ serverless info
 ## Options
 
 - `--function` or `-f` The name of the function which should be fetched.
-- `--verbose` or `-v` Shows displays any Stack Output.
+- `--verbose` Shows displays any Stack Output.

--- a/docs/providers/spotinst/cli-reference/remove.md
+++ b/docs/providers/spotinst/cli-reference/remove.md
@@ -22,4 +22,4 @@ serverless remove
 
 ## Options
 
-- `--verbose` or `-v` Shows all stack events during deployment.
+- `--verbose` Shows all stack events during deployment.

--- a/docs/providers/tencent/cli-reference/rollback.md
+++ b/docs/providers/tencent/cli-reference/rollback.md
@@ -25,7 +25,7 @@ If `timestamp` is not specified, Framework will show your existing deployments.
 ## Options
 
 - `--timestamp` or `-t` The deployment you want to rollback to.
-- `--verbose` or `-v` Shows any history deployment.
+- `--verbose` Shows any history deployment.
 
 ## Examples
 


### PR DESCRIPTION
Addresses: #10707