### PR TITLE
Console: Ensure to send lambda requests and responses to ingestion server

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -360,22 +360,24 @@ Object.defineProperties(
     deferredFunctionEnvironmentVariables: d(function () {
       return this.deferredOtelIngestionToken.then((otelIngestionToken) => {
         const userSettings = {};
-        if (this.config.disableLogsCollection) userSettings.disableLogsMonitoring = true;
-        if (this.config.disableRequestResponseCollection) {
-          userSettings.disableRequestResponseMonitoring = true;
-        }
         const result = {
           SLS_OTEL_REPORT_REQUEST_HEADERS: `serverless_token=${otelIngestionToken}`,
           SLS_OTEL_REPORT_METRICS_URL: `${this.otelIngestionUrl}/v1/metrics`,
           SLS_OTEL_REPORT_TRACES_URL: `${this.otelIngestionUrl}/v1/traces`,
-          SLS_OTEL_USER_SETTINGS: JSON.stringify(userSettings),
           OTEL_RESOURCE_ATTRIBUTES: `sls_service_name=${this.service},sls_stage=${this.stage},sls_org_id=${this.orgId}`,
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension/internal/exec-wrapper.sh',
         };
-        if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.DEBUG_SLS_OTEL_LAYER = '1';
-        if (!this.config.disableLogsCollection) {
+        if (this.config.disableLogsCollection) {
+          userSettings.disableLogsMonitoring = true;
+        } else {
           result.SLS_OTEL_REPORT_LOGS_URL = `${this.otelIngestionUrl}/v1/logs`;
         }
+        if (this.config.disableRequestResponseCollection) {
+          userSettings.disableRequestResponseMonitoring = true;
+        }
+        if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.DEBUG_SLS_OTEL_LAYER = '1';
+
+        result.SLS_OTEL_USER_SETTINGS = JSON.stringify(userSettings);
         return result;
       });
     }),

--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -374,6 +374,8 @@ Object.defineProperties(
         }
         if (this.config.disableRequestResponseCollection) {
           userSettings.disableRequestResponseMonitoring = true;
+        } else {
+          result.SLS_OTEL_REPORT_REQUEST_RESPONSE_URL = `${this.otelIngestionUrl}/v1/request-response`;
         }
         if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.DEBUG_SLS_OTEL_LAYER = '1';
 

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
       "@serverless/test/setup/mock-cwd",
       "@serverless/test/setup/restore-env"
     ],
-    "timeout": 45000
+    "timeout": 60000
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
It appears in a meantime extension was configured with additional server URL (to be read from environment variables) and Framework didn't set it up. This PR fills the gap