### PR TITLE
fix(Telemetry): Ensure excluding `shouldSendTelemetry` from payload

### DIFF
--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -511,7 +511,7 @@ processSpanPromise = (async () => {
         });
       }
 
-      await finalize({ telemetryData: { outcome: 'success', shouldSendTelemetry: true } });
+      await finalize({ telemetryData: { outcome: 'success' }, shouldSendTelemetry: true });
       return;
     }
 
@@ -688,7 +688,8 @@ processSpanPromise = (async () => {
       }
 
       const backendNotificationRequest = await finalize({
-        telemetryData: { outcome: 'success', shouldSendTelemetry: commands.join(' ') === 'deploy' },
+        telemetryData: { outcome: 'success' },
+        shouldSendTelemetry: commands.join(' ') === 'deploy',
       });
       if (backendNotificationRequest) {
         await processBackendNotificationRequest(backendNotificationRequest);


### PR DESCRIPTION
I've noticed that some of the events have `shouldSendTelemetry` field included in the payload while inspecting telemetry implementation for totally unrelated purposes. This PR should fix it.
