### PR TITLE
Console: Report logs with opt out option

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -40,9 +40,9 @@ class Console {
   }
 
   async initialize() {
+    const { configurationInput: configuration } = this.serverless;
     this.isEnabled = (() => {
       const {
-        configurationInput: configuration,
         processedInput: { commands, options },
       } = this.serverless;
       if (!_.get(configuration, 'console')) return false;
@@ -88,6 +88,7 @@ class Console {
     this.service = this.serverless.service.service;
     this.stage = this.provider.getStage();
     this.region = this.provider.getRegion();
+    this.shouldDisableLogsCollection = configuration.console.disableLogsCollection;
     this.otelIngestionUrl = (() => {
       if (process.env.SLS_CONSOLE_OTEL_INGESTION_URL) {
         return process.env.SLS_CONSOLE_OTEL_INGESTION_URL;
@@ -366,6 +367,9 @@ Object.defineProperties(
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension/internal/exec-wrapper.sh',
         };
         if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.DEBUG_SLS_OTEL_LAYER = '1';
+        if (!this.shouldDisableLogsCollection) {
+          result.SLS_OTEL_REPORT_LOGS_URL = `${this.otelIngestionUrl}/v1/logs`;
+        }
         return result;
       });
     }),

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -15,7 +15,18 @@ const schema = {
      *  The default is `warn`, and will be set to `error` in v2
      */
     configValidationMode: { enum: ['error', 'warn', 'off'] },
-    console: { type: 'boolean' },
+    console: {
+      anyOf: [
+        { type: 'boolean' },
+        {
+          type: 'object',
+          properties: {
+            disableLogsCollection: { type: 'boolean' },
+          },
+          additionalProperties: false,
+        },
+      ],
+    },
     custom: {
       type: 'object',
       properties: {},


### PR DESCRIPTION
We want to report all logs by default, yet with opt out option (in form of `console.disableLogsCollection`)