### PR TITLE
Console: Upgrade otel extension & fix packaging

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -343,7 +343,7 @@ Object.defineProperties(
           SLS_OTEL_REPORT_METRICS_URL: `${this.otelIngestionUrl}/v1/metrics`,
           SLS_OTEL_REPORT_TRACES_URL: `${this.otelIngestionUrl}/v1/traces`,
           OTEL_RESOURCE_ATTRIBUTES: `sls_service_name=${this.service},sls_stage=${this.stage},sls_org_id=${this.orgId}`,
-          AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension/otel-handler',
+          AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension/internal/exec-wrapper.sh',
         };
         if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.DEBUG_SLS_OTEL_LAYER = '1';
         return result;
@@ -359,7 +359,7 @@ Object.defineProperties(
       }
       const extensionVersionMetadata = await resolvePackageVersionMetadata(
         '@serverless/aws-lambda-otel-extension-dist',
-        '^0.1'
+        '^0.2'
       );
       log.debug('target extension version: %s', extensionVersionMetadata.version);
       const extensionArtifactFilename = path.resolve(

--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -6,6 +6,7 @@ const lazy = require('d/lazy');
 const path = require('path');
 const os = require('os');
 const fsp = require('fs').promises;
+const fse = require('fs-extra');
 const fetch = require('node-fetch');
 const tar = require('tar');
 const filesize = require('filesize');
@@ -264,6 +265,7 @@ class Console {
   async packageOtelExtensionLayer() {
     const layerFilename = await this.deferredExtensionLayerFilename;
     log.debug('copy extension file (%s) to package directory', layerFilename);
+    await fse.ensureDir(path.join(this.serverless.serviceDir, '.serverless'));
     await fsp.copyFile(
       layerFilename,
       path.join(


### PR DESCRIPTION
- Upgrade to rely on `0.2` version of the layer extension
- Fix handling, when no creation template is created (custom deployment bucket), extension packaging then failed as `.serverless` dir wasn't ensured to exist yet.