### PR TITLE
Console: Fix custom deployment bucket handling

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -236,6 +236,8 @@ class Console {
   }
 
   overrideSettings({ otelIngestionToken, extensionLayerVersionPostfix, service, stage }) {
+    // Store at "_usedExtensionLayerVersionPostfix" for telemetry purposes
+    this._usedExtensionLayerVersionPostfix = extensionLayerVersionPostfix;
     Object.defineProperties(this, {
       deferredOtelIngestionToken: d(Promise.resolve(otelIngestionToken)),
       deferredExtensionLayerVersionPostfix: d(Promise.resolve(extensionLayerVersionPostfix)),
@@ -393,10 +395,12 @@ Object.defineProperties(
       return `sls-otel.${await this.deferredExtensionLayerVersionPostfix}.zip`;
     }),
     deferredExtensionLayerVersionPostfix: d(async function () {
-      if (process.env.SLS_OTEL_LAYER_FILENAME) {
-        return (Date.now() - devVersionTimeBase).toString(32);
-      }
-      return path.basename(await this.deferredExtensionLayerFilename, '.zip');
+      const extensionLayerVersionPostfix = process.env.SLS_OTEL_LAYER_FILENAME
+        ? (Date.now() - devVersionTimeBase).toString(32)
+        : path.basename(await this.deferredExtensionLayerFilename, '.zip');
+      // Store at "_usedExtensionLayerVersionPostfix" for telemetry purposes
+      this._usedExtensionLayerVersionPostfix = extensionLayerVersionPostfix;
+      return extensionLayerVersionPostfix;
     }),
   })
 );

--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -253,7 +253,7 @@ class Console {
       Type: 'AWS::Lambda::LayerVersion',
       Properties: {
         Content: {
-          S3Bucket: { Ref: 'ServerlessDeploymentBucket' },
+          S3Bucket: await this.deferredBucketName,
           S3Key: `${this.serverless.service.package.artifactsS3KeyDirname}/${await this
             .deferredExtensionLayerBasename}`,
         },

--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -286,11 +286,10 @@ class Console {
     if (!layerVersionMeta) {
       log.debug('publish layer version (%s)', layerName);
       await this.uploadOtelExtensionLayer({ readFromTheSource: true });
-      await setBucketName.call(this);
       await this.provider.request('Lambda', 'publishLayerVersion', {
         LayerName: layerName,
         Content: {
-          S3Bucket: this.bucketName,
+          S3Bucket: await this.deferredBucketName,
           S3Key: `${this.serverless.service.package.artifactsS3KeyDirname}/${await this
             .deferredExtensionLayerBasename}`,
         },
@@ -310,10 +309,9 @@ class Console {
   async uploadOtelExtensionLayer(options = {}) {
     const layerBasename = await this.deferredExtensionLayerBasename;
     log.debug('check if extension file (%s) is already uploaded to S3', layerBasename);
-    await setBucketName.call(this);
     try {
       await this.provider.request('S3', 'headObject', {
-        Bucket: this.bucketName,
+        Bucket: await this.deferredBucketName,
         Key: `${this.serverless.service.package.artifactsS3KeyDirname}/${layerBasename}`,
       });
       // Extension layer is already available at S3, skip
@@ -338,6 +336,11 @@ class Console {
 Object.defineProperties(
   Console.prototype,
   lazy({
+    deferredBucketName: d(async function () {
+      const tmpObject = { provider: this.provider };
+      await setBucketName.call(tmpObject);
+      return tmpObject.bucketName;
+    }),
     deferredFunctionEnvironmentVariables: d(function () {
       return this.deferredOtelIngestionToken.then((otelIngestionToken) => {
         const result = {

--- a/lib/utils/telemetry/generate-payload.js
+++ b/lib/utils/telemetry/generate-payload.js
@@ -258,8 +258,10 @@ module.exports = ({
     payload.isConfigValid = getConfigurationValidationResult(configuration);
     payload.dashboard.orgUid =
       serverless && serverless.isDashboardEnabled ? serverless.service.orgUid : undefined;
-    payload.console.orgUid =
-      serverless && serverless.console.isEnabled ? serverless.service.orgUid : undefined;
+    if (_.get(serverless, 'console.isEnabled')) {
+      payload.console.orgUid = serverless.service.orgUid;
+      payload.console.extensionVersion = serverless.console._usedExtensionLayerVersionPostfix;
+    }
     if (isAwsProvider && serverless && commandsReportingProjectId.has(command)) {
       const serviceName = isObject(configuration.service)
         ? configuration.service.name


### PR DESCRIPTION
It appears https://github.com/serverless/serverless/pull/10860 wasn't good enough. Configured some tests to cover that test case this time.

Additionally report to telemetry eventually used extension version