### PR TITLE
docs: Fix `schemas` documentation following v3 release

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -750,7 +750,7 @@ functions:
               querystrings:
                 paramName: true # mark query string
             # Request schema validation mapped by content type
-            schema:
+            schemas:
               # Define the valid JSON Schema for this content-type
               application/json: ${file(create_request.json)}
               application/json+abc:


### PR DESCRIPTION
Reported to @garethmcc: in v3 the key has been renamed from `schema` to `schemas` (https://www.serverless.com/framework/docs/deprecations#aws-api-gateway-schemas).

Please double-check my change just in case :)