### PR TITLE
docs: Fix incorrect `apiKeys` example

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -261,7 +261,7 @@ provider:
     apiKeySourceType: HEADER
     # List of API keys for the REST API
     apiKeys:
-      - myFirstKey
+      - name: myFirstKey
         value: myFirstKeyValue
         description: myFirstKeyDescription
         customerId: myFirstKeyCustomerId

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -309,7 +309,7 @@ provider:
           # Optional: Name of the API Gateway model
           name: GlobalModel
           # Optional: Description of the API Gateway model
-          description: "A global model that can be referenced in functions"
+          description: 'A global model that can be referenced in functions'
 ```
 
 ### ALB


### PR DESCRIPTION
I was unable to use the syntax as provided. 
```yaml
    apiKeys:
      - myFirstKey
        value: myFirstKeyValue
        description: myFirstKeyDescription
        customerId: myFirstKeyCustomerId
        # Can be used to disable the API key without removing it (default: true)
        enabled: false
```
It gave an error:
```
Cannot parse "serverless.yml": bad indentation of a sequence entry in "/src/serverless.yml" (14:20)
```
From trial and error, I realized that it should be this:
```yaml
    apiKeys:
      - name: myFirstKey
        value: myFirstKeyValue
        description: myFirstKeyDescription
        customerId: myFirstKeyCustomerId
        # Can be used to disable the API key without removing it (default: true)
        enabled: false
```