### PR TITLE
Console: Onboarding improvements & url display

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -408,6 +408,13 @@ Object.defineProperties(
       this._usedExtensionLayerVersionPostfix = extensionLayerVersionPostfix;
       return extensionLayerVersionPostfix;
     }),
+    url: d(function () {
+      return (
+        `https://console.serverless.com/${this.org}/metrics/functions` +
+        `?globalEnvironments=${this.stage}&globalNamespaces=${this.service}` +
+        `&globalRegions=${this.region}&globalScope=functions&globalTimeFrame=15m`
+      );
+    }),
   })
 );
 

--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -80,6 +80,7 @@ class Console {
     this.orgId = (await this.sdk.getOrgByName(this.org)).orgUid;
     this.service = this.serverless.service.service;
     this.stage = this.provider.getStage();
+    this.region = this.provider.getRegion();
     this.otelIngestionUrl = (() => {
       if (process.env.SLS_CONSOLE_OTEL_INGESTION_URL) {
         return process.env.SLS_CONSOLE_OTEL_INGESTION_URL;
@@ -235,7 +236,7 @@ class Console {
     await response.text();
   }
 
-  overrideSettings({ otelIngestionToken, extensionLayerVersionPostfix, service, stage }) {
+  overrideSettings({ otelIngestionToken, extensionLayerVersionPostfix, service, stage, region }) {
     // Store at "_usedExtensionLayerVersionPostfix" for telemetry purposes
     this._usedExtensionLayerVersionPostfix = extensionLayerVersionPostfix;
     Object.defineProperties(this, {
@@ -243,6 +244,7 @@ class Console {
       deferredExtensionLayerVersionPostfix: d(Promise.resolve(extensionLayerVersionPostfix)),
       service: d('cew', service),
       stage: d('cew', stage),
+      region: d('cew', region),
     });
   }
 

--- a/lib/classes/plugin-manager.js
+++ b/lib/classes/plugin-manager.js
@@ -487,10 +487,10 @@ class PluginManager {
 
         // Invalid command, can happen only when Framework is used programmatically,
         // as otherwise command is validated in main script
-        throw new new ServerlessError(
+        throw new ServerlessError(
           `Unrecognized command "${commandsArray.join(' ')}"`,
           'UNRECOGNIZED COMMAND'
-        )();
+        );
       },
       { commands: this.commands }
     );

--- a/lib/cli/interactive-setup/deploy.js
+++ b/lib/cli/interactive-setup/deploy.js
@@ -5,7 +5,6 @@ const { writeText, style, log } = require('@serverless/utils/log');
 const promptWithHistory = require('@serverless/utils/inquirer/prompt-with-history');
 const isDashboardEnabled = require('../../configuration/is-dashboard-enabled');
 const { doesServiceInstanceHaveLinkedProvider } = require('./utils');
-const resolveVariables = require('../../configuration/variables');
 const _ = require('lodash');
 const AWS = require('aws-sdk');
 const isAuthenticated = require('@serverless/dashboard-plugin/lib/is-authenticated');
@@ -89,19 +88,6 @@ module.exports = {
     });
 
     await serverless.init();
-    await resolveVariables({
-      ...context,
-      sources: {
-        sls: require('../../configuration/variables/sources/instance-dependent/get-sls')(
-          serverless
-        ),
-        env: require('../../configuration/variables/sources/env'),
-        file: require('../../configuration/variables/sources/file'),
-        opt: require('../../configuration/variables/sources/opt'),
-        self: require('../../configuration/variables/sources/self'),
-        strToBool: require('../../configuration/variables/sources/str-to-bool'),
-      },
-    });
     await serverless.run();
     context.serverless = serverless;
 

--- a/lib/configuration/variables/index.js
+++ b/lib/configuration/variables/index.js
@@ -15,6 +15,7 @@ const defaultSources = {
   opt: require('./sources/opt'),
   self: require('./sources/self'),
   strToBool: require('./sources/str-to-bool'),
+  sls: require('./sources/instance-dependent/get-sls')(),
 };
 
 const reportEventualErrors = (variablesMeta) => {

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -159,11 +159,18 @@ class AwsDeploy {
               'CONSOLE_ORG_MISMATCH'
             );
           }
+          if (this.state.console.region !== this.console.region) {
+            throw new ServerlessError(
+              'Cannot deploy service: Service was packaged in context of different AWS region',
+              'CONSOLE_REGION_MISMATCH'
+            );
+          }
           this.console.overrideSettings({
             otelIngestionToken: this.state.console.otelIngestionToken,
             extensionLayerVersionPostfix: this.state.console.extensionLayerVersionPostfix,
             service: this.state.console.service,
             stage: this.state.console.stage,
+            region: this.state.console.region,
           });
           await this.console.activateOtelIngestionToken();
         } else if (this.state.console) {

--- a/lib/plugins/aws/info/display.js
+++ b/lib/plugins/aws/info/display.js
@@ -11,6 +11,7 @@ module.exports = {
       this.serverless.serviceOutputs.set('region', this.provider.getRegion());
       this.serverless.serviceOutputs.set('stack', this.provider.naming.getStackName());
     }
+    if (this.console.isEnabled) this.serverless.serviceOutputs.set('console', this.console.url);
   },
 
   displayApiKeys() {

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const BbPromise = require('bluebird');
 const { progress, style } = require('@serverless/utils/log');
 const writeServiceOutputs = require('../../../cli/write-service-outputs');
 const validate = require('../lib/validate');
@@ -42,38 +41,24 @@ class AwsInfo {
 
     this.hooks = {
       'info:info': async () => this.serverless.pluginManager.spawn('aws:info'),
-
-      'deploy:deploy': async () =>
-        BbPromise.bind(this).then(() => {
-          return this.serverless.pluginManager.spawn('aws:info');
-        }),
-
+      'deploy:deploy': async () => this.serverless.pluginManager.spawn('aws:info'),
       'before:aws:info:validate': () => {
         const isDeployCommand = this.serverless.processedInput.commands.join(' ') === 'deploy';
         if (!isDeployCommand) return;
         mainProgress.notice('Retrieving CloudFormation stack', { isMainEvent: true });
       },
-      'aws:info:validate': async () => BbPromise.bind(this).then(this.validate),
-
-      'aws:info:gatherData': async () =>
-        BbPromise.bind(this)
-          .then(this.getStackInfo)
-          .then(this.getResourceCount)
-          .then(this.getApiKeyValues),
-
-      'aws:info:displayServiceInfo': async () => BbPromise.bind(this).then(this.displayServiceInfo),
-
-      'aws:info:displayApiKeys': async () => BbPromise.bind(this).then(this.displayApiKeys),
-
-      'aws:info:displayEndpoints': async () => BbPromise.bind(this).then(this.displayEndpoints),
-
-      'aws:info:displayFunctions': async () => BbPromise.bind(this).then(this.displayFunctions),
-
-      'aws:info:displayLayers': async () => BbPromise.bind(this).then(this.displayLayers),
-
-      'aws:info:displayStackOutputs': async () =>
-        BbPromise.bind(this).then(this.displayStackOutputs),
-
+      'aws:info:validate': async () => this.validate(),
+      'aws:info:gatherData': async () => {
+        await this.getStackInfo();
+        await this.getResourceCount();
+        await this.getApiKeyValues();
+      },
+      'aws:info:displayServiceInfo': async () => this.displayServiceInfo(),
+      'aws:info:displayApiKeys': async () => this.displayApiKeys(),
+      'aws:info:displayEndpoints': async () => this.displayEndpoints(),
+      'aws:info:displayFunctions': async () => this.displayFunctions(),
+      'aws:info:displayLayers': async () => this.displayLayers(),
+      'aws:info:displayStackOutputs': async () => this.displayStackOutputs(),
       'after:aws:info:gatherData': () => {
         if (this.gatheredData && this.gatheredData.info.resourceCount >= 450) {
           log.warning(
@@ -85,7 +70,6 @@ class AwsInfo {
           );
         }
       },
-
       'finalize': () => {
         if (this.serverless.processedInput.commands.join(' ') !== 'info') return;
         writeServiceOutputs(this.serverless.serviceOutputs);

--- a/lib/plugins/aws/info/index.js
+++ b/lib/plugins/aws/info/index.js
@@ -15,6 +15,7 @@ const mainProgress = progress.get('main');
 class AwsInfo {
   constructor(serverless, options) {
     this.serverless = serverless;
+    this.console = serverless.console;
     this.provider = this.serverless.getProvider('aws');
     this.options = options || {};
     Object.assign(this, validate, getStackInfo, getResourceCount, getApiKeyValues, display);

--- a/lib/plugins/aws/package/lib/save-service-state.js
+++ b/lib/plugins/aws/package/lib/save-service-state.js
@@ -41,6 +41,7 @@ module.exports = {
         extensionLayerVersionPostfix: await this.console.deferredExtensionLayerVersionPostfix,
         service: this.console.service,
         stage: this.console.stage,
+        region: this.console.region,
         orgId: this.console.orgId,
       };
     }


### PR DESCRIPTION
- Ensure that existing projects have fully resolved configuration when they enter onboarding (so far they went the same route as new services, where only basic variable sources were resolved - those which can be resolved when not having `Serverless` instance in hand)
- Improve fix that ensures that `sls:stage` is resolved in starting templates (initially done at #10784). It improves the variables resolution that was already preconfigured and does not initialize new one
- Configure processing flow debug logs 
- Prevent AWS region mismatch in console deployments
- Fix internal unrecognized command handling (not surfaces as it was applicable only for programmatic usage)
- Print URL to console after the successful deployment
- Refactor noisy Bluebird usage into clean async/await