### PR TITLE
chore: Remove references to git.io

### DIFF
--- a/lib/plugins/aws/deploy/lib/check-for-changes.js
+++ b/lib/plugins/aws/deploy/lib/check-for-changes.js
@@ -235,7 +235,7 @@ module.exports = {
    * before deleting the old one. This precompile process aims to delete existent
    * subscription filters of functions that a new filter was provided, by checking the
    * current ARN with the new one that will be generated.
-   * See: https://git.io/fpKCM
+   * See: https://github.com/serverless/serverless/issues/3447
    */
   async checkLogGroupSubscriptionFilterResourceLimitExceeded() {
     const region = this.provider.getRegion();


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/
