### PR TITLE
Standalone: Ensure error in China upload don't break GitHub upload

### DIFF
--- a/scripts/pkg/upload/index.js
+++ b/scripts/pkg/upload/index.js
@@ -40,5 +40,6 @@ if (!/^v\d+\.\d+\.\d+$/.test(versionTag)) {
   return;
 }
 
-require('./world')(versionTag, { isLegacyVersion: argv.legacy });
-require('./china')(versionTag, { isLegacyVersion: argv.legacy });
+const chinaUploadDeferred = require('./china')(versionTag, { isLegacyVersion: argv.legacy });
+// Ensure eventual error in Tencent upload does not break regular standalone upload
+require('./world')(versionTag, { isLegacyVersion: argv.legacy }).then(() => chinaUploadDeferred);


### PR DESCRIPTION
Mitigate issue where on publication, assets are not uploaded to GitHub as expected.

We upload to two servers in parallel, failure of any of them was resulting in rejection and immediate process exit, therefore breaking the upload of the other.

In this patch, I've ensured that we put priority on GitHub upload and handle eventual error in China upload, after successful GitHub upload. It's ok for China, as for them new releases of `serverless` are mostly meaningless. It's only about triage logic, which in turn falls back to Tencent Cli, and that triage doesn't change across releases

Fixes #10852