### PR TITLE
fix: Add CustomSenders as lambda cognito user pool target

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -1098,6 +1098,12 @@ functions:
           existing: true
           # Optional, for forcing deployment of triggers on existing User Pools
           forceDeploy: true
+          # Mandatory in case trigger is one of CustomSMSSender or CustomeEmailSender
+          # Specify KMS ARN that will be used to encrypt temporary passwords and authorization codes
+          kmsKeyId: arn:aws:kms:eu-west-1:111111111111:key/12345678-9abc-def0-1234-56789abcdef1
+          # Optional, used only in case trigger is one of CustomSMSSender or CustomeEmailSender
+          # Specify lambda version to use. Dkmsefault is V1_0
+          lambdaVersion: V1_0
 ```
 
 ### ALB

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
@@ -2,6 +2,10 @@
 
 const { awsRequest } = require('../../utils');
 
+const customSenderSources = ['CustomSMSSender', 'CustomEmailSender'];
+
+const KMSKeyID = 'KMSKeyID';
+
 function getUpdateConfigFromCurrentSetup(currentSetup) {
   const updatedConfig = Object.assign({}, currentSetup);
   delete updatedConfig.Id;
@@ -68,14 +72,19 @@ async function updateConfiguration(config) {
   return getConfiguration(config).then((res) => {
     const UserPoolId = res.UserPool.Id;
     let { LambdaConfig } = res.UserPool;
-    // remove configurations for this specific function
-    LambdaConfig = Object.keys(LambdaConfig).reduce((accum, key) => {
-      if (LambdaConfig[key] === lambdaArn) delete accum[key];
-      return accum;
-    }, LambdaConfig);
+
+    LambdaConfig = removeExistingLambdas(LambdaConfig, lambdaArn);
 
     userPoolConfigs.forEach((poolConfig) => {
-      LambdaConfig[poolConfig.Trigger] = lambdaArn;
+      if (customSenderSources.includes(poolConfig.Trigger)) {
+        LambdaConfig[poolConfig.Trigger] = {
+          LambdaArn: lambdaArn,
+          LambdaVersion: poolConfig.LambdaVersion,
+        };
+        LambdaConfig[KMSKeyID] = poolConfig.KmsKeyId;
+      } else {
+        LambdaConfig[poolConfig.Trigger] = lambdaArn;
+      }
     });
 
     const updatedConfig = getUpdateConfigFromCurrentSetup(res.UserPool);
@@ -99,10 +108,7 @@ async function removeConfiguration(config) {
     const UserPoolId = res.UserPool.Id;
     let { LambdaConfig } = res.UserPool;
     // remove configurations for this specific function
-    LambdaConfig = Object.keys(LambdaConfig).reduce((accum, key) => {
-      if (LambdaConfig[key] === lambdaArn) delete accum[key];
-      return accum;
-    }, LambdaConfig);
+    LambdaConfig = removeExistingLambdas(LambdaConfig, lambdaArn);
 
     const updatedConfig = getUpdateConfigFromCurrentSetup(res.UserPool);
     Object.assign(updatedConfig, {
@@ -116,6 +122,21 @@ async function removeConfiguration(config) {
       updatedConfig
     );
   });
+}
+
+function removeExistingLambdas(lambdaConfig, lambdaArn) {
+  const res = Object.fromEntries(
+    Object.entries(lambdaConfig).filter(([key, value]) => {
+      return (
+        !(customSenderSources.includes(key) && value.LambdaArn === lambdaArn) && value !== lambdaArn
+      );
+    })
+  );
+  // if there are no customSenderSources delete also KMSKeyId
+  if (KMSKeyID in res && customSenderSources.every((source) => !(source in res))) {
+    delete res[KMSKeyID];
+  }
+  return res;
 }
 
 module.exports = {

--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -5,6 +5,8 @@ const BbPromise = require('bluebird');
 const { addCustomResourceToService } = require('../../../custom-resources');
 const ServerlessError = require('../../../../../serverless-error');
 
+const customSenderSources = ['CustomSMSSender', 'CustomEmailSender'];
+
 const validTriggerSources = [
   'PreSignUp',
   'PostConfirmation',
@@ -16,7 +18,11 @@ const validTriggerSources = [
   'CreateAuthChallenge',
   'VerifyAuthChallengeResponse',
   'UserMigration',
-];
+].concat(customSenderSources);
+
+const lambdaVersion10 = 'V1_0';
+
+const validLambdaVersions = [lambdaVersion10];
 
 class AwsCompileCognitoUserPoolEvents {
   constructor(serverless, options) {
@@ -40,6 +46,8 @@ class AwsCompileCognitoUserPoolEvents {
         trigger: { enum: validTriggerSources },
         existing: { type: 'boolean' },
         forceDeploy: { type: 'boolean' },
+        kmsKeyId: { type: 'string' },
+        lambdaVersion: { enum: validLambdaVersions },
       },
       required: ['pool', 'trigger'],
       additionalProperties: false,
@@ -142,7 +150,7 @@ class AwsCompileCognitoUserPoolEvents {
         functionObj.events.forEach((event) => {
           if (event.cognitoUserPool && event.cognitoUserPool.existing) {
             numEventsForFunc++;
-            const { pool, trigger, forceDeploy } = event.cognitoUserPool;
+            const { pool, trigger, forceDeploy, kmsKeyId, lambdaVersion } = event.cognitoUserPool;
             usesExistingCognitoUserPool = funcUsesExistingCognitoUserPool = true;
 
             if (!currentPoolName) {
@@ -174,6 +182,25 @@ class AwsCompileCognitoUserPoolEvents {
             let customCognitoUserPoolResource;
             const forceDeployProperty = forceDeploy ? Date.now() : undefined;
             if (numEventsForFunc === 1) {
+              let userPoolConfig = {
+                Trigger: trigger,
+              };
+              if (customSenderSources.includes(trigger)) {
+                iamRoleStatements.push({
+                  Effect: 'Allow',
+                  Resource: kmsKeyId,
+                  Action: ['kms:CreateGrant'],
+                });
+
+                userPoolConfig = {
+                  ...userPoolConfig,
+                  ...{
+                    KmsKeyId: kmsKeyId,
+                    LambdaVersion: lambdaVersion,
+                  },
+                };
+              }
+
               customCognitoUserPoolResource = {
                 [customPoolResourceLogicalId]: {
                   Type: 'Custom::CognitoUserPool',
@@ -185,11 +212,7 @@ class AwsCompileCognitoUserPoolEvents {
                     },
                     FunctionName,
                     UserPoolName: pool,
-                    UserPoolConfigs: [
-                      {
-                        Trigger: trigger,
-                      },
-                    ],
+                    UserPoolConfigs: [userPoolConfig],
                     ForceDeploy: forceDeployProperty,
                   },
                 },
@@ -278,6 +301,8 @@ class AwsCompileCognitoUserPoolEvents {
               functionName,
               poolName: event.cognitoUserPool.pool,
               triggerSource: event.cognitoUserPool.trigger,
+              kmsKeyId: event.cognitoUserPool.kmsKeyId,
+              lambdaVersion: event.cognitoUserPool.lambdaVersion,
             });
 
             // Save user pools so we can use them to generate
@@ -295,12 +320,27 @@ class AwsCompileCognitoUserPoolEvents {
     const lambdaConfig = currentPoolTriggerFunctions.reduce((result, value) => {
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(value.functionName);
 
+      let triggerObject;
+      if (customSenderSources.includes(value.triggerSource)) {
+        triggerObject = {
+          [value.triggerSource]: {
+            LambdaArn: {
+              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+            },
+            LambdaVersion: value.lambdaVersion,
+          },
+          KMSKeyID: value.kmsKeyId,
+        };
+      } else {
+        triggerObject = {
+          [value.triggerSource]: {
+            'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+          },
+        };
+      }
+
       // Return a new object to avoid lint errors
-      return Object.assign({}, result, {
-        [value.triggerSource]: {
-          'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-        },
-      });
+      return Object.assign({}, result, triggerObject);
     }, {});
 
     const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);


### PR DESCRIPTION
AWS Cognito user pool support two new lambda triggers: CustomSMSSender and CustomEmailSender. To use those two trigger user has to specifiy `kmsKeyId` and `lambdaVersion` property.

Closes #8889

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

