### PR TITLE
AWS Deploy: Ensure no internal dependency on `console`

### DIFF
--- a/lib/plugins/aws/info/get-stack-info.js
+++ b/lib/plugins/aws/info/get-stack-info.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BbPromise = require('bluebird');
+const _ = require('lodash');
 const resolveCfImportValue = require('../utils/resolve-cf-import-value');
 const ServerlessError = require('../../../serverless-error');
 
@@ -90,7 +91,9 @@ module.exports = {
           }
           this.gatheredData.info.layers.push(layerInfo);
         });
-        if (this.console.isEnabled) {
+        // In Framework `this.console` is guranteed, still there are plugins adapting
+        // this method, and then `this.console` is undefined
+        if (_.get(this.console, 'isEnabled')) {
           const layerMeta = (
             await this.provider.request('Lambda', 'listLayerVersions', {
               LayerName: await this.console.deferredExtensionLayerName,


### PR DESCRIPTION
It's to avoid plugin breakage as communicated at https://github.com/serverless/serverless/pull/10895#issuecomment-1079705625