### PR TITLE
ci: Ensure id for cache step when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Retrieve dependencies from cache
         uses: actions/cache@v2
+        id: cacheNpm
         with:
           path: |
             ~/.npm
@@ -64,6 +65,7 @@ jobs:
 
       - name: Retrieve dependencies from cache
         uses: actions/cache@v2
+        id: cacheNpm
         with:
           path: |
             ~/.npm


### PR DESCRIPTION
Spotted in https://github.com/serverless/serverless/pull/10735#pullrequestreview-889594161