### PR TITLE
refactor(CLI): Fix typos in `create` CLI messages

### DIFF
--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -55,7 +55,7 @@ class Create {
 
       log.notice();
       log.notice.success(
-        `Project sucessfully created in "${this.options.path || './'}" from "${
+        `Project successfully created in "${this.options.path || './'}" from "${
           this.options.template
         }" template ${style.aside(
           `(${Math.floor(
@@ -115,7 +115,7 @@ class Create {
       }
       log.notice();
       log.notice.success(
-        `Project sucessfully created in "${this.options.path || `./${this.options.name}`}"`
+        `Project successfully created in "${this.options.path || `./${this.options.name}`}"`
       );
     } else {
       const errorMessage = [


### PR DESCRIPTION
This PR fixes a typo in CLI that occurs after creating a project:

```
✔ Project sucessfully created in
```

->

```
✔ Project successfully created in
```