### PR TITLE
Console: New monitoring configuration options

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -361,6 +361,9 @@ Object.defineProperties(
       return this.deferredOtelIngestionToken.then((otelIngestionToken) => {
         const userSettings = {};
         if (this.config.disableLogsCollection) userSettings.disableLogsMonitoring = true;
+        if (this.config.disableRequestResponseCollection) {
+          userSettings.disableRequestResponseMonitoring = true;
+        }
         const result = {
           SLS_OTEL_REPORT_REQUEST_HEADERS: `serverless_token=${otelIngestionToken}`,
           SLS_OTEL_REPORT_METRICS_URL: `${this.otelIngestionUrl}/v1/metrics`,

--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -88,7 +88,7 @@ class Console {
     this.service = this.serverless.service.service;
     this.stage = this.provider.getStage();
     this.region = this.provider.getRegion();
-    this.shouldDisableLogsCollection = configuration.console.disableLogsCollection;
+    this.config = configuration.console;
     this.otelIngestionUrl = (() => {
       if (process.env.SLS_CONSOLE_OTEL_INGESTION_URL) {
         return process.env.SLS_CONSOLE_OTEL_INGESTION_URL;
@@ -367,7 +367,7 @@ Object.defineProperties(
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension/internal/exec-wrapper.sh',
         };
         if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.DEBUG_SLS_OTEL_LAYER = '1';
-        if (!this.shouldDisableLogsCollection) {
+        if (!this.config.disableLogsCollection) {
           result.SLS_OTEL_REPORT_LOGS_URL = `${this.otelIngestionUrl}/v1/logs`;
         }
         return result;

--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -359,10 +359,13 @@ Object.defineProperties(
     }),
     deferredFunctionEnvironmentVariables: d(function () {
       return this.deferredOtelIngestionToken.then((otelIngestionToken) => {
+        const userSettings = {};
+        if (this.config.disableLogsCollection) userSettings.disableLogsMonitoring = true;
         const result = {
           SLS_OTEL_REPORT_REQUEST_HEADERS: `serverless_token=${otelIngestionToken}`,
           SLS_OTEL_REPORT_METRICS_URL: `${this.otelIngestionUrl}/v1/metrics`,
           SLS_OTEL_REPORT_TRACES_URL: `${this.otelIngestionUrl}/v1/traces`,
+          SLS_OTEL_USER_SETTINGS: JSON.stringify(userSettings),
           OTEL_RESOURCE_ATTRIBUTES: `sls_service_name=${this.service},sls_stage=${this.stage},sls_org_id=${this.orgId}`,
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension/internal/exec-wrapper.sh',
         };

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -22,6 +22,7 @@ const schema = {
           type: 'object',
           properties: {
             disableLogsCollection: { type: 'boolean' },
+            disableRequestResponseCollection: { type: 'boolean' },
           },
           additionalProperties: false,
         },

--- a/lib/utils/telemetry/generate-payload.js
+++ b/lib/utils/telemetry/generate-payload.js
@@ -261,7 +261,7 @@ module.exports = ({
     payload.dashboard.orgUid =
       serverless && serverless.isDashboardEnabled ? serverless.service.orgUid : undefined;
     if (_.get(serverless, 'console.isEnabled')) {
-      payload.console.orgUid = serverless.service.orgUid;
+      payload.console.orgUid = serverless.console.orgId;
       payload.console.extensionVersion = serverless.console._usedExtensionLayerVersionPostfix;
     }
     if (isAwsProvider && serverless && commandsReportingProjectId.has(command)) {

--- a/lib/utils/telemetry/generate-payload.js
+++ b/lib/utils/telemetry/generate-payload.js
@@ -7,6 +7,7 @@ const isPlainObject = require('type/plain-object/is');
 const isObject = require('type/object/is');
 const userConfig = require('@serverless/utils/config');
 const getNotificationsMode = require('@serverless/utils/get-notifications-mode');
+const log = require('@serverless/utils/log').log.get('telemetry');
 const isStandalone = require('../is-standalone-executable');
 const { getConfigurationValidationResult } = require('../../classes/config-schema-handler');
 const { triggeredDeprecations } = require('../log-deprecation');
@@ -287,5 +288,6 @@ module.exports = ({
     payload.commandUsage = commandUsage;
   }
 
+  log.debug('payload %o', payload);
   return payload;
 };

--- a/test/unit/lib/classes/console.test.js
+++ b/test/unit/lib/classes/console.test.js
@@ -269,6 +269,10 @@ describe('test/unit/lib/classes/console.test.js', () => {
       it('should propagate `disableLogsCollection`', () => {
         expect(userSettings.disableLogsMonitoring).to.be.true;
       });
+
+      it('should propagate `disableRequestResponseCollection`', () => {
+        expect(userSettings.disableRequestResponseMonitoring).to.be.true;
+      });
     });
 
     describe('package with "provider.layers" configuration', () => {


### PR DESCRIPTION
- Propagate `disableLogsCollection` into extension, so it doesn't observe logs internally
- Propagate `disableRequestResponseCollection` into extension so no request and response data is collected

Additionally fixed issue in telemetry related to console deployment reporting. It appears Console deployments were reported only when they came together with Dashboard deployments. I was surprised to see a Dashboard advertisement when doing console deployment and when investigating that found the issue.