### PR TITLE
Console: Support dashboard providers and validate layers count

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -21,7 +21,14 @@ const safeMoveFile = require('../utils/fs/safe-move-file');
 const { setBucketName } = require('../plugins/aws/lib/set-bucket-name');
 const { uploadZipFile } = require('../plugins/aws/lib/upload-zip-file');
 
-const supportedCommands = new Set(['deploy', 'deploy function', 'package', 'remove', 'rollback']);
+const supportedCommands = new Set([
+  'deploy',
+  'deploy function',
+  'info',
+  'package',
+  'remove',
+  'rollback',
+]);
 const devVersionTimeBase = new Date(2022, 1, 17).getTime();
 const extensionCachePath = path.resolve(os.homedir(), '.serverless/aws-lambda-otel-extension');
 

--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -251,23 +251,12 @@ module.exports = {
     }
 
     const isConsole = Boolean(options.console || configuration.console);
-    const isDashboard = Boolean(
-      (() => {
-        if (configuration.console) return configuration.dashboard;
-        if (options.console) return configuration.app;
-        return true;
-      })()
-    );
+    const isDashboard = Boolean(!isConsole || configuration.app || options.app);
     const isConsolePreconfigured = Boolean(configuration.console);
     const isMonitoringPreconfigured = Boolean(configuration.org);
 
     if (isConsole && !isDashboard) {
       const isFullyPreconfigured = isConsolePreconfigured && isMonitoringPreconfigured;
-      if (options.app) {
-        log.error();
-        log.error('"--app" is not supported in console integrated serviced.');
-        delete options.app;
-      }
       const orgName = options.org || configuration.org;
 
       const isMonitoringOverridenByCli =

--- a/lib/cli/interactive-setup/utils.js
+++ b/lib/cli/interactive-setup/utils.js
@@ -15,7 +15,6 @@ const yamlExtensions = new Set(['.yml', '.yaml']);
 const appPattern = /^(?:#\s*)?app\s*:.+/m;
 const orgPattern = /^(?:#\s*)?org\s*:.+/m;
 const consolePattern = /^(?:#\s*)?console\s*:(.*)/m;
-const dashboardPattern = /^(?:#\s*)?dashboard\s*:.+/m;
 
 const ServerlessError = require('../../serverless-error');
 const resolveStage = require('../../utils/resolve-stage');
@@ -102,14 +101,6 @@ module.exports = {
         ymlString = `console: true\n${ymlString}`;
       }
     }
-    if (isConsole && isDashboard) {
-      const dashboardMatch = ymlString.match(dashboardPattern);
-      if (dashboardMatch) {
-        ymlString = ymlString.replace(dashboardMatch[0], 'dashboard: true');
-      } else {
-        ymlString = `dashboard: true\n${ymlString}`;
-      }
-    }
 
     if (appName) {
       const appMatch = ymlString.match(appPattern);
@@ -131,7 +122,6 @@ module.exports = {
     if (appName) configuration.app = appName;
     if (isConsole) {
       if (!configuration.console) configuration.console = true;
-      if (isDashboard) configuration.dashboard = true;
     }
   },
   showOnboardingWelcome: memoizee(

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -22,7 +22,11 @@ const schema = {
       required: [],
       // User is free to add any properties for its own purpose
     },
-    dashboard: { type: 'boolean' },
+    dashboard: {
+      type: 'object',
+      properties: { disableMonitoring: { type: 'boolean' } },
+      additionalProperties: false,
+    },
     deprecationNotificationMode: {
       enum: ['error', 'warn', 'warn:summary'],
     },

--- a/lib/configuration/is-dashboard-enabled.js
+++ b/lib/configuration/is-dashboard-enabled.js
@@ -1,9 +1,8 @@
 'use strict';
 
-module.exports = ({ configuration, options }) => {
-  if (configuration) {
-    if (configuration.console && !configuration.dashboard) return false;
-    if (configuration.org) return true;
-  }
-  return Boolean(options.org);
-};
+const _ = require('lodash');
+
+module.exports = ({ configuration, options }) =>
+  Boolean(_.get(configuration, 'org') || options.org) &&
+  Boolean(_.get(configuration, 'app') || options.app) &&
+  !_.get(configuration, 'dashboard.disableMonitoring');

--- a/lib/plugins/aws/info/get-stack-info.js
+++ b/lib/plugins/aws/info/get-stack-info.js
@@ -56,7 +56,7 @@ module.exports = {
     }
 
     // Get info from CloudFormation Outputs
-    return BbPromise.all(sdkRequests).then(() => {
+    return BbPromise.all(sdkRequests).then(async () => {
       let outputs;
 
       if (stackData.outputs) {
@@ -90,6 +90,19 @@ module.exports = {
           }
           this.gatheredData.info.layers.push(layerInfo);
         });
+        if (this.console.isEnabled) {
+          const layerMeta = (
+            await this.provider.request('Lambda', 'listLayerVersions', {
+              LayerName: await this.console.deferredExtensionLayerName,
+            })
+          ).LayerVersions[0];
+          if (layerMeta) {
+            this.gatheredData.info.layers.push({
+              name: '<console extension>',
+              arn: layerMeta.LayerVersionArn,
+            });
+          }
+        }
 
         // CloudFront
         const cloudFrontDomainName = outputs.find(

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -412,7 +412,8 @@ class AwsCompileFunctions {
     if (functionObject.layers) {
       functionResource.Properties.Layers = functionObject.layers;
     } else if (this.serverless.service.provider.layers) {
-      functionResource.Properties.Layers = this.serverless.service.provider.layers;
+      // To avoid unwanted side effects ensure to not reference same array instace on each function
+      functionResource.Properties.Layers = Array.from(this.serverless.service.provider.layers);
     }
 
     if (this.console.isEnabled && this.console.isFunctionSupported(functionObject)) {

--- a/lib/plugins/aws/package/index.js
+++ b/lib/plugins/aws/package/index.js
@@ -9,6 +9,7 @@ const saveServiceState = require('./lib/save-service-state');
 const saveCompiledTemplate = require('./lib/save-compiled-template');
 const mergeIamTemplates = require('./lib/merge-iam-templates');
 const addExportNameForOutputs = require('./lib/add-export-name-for-outputs');
+const validateTemplate = require('./lib/validate-template');
 const { log, style, progress } = require('@serverless/utils/log');
 
 const mainProgress = progress.get('main');
@@ -34,7 +35,8 @@ class AwsPackage {
       mergeCustomProviderResources,
       stripNullPropsFromTemplateResources,
       saveServiceState,
-      saveCompiledTemplate
+      saveCompiledTemplate,
+      validateTemplate
     );
 
     // Define inner lifecycles
@@ -113,6 +115,7 @@ class AwsPackage {
         this.stripNullPropsFromTemplateResources(),
 
       'aws:package:finalize:saveServiceState': async () => {
+        this.validateTemplate();
         await this.saveCompiledTemplate();
         await this.saveServiceState();
         return this.serverless.pluginManager.spawn('aws:common:moveArtifactsToPackage');

--- a/lib/plugins/aws/package/lib/validate-template.js
+++ b/lib/plugins/aws/package/lib/validate-template.js
@@ -1,0 +1,32 @@
+// Improve error reporting for Framework specific functionalities
+
+'use strict';
+
+const ServerlessError = require('../../../../serverless-error');
+
+module.exports = {
+  validateTemplate() {
+    if (this.console.isEnabled) {
+      const cfResources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+      for (const functionName of this.serverless.service.getAllFunctions()) {
+        const functionConfig = this.serverless.service.getFunction(functionName);
+        if (!this.console.isFunctionSupported(functionConfig)) continue;
+        const functionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
+        const functionResource = cfResources[functionLogicalId];
+        if (!functionResource) continue; // Unexpected CF stack state, ignore
+        const layers = functionResource.Properties.Layers;
+        if (!layers || layers.length <= 5) continue;
+        const nonConsoleLayers = layers.filter(
+          (layer) => layer.Ref !== this.provider.naming.getConsoleExtensionLayerLogicalId()
+        );
+        throw new ServerlessError(
+          `${
+            `Cannot setup Serverless Console integration, as "${functionName}" function, ` +
+            'has already maximum (5) number of layers referenced:\n  '
+          }${nonConsoleLayers.map((layer) => JSON.stringify(layer)).join(',\n  ')}`,
+          'TOO_MANY_LAYERS_TO_SETUP_CONSOLE'
+        );
+      }
+    }
+  },
+};

--- a/test/unit/lib/classes/console.test.js
+++ b/test/unit/lib/classes/console.test.js
@@ -622,7 +622,7 @@ describe('test/unit/lib/classes/console.test.js', () => {
     );
     it(
       'should throw mismatch error when attempting to deploy package, ' +
-        'packaged with different org',
+        'packaged with different region',
       async () => {
         const fetchStub = createFetchStub().stub;
         const {

--- a/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -693,11 +693,9 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
         expect(serviceConfig.org).to.equal('testinteractivecli');
         expect(serviceConfig.app).to.equal('some-aws-service-app');
         expect(serviceConfig.console).to.be.true;
-        expect(serviceConfig.dashboard).to.be.true;
         expect(context.configuration.org).to.equal('testinteractivecli');
         expect(context.configuration.app).to.equal('some-aws-service-app');
         expect(context.configuration.console).to.be.true;
-        expect(context.configuration.dashboard).to.be.true;
         expect(Array.from(context.stepHistory.valuesMap())).to.deep.equal(Array.from(new Map()));
       });
     });

--- a/test/unit/lib/cli/interactive-setup/deploy.test.js
+++ b/test/unit/lib/cli/interactive-setup/deploy.test.js
@@ -61,7 +61,7 @@ describe('test/unit/lib/cli/interactive-setup/deploy.test.js', () => {
 
     expect(
       await mockedStep.isApplicable({
-        configuration: { provider: { name: 'aws' }, org: 'someorg' },
+        configuration: { provider: { name: 'aws' }, org: 'someorg', app: 'someapp' },
         serviceDir: '/foo',
         options: {},
         history: new Map([['awsCredentials', []]]),


### PR DESCRIPTION
- Revert from disabling Dashboard integration when `console: true` (user needed to add `dashboard: true` to have Dashboard enabled). After this change, `org` and `console` enables the Console, and `org` and `app` enables the Dashboard (so with `org`, `app` and `console`, both Console and Dashboard integrations are on)
- Support `dashboard.disableMonitoring` to introduce a way to rely on Dashboard providers feature but having Dashbaord integration turned off (needs also https://github.com/serverless/dashboard-plugin/pull/685)
- List extension layer in `layers` outputs section
- Introduce meaningful error reporting when service for given function has already 5 layers configured
- Fix issue (reported in contributors slack channel) where for layers configured at `providers.layers` console extension layer setup became multiplied