### PR TITLE
fix(AWS Lambda): Properly format `logs` with missing init duration

### DIFF
--- a/lib/plugins/aws/utils/format-lambda-log-event.js
+++ b/lib/plugins/aws/utils/format-lambda-log-event.js
@@ -16,13 +16,15 @@ module.exports = (msgParam) => {
 
   if (msg.startsWith('REPORT')) {
     const splitted = msg.split('\t');
-    const durationItem = splitted[1];
-    const maxMemoryUsedItem = splitted[4];
-    const initDurationItem = splitted[5];
+    const duration = splitted[1];
+    const maxMemoryUsed = splitted[4].slice(4);
+    const initDuration = splitted[5] && splitted[5].split(':')[1];
     // Simplify the output and trim out unnecessary information
-    msg = `END ${durationItem} (init:${initDurationItem.split(':')[1]}) ${maxMemoryUsedItem.slice(
-      4
-    )}`;
+    if (initDuration) {
+      msg = `END ${duration} (init:${initDuration}) ${maxMemoryUsed}`;
+    } else {
+      msg = `END ${duration} ${maxMemoryUsed}`;
+    }
     return style.aside(msg);
   }
 


### PR DESCRIPTION
Reported internally, addresses a bug when init duration is not available.
