### PR TITLE
Improve v3 upgrade guide

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -122,11 +122,11 @@ Starting with `v4.0.0`, `--function` or `-f` option for `deploy` command will no
 
 Deprecation code: `LAMBDA_HASHING_VERSION_PROPERTY`
 
-Lambda version hashes were improved with a better algorithm (that fixed determinism issues), which is used by default, starting with v3.0.0.
+Lambda version hashes were improved with a better algorithm (that fixed determinism issues). It is used by default starting with v3.0.0.
 
-If you previously opted-in to use new algorithm by setting `provider.lambdaHashingVersion` to `20201221`, you can safely remove that property from your configuration to silence the deprecation.
+If you previously opted-in to use new algorithm by setting `provider.lambdaHashingVersion: 20201221`, you can safely remove that property from your configuration in v3.
 
-The old `20200924` algorithm is deprecated and it is recommended to migrate to the new version. In order to do that, you can follow the guide in [Functions Docs](./providers/aws/guide/functions.md#lambda-hashing-algorithm-migration).
+To get more details, read [the v3 upgrade guide](./guides/upgrading-v3.md#lambda-hashing-algorithm).
 
 <a name="AwS_EVENT_BRIDGE_CUSTOM_RESOURCE_LEGACY_OPT_IN"><div>&nbsp;</div></a>
 
@@ -432,21 +432,14 @@ Org, app, service, stage, and region are required to resolve variables when logg
 
 Deprecation code: `LAMBDA_HASHING_VERSION_V2`
 
-Lambda version hashes were improved with a better algorithm (that fixed determinism issues). It will be used by default starting with v3.0.0.
+Lambda version hashes were improved with a more robust algorithm (that fixes determinism issues). It is used by default starting with v3.0.0.
 
-You can adapt your services to use it now by setting `provider.lambdaHashingVersion` to `20201221`.
+You can either:
 
-While not recommended, you can keep using the old hashing algorithm by setting `provider.lambdaHashingVersion` to `20200924`. That will silence the deprecation and allow to upgrade to v3.
+- keep using the deprecated algorithm in v3 (easy upgrade),
+- or upgrade to the new algorithm (recommended).
 
-**Notice:** If you apply this on already deployed service without any changes to lambda code, you might encounter an error similar to the one below:
-
-```
-  Serverless Error ---------------------------------------
-
-  An error occurred: FooLambdaVersion3IV5NZ3sE5T2UFimCOai2Tc6eCaW7yIYOP786U0Oc - A version for this Lambda function exists ( 11 ). Modify the function to create a new version..
-```
-
-It is an expected behavior. AWS complains here that received a different hash for very same lambda configuration. To workaround that, you need to modify your function(s) code and try to redeploy it again. One common approach is to modify an utility function that is used by all/most of your Lambda functions. There's also a semi-automated migration available and described in [V3 Upgrade docs](./guides/upgrading-v3.md#lambda-hashing-algorithm).
+Read [the instructions in the v3 upgrade guide](./guides/upgrading-v3.md#lambda-hashing-algorithm).
 
 <a name="LOAD_VARIABLES_FROM_ENV_FILES"><div>&nbsp;</div></a>
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -246,23 +246,21 @@ Check [Packaging Patterns](/framework/docs/providers/aws/guide/packaging/#patter
 
 Deprecation code: `UNSUPPORTED_CLI_OPTIONS`
 
-Framework was upgraded with extensive CLI options validation and that required dropping support for _free form_ CLI options (keeping that in will make it not possible to reliably detect accidental typos in option names).
+CLI options validation was introduced to detect typos and mistakes. That required dropping support for _free-form_ CLI options in v3 (because free-form CLI options cannot be validated).
 
-For _free form_ process configuration options it is advised to rely on environment variables instead, as e.g.:
+An alternative to free-form CLI options is to use [environment variables](./providers/aws/guide/variables#referencing-environment-variables). Another option is to use [the `--param` option](./parameters.md#cli-parameters) introduced in Serverless Framework **v3.3.0**:
 
 ```yaml
 provider:
-  stackName: ${env:STACK_NAME, 'T001'}
+  environement:
+    APP_DOMAIN: ${param:domain, 'preview.myapp.com'}
 ```
 
 ```bash
-STACK_NAME=test sls deploy
+sls deploy --param="domain=myapp.com"
 ```
 
-_Note that setup of environment variables is way more
-convenient since we've added support for [`.env`](/framework/docs/environment-variables#support-for-env-files) files._
-
-Starting with v3.0.0, Serverless will report unrecognized options with a thrown error.
+Starting with v3.0.0, Serverless throws an error in case of unknown CLI options.
 
 <a name="CLI_OPTIONS_BEFORE_COMMAND"><div>&nbsp;</div></a>
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -310,11 +310,22 @@ If you want to keep using the old deployment method for your AWS EventBridge res
 
 Deprecation code: `NEW_VARIABLES_RESOLVER`
 
-Framework was updated with a new implementation of variables resolver.
+A more robust and powerful variable resolver engine was introduced (disabled by default) in Serverless Framework v2. It is used by default in v3.
 
-It supports very same variable syntax, and is being updated with support for same resolution sources. Still as it has improved internal resolution rules (which leave no room for ambiguity) in some edge cases it may report errors on which old parser passed by.
+It supports the same variables with the same syntax. The main impacts are:
 
-It's recommended to expose all errors that eventually new resolver may report (those will be an unconditional errors in v3). You can turn that behavior on by adding `variablesResolutionMode: 20210326` to service configuration
+- Some edge cases (ambiguous configuration) now throw errors
+- A very small share of unmaintained plugins haven't been updated to support the new engine
+
+You can prepare the upgrade from v2 to v3 by enabling the new engine:
+
+```yaml
+# serverless.yml
+service: myapp
+variablesResolutionMode: 20210326
+```
+
+In v3, the `variablesResolutionMode` option can be removed as the new engine becomes the default.
 
 <a name="AWS_HTTP_API_USE_PROVIDER_TAGS"><div>&nbsp;</div></a>
 

--- a/docs/guides/upgrading-v3.md
+++ b/docs/guides/upgrading-v3.md
@@ -87,6 +87,8 @@ serverless deploy --foo=bar
 serverless deploy --param="foo=bar"
 ```
 
+In the example above, the `${opt:foo}` variable must be replaced with `${param:foo}` in the service configuration.
+
 [Learn more about this change](../deprecations.md#handling-of-unrecognized-cli-options).
 
 Additionally, all CLI options must now be passed at the end of the commands:

--- a/docs/guides/upgrading-v3.md
+++ b/docs/guides/upgrading-v3.md
@@ -254,6 +254,25 @@ However, we highly encourage upgrading to the new algorithm. To upgrade, you mus
 
 Remember that you will need to deploy with changes to each stage you have previously deployed. For development stages another option is to remove and recreate the stage entirely.
 
+### New variable resolver engine
+
+A more robust and powerful variable resolver engine was introduced behind a flag in Serverless Framework v2. This new engine is used by default in v3.
+
+It supports the same variables with the same syntax. The main impacts are:
+
+- Some edge cases (ambiguous configuration) now throw errors
+- A very small share of unmaintained plugins haven't been updated to support the new engine
+
+You can prepare the upgrade from v2 to v3 by enabling the new engine:
+
+```yaml
+# serverless.yml
+service: myapp
+variablesResolutionMode: 20210326
+```
+
+In v3, the `variablesResolutionMode` option can be removed as the new engine becomes the default.
+
 ### Low-level changes
 
 Internal changes that may impact plugins or advanced use cases:

--- a/docs/guides/upgrading-v3.md
+++ b/docs/guides/upgrading-v3.md
@@ -77,7 +77,17 @@ You will find below a complete list of all breaking changes. All those breaking 
 
 The `serverless` CLI no longer runs on Node v10 because [that version is obsolete](https://endoflife.date/nodejs): upgrade to v12.13.0 (LTS) or greater to run `serverless` on your machine.
 
-The `serverless` CLI used to accept free-form CLI options. This feature was deprecated and has been removed. The main reason is that this prevented us from detecting typos in options, which sometimes created unexpected situations and overall a bad user experience. [Learn more about this change](../deprecations.md#handling-of-unrecognized-cli-options).
+The `serverless` CLI used to accept free-form CLI options. This feature was deprecated and has been removed. The main reason is that this prevented us from detecting typos in options, which sometimes created unexpected situations and overall a bad user experience. You can use [the `--param` option](./parameters.md#cli-parameters) as a replacement, for example:
+
+```bash
+# Will no longer work in v3:
+serverless deploy --foo=bar
+
+# Alternative in v3.3 and greater:
+serverless deploy --param="foo=bar"
+```
+
+[Learn more about this change](../deprecations.md#handling-of-unrecognized-cli-options).
 
 Additionally, all CLI options must now be passed at the end of the commands:
 


### PR DESCRIPTION
Improved documentation for the 3 main deprecations impacting v2 users:

- CLI free-form options: mention `--param`
- New variable resolver: dedicated section in the upgrade guide, more explicitly instructions in the deprecation docs
- Lambda hashing version: fix links, centralize and simplify instructions