### PR TITLE
docs: Rename menu to "Provider References"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ menuItems:
   - {menuText: "- Access Roles", path: /framework/docs/guides/access-roles/}
   - {menuText: "- Profiles", path: /framework/docs/guides/profiles/}
   - {menuText: "- Pipelines", path: /framework/docs/guides/pipelines/}
-  - {menuText: "Provider CLI References", path: /framework/docs/providers}
+  - {menuText: "Provider References", path: /framework/docs/providers}
   - {menuText: "- AWS", path: /framework/docs/providers/aws/}
   - {menuText: "- Azure", path: /framework/docs/providers/azure/}
   - {menuText: "- fn", path: /framework/docs/providers/fn/}

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -1,6 +1,6 @@
 <!--
 title: Serverless - Infrastructure & Compute Providers
-menuText: Provider CLI References
+menuText: Provider References
 layout: Doc
 -->
 


### PR DESCRIPTION
<img width="876" alt="Screen-000115" src="https://user-images.githubusercontent.com/720328/156752387-59b8c65b-3a23-4f85-9bef-92ad44cd3dbf.png">

Since almost all of the actually useful documentation is currently in "Provider > AWS", I thought it would make sense to rename the menu. Mentioning "CLI" is confusing to me, because most of the documentation is also about YAML configuration.

My guess is that the "CLI" word made sense with the perspective of mixing Dashboard documentation with Framework docs. But at the moment I think it's bringing more confusion.

**Note: I don't know enough about how the menu is built to guarantee that this PR will actually change the menu, code review on this is welcome.**