### PR TITLE
fix(AWS API Gateway): Correctly construct resource name for schema

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -305,7 +305,7 @@ module.exports = {
   },
   getEndpointModelLogicalId(resourceId, methodName, contentType) {
     return `${this.getMethodLogicalId(resourceId, methodName)}${_.startCase(contentType).replace(
-      ' ',
+      / /g,
       ''
     )}Model`;
   },

--- a/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -448,8 +448,12 @@ describe('#naming()', () => {
   describe('#getEndpointModelLogicalId()', () => {
     it('', () => {
       expect(
-        sdk.naming.getEndpointModelLogicalId('ResourceId', 'get', 'application/json')
-      ).to.equal('ApiGatewayMethodResourceIdGetApplicationJsonModel');
+        sdk.naming.getEndpointModelLogicalId(
+          'ResourceId',
+          'get',
+          'application/x-www-form-urlencoded'
+        )
+      ).to.equal('ApiGatewayMethodResourceIdGetApplicationXWwwFormUrlencodedModel');
     });
   });
 


### PR DESCRIPTION
I could not use `replaceAll` because it's only available since Node 15. 

I decided to not replace `-` with `Dash` word to keep the consistency with the previous intention. 

Closes: #10938 
