### PR TITLE
Moving away from Lambci to AWS docker images

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -322,7 +322,7 @@ class AwsInvokeLocal {
     return spawnExt('docker', [
       'pull',
       '--disable-content-trust=false',
-      `lambci/lambda:${runtime}`,
+      `amazon/aws-sam-cli-emulation-image-${runtime}:latest`,
     ]);
   }
 
@@ -388,16 +388,11 @@ class AwsInvokeLocal {
     return `sls-docker-${this.getRuntime()}`;
   }
 
-  async buildDockerImage(layerPaths) {
+  async buildDockerImage() {
     const runtime = this.getRuntime();
     const imageName = this.getDockerImageName();
 
-    let dockerFileContent = `FROM lambci/lambda:${runtime}`;
-    for (const layerPath of layerPaths) {
-      dockerFileContent += `\nADD --chown=sbx_user1051:495 ${
-        os.platform() === 'win32' ? layerPath.replace(/\\/g, '/') : layerPath
-      } /opt`;
-    }
+    const dockerFileContent = `FROM amazon/aws-sam-cli-emulation-image-${runtime}:latest`;
 
     const dockerfilePath = path.join('.serverless', 'invokeLocal', runtime, 'Dockerfile');
     const dockerfileCachePath = path.join(cachePath, 'dockerfiles', runtime, 'Dockerfile');
@@ -513,10 +508,12 @@ class AwsInvokeLocal {
     mainProgress.notice('Invoking function locally', { isMainEvent: true });
     await this.checkDockerDaemonStatus();
     const results = await Promise.all([
-      this.checkDockerImage(`lambci/lambda:${runtime}`).then((exists) => {
-        return exists ? {} : this.pullDockerImage();
-      }),
-      this.getLayerPaths().then((layerPaths) => this.buildDockerImage(layerPaths)),
+      this.checkDockerImage(`amazon/aws-sam-cli-emulation-image-${runtime}:latest`).then(
+        (exists) => {
+          return exists ? {} : this.pullDockerImage();
+        }
+      ),
+      this.getLayerPaths().then(this.buildDockerImage()),
       this.extractArtifact(),
     ]);
     const imageName = results[1];

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -388,11 +388,16 @@ class AwsInvokeLocal {
     return `sls-docker-${this.getRuntime()}`;
   }
 
-  async buildDockerImage() {
+  async buildDockerImage(layerPaths) {
     const runtime = this.getRuntime();
     const imageName = this.getDockerImageName();
 
-    const dockerFileContent = `FROM amazon/aws-sam-cli-emulation-image-${runtime}:latest`;
+    let dockerFileContent = `FROM amazon/aws-sam-cli-emulation-image-${runtime}:latest`;
+    for (const layerPath of layerPaths) {
+      dockerFileContent += `\nADD ${
+        os.platform() === 'win32' ? layerPath.replace(/\\/g, '/') : layerPath
+      } /opt`;
+    }
 
     const dockerfilePath = path.join('.serverless', 'invokeLocal', runtime, 'Dockerfile');
     const dockerfileCachePath = path.join(cachePath, 'dockerfiles', runtime, 'Dockerfile');
@@ -513,7 +518,7 @@ class AwsInvokeLocal {
           return exists ? {} : this.pullDockerImage();
         }
       ),
-      this.getLayerPaths().then(this.buildDockerImage()),
+      this.getLayerPaths().then((layerPaths) => this.buildDockerImage(layerPaths)),
       this.extractArtifact(),
     ]);
     const imageName = results[1];

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -657,7 +657,7 @@ describe('AwsInvokeLocal', () => {
       expect(spawnExtStub.getCall(0).args).to.deep.equal(['docker', ['version']]);
       expect(spawnExtStub.getCall(1).args).to.deep.equal([
         'docker',
-        ['images', '-q', 'lambci/lambda:nodejs12.x'],
+        ['images', '-q', 'amazon/aws-sam-cli-emulation-image-nodejs12.x:latest'],
       ]);
       expect(spawnExtStub.getCall(3).args).to.deep.equal([
         'docker',


### PR DESCRIPTION
This PR moves us away from lambci/lambda to amazon/aws-sam-cli-emulation-image-${runtime}. Lambci has been inactive for over 12 months and is missing support for many updates to major languages, including (but not limited to): Python 3.9, .NET 6 and Node 14.x.

Solution to use the AWS images was discussed in #10797 

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #10797 
Closes: #9980
