### PR TITLE
Fixed artifact permissions for AWS Rust local invoke

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -460,7 +460,10 @@ class AwsInvokeLocal {
     // Java zip/jar implementaion doesn't preserve file permissions in a zip file.
     // https://bugs.openjdk.java.net/browse/JDK-6194856
     // So we follow Java's way in java.util.zip.ZipEntry#isDirectory() to detect directory.
-    await decompress(artifact, destination, { filter: (file) => !file.path.endsWith('/') });
+    const artifactFiles = await decompress(artifact, destination, { filter: (file) => !file.path.endsWith('/') });
+    for (const file of artifactFiles) {
+      await fse.chmodSync(destination + '/' + file.path, 0o755);
+    }
     return destination;
   }
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

Without this PR the following error is returned for local rust function invoke:
```
$ npx serverless invoke local -f es-export
...
Serverless: Building Rust es-export func...
Serverless: Running local cargo build on darwin
...
Serverless: Packaging service...
...
Serverless: Writing Dockerfile...
Serverless: Building Docker image...
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
START RequestId: 7e9540d4-2a60-18b5-eeee-a6efdf55a82c Version: $LATEST
END RequestId: 7e9540d4-2a60-18b5-eeee-a6efdf55a82c
REPORT RequestId: 7e9540d4-2a60-18b5-eeee-a6efdf55a82c	Init Duration: 201.74 ms	Duration: 53.32 ms	Billed Duration: 54 ms	Memory Size: 3008 MMax Memory Used: 29 MB	

{"errorType":"exitError","errorMessage":"RequestId: 7e9540d4-2a60-18b5-eeee-a6efdf55a82c Error: fork/exec /var/task/bootstrap: permission denied"}
 
 Serverless Error ----------------------------------------
 
  Failed to run docker for rust image (exit code 1})
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
 
  Your Environment Information ---------------------------
     Operating System:          darwin
     Node Version:              12.22.10
     Framework Version:         2.72.3 (local)
     Plugin Version:            5.5.4
     SDK Version:               4.3.2
     Components Version:        3.18.2
 ```

This PR fixes it.
