### PR TITLE
docs: Add example for EventBridge with content filtering

### DIFF
--- a/docs/providers/aws/events/event-bridge.md
+++ b/docs/providers/aws/events/event-bridge.md
@@ -16,7 +16,7 @@ layout: Doc
 
 The [EventBridge](https://aws.amazon.com/eventbridge/) makes it possible to connect applications using data from external sources (e.g. own applications, SaaS) or AWS services. The `eventBridge` event types helps setting up AWS Lambda functions to react to events coming in via the EventBridge.
 
-_Note_: Prior to `2.27.0` version of the Framework, `eventBridge` resources were provisioned with Custom Resources. With `2.27.0` an optional support for native CloudFormation was introduced and can be turned on by setting `provider.eventBridge.useCloudFormation: true`. It is recommended to migrate to native CloudFormation as it will become a default with v3. It also adds the ability to define `eventBus` with CF intrinsic functions as values.
+_Note_: Prior to `2.27.0` version of the Framework, `eventBridge` resources were provisioned with Custom Resources. With `2.27.0` an optional support for native CloudFormation was introduced and can be turned on by setting `provider.eventBridge.useCloudFormation: true`. It is recommended to migrate to native CloudFormation as it's by default with v3. It also adds the ability to define `eventBus` with CF intrinsic functions as values.
 
 ## Setting up a scheduled event
 
@@ -63,6 +63,30 @@ functions:
             detail:
               eventSource:
                 - cloudformation.amazonaws.com
+```
+
+You can build a more robust pattern matching thanks to [content filtering](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html).
+
+For example, if you defined a s3 bucket with EventBridge notification enabled, you can handle the same event as the default s3 from serverless:
+
+```yml
+functions:
+  myFunction:
+    handler: index.handler
+    events:
+      - eventBridge:
+          pattern:
+            source:
+              - aws.s3
+            detail-type:
+              - Object Created
+            detail:
+              bucket:
+                name:
+                  - photos
+              object:
+                key:
+                  - prefix: 'uploads/'
 ```
 
 ## Using a different Event Bus

--- a/docs/providers/aws/events/event-bridge.md
+++ b/docs/providers/aws/events/event-bridge.md
@@ -65,9 +65,7 @@ functions:
                 - cloudformation.amazonaws.com
 ```
 
-You can build a more robust pattern matching thanks to [content filtering](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html).
-
-For example, if you defined a s3 bucket with EventBridge notification enabled, you can handle the same event as the default s3 from serverless:
+Here is an example that uses "[prefix matching](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns-content-based-filtering.html#eb-filtering-prefix-matching)" to filter EventBridge events produced by S3 (the bucket must have the [EventBridge notification enabled](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications-eventbridge.html)):
 
 ```yml
 functions:


### PR DESCRIPTION
I was looking for a way to use EventBridge with s3 event instead of the existing s3 event integration.
I then discovered we can have a robust content filtering for EventBridge pattern and thought it was a good idea to add it to the documentation.