### PR TITLE
fix: Ensure to attempt minimal config resolution for plugin commands

### DIFF
--- a/commands/plugin-install.js
+++ b/commands/plugin-install.js
@@ -35,7 +35,14 @@ module.exports = async ({ configuration, serviceDir, configurationFilename, opti
     { isMainEvent: true }
   );
   await installPlugin(context);
-  await addPluginToServerlessFile(context);
+  // Check if plugin is already added
+  const pluginAlreadyPresentInConfig =
+    (_.get(configuration, 'plugins.modules') &&
+      configuration.plugin.modules.includes(pluginName)) ||
+    (configuration.plugins && configuration.plugins.includes(pluginName));
+  if (!pluginAlreadyPresentInConfig) {
+    await addPluginToServerlessFile(context);
+  }
 
   log.notice();
   log.notice.success(

--- a/commands/plugin-uninstall.js
+++ b/commands/plugin-uninstall.js
@@ -77,7 +77,7 @@ const removePluginFromServerlessFile = async ({ configurationFilePath, pluginNam
     schema: cloudformationSchema,
   });
   if (serverlessFileObj.plugins != null) {
-    // Plugins section can be behind veriables, opt-out in such case
+    // Plugins section can be behind variables, opt-out in such case
     if (isPlainObject(serverlessFileObj.plugins)) {
       if (
         serverlessFileObj.plugins.modules != null &&

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -448,7 +448,6 @@ processSpanPromise = (async () => {
               }
             }
           }
-
           if (isHelpRequest || commands[0] === 'plugin') {
             processLog.debug('resolve variables in "plugins"');
             // We do not need full config resolved, we just need to know what
@@ -475,6 +474,12 @@ processSpanPromise = (async () => {
           if (!variablesMeta.size) return; // All properties successuflly resolved
 
           if (!ensureResolvedProperty('plugins')) return;
+
+          // At this point we have all properties needed for `plugin install/uninstall` commands
+          if (commands[0] === 'plugin') {
+            return;
+          }
+
           if (!ensureResolvedProperty('package\0path')) return;
 
           if (!ensureResolvedProperty('frameworkVersion')) return;

--- a/test/unit/commands/plugin-install.test.js
+++ b/test/unit/commands/plugin-install.test.js
@@ -14,49 +14,88 @@ chai.use(require('chai-as-promised'));
 const npmCommand = 'npm';
 
 describe('test/unit/commands/plugin-install.test.js', async () => {
-  let spawnFake;
-  let serviceDir;
-  let configurationFilePath;
-
+  const spawnFake = sinon.fake();
+  const installPlugin = proxyquire('../../../commands/plugin-install', {
+    'child-process-ext/spawn': spawnFake,
+  });
   const pluginName = 'serverless-plugin-1';
 
-  before(async () => {
-    spawnFake = sinon.fake();
-    const installPlugin = proxyquire('../../../commands/plugin-install', {
-      'child-process-ext/spawn': spawnFake,
+  afterEach(() => {
+    spawnFake.resetHistory();
+  });
+
+  describe('without plugins in configuration', () => {
+    let serviceDir;
+    let configurationFilePath;
+    before(async () => {
+      const fixture = await fixturesEngine.setup('function');
+      const configuration = fixture.serviceConfig;
+      serviceDir = fixture.servicePath;
+      configurationFilePath = await resolveConfigurationPath({
+        cwd: serviceDir,
+      });
+      const configurationFilename = configurationFilePath.slice(serviceDir.length + 1);
+      const options = {
+        name: pluginName,
+      };
+
+      await installPlugin({
+        configuration,
+        serviceDir,
+        configurationFilename,
+        options,
+      });
     });
 
-    const fixture = await fixturesEngine.setup('function');
-
-    const configuration = fixture.serviceConfig;
-    serviceDir = fixture.servicePath;
-    configurationFilePath = await resolveConfigurationPath({
-      cwd: serviceDir,
+    it('should install plugin', () => {
+      const firstCall = spawnFake.firstCall;
+      const command = [firstCall.args[0], ...firstCall.args[1]].join(' ');
+      const expectedCommand = `${npmCommand} install --save-dev ${pluginName}`;
+      expect(command).to.have.string(expectedCommand);
     });
-    const configurationFilename = configurationFilePath.slice(serviceDir.length + 1);
-    const options = {
-      name: pluginName,
-    };
 
-    await installPlugin({
-      configuration,
-      serviceDir,
-      configurationFilename,
-      options,
+    it('should add plugin to serverless file', async () => {
+      const serverlessFileObj = yaml.load(await fse.readFile(configurationFilePath, 'utf8'), {
+        filename: configurationFilePath,
+      });
+      expect(serverlessFileObj.plugins).to.include(pluginName);
     });
   });
 
-  it('should install plugin', () => {
-    const firstCall = spawnFake.firstCall;
-    const command = [firstCall.args[0], ...firstCall.args[1]].join(' ');
-    const expectedCommand = `${npmCommand} install --save-dev ${pluginName}`;
-    expect(command).to.have.string(expectedCommand);
-  });
+  describe('with plugins in configuration', () => {
+    it('should not add plugin to serverless file if it is already present in configuration but configured behind a variable', async () => {
+      const fixture = await fixturesEngine.setup('function', {
+        configExt: {
+          plugins: ['${self:custom.pluginName}'],
+          custom: {
+            pluginName,
+          },
+        },
+      });
 
-  it('should add plugin to serverless file', async () => {
-    const serverlessFileObj = yaml.load(await fse.readFile(configurationFilePath, 'utf8'), {
-      filename: configurationFilePath,
+      const configuration = fixture.serviceConfig;
+
+      // Simulate that the variable has been resolved
+      configuration.plugins = [pluginName];
+      const serviceDir = fixture.servicePath;
+      const configurationFilePath = await resolveConfigurationPath({
+        cwd: serviceDir,
+      });
+      const configurationFilename = configurationFilePath.slice(serviceDir.length + 1);
+      const options = {
+        name: pluginName,
+      };
+
+      await installPlugin({
+        configuration,
+        serviceDir,
+        configurationFilename,
+        options,
+      });
+      const serverlessFileObj = yaml.load(await fse.readFile(configurationFilePath, 'utf8'), {
+        filename: configurationFilePath,
+      });
+      expect(serverlessFileObj.plugins).not.to.include(pluginName);
     });
-    expect(serverlessFileObj.plugins).to.include(pluginName);
   });
 });


### PR DESCRIPTION
Discovered as a part of Discussion: https://github.com/serverless/serverless/discussions/10980

Ensures to only ensure selected properties are resolved for plugin commands + ensures to not add duplicate entries for plugins if they're hidden behind a variable.

