### PR TITLE
fix(AWS Local Invocation): Ensure env vars resolve for docker

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -167,6 +167,36 @@ class AwsInvokeLocal {
       }, {});
   }
 
+  async resolveConfiguredEnvVars(configuredEnvVars) {
+    await Promise.all(
+      Object.entries(configuredEnvVars).map(async ([name, value]) => {
+        if (!_.isObject(value)) return;
+        try {
+          if (value['Fn::ImportValue']) {
+            configuredEnvVars[name] = await resolveCfImportValue(
+              this.provider,
+              value['Fn::ImportValue']
+            );
+          } else if (value.Ref) {
+            configuredEnvVars[name] = await resolveCfRefValue(this.provider, value.Ref);
+          } else {
+            throw new ServerlessError(
+              `Unsupported environment variable format: ${inspect(value)}`,
+              'INVOKE_LOCAL_UNSUPPORTED_ENV_VARIABLE'
+            );
+          }
+        } catch (error) {
+          throw new ServerlessError(
+            `Could not resolve "${name}" environment variable: ${error.message}`,
+            'INVOKE_LOCAL_INVALID_ENV_VARIABLE'
+          );
+        }
+      })
+    );
+
+    return configuredEnvVars;
+  }
+
   async loadEnvVars() {
     const lambdaName = this.options.functionObj.name;
     const memorySize =
@@ -198,33 +228,7 @@ class AwsInvokeLocal {
       lambdaDefaultEnvVars.AWS_PROFILE = profileOverride;
     }
 
-    const configuredEnvVars = this.getConfiguredEnvVars();
-
-    await Promise.all(
-      Object.entries(configuredEnvVars).map(async ([name, value]) => {
-        if (!_.isObject(value)) return;
-        try {
-          if (value['Fn::ImportValue']) {
-            configuredEnvVars[name] = await resolveCfImportValue(
-              this.provider,
-              value['Fn::ImportValue']
-            );
-          } else if (value.Ref) {
-            configuredEnvVars[name] = await resolveCfRefValue(this.provider, value.Ref);
-          } else {
-            throw new ServerlessError(
-              `Unsupported environment variable format: ${inspect(value)}`,
-              'INVOKE_LOCAL_UNSUPPORTED_ENV_VARIABLE'
-            );
-          }
-        } catch (error) {
-          throw new ServerlessError(
-            `Could not resolve "${name}" environment variable: ${error.message}`,
-            'INVOKE_LOCAL_INVALID_ENV_VARIABLE'
-          );
-        }
-      })
-    );
+    const configuredEnvVars = await this.resolveConfiguredEnvVars(this.getConfiguredEnvVars());
 
     _.merge(process.env, lambdaDefaultEnvVars, credentialEnvVars, configuredEnvVars);
   }
@@ -531,7 +535,7 @@ class AwsInvokeLocal {
       AWS_LAMBDA_FUNCTION_MEMORY_SIZE: memorySize,
     };
     const credentialEnvVars = this.getCredentialEnvVars();
-    const configuredEnvVars = this.getConfiguredEnvVars();
+    const configuredEnvVars = await this.resolveConfiguredEnvVars(this.getConfiguredEnvVars());
     const envVarsFromOptions = this.getEnvVarsFromOptions();
     const envVars = _.merge(
       lambdaDefaultEnvVars,


### PR DESCRIPTION
# Steps to reproduce

1. Clone the latest https://github.com/SerheyDolgushev/serverless-rust-example:
    ```bash
    git clone git@github.com:SerheyDolgushev/serverless-rust-example.git
    cd serverless-rust-example
    ```

2. Install Node.js dependencies:
    ```bash
    npm install --only=dev
    ```

3. Run `get_variable` action for `AccountElasticsearchDomainEndpoint` variable:
    ```bash
    npx serverless invoke local -f hello -d '{"action": "get_variable", "name": "AccountElasticsearchDomainEndpoint"}'
    ```

## Actual result
```bash
{"name":"AccountElasticsearchDomainEndpoint","value":"[object Object]"}
```

## Expected result

```bash
{"name":"AccountElasticsearchDomainEndpoint","value":"search-account-test-24zc7k4nrcwra44odfw7jy4v44.us-east-1.es.amazonaws.com"}
```