### PR TITLE
feat(AWS Websocket): Add ability to configure log format and types

### DIFF
--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -262,3 +262,37 @@ provider:
 ```
 
 Valid values are INFO, ERROR.
+
+You can specify your own [format for API Gateway Access Logs](https://docs.aws.amazon.com/apigateway/latest/developerguide/websocket-api-logging.html) by including your preferred string in the `format` property:
+
+```yml
+# serverless.yml
+provider:
+  name: aws
+  logs:
+    websocket:
+      format: '{ "requestId":"$context.requestId",   "ip": "$context.identity.sourceIp" }'
+```
+
+The existence of the `logs` property enables both access and execution logging. If you want to disable one or both of them, you can do so with the following:
+
+```yml
+# serverless.yml
+provider:
+  name: aws
+  logs:
+    websocket:
+      accessLogging: false
+      executionLogging: false
+```
+
+By default, the full requests and responses data will be logged. If you want to disable like so:
+
+```yml
+# serverless.yml
+provider:
+  name: aws
+  logs:
+    websocket:
+      fullExecutionData: false
+```

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -540,8 +540,16 @@ provider:
     # Enable Websocket API logs
     # This can either be set to `websocket: true` to use defaults, or configured via subproperties.
     websocket:
-      # Log level to use for execution logging: INFO or ERROR.
+      # Enables HTTP access logs (default: true)
+      accessLogging: true
+      # Log format to use for access logs
+      format: 'requestId: $context.requestId'
+      # Enable execution logging (default: true)
+      executionLogging: true
+      # Log level to use for execution logging: INFO or ERROR
       level: INFO
+      # Log full requests/responses for execution logging (default: true)
+      fullExecutionData: true
 
     # Optional, whether to write CloudWatch logs for custom resource lambdas as added by the framework
     frameworkLambda: true

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -6,6 +6,14 @@ const ServerlessError = require('../../../../../../../serverless-error');
 
 const defaultLogLevel = 'INFO';
 const validLogLevels = new Set(['INFO', 'ERROR']);
+const defaultLogFormat = [
+  '$context.identity.sourceIp',
+  '$context.identity.caller',
+  '$context.identity.user',
+  '[$context.requestTime]',
+  '"$context.eventType $context.routeKey $context.connectionId"',
+  '$context.requestId',
+].join(' ');
 
 module.exports = {
   async compileStage() {
@@ -39,8 +47,19 @@ module.exports = {
 
       if (!logs) return null;
 
+      const accessLogging = logs.accessLogging == null ? true : logs.accessLogging;
+      const executionLogging = logs.executionLogging == null ? true : logs.executionLogging;
+      const fullExecutionData = logs.fullExecutionData == null ? true : logs.fullExecutionData;
+
+      let logFormat = defaultLogFormat;
+      if (logs.format) {
+        logFormat = logs.format;
+      }
+
       let level = defaultLogLevel;
-      if (logs.level) {
+      if (!executionLogging) {
+        level = 'OFF';
+      } else if (logs.level) {
         level = logs.level;
         if (!validLogLevels.has(level)) {
           throw new ServerlessError(
@@ -53,25 +72,21 @@ module.exports = {
       }
 
       // create log-specific resources
-      Object.assign(stageResource.Properties, {
-        AccessLogSettings: {
+      const logProperties = {
+        DefaultRouteSettings: {
+          DataTraceEnabled: fullExecutionData,
+          LoggingLevel: level,
+        },
+      };
+      if (accessLogging) {
+        logProperties.AccessLogSettings = {
           DestinationArn: {
             'Fn::Sub': `arn:\${AWS::Partition}:logs:\${AWS::Region}:\${AWS::AccountId}:log-group:\${${logGroupLogicalId}}`,
           },
-          Format: [
-            '$context.identity.sourceIp',
-            '$context.identity.caller',
-            '$context.identity.user',
-            '[$context.requestTime]',
-            '"$context.eventType $context.routeKey $context.connectionId"',
-            '$context.requestId',
-          ].join(' '),
-        },
-        DefaultRouteSettings: {
-          DataTraceEnabled: true,
-          LoggingLevel: level,
-        },
-      });
+          Format: logFormat,
+        };
+      }
+      Object.assign(stageResource.Properties, logProperties);
 
       Object.assign(cfTemplate.Resources, {
         [logGroupLogicalId]: getLogGroupResource(service, stage, this.provider),

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1091,6 +1091,10 @@ class AwsProvider {
                     {
                       type: 'object',
                       properties: {
+                        accessLogging: { type: 'boolean' },
+                        executionLogging: { type: 'boolean' },
+                        format: { type: 'string' },
+                        fullExecutionData: { type: 'boolean' },
                         level: { enum: ['INFO', 'ERROR'] },
                       },
                       additionalProperties: false,

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -249,8 +249,8 @@ describe('lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js', 
     let resource;
     const customLogFormat = ['$context.identity.sourceIp', '$context.requestId'].join(' ');
 
-    before(() =>
-      runServerless({
+    before(async () => {
+      const { cfTemplate, awsNaming } = await runServerless({
         fixture: 'websocket',
         configExt: {
           provider: {
@@ -266,11 +266,10 @@ describe('lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js', 
           },
         },
         command: 'package',
-      }).then(({ cfTemplate, awsNaming }) => {
-        const stageLogicalId = awsNaming.getWebsocketsStageLogicalId();
-        resource = cfTemplate.Resources[stageLogicalId];
-      })
-    );
+      });
+      const stageLogicalId = awsNaming.getWebsocketsStageLogicalId();
+      resource = cfTemplate.Resources[stageLogicalId];
+    });
 
     it('should set accessLogging off', async () => {
       expect(resource.Properties.AccessLogSettings).to.be.undefined;

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -191,5 +191,139 @@ describe('#compileStage()', () => {
         ).to.equal(true);
       });
     });
+
+    it('should set a specific log Format if provider has format', () => {
+      const customFormat = ['$context.identity.sourceIp', '$context.requestId'].join(' ');
+      awsCompileWebsocketsEvents.serverless.service.provider.logs = {
+        websocket: {
+          format: customFormat,
+        },
+      };
+
+      return awsCompileWebsocketsEvents.compileStage().then(() => {
+        const resources =
+          awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources;
+
+        expect(resources[stageLogicalId].Properties.AccessLogSettings.Format).to.equal(
+          customFormat
+        );
+      });
+    });
+
+    it('should set LoggingLevel if provider has executionLogging', () => {
+      awsCompileWebsocketsEvents.serverless.service.provider.logs = {
+        websocket: {
+          executionLogging: false,
+        },
+      };
+
+      return awsCompileWebsocketsEvents.compileStage().then(() => {
+        const resources =
+          awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources;
+
+        expect(resources[stageLogicalId]).to.deep.equal({
+          Type: 'AWS::ApiGatewayV2::Stage',
+          Properties: {
+            ApiId: {
+              Ref: awsCompileWebsocketsEvents.websocketsApiLogicalId,
+            },
+            StageName: 'dev',
+            Description: 'Serverless Websockets',
+            AccessLogSettings: {
+              DestinationArn: {
+                'Fn::Sub':
+                  'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${WebsocketsLogGroup}',
+              },
+              Format: [
+                '$context.identity.sourceIp',
+                '$context.identity.caller',
+                '$context.identity.user',
+                '[$context.requestTime]',
+                '"$context.eventType $context.routeKey $context.connectionId"',
+                '$context.requestId',
+              ].join(' '),
+            },
+            DefaultRouteSettings: {
+              DataTraceEnabled: true,
+              LoggingLevel: 'OFF',
+            },
+          },
+        });
+      });
+    });
+
+    it('should set DataTraceEnabled if provider has fullExecutionData', () => {
+      awsCompileWebsocketsEvents.serverless.service.provider.logs = {
+        websocket: {
+          fullExecutionData: false,
+        },
+      };
+
+      return awsCompileWebsocketsEvents.compileStage().then(() => {
+        const resources =
+          awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources;
+
+        expect(resources[stageLogicalId]).to.deep.equal({
+          Type: 'AWS::ApiGatewayV2::Stage',
+          Properties: {
+            ApiId: {
+              Ref: awsCompileWebsocketsEvents.websocketsApiLogicalId,
+            },
+            StageName: 'dev',
+            Description: 'Serverless Websockets',
+            AccessLogSettings: {
+              DestinationArn: {
+                'Fn::Sub':
+                  'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${WebsocketsLogGroup}',
+              },
+              Format: [
+                '$context.identity.sourceIp',
+                '$context.identity.caller',
+                '$context.identity.user',
+                '[$context.requestTime]',
+                '"$context.eventType $context.routeKey $context.connectionId"',
+                '$context.requestId',
+              ].join(' '),
+            },
+            DefaultRouteSettings: {
+              DataTraceEnabled: false,
+              LoggingLevel: 'INFO',
+            },
+          },
+        });
+      });
+    });
+
+    it('should set AccessLogSettings if provider has accessLogging', () => {
+      awsCompileWebsocketsEvents.serverless.service.provider.logs = {
+        websocket: {
+          accessLogging: false,
+        },
+      };
+
+      return awsCompileWebsocketsEvents.compileStage().then(() => {
+        const resources =
+          awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources;
+
+        expect(resources[stageLogicalId]).to.deep.equal({
+          Type: 'AWS::ApiGatewayV2::Stage',
+          Properties: {
+            ApiId: {
+              Ref: awsCompileWebsocketsEvents.websocketsApiLogicalId,
+            },
+            StageName: 'dev',
+            Description: 'Serverless Websockets',
+            DefaultRouteSettings: {
+              DataTraceEnabled: true,
+              LoggingLevel: 'INFO',
+            },
+          },
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Addresses: #6218
Also related to #6578 and #7836

The PR adds `accessLogging`, `executionLogging`, `fullExecutionData`, and `format` options to websocket log configuration, which only provides the `level` option now.
By that, you can configure websocket log just like restApi log.
```yaml
# serverless.yml
provider:
  name: aws
  logs:
    websocket:
      level: INFO
      fullExecutionData: false
```

It's more like a bug fix rather than feature improvement, becuase it just implements what [the documentation describes](https://github.com/serverless/serverless/blob/main/docs/providers/aws/events/apigateway.md#logs).