### PR TITLE
feat(AWS Websocket): Allow propagating tags to Websocket APIGW

### DIFF
--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -116,6 +116,15 @@ Deprecation code: `CLI_DEPLOY_FUNCTION_OPTION_V3`
 
 Starting with `v4.0.0`, `--function` or `-f` option for `deploy` command will no longer be supported. In order to deploy a single function, please use `deploy function` command instead.
 
+<a name="AWS_WEBSOCKET_API_USE_PROVIDER_TAGS"><div>&nbsp;</div></a>
+
+## Property `provider.websocketsUseProviderTags`
+
+Deprecation code: `AWS_WEBSOCKET_API_USE_PROVIDER_TAGS`
+
+Starting with v4.0.0, `provider.tags` will be applied to Websocket Api Gateway by default
+Set `provider.websocketsUseProviderTags` to `true` to adapt to the new behavior now.
+
 <a name="LAMBDA_HASHING_VERSION_PROPERTY"><div>&nbsp;</div></a>
 
 ## Property `provider.lambdaHashingVersion`

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -118,12 +118,12 @@ Starting with `v4.0.0`, `--function` or `-f` option for `deploy` command will no
 
 <a name="AWS_WEBSOCKET_API_USE_PROVIDER_TAGS"><div>&nbsp;</div></a>
 
-## Property `provider.websockets.useProviderTags`
+## Property `provider.websocket.useProviderTags`
 
 Deprecation code: `AWS_WEBSOCKET_API_USE_PROVIDER_TAGS`
 
 Starting with v4.0.0, `provider.tags` will be applied to Websocket Api Gateway by default
-Set `provider.websockets.useProviderTags` to `true` to adapt to the new behavior now.
+Set `provider.websocket.useProviderTags` to `true` to adapt to the new behavior now.
 
 <a name="LAMBDA_HASHING_VERSION_PROPERTY"><div>&nbsp;</div></a>
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -118,12 +118,12 @@ Starting with `v4.0.0`, `--function` or `-f` option for `deploy` command will no
 
 <a name="AWS_WEBSOCKET_API_USE_PROVIDER_TAGS"><div>&nbsp;</div></a>
 
-## Property `provider.websocketsUseProviderTags`
+## Property `provider.websockets.useProviderTags`
 
 Deprecation code: `AWS_WEBSOCKET_API_USE_PROVIDER_TAGS`
 
 Starting with v4.0.0, `provider.tags` will be applied to Websocket Api Gateway by default
-Set `provider.websocketsUseProviderTags` to `true` to adapt to the new behavior now.
+Set `provider.websockets.useProviderTags` to `true` to adapt to the new behavior now.
 
 <a name="LAMBDA_HASHING_VERSION_PROPERTY"><div>&nbsp;</div></a>
 

--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -296,3 +296,16 @@ provider:
     websocket:
       fullExecutionData: false
 ```
+
+## Tags
+
+When using Websocket API, it is possible to tag the corresponding API Gateway resources. By setting `provider.websocketsUseProviderTags` to `true`, all tags defined on `provider.tags` will be applied to API Gateway and API Gateway Stage.
+
+```yaml
+provider:
+  tags:
+    project: myProject
+  websocketsUseProviderTags: true
+```
+
+In the above example, the tag project: myProject will be applied to API Gateway and API Gateway Stage.

--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -299,13 +299,14 @@ provider:
 
 ## Tags
 
-When using Websocket API, it is possible to tag the corresponding API Gateway resources. By setting `provider.websocketsUseProviderTags` to `true`, all tags defined on `provider.tags` will be applied to API Gateway and API Gateway Stage.
+When using Websocket API, it is possible to tag the corresponding API Gateway resources. By setting `provider.websockets.useProviderTags` to `true`, all tags defined on `provider.tags` will be applied to API Gateway and API Gateway Stage.
 
 ```yaml
 provider:
   tags:
     project: myProject
-  websocketsUseProviderTags: true
+  websockets:
+    useProviderTags: true
 ```
 
 In the above example, the tag project: myProject will be applied to API Gateway and API Gateway Stage.

--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -299,13 +299,13 @@ provider:
 
 ## Tags
 
-When using Websocket API, it is possible to tag the corresponding API Gateway resources. By setting `provider.websockets.useProviderTags` to `true`, all tags defined on `provider.tags` will be applied to API Gateway and API Gateway Stage.
+When using Websocket API, it is possible to tag the corresponding API Gateway resources. By setting `provider.websocket.useProviderTags` to `true`, all tags defined on `provider.tags` will be applied to API Gateway and API Gateway Stage.
 
 ```yaml
 provider:
   tags:
     project: myProject
-  websockets:
+  websocket:
     useProviderTags: true
 ```
 

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -13,14 +13,14 @@ module.exports = {
 
     if (
       this.serverless.service.provider.tags &&
-      (!this.serverless.service.provider.websockets ||
-        !this.serverless.service.provider.websockets.useProviderTags)
+      (!this.serverless.service.provider.websocket ||
+        !this.serverless.service.provider.websocket.useProviderTags)
     ) {
       this.serverless._logDeprecation(
         'AWS_WEBSOCKET_API_USE_PROVIDER_TAGS',
         'Starting with next major version, the provider tags ' +
           'will be applied to Websocket Api Gateway by default. \n' +
-          'Set "provider.websockets.useProviderTags" to "true" ' +
+          'Set "provider.websocket.useProviderTags" to "true" ' +
           'to adapt to the new behavior now.'
       );
     }
@@ -34,8 +34,8 @@ module.exports = {
     // Tags
     const tags =
       this.serverless.service.provider.tags &&
-      this.serverless.service.provider.websockets &&
-      this.serverless.service.provider.websockets.useProviderTags
+      this.serverless.service.provider.websocket &&
+      this.serverless.service.provider.websocket.useProviderTags
         ? Object.assign({}, this.serverless.service.provider.tags)
         : {};
 

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -17,6 +17,18 @@ module.exports = {
       this.serverless.service.provider.websocketsApiRouteSelectionExpression ||
       '$request.body.action';
 
+    // Tags
+    const tagsMerged = Object.assign(
+      {},
+      this.serverless.service.provider.stackTags,
+      this.serverless.service.provider.tags
+    );
+
+    const tags = {};
+    Object.entries(tagsMerged).forEach((pair) => {
+      tags[pair[0]] = pair[1];
+    });
+
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       [this.websocketsApiLogicalId]: {
         Type: 'AWS::ApiGatewayV2::Api',
@@ -26,6 +38,7 @@ module.exports = {
           Description:
             this.serverless.service.provider.websocketsDescription || 'Serverless Websockets',
           ProtocolType: 'WEBSOCKET',
+          Tags: tags,
         },
       },
     });

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -31,25 +31,28 @@ module.exports = {
       this.serverless.service.provider.websocketsApiRouteSelectionExpression ||
       '$request.body.action';
 
+    const properties = {
+      Name: this.provider.naming.getWebsocketsApiName(),
+      RouteSelectionExpression,
+      Description:
+        this.serverless.service.provider.websocketsDescription || 'Serverless Websockets',
+      ProtocolType: 'WEBSOCKET',
+    };
+
     // Tags
-    const tags =
+    if (
       this.serverless.service.provider.tags &&
       this.serverless.service.provider.websocket &&
       this.serverless.service.provider.websocket.useProviderTags
-        ? Object.assign({}, this.serverless.service.provider.tags)
-        : {};
+    ) {
+      const tags = Object.assign({}, this.serverless.service.provider.tags);
+      properties.Tags = tags;
+    }
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       [this.websocketsApiLogicalId]: {
         Type: 'AWS::ApiGatewayV2::Api',
-        Properties: {
-          Name: this.provider.naming.getWebsocketsApiName(),
-          RouteSelectionExpression,
-          Description:
-            this.serverless.service.provider.websocketsDescription || 'Serverless Websockets',
-          ProtocolType: 'WEBSOCKET',
-          Tags: tags,
-        },
+        Properties: properties,
       },
     });
 

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -11,6 +11,19 @@ module.exports = {
       return;
     }
 
+    if (
+      this.serverless.service.provider.tags &&
+      !this.serverless.service.provider.websocketsUseProviderTags
+    ) {
+      this.serverless._logDeprecation(
+        'AWS_WEBSOCKET_API_USE_PROVIDER_TAGS',
+        'Starting with next major version, the provider tags ' +
+          'will be applied to Websocket Api Gateway by default. \n' +
+          'Set "provider.websocketsUseProviderTags" to "true" ' +
+          'to adapt to the new behavior now.'
+      );
+    }
+
     this.websocketsApiLogicalId = this.provider.naming.getWebsocketsApiLogicalId();
 
     const RouteSelectionExpression =

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -18,16 +18,11 @@ module.exports = {
       '$request.body.action';
 
     // Tags
-    const tagsMerged = Object.assign(
-      {},
-      this.serverless.service.provider.stackTags,
-      this.serverless.service.provider.tags
-    );
-
-    const tags = {};
-    Object.entries(tagsMerged).forEach((pair) => {
-      tags[pair[0]] = pair[1];
-    });
+    const tags =
+      this.serverless.service.provider.tags &&
+      this.serverless.service.provider.websocketsUseProviderTags
+        ? Object.assign({}, this.serverless.service.provider.tags)
+        : {};
 
     _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
       [this.websocketsApiLogicalId]: {

--- a/lib/plugins/aws/package/compile/events/websockets/lib/api.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/api.js
@@ -13,13 +13,14 @@ module.exports = {
 
     if (
       this.serverless.service.provider.tags &&
-      !this.serverless.service.provider.websocketsUseProviderTags
+      (!this.serverless.service.provider.websockets ||
+        !this.serverless.service.provider.websockets.useProviderTags)
     ) {
       this.serverless._logDeprecation(
         'AWS_WEBSOCKET_API_USE_PROVIDER_TAGS',
         'Starting with next major version, the provider tags ' +
           'will be applied to Websocket Api Gateway by default. \n' +
-          'Set "provider.websocketsUseProviderTags" to "true" ' +
+          'Set "provider.websockets.useProviderTags" to "true" ' +
           'to adapt to the new behavior now.'
       );
     }
@@ -33,7 +34,8 @@ module.exports = {
     // Tags
     const tags =
       this.serverless.service.provider.tags &&
-      this.serverless.service.provider.websocketsUseProviderTags
+      this.serverless.service.provider.websockets &&
+      this.serverless.service.provider.websockets.useProviderTags
         ? Object.assign({}, this.serverless.service.provider.tags)
         : {};
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1202,6 +1202,7 @@ class AwsProvider {
             websocketsApiName: { type: 'string' },
             websocketsApiRouteSelectionExpression: { type: 'string' },
             websocketsDescription: { type: 'string' },
+            websocketsUseProviderTags: { type: 'boolean' },
           },
         },
         function: {

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1199,7 +1199,7 @@ class AwsProvider {
             vpc: { $ref: '#/definitions/awsLambdaVpcConfig' },
             vpcEndpointIds: { $ref: '#/definitions/awsCfArrayInstruction' },
             versionFunctions: { $ref: '#/definitions/awsLambdaVersioning' },
-            websockets: {
+            websocket: {
               type: 'object',
               properties: {
                 useProviderTags: { type: 'boolean' },

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1199,10 +1199,16 @@ class AwsProvider {
             vpc: { $ref: '#/definitions/awsLambdaVpcConfig' },
             vpcEndpointIds: { $ref: '#/definitions/awsCfArrayInstruction' },
             versionFunctions: { $ref: '#/definitions/awsLambdaVersioning' },
+            websockets: {
+              type: 'object',
+              properties: {
+                useProviderTags: { type: 'boolean' },
+              },
+              additionalProperties: false,
+            },
             websocketsApiName: { type: 'string' },
             websocketsApiRouteSelectionExpression: { type: 'string' },
             websocketsDescription: { type: 'string' },
-            websocketsUseProviderTags: { type: 'boolean' },
           },
         },
         function: {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -145,6 +145,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
           RouteSelectionExpression: '$request.body.action',
           Description: 'Serverless Websockets',
           ProtocolType: 'WEBSOCKET',
+          Tags: {},
         },
       });
     });
@@ -157,6 +158,54 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
         Effect: 'Allow',
         Action: ['execute-api:ManageConnections'],
         Resource: [{ 'Fn::Sub': 'arn:${AWS::Partition}:execute-api:*:*:*/@connections/*' }],
+      });
+    });
+  });
+
+  describe('regular configuration with tags', () => {
+    let cfTemplate;
+    let awsNaming;
+    before(async () => {
+      ({ cfTemplate, awsNaming } = await runServerless({
+        fixture: 'function',
+        command: 'package',
+
+        configExt: {
+          provider: {
+            stackTags: {
+              stack_tag: 'foo',
+            },
+            tags: {
+              tag: 'bar',
+            },
+          },
+          functions: {
+            basic: {
+              events: [
+                {
+                  websocket: '$connect',
+                },
+              ],
+            },
+          },
+        },
+      }));
+    });
+
+    it('should create a websocket api resource with tags', () => {
+      const websocketsApiName = awsNaming.getWebsocketsApiName();
+      expect(cfTemplate.Resources.WebsocketsApi).to.deep.equal({
+        Type: 'AWS::ApiGatewayV2::Api',
+        Properties: {
+          Name: websocketsApiName,
+          RouteSelectionExpression: '$request.body.action',
+          Description: 'Serverless Websockets',
+          ProtocolType: 'WEBSOCKET',
+          Tags: {
+            stack_tag: 'foo',
+            tag: 'bar',
+          },
+        },
       });
     });
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -123,6 +123,11 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
         command: 'package',
 
         configExt: {
+          provider: {
+            tags: {
+              tag: 'bar',
+            },
+          },
           functions: {
             basic: {
               events: [
@@ -178,6 +183,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
             tags: {
               tag: 'bar',
             },
+            websocketsUseProviderTags: true,
           },
           functions: {
             basic: {
@@ -202,7 +208,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
           Description: 'Serverless Websockets',
           ProtocolType: 'WEBSOCKET',
           Tags: {
-            stack_tag: 'foo',
             tag: 'bar',
           },
         },

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -124,9 +124,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
 
         configExt: {
           provider: {
-            tags: {
-              tag: 'bar',
-            },
             websocket: {
               useProviderTags: true,
             },
@@ -153,9 +150,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
           RouteSelectionExpression: '$request.body.action',
           Description: 'Serverless Websockets',
           ProtocolType: 'WEBSOCKET',
-          Tags: {
-            tag: 'bar',
-          },
         },
       });
     });

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -127,6 +127,9 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
             tags: {
               tag: 'bar',
             },
+            websockets: {
+              useProviderTags: true,
+            },
           },
           functions: {
             basic: {
@@ -150,7 +153,9 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
           RouteSelectionExpression: '$request.body.action',
           Description: 'Serverless Websockets',
           ProtocolType: 'WEBSOCKET',
-          Tags: {},
+          Tags: {
+            tag: 'bar',
+          },
         },
       });
     });
@@ -183,7 +188,9 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
             tags: {
               tag: 'bar',
             },
-            websocketsUseProviderTags: true,
+            websockets: {
+              useProviderTags: true,
+            },
           },
           functions: {
             basic: {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/index.test.js
@@ -127,7 +127,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
             tags: {
               tag: 'bar',
             },
-            websockets: {
+            websocket: {
               useProviderTags: true,
             },
           },
@@ -188,7 +188,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/websockets/index.test
             tags: {
               tag: 'bar',
             },
-            websockets: {
+            websocket: {
               useProviderTags: true,
             },
           },


### PR DESCRIPTION
**What is problem?**

Websockets API Gateway created by serverless framework does not have tags.

**Fix**

Adding of tags for Websocket API GW wasn't implemented.  The fix is ​​to add the missing functionality.