### PR TITLE
AWS Local Invocation: Improve debugabilty of Python invocations

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -606,12 +606,9 @@ class AwsInvokeLocal {
     const wrapperPath = await this.resolveRuntimeWrapperPath('invoke.py');
 
     return new Promise((resolve, reject) => {
-      const python = spawn(
-        runtime.split('.')[0],
-        ['-u', wrapperPath, handlerPath, handlerName],
-        { env: process.env },
-        { shell: true }
-      );
+      const python = spawn(runtime.split('.')[0], ['-u', wrapperPath, handlerPath, handlerName], {
+        env: process.env,
+      });
       python.stdout.on('data', (buf) => {
         writeText(buf.toString());
       });

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -605,28 +605,25 @@ class AwsInvokeLocal {
 
     const wrapperPath = await this.resolveRuntimeWrapperPath('invoke.py');
 
-    return new Promise((resolve, reject) => {
-      const python = spawn(runtime.split('.')[0], ['-u', wrapperPath, handlerPath, handlerName], {
-        env: process.env,
-      });
+    return new Promise((resolve) => {
+      const python = spawnExt(
+        runtime.split('.')[0],
+        ['-u', wrapperPath, handlerPath, handlerName],
+        {
+          env: process.env,
+        }
+      );
       python.stdout.on('data', (buf) => {
         writeText(buf.toString());
       });
       python.stderr.on('data', (buf) => {
         writeText(buf.toString());
       });
-      python.on('close', () => resolve());
-      let isRejected = false;
-      python.on('error', (error) => {
-        isRejected = true;
-        reject(error);
-      });
 
-      process.nextTick(() => {
-        if (isRejected) return; // Runtime not available
-        python.stdin.write(input);
-        python.stdin.end();
-      });
+      python.child.stdin.write(input);
+      python.child.stdin.end();
+
+      resolve(python);
     });
   }
 


### PR DESCRIPTION
Occasionally we observe timeout issues on Windows in CI (e.g. https://github.com/serverless/serverless/runs/6131171414?check_suite_focus=true), yet written logs do not provide a clue.

Switch to observable `spawn`, so child process logs are provided in test output