### PR TITLE
feat(AWS Lambda): Add support for `dotnet6` runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -551,6 +551,7 @@ class AwsProvider {
           },
           awsLambdaRuntime: {
             enum: [
+              'dotnet6',
               'dotnetcore3.1',
               'go1.x',
               'java11',


### PR DESCRIPTION
Add support for the new [.NET 6 runtime](https://aws.amazon.com/blogs/compute/introducing-the-net-6-runtime-for-aws-lambda/).
