### PR TITLE
fix(AWS Kafka): Allow usage of Server Root CA without client TLS auth

### DIFF
--- a/lib/plugins/aws/package/compile/events/kafka.js
+++ b/lib/plugins/aws/package/compile/events/kafka.js
@@ -130,12 +130,7 @@ class AwsCompileKafkaEvents {
         if (!event.kafka) return;
 
         const {
-          accessConfigurations: {
-            vpcSecurityGroup,
-            vpcSubnet,
-            clientCertificateTlsAuth,
-            serverRootCaCertificate,
-          },
+          accessConfigurations: { vpcSecurityGroup, vpcSubnet },
         } = event.kafka;
 
         if ((vpcSecurityGroup && !vpcSubnet) || (vpcSubnet && !vpcSecurityGroup)) {
@@ -143,13 +138,6 @@ class AwsCompileKafkaEvents {
           throw new ServerlessError(
             `You must specify at least one "${missing}" accessConfiguration for function: ${functionName}`,
             'FUNCTION_KAFKA_VPC_ACCESS_CONFIGURATION_INVALID'
-          );
-        }
-
-        if (serverRootCaCertificate && !clientCertificateTlsAuth) {
-          throw new ServerlessError(
-            `You cannot specify "serverRootCaCertificate" accessConfiguration without providing "clientCertificateTlsAuth" accessConfiguration for function: ${functionName}`,
-            'FUNCTION_KAFKA_CLIENT_CERTIFICATE_TLS_AUTH_CONFIGURATION_MISSING'
           );
         }
 

--- a/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
@@ -457,35 +457,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/kafka.test.js', () =>
         await runCompileEventSourceMappingTest(eventConfig);
       });
 
-      it('should fail to compile EventSourceMapping resource properties for SERVER_ROOT_CA_CERTIFICATE with no CLIENT_CERTIFICATE_TLS_AUTH', async () => {
-        await expect(
-          runServerless({
-            fixture: 'function',
-            configExt: {
-              functions: {
-                basic: {
-                  events: [
-                    {
-                      kafka: {
-                        topic,
-                        bootstrapServers: ['abc.xyz:9092'],
-                        accessConfigurations: {
-                          serverRootCaCertificate: serverRootCaCertificateArn,
-                        },
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-            command: 'package',
-          })
-        ).to.be.rejected.and.eventually.have.property(
-          'code',
-          'FUNCTION_KAFKA_CLIENT_CERTIFICATE_TLS_AUTH_CONFIGURATION_MISSING'
-        );
-      });
-
       it('should update default IAM role with EC2 statement when VPC accessConfiguration is provided', async () => {
         const { cfTemplate } = await runServerless({
           fixture: 'function',


### PR DESCRIPTION
This removes a check that prevented us from using a Kafka server root ca cert without using TLS client auth.
The check was previously implemented based on wrong assumptions. The two certs are actually independent from each other.

Addresses: [#10260](https://github.com/serverless/serverless/issues/10260)
