### PR TITLE
refactor(Telemetry): Rely on direct evaluation of `isTtyTerminal`

### DIFF
--- a/lib/utils/telemetry/generate-payload.js
+++ b/lib/utils/telemetry/generate-payload.js
@@ -6,7 +6,6 @@ const _ = require('lodash');
 const isPlainObject = require('type/plain-object/is');
 const isObject = require('type/object/is');
 const userConfig = require('@serverless/utils/config');
-const { isInteractive } = require('@serverless/utils/log');
 const getNotificationsMode = require('@serverless/utils/get-notifications-mode');
 const isStandalone = require('../is-standalone-executable');
 const { getConfigurationValidationResult } = require('../../classes/config-schema-handler');
@@ -196,7 +195,7 @@ module.exports = ({
 
   const payload = {
     ciName,
-    isTtyTerminal: isInteractive,
+    isTtyTerminal: process.stdin.isTTY && process.stdout.isTTY,
     cliName: 'serverless',
     command,
     commandOptionNames,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@serverless/aws-lambda-otel-extension-dist": "^0.1.6",
     "@serverless/dashboard-plugin": "^6.1.5",
     "@serverless/platform-client": "^4.3.2",
-    "@serverless/utils": "^6.0.2",
+    "@serverless/utils": "^6.0.3",
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",
     "archiver": "^5.3.0",


### PR DESCRIPTION
After upgrade to `isInteractive` logic in `serverless/utils`, we should not rely on that for `isTtyTerminal` as it might have false negatives in CI environments.