### PR TITLE
refactor(Telemetry): Ensure to pass unique id with events

### DIFF
--- a/lib/utils/telemetry/index.js
+++ b/lib/utils/telemetry/index.js
@@ -101,7 +101,11 @@ function storeLocally(payload, options = {}) {
 
   return (function self() {
     try {
-      return fse.writeJsonSync(join(cacheDirPath, id), { payload, timestamp: Date.now() });
+      // Additionally, we also append `id` to the payload to be used as $insert_id in Mixpanel to ensure event deduplication
+      return fse.writeJsonSync(join(cacheDirPath, id), {
+        payload: { ...payload, id },
+        timestamp: Date.now(),
+      });
     } catch (error) {
       if (error.code === 'ENOENT') {
         try {

--- a/test/unit/lib/utils/telemetry/index.test.js
+++ b/test/unit/lib/utils/telemetry/index.test.js
@@ -67,7 +67,7 @@ describe('test/unit/lib/utils/telemetry/index.test.js', () => {
     const dirFilenames = await fsp.readdir(cacheDirPath);
     expect(dirFilenames.length).to.equal(1);
     const persistedEvent = await fse.readJson(path.join(cacheDirPath, dirFilenames[0]));
-    expect(persistedEvent.payload).to.deep.equal(payload);
+    expect(persistedEvent.payload).to.deep.equal({ ...payload, id: dirFilenames[0] });
     expect(persistedEvent).to.have.property('timestamp');
   });
 


### PR DESCRIPTION
Reported internally - pass unique ID to events for deduplication purposes
