### PR TITLE
feat(CLI Onboarding): Support all runtimes for dashboard

### DIFF
--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -223,10 +223,16 @@ module.exports = {
     }
     const sdk = new ServerlessSDK();
     const { supportedRegions, supportedRuntimes } = await sdk.metadata.get();
-    if (!supportedRuntimes.includes(_.get(configuration.provider, 'runtime') || 'nodejs12.x')) {
+
+    // We want to still allow onboarding from Dashboard (idenfitied by explicit `--org` passed)
+    if (
+      !options.org &&
+      !supportedRuntimes.includes(_.get(configuration.provider, 'runtime') || 'nodejs12.x')
+    ) {
       context.inapplicabilityReasonCode = 'UNSUPPORTED_RUNTIME';
       return false;
     }
+
     if (
       !supportedRegions.includes(options.region || configuration.provider.region || 'us-east-1')
     ) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sls": "./bin/serverless.js"
   },
   "dependencies": {
-    "@serverless/dashboard-plugin": "^6.2.0",
+    "@serverless/dashboard-plugin": "^6.2.1",
     "@serverless/platform-client": "^4.3.2",
     "@serverless/utils": "^6.0.3",
     "ajv": "^8.11.0",


### PR DESCRIPTION
Reported internally, this change removes the check for unsupported runtimes in Dashboard as it's still possible to track deployments of services, user dashboard params, or providers with unsupported runtimes, as seen below:
![BF9D3ED2-624E-4F19-9C65-B4182A3E9AA6_1_105_c](https://user-images.githubusercontent.com/17499590/161294288-9bb7603c-516c-448e-a0b2-b012cc00a4e2.jpeg)


During deployment, the warning will still be visible and inform that Dashboard doesn't support certain runtimes
![1A94A733-9804-4E68-835E-0E0AE8E0ECA5_4_5005_c](https://user-images.githubusercontent.com/17499590/161294119-858b96b2-d1ef-4727-943c-e0346d8f5346.jpeg)


