### PR TITLE
refactor: Support custom error message for variables resolution

### DIFF
--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -234,10 +234,13 @@ class VariablesResolver {
         // Last source reported no value and there's no further fallback, we treat it as an error
         // In further processing ideally it should be surfaced and prevent command from continuing
         delete variableMeta.sources;
+        const detailedErrorMessage =
+          resolvedData.eventualErrorMessage ||
+          `Value not found at "${previousSourceData.type}" source`;
         variableMeta.error = new ServerlessError(
           `Cannot resolve variable at "${humanizePropertyPath(
             propertyPath.split('\0')
-          )}": Value not found at "${previousSourceData.type}" source`,
+          )}": ${detailedErrorMessage}`,
           'MISSING_VARIABLE_RESULT'
         );
         return;

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -78,6 +78,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       sharedSourceResolution2: '${sourceProperty(sharedSourceResolution1, sharedFinal)}',
       sharedPropertyResolution1: '${sourceSharedProperty:}',
       sharedPropertyResolution2: '${sourceProperty(sharedPropertyResolution1, sharedFinal)}',
+      nullWithCustomErrorMessage: '${sourceDirectNull:}',
     };
     let variablesMeta;
     const sources = {
@@ -91,6 +92,9 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       },
       sourceDirect: {
         resolve: () => ({ value: 234 }),
+      },
+      sourceDirectNull: {
+        resolve: () => ({ value: null, eventualErrorMessage: 'Custom error message from source' }),
       },
       sourceProperty: {
         resolve: async ({ params, resolveConfigurationProperty }) => {
@@ -442,6 +446,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
         'invalidResultNonJson',
         'invalidResultNonJsonCircular',
         'invalidResultValue',
+        'nullWithCustomErrorMessage',
         `infiniteResolutionRecursion${'\0nest'.repeat(10)}`,
       ]);
     });
@@ -463,6 +468,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
         'sourceInfinite',
         'sourceShared',
         'sourceSharedProperty',
+        'sourceDirectNull',
       ]);
     });
 
@@ -483,6 +489,13 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
         expect(valueMeta).to.not.have.property('variables');
         expect(valueMeta.error.code).to.equal('VARIABLE_RESOLUTION_ERROR');
       });
+    });
+
+    it('should recognize custom error message for null values', () => {
+      const valueMeta = variablesMeta.get('nullWithCustomErrorMessage');
+      expect(valueMeta).to.not.have.property('variables');
+      expect(valueMeta.error.code).to.equal('MISSING_VARIABLE_RESULT');
+      expect(valueMeta.error.message).to.include('Custom error message from source');
     });
   });
 


### PR DESCRIPTION
Reported internally

Support custom error in variable resolution mechanism, e.g. along those lines
![B670704E-F7B7-4685-8B27-C7592097BA13](https://user-images.githubusercontent.com/17499590/164203278-d87ce3c4-22ff-4c46-bafd-93579078d5ba.jpeg)

Related: https://github.com/serverless/dashboard-plugin/pull/690