### PR TITLE
[Docs] Add maximumRetryAttempts to AWS guide

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -132,8 +132,6 @@ provider:
   versionFunctions: false
   # Processor architecture: 'x86_64' or 'arm64' via Graviton2 (default: x86_64)
   architecture: x86_64
-  # Maximum retry attempts when an asynchronous invocation fails (between 0 and 2; default: 2)
-  maximumRetryAttempts: 1
 ```
 
 ### Deployment bucket
@@ -678,6 +676,10 @@ functions:
       arn: arn:aws:elasticfilesystem:us-east-1:11111111:access-point/fsap-a1a1a1
       # Path under which EFS will be mounted and accessible in Lambda
       localMountPath: /mnt/example
+    # Maximum retry attempts when an asynchronous invocation fails (between 0 and 2; default: 2)
+    maximumRetryAttempts: 1
+    # Maximum event age in seconds when invoking asynchornously (between 60 and 21600)
+    maximumEventAge: 7200
 ```
 
 ## Lambda events

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -132,6 +132,8 @@ provider:
   versionFunctions: false
   # Processor architecture: 'x86_64' or 'arm64' via Graviton2 (default: x86_64)
   architecture: x86_64
+  # Maximum retry attempts when an asynchronous invocation fails (between 0 and 2; default: 2)
+  maximumRetryAttempts: 1
 ```
 
 ### Deployment bucket

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -678,7 +678,7 @@ functions:
       localMountPath: /mnt/example
     # Maximum retry attempts when an asynchronous invocation fails (between 0 and 2; default: 2)
     maximumRetryAttempts: 1
-    # Maximum event age in seconds when invoking asynchornously (between 60 and 21600)
+    # Maximum event age in seconds when invoking asynchronously (between 60 and 21600)
     maximumEventAge: 7200
 ```
 


### PR DESCRIPTION
Document max retry attempts for async Lambda invocations: https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html

It's supported by Serverless, just not documented as far as I can see