### PR TITLE
Re-introduce ability to use direct stack updates

### DIFF
--- a/docs/providers/aws/guide/deploying.md
+++ b/docs/providers/aws/guide/deploying.md
@@ -44,6 +44,16 @@ The Serverless Framework translates all syntax in `serverless.yml` to a single A
 - The CloudFormation Stack is updated with the new CloudFormation template.
 - Each deployment publishes a new version for each function in your service.
 
+### Deployment method
+
+Since v3 release, by default, Framework uses [change sets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html) to update CloudFormation stacks. Alternatively, it is also possible to update stacks [directly](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-direct.html), which might be faster than changesets-based method in a lot of cases. In order to use `direct` method, you need to configure it explicitly:
+
+```
+provider:
+  name: aws
+  deploymentMethod: direct
+```
+
 ### Tips
 
 - Use this in your CI/CD systems, as it is the safest method of deployment.

--- a/docs/providers/aws/guide/deploying.md
+++ b/docs/providers/aws/guide/deploying.md
@@ -46,7 +46,11 @@ The Serverless Framework translates all syntax in `serverless.yml` to a single A
 
 ### Deployment method
 
-Since v3 release, by default, Framework uses [change sets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html) to update CloudFormation stacks. Alternatively, it is also possible to update stacks [directly](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-direct.html), which might be faster than changesets-based method in a lot of cases. In order to use `direct` method, you need to configure it explicitly:
+Since Serverless Framework v3, deployments are done using [CloudFormation change sets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html). It is possible to use [CloudFormation direct deployments](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-direct.html) instead.
+
+Direct deployments **are faster** and have no downsides (unless you specifically use the generated change sets). They will become the default in Serverless Framework 4.
+
+You are encouraged to enable direct deployments via the `deploymentMethod` option:
 
 ```
 provider:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -83,7 +83,8 @@ provider:
   # Optional CloudFormation tags to apply to the stack
   stackTags:
     key: value
-  # Method used during `deploy` for CloudFormation stack deployments (default: changesets), can be 'changesets' or 'direct'
+  # Method used for CloudFormation deployments: 'changesets' or 'direct' (default: changesets)
+  # See https://www.serverless.com/framework/docs/providers/aws/guide/deploying#deployment-method
   deploymentMethod: direct
   # List of existing Amazon SNS topics in the same region where notifications about stack events are sent.
   notificationArns:

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -83,6 +83,8 @@ provider:
   # Optional CloudFormation tags to apply to the stack
   stackTags:
     key: value
+  # Method used during `deploy` for CloudFormation stack deployments (default: changesets), can be 'changesets' or 'direct'
+  deploymentMethod: direct
   # List of existing Amazon SNS topics in the same region where notifications about stack events are sent.
   notificationArns:
     - 'arn:aws:sns:us-east-1:XXXXXX:mytopic'

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -9,6 +9,7 @@ const checkForChanges = require('./lib/check-for-changes');
 const monitorStack = require('../lib/monitor-stack');
 const checkIfBucketExists = require('../lib/check-if-bucket-exists');
 const getCreateChangeSetParams = require('../lib/get-create-change-set-params');
+const getSharedStackActionParams = require('../lib/get-shared-stack-action-params');
 const getCreateStackParams = require('../lib/get-create-stack-params');
 const getUpdateStackParams = require('../lib/get-update-stack-params');
 const getExecuteChangeSetParams = require('../lib/get-execute-change-set-params');
@@ -56,7 +57,8 @@ class AwsDeploy {
       getCreateChangeSetParams,
       getCreateStackParams,
       getExecuteChangeSetParams,
-      getUpdateStackParams
+      getUpdateStackParams,
+      getSharedStackActionParams
     );
 
     this.getFileStats = memoize(this.getFileStats.bind(this), { promise: true });

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -9,6 +9,8 @@ const checkForChanges = require('./lib/check-for-changes');
 const monitorStack = require('../lib/monitor-stack');
 const checkIfBucketExists = require('../lib/check-if-bucket-exists');
 const getCreateChangeSetParams = require('../lib/get-create-change-set-params');
+const getCreateStackParams = require('../lib/get-create-stack-params');
+const getUpdateStackParams = require('../lib/get-update-stack-params');
 const getExecuteChangeSetParams = require('../lib/get-execute-change-set-params');
 const waitForChangeSetCreation = require('../lib/wait-for-change-set-creation');
 const uploadZipFile = require('../lib/upload-zip-file');
@@ -52,7 +54,9 @@ class AwsDeploy {
       waitForChangeSetCreation,
       uploadZipFile,
       getCreateChangeSetParams,
-      getExecuteChangeSetParams
+      getCreateStackParams,
+      getExecuteChangeSetParams,
+      getUpdateStackParams
     );
 
     this.getFileStats = memoize(this.getFileStats.bind(this), { promise: true });
@@ -246,6 +250,7 @@ class AwsDeploy {
           );
           return;
         }
+
         if (this.serverless.service.provider.deploymentWithEmptyChangeSet) {
           log.notice();
           log.notice.skip(
@@ -257,6 +262,7 @@ class AwsDeploy {
           );
           return;
         }
+
         if (this.console.isEnabled) await this.console.deactivateOtherOtelIngestionTokens();
         log.notice();
         log.notice.success(

--- a/lib/plugins/aws/deploy/lib/create-stack.js
+++ b/lib/plugins/aws/deploy/lib/create-stack.js
@@ -10,38 +10,49 @@ module.exports = {
     // Note: using three dots instead of ellipsis to support non uni-code consoles.
     progress.get('main').notice('Creating CloudFormation stack', { isMainEvent: true });
     const stackName = this.provider.naming.getStackName();
-    const changeSetName = this.provider.naming.getStackChangeSetName();
-    const createChangeSetParams = this.getCreateChangeSetParams({
-      changeSetType: 'CREATE',
-      templateBody: this.serverless.service.provider.coreCloudFormationTemplate,
-    });
+    let monitorCfData;
 
-    const executeChangeSetParams = this.getExecuteChangeSetParams();
-
-    // Create new change set
-    log.info('Creating new change set');
-    await this.provider.request('CloudFormation', 'createChangeSet', createChangeSetParams);
-
-    // Wait for changeset to be created
-    log.info('Waiting for new change set to be created');
-    const changeSetDescription = await this.waitForChangeSetCreation(changeSetName, stackName);
-
-    // Check if stack has changes
-    if (isChangeSetWithoutChanges(changeSetDescription)) {
-      // Cleanup changeset when it does not include any changes
-      log.info('Created change set does not include any changes, removing it');
-      await this.provider.request('CloudFormation', 'deleteChangeSet', {
-        StackName: stackName,
-        ChangeSetName: changeSetName,
+    if (this.serverless.service.provider.deploymentMethod === 'direct') {
+      const params = this.getCreateStackParams({
+        templateBody: this.serverless.service.provider.coreCloudFormationTemplate,
       });
-      this.serverless.service.provider.deploymentWithEmptyChangeSet = true;
-      return;
-    }
+      monitorCfData = await this.provider.request('CloudFormation', 'createStack', params);
+    } else {
+      // Change-set based deployment
+      const changeSetName = this.provider.naming.getStackChangeSetName();
+      const createChangeSetParams = this.getCreateChangeSetParams({
+        changeSetType: 'CREATE',
+        templateBody: this.serverless.service.provider.coreCloudFormationTemplate,
+      });
 
-    this.provider.didCreateService = true;
-    log.info('Executing created change set');
-    await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
-    await this.monitorStack('create', changeSetDescription);
+      const executeChangeSetParams = this.getExecuteChangeSetParams();
+
+      // Create new change set
+      log.info('Creating new change set');
+      await this.provider.request('CloudFormation', 'createChangeSet', createChangeSetParams);
+
+      // Wait for changeset to be created
+      log.info('Waiting for new change set to be created');
+      const changeSetDescription = await this.waitForChangeSetCreation(changeSetName, stackName);
+
+      // Check if stack has changes
+      if (isChangeSetWithoutChanges(changeSetDescription)) {
+        // Cleanup changeset when it does not include any changes
+        log.info('Created change set does not include any changes, removing it');
+        await this.provider.request('CloudFormation', 'deleteChangeSet', {
+          StackName: stackName,
+          ChangeSetName: changeSetName,
+        });
+        this.serverless.service.provider.deploymentWithEmptyChangeSet = true;
+        return;
+      }
+
+      this.provider.didCreateService = true;
+      log.info('Executing created change set');
+      await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
+      monitorCfData = changeSetDescription;
+    }
+    await this.monitorStack('create', monitorCfData);
   },
 
   async createStack() {

--- a/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
+++ b/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
@@ -93,37 +93,46 @@ module.exports = {
       this.serverless.service.provider.coreCloudFormationTemplate.Outputs
     );
 
-    const createChangeSetParams = this.getCreateChangeSetParams({
-      changeSetType: 'UPDATE',
-      templateBody,
-    });
+    let monitorCfData;
 
-    const executeChangeSetParams = this.getExecuteChangeSetParams();
+    if (this.serverless.service.provider.deploymentMethod === 'direct') {
+      const params = this.getUpdateStackParams({ templateBody });
 
-    // Ensure that previous change set has been removed
-    await this.provider.request('CloudFormation', 'deleteChangeSet', {
-      StackName: stackName,
-      ChangeSetName: changeSetName,
-    });
+      monitorCfData = await this.provider.request('CloudFormation', 'updateStack', params);
+    } else {
+      const createChangeSetParams = this.getCreateChangeSetParams({
+        changeSetType: 'UPDATE',
+        templateBody,
+      });
 
-    log.info('Creating new change set.');
-    // Create new change set
-    const changeSet = await this.provider.request(
-      'CloudFormation',
-      'createChangeSet',
-      createChangeSetParams
-    );
+      const executeChangeSetParams = this.getExecuteChangeSetParams();
 
-    // Wait for changeset to be created
-    log.info('Waiting for new change set to be created.');
-    await this.waitForChangeSetCreation(changeSetName, stackName);
+      // Ensure that previous change set has been removed
+      await this.provider.request('CloudFormation', 'deleteChangeSet', {
+        StackName: stackName,
+        ChangeSetName: changeSetName,
+      });
 
-    // We are not checking if change set has any changes here because we already know that there was no deployment bucket
-    // that needs to be created as a part of change set
-    // If that would not be the case, that means we have a bug in the logic above
+      log.info('Creating new change set.');
+      // Create new change set
+      const changeSet = await this.provider.request(
+        'CloudFormation',
+        'createChangeSet',
+        createChangeSetParams
+      );
 
-    await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
-    await this.monitorStack('update', changeSet);
+      // Wait for changeset to be created
+      log.info('Waiting for new change set to be created.');
+      await this.waitForChangeSetCreation(changeSetName, stackName);
+
+      // We are not checking if change set has any changes here because we already know that there was no deployment bucket
+      // that needs to be created as a part of change set
+      // If that would not be the case, that means we have a bug in the logic above
+
+      await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
+      monitorCfData = changeSet;
+    }
+    await this.monitorStack('update', monitorCfData);
     await this.setBucketName();
   },
 };

--- a/lib/plugins/aws/lib/get-create-change-set-params.js
+++ b/lib/plugins/aws/lib/get-create-change-set-params.js
@@ -2,71 +2,17 @@
 
 module.exports = {
   getCreateChangeSetParams({ changeSetType, templateUrl, templateBody }) {
-    let stackTags = { STAGE: this.provider.getStage() };
-    const stackName = this.provider.naming.getStackName();
     const changeSetName = this.provider.naming.getStackChangeSetName();
-
-    // Merge additional stack tags
-    if (this.serverless.service.provider.stackTags) {
-      const customKeys = Object.keys(this.serverless.service.provider.stackTags);
-      const collisions = Object.keys(stackTags).filter((defaultKey) =>
-        customKeys.some((key) => defaultKey.toLowerCase() === key.toLowerCase())
-      );
-
-      // Delete collisions upfront
-      for (const key of collisions) {
-        delete stackTags[key];
-      }
-
-      stackTags = Object.assign(stackTags, this.serverless.service.provider.stackTags);
-    }
-
-    const createChangeSetParams = {
-      StackName: stackName,
+    const params = {
+      ...this.getSharedStackActionParams({ templateUrl, templateBody }),
       ChangeSetName: changeSetName,
       ChangeSetType: changeSetType,
-      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
-      Parameters: [],
-      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
 
-    if (templateUrl) {
-      createChangeSetParams.TemplateURL = templateUrl;
-    }
-
-    if (templateBody) {
-      createChangeSetParams.TemplateBody = JSON.stringify(templateBody);
-    }
-
-    if (
-      (templateUrl &&
-        this.serverless.service.provider.compiledCloudFormationTemplate &&
-        this.serverless.service.provider.compiledCloudFormationTemplate.Transform) ||
-      (templateBody && templateBody.Transform)
-    ) {
-      createChangeSetParams.Capabilities.push('CAPABILITY_AUTO_EXPAND');
-    }
-
-    const customDeploymentRole = this.provider.getCustomDeploymentRole();
-    if (customDeploymentRole) {
-      createChangeSetParams.RoleARN = customDeploymentRole;
-    }
-
-    if (this.serverless.service.provider.notificationArns) {
-      createChangeSetParams.NotificationARNs = this.serverless.service.provider.notificationArns;
-    } else {
-      createChangeSetParams.NotificationARNs = [];
-    }
-
-    if (this.serverless.service.provider.stackParameters) {
-      createChangeSetParams.Parameters = this.serverless.service.provider.stackParameters;
-    }
-
     if (this.serverless.service.provider.rollbackConfiguration) {
-      createChangeSetParams.RollbackConfiguration =
-        this.serverless.service.provider.rollbackConfiguration;
+      params.RollbackConfiguration = this.serverless.service.provider.rollbackConfiguration;
     }
 
-    return createChangeSetParams;
+    return params;
   },
 };

--- a/lib/plugins/aws/lib/get-create-stack-params.js
+++ b/lib/plugins/aws/lib/get-create-stack-params.js
@@ -1,0 +1,63 @@
+'use strict';
+
+module.exports = {
+  getCreateStackParams({ templateUrl, templateBody }) {
+    let stackTags = { STAGE: this.provider.getStage() };
+    const stackName = this.provider.naming.getStackName();
+    // Merge additional stack tags
+    if (this.serverless.service.provider.stackTags) {
+      const customKeys = Object.keys(this.serverless.service.provider.stackTags);
+      const collisions = Object.keys(stackTags).filter((defaultKey) =>
+        customKeys.some((key) => defaultKey.toLowerCase() === key.toLowerCase())
+      );
+      // Delete collisions upfront
+      for (const key of collisions) {
+        delete stackTags[key];
+      }
+      stackTags = Object.assign(stackTags, this.serverless.service.provider.stackTags);
+    }
+
+    const params = {
+      StackName: stackName,
+      OnFailure: 'DELETE',
+      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+      Parameters: [],
+      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
+    };
+
+    if (templateBody) {
+      params.TemplateBody = JSON.stringify(templateBody);
+    }
+
+    if (templateUrl) {
+      params.TemplateURL = templateUrl;
+    }
+
+    if (
+      this.serverless.service.provider.compiledCloudFormationTemplate &&
+      this.serverless.service.provider.compiledCloudFormationTemplate.Transform
+    ) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND');
+    }
+
+    const customDeploymentRole = this.provider.getCustomDeploymentRole();
+    if (customDeploymentRole) {
+      params.RoleARN = customDeploymentRole;
+    }
+
+    if (this.serverless.service.provider.notificationArns) {
+      params.NotificationARNs = this.serverless.service.provider.notificationArns;
+    }
+
+    if (this.serverless.service.provider.disableRollback) {
+      delete params.OnFailure;
+      params.DisableRollback = this.serverless.service.provider.disableRollback;
+    }
+
+    if (this.serverless.service.provider.stackParameters) {
+      params.Parameters = this.serverless.service.provider.stackParameters;
+    }
+
+    return params;
+  },
+};

--- a/lib/plugins/aws/lib/get-create-stack-params.js
+++ b/lib/plugins/aws/lib/get-create-stack-params.js
@@ -1,61 +1,15 @@
 'use strict';
 
 module.exports = {
-  getCreateStackParams({ templateUrl, templateBody }) {
-    let stackTags = { STAGE: this.provider.getStage() };
-    const stackName = this.provider.naming.getStackName();
-    // Merge additional stack tags
-    if (this.serverless.service.provider.stackTags) {
-      const customKeys = Object.keys(this.serverless.service.provider.stackTags);
-      const collisions = Object.keys(stackTags).filter((defaultKey) =>
-        customKeys.some((key) => defaultKey.toLowerCase() === key.toLowerCase())
-      );
-      // Delete collisions upfront
-      for (const key of collisions) {
-        delete stackTags[key];
-      }
-      stackTags = Object.assign(stackTags, this.serverless.service.provider.stackTags);
-    }
-
+  getCreateStackParams(options) {
     const params = {
-      StackName: stackName,
+      ...this.getSharedStackActionParams(options),
       OnFailure: 'DELETE',
-      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
-      Parameters: [],
-      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
     };
-
-    if (templateBody) {
-      params.TemplateBody = JSON.stringify(templateBody);
-    }
-
-    if (templateUrl) {
-      params.TemplateURL = templateUrl;
-    }
-
-    if (
-      this.serverless.service.provider.compiledCloudFormationTemplate &&
-      this.serverless.service.provider.compiledCloudFormationTemplate.Transform
-    ) {
-      params.Capabilities.push('CAPABILITY_AUTO_EXPAND');
-    }
-
-    const customDeploymentRole = this.provider.getCustomDeploymentRole();
-    if (customDeploymentRole) {
-      params.RoleARN = customDeploymentRole;
-    }
-
-    if (this.serverless.service.provider.notificationArns) {
-      params.NotificationARNs = this.serverless.service.provider.notificationArns;
-    }
 
     if (this.serverless.service.provider.disableRollback) {
       delete params.OnFailure;
       params.DisableRollback = this.serverless.service.provider.disableRollback;
-    }
-
-    if (this.serverless.service.provider.stackParameters) {
-      params.Parameters = this.serverless.service.provider.stackParameters;
     }
 
     return params;

--- a/lib/plugins/aws/lib/get-shared-stack-action-params.js
+++ b/lib/plugins/aws/lib/get-shared-stack-action-params.js
@@ -1,0 +1,62 @@
+'use strict';
+
+module.exports = {
+  getSharedStackActionParams({ templateUrl, templateBody }) {
+    let stackTags = { STAGE: this.provider.getStage() };
+    const stackName = this.provider.naming.getStackName();
+
+    // Merge additional stack tags
+    if (this.serverless.service.provider.stackTags) {
+      const customKeys = Object.keys(this.serverless.service.provider.stackTags);
+      const collisions = Object.keys(stackTags).filter((defaultKey) =>
+        customKeys.some((key) => defaultKey.toLowerCase() === key.toLowerCase())
+      );
+      // Delete collisions upfront
+      for (const key of collisions) {
+        delete stackTags[key];
+      }
+      stackTags = Object.assign(stackTags, this.serverless.service.provider.stackTags);
+    }
+
+    const params = {
+      StackName: stackName,
+      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+      Parameters: [],
+      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
+    };
+
+    if (templateBody) {
+      params.TemplateBody = JSON.stringify(templateBody);
+    }
+
+    if (templateUrl) {
+      params.TemplateURL = templateUrl;
+    }
+
+    if (
+      (templateUrl &&
+        this.serverless.service.provider.compiledCloudFormationTemplate &&
+        this.serverless.service.provider.compiledCloudFormationTemplate.Transform) ||
+      (templateBody && templateBody.Transform)
+    ) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND');
+    }
+
+    const customDeploymentRole = this.provider.getCustomDeploymentRole();
+    if (customDeploymentRole) {
+      params.RoleARN = customDeploymentRole;
+    }
+
+    if (this.serverless.service.provider.notificationArns) {
+      params.NotificationARNs = this.serverless.service.provider.notificationArns;
+    } else {
+      params.NotificationARNs = [];
+    }
+
+    if (this.serverless.service.provider.stackParameters) {
+      params.Parameters = this.serverless.service.provider.stackParameters;
+    }
+
+    return params;
+  },
+};

--- a/lib/plugins/aws/lib/get-update-stack-params.js
+++ b/lib/plugins/aws/lib/get-update-stack-params.js
@@ -1,57 +1,8 @@
 'use strict';
 
 module.exports = {
-  getUpdateStackParams({ templateUrl, templateBody }) {
-    let stackTags = { STAGE: this.provider.getStage() };
-    const stackName = this.provider.naming.getStackName();
-
-    // Merge additional stack tags
-    if (this.serverless.service.provider.stackTags) {
-      const customKeys = Object.keys(this.serverless.service.provider.stackTags);
-      const collisions = Object.keys(stackTags).filter((defaultKey) =>
-        customKeys.some((key) => defaultKey.toLowerCase() === key.toLowerCase())
-      );
-      // Delete collisions upfront
-      for (const key of collisions) {
-        delete stackTags[key];
-      }
-      stackTags = Object.assign(stackTags, this.serverless.service.provider.stackTags);
-    }
-
-    const params = {
-      StackName: stackName,
-      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
-      Parameters: [],
-      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
-    };
-
-    if (templateBody) {
-      params.TemplateBody = JSON.stringify(templateBody);
-    }
-
-    if (templateUrl) {
-      params.TemplateURL = templateUrl;
-    }
-
-    if (
-      this.serverless.service.provider.compiledCloudFormationTemplate &&
-      this.serverless.service.provider.compiledCloudFormationTemplate.Transform
-    ) {
-      params.Capabilities.push('CAPABILITY_AUTO_EXPAND');
-    }
-
-    const customDeploymentRole = this.provider.getCustomDeploymentRole();
-    if (customDeploymentRole) {
-      params.RoleARN = customDeploymentRole;
-    }
-
-    if (this.serverless.service.provider.notificationArns) {
-      params.NotificationARNs = this.serverless.service.provider.notificationArns;
-    }
-
-    if (this.serverless.service.provider.stackParameters) {
-      params.Parameters = this.serverless.service.provider.stackParameters;
-    }
+  getUpdateStackParams(options) {
+    const params = this.getSharedStackActionParams(options);
 
     // Policy must have at least one statement, otherwise no updates would be possible at all
     if (

--- a/lib/plugins/aws/lib/get-update-stack-params.js
+++ b/lib/plugins/aws/lib/get-update-stack-params.js
@@ -1,0 +1,75 @@
+'use strict';
+
+module.exports = {
+  getUpdateStackParams({ templateUrl, templateBody }) {
+    let stackTags = { STAGE: this.provider.getStage() };
+    const stackName = this.provider.naming.getStackName();
+
+    // Merge additional stack tags
+    if (this.serverless.service.provider.stackTags) {
+      const customKeys = Object.keys(this.serverless.service.provider.stackTags);
+      const collisions = Object.keys(stackTags).filter((defaultKey) =>
+        customKeys.some((key) => defaultKey.toLowerCase() === key.toLowerCase())
+      );
+      // Delete collisions upfront
+      for (const key of collisions) {
+        delete stackTags[key];
+      }
+      stackTags = Object.assign(stackTags, this.serverless.service.provider.stackTags);
+    }
+
+    const params = {
+      StackName: stackName,
+      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+      Parameters: [],
+      Tags: Object.keys(stackTags).map((key) => ({ Key: key, Value: stackTags[key] })),
+    };
+
+    if (templateBody) {
+      params.TemplateBody = JSON.stringify(templateBody);
+    }
+
+    if (templateUrl) {
+      params.TemplateURL = templateUrl;
+    }
+
+    if (
+      this.serverless.service.provider.compiledCloudFormationTemplate &&
+      this.serverless.service.provider.compiledCloudFormationTemplate.Transform
+    ) {
+      params.Capabilities.push('CAPABILITY_AUTO_EXPAND');
+    }
+
+    const customDeploymentRole = this.provider.getCustomDeploymentRole();
+    if (customDeploymentRole) {
+      params.RoleARN = customDeploymentRole;
+    }
+
+    if (this.serverless.service.provider.notificationArns) {
+      params.NotificationARNs = this.serverless.service.provider.notificationArns;
+    }
+
+    if (this.serverless.service.provider.stackParameters) {
+      params.Parameters = this.serverless.service.provider.stackParameters;
+    }
+
+    // Policy must have at least one statement, otherwise no updates would be possible at all
+    if (
+      this.serverless.service.provider.stackPolicy &&
+      Object.keys(this.serverless.service.provider.stackPolicy).length
+    ) {
+      params.StackPolicyBody = JSON.stringify({
+        Statement: this.serverless.service.provider.stackPolicy,
+      });
+    }
+
+    if (this.serverless.service.provider.rollbackConfiguration) {
+      params.RollbackConfiguration = this.serverless.service.provider.rollbackConfiguration;
+    }
+
+    if (this.serverless.service.provider.disableRollback) {
+      params.DisableRollback = this.serverless.service.provider.disableRollback;
+    }
+    return params;
+  },
+};

--- a/lib/plugins/aws/lib/update-stack.js
+++ b/lib/plugins/aws/lib/update-stack.js
@@ -5,49 +5,62 @@ const getS3EndpointForRegion = require('../utils/get-s3-endpoint-for-region');
 const { log, progress } = require('@serverless/utils/log');
 const isChangeSetWithoutChanges = require('../utils/is-change-set-without-changes');
 
+const NO_UPDATE_MESSAGE = 'No updates are to be performed.';
+
 module.exports = {
   async createFallback() {
     this.createLater = false;
     progress.get('main').notice('Creating CloudFormation stack', { isMainEvent: true });
 
     const stackName = this.provider.naming.getStackName();
-    const changeSetName = this.provider.naming.getStackChangeSetName();
-
     const compiledTemplateFileName = this.provider.naming.getCompiledTemplateS3Suffix();
     const s3Endpoint = getS3EndpointForRegion(this.provider.getRegion());
     const templateUrl = `https://${s3Endpoint}/${this.bucketName}/${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`;
 
-    const createChangeSetParams = this.getCreateChangeSetParams({
-      changeSetType: 'CREATE',
-      templateUrl,
-    });
-
-    const executeChangeSetParams = this.getExecuteChangeSetParams();
-
-    // Create new change set
-    this.provider.didCreateService = true;
-    log.info('Creating new change set');
-    await this.provider.request('CloudFormation', 'createChangeSet', createChangeSetParams);
-
-    // Wait for changeset to be created
-    log.info('Waiting for new change set to be created');
-    const changeSetDescription = await this.waitForChangeSetCreation(changeSetName, stackName);
-
-    // Check if stack has changes
-    if (isChangeSetWithoutChanges(changeSetDescription)) {
-      // Cleanup changeset when it does not include any changes
-      log.info('Created change set does not include any changes, removing it');
-      await this.provider.request('CloudFormation', 'deleteChangeSet', {
-        StackName: stackName,
-        ChangeSetName: changeSetName,
+    let monitorCfData;
+    if (this.serverless.service.provider.deploymentMethod === 'direct') {
+      const params = this.getCreateStackParams({
+        templateUrl,
       });
-      this.serverless.service.provider.deploymentWithEmptyChangeSet = true;
-      return false;
-    }
 
-    log.info('Executing created change set');
-    await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
-    return await this.monitorStack('create', changeSetDescription);
+      monitorCfData = await this.provider.request('CloudFormation', 'createStack', params);
+    } else {
+      const changeSetName = this.provider.naming.getStackChangeSetName();
+
+      const createChangeSetParams = this.getCreateChangeSetParams({
+        changeSetType: 'CREATE',
+        templateUrl,
+      });
+
+      const executeChangeSetParams = this.getExecuteChangeSetParams();
+
+      // Create new change set
+      this.provider.didCreateService = true;
+      log.info('Creating new change set');
+      await this.provider.request('CloudFormation', 'createChangeSet', createChangeSetParams);
+
+      // Wait for changeset to be created
+      log.info('Waiting for new change set to be created');
+      const changeSetDescription = await this.waitForChangeSetCreation(changeSetName, stackName);
+
+      // Check if stack has changes
+      if (isChangeSetWithoutChanges(changeSetDescription)) {
+        // Cleanup changeset when it does not include any changes
+        log.info('Created change set does not include any changes, removing it');
+        await this.provider.request('CloudFormation', 'deleteChangeSet', {
+          StackName: stackName,
+          ChangeSetName: changeSetName,
+        });
+        this.serverless.service.provider.deploymentWithEmptyChangeSet = true;
+        return false;
+      }
+
+      log.info('Executing created change set');
+      await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
+      monitorCfData = changeSetDescription;
+    }
+    await this.monitorStack('create', monitorCfData);
+    return true;
   },
 
   async update() {
@@ -56,50 +69,69 @@ module.exports = {
     const templateUrl = `https://${s3Endpoint}/${this.bucketName}/${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`;
 
     const stackName = this.provider.naming.getStackName();
-    const changeSetName = this.provider.naming.getStackChangeSetName();
 
-    const createChangeSetParams = this.getCreateChangeSetParams({
-      changeSetType: 'UPDATE',
-      templateUrl,
-    });
+    let monitorCfData;
+    if (this.serverless.service.provider.deploymentMethod === 'direct') {
+      const params = this.getUpdateStackParams({ templateUrl });
 
-    const executeChangeSetParams = this.getExecuteChangeSetParams();
+      try {
+        monitorCfData = await this.provider.request('CloudFormation', 'updateStack', params);
+      } catch (e) {
+        if (e.message.includes(NO_UPDATE_MESSAGE)) {
+          return false;
+        }
+        throw e;
+      }
+    } else {
+      const changeSetName = this.provider.naming.getStackChangeSetName();
 
-    // Ensure that previous change set has been removed
-    await this.provider.request('CloudFormation', 'deleteChangeSet', {
-      StackName: stackName,
-      ChangeSetName: changeSetName,
-    });
+      const createChangeSetParams = this.getCreateChangeSetParams({
+        changeSetType: 'UPDATE',
+        templateUrl,
+      });
 
-    // Create new change set
-    log.info('Creating new change set');
-    await this.provider.request('CloudFormation', 'createChangeSet', createChangeSetParams);
+      const executeChangeSetParams = this.getExecuteChangeSetParams();
 
-    // Wait for changeset to be created
-    log.info('Waiting for new change set to be created');
-    const changeSetDescription = await this.waitForChangeSetCreation(changeSetName, stackName);
-
-    // Check if stack has changes
-    if (isChangeSetWithoutChanges(changeSetDescription)) {
-      // Cleanup changeset when it does not include any changes
-      log.info('Created change set does not include any changes, removing it');
+      // Ensure that previous change set has been removed
       await this.provider.request('CloudFormation', 'deleteChangeSet', {
         StackName: stackName,
         ChangeSetName: changeSetName,
       });
-      this.serverless.service.provider.deploymentWithEmptyChangeSet = true;
-      return false;
+
+      // Create new change set
+      log.info('Creating new change set');
+      await this.provider.request('CloudFormation', 'createChangeSet', createChangeSetParams);
+
+      // Wait for changeset to be created
+      log.info('Waiting for new change set to be created');
+      const changeSetDescription = await this.waitForChangeSetCreation(changeSetName, stackName);
+
+      // Check if stack has changes
+      if (isChangeSetWithoutChanges(changeSetDescription)) {
+        // Cleanup changeset when it does not include any changes
+        log.info('Created change set does not include any changes, removing it');
+        await this.provider.request('CloudFormation', 'deleteChangeSet', {
+          StackName: stackName,
+          ChangeSetName: changeSetName,
+        });
+        this.serverless.service.provider.deploymentWithEmptyChangeSet = true;
+        return false;
+      }
+
+      log.info('Executing created change set');
+      await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
+      monitorCfData = changeSetDescription;
     }
 
-    log.info('Executing created change set');
-    await this.provider.request('CloudFormation', 'executeChangeSet', executeChangeSetParams);
-
-    await this.monitorStack('update', changeSetDescription);
+    await this.monitorStack('update', monitorCfData);
 
     // Policy must have at least one statement, otherwise no updates would be possible at all
     // Stack policy must be set after change set has been executed,
     // as it might reference resources newly added in that change set.
+    // Applied only for ChangeSet deployments which is a default method
     if (
+      (!this.serverless.service.provider.deploymentMethod ||
+        this.serverless.service.provider.deploymentMethod === 'changesets') &&
       this.serverless.service.provider.stackPolicy &&
       Object.keys(this.serverless.service.provider.stackPolicy).length
     ) {

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1161,6 +1161,7 @@ class AwsProvider {
               additionalProperties: false,
             },
             runtime: { $ref: '#/definitions/awsLambdaRuntime' },
+            deploymentMethod: { enum: ['changesets', 'direct'] },
             s3: {
               type: 'object',
               additionalProperties: require('./package/compile/events/s3/config-schema'),

--- a/lib/plugins/aws/rollback.js
+++ b/lib/plugins/aws/rollback.js
@@ -7,6 +7,9 @@ const monitorStack = require('./lib/monitor-stack');
 const waitForChangeSetCreation = require('./lib/wait-for-change-set-creation');
 const getCreateChangeSetParams = require('./lib/get-create-change-set-params');
 const getExecuteChangeSetParams = require('./lib/get-execute-change-set-params');
+const getSharedStackActionParams = require('./lib/get-shared-stack-action-params');
+const getCreateStackParams = require('./lib/get-create-stack-params');
+const getUpdateStackParams = require('./lib/get-update-stack-params');
 const findAndGroupDeployments = require('./utils/find-and-group-deployments');
 const ServerlessError = require('../../serverless-error');
 const { style, log, progress } = require('@serverless/utils/log');
@@ -30,7 +33,10 @@ class AwsRollback {
       monitorStack,
       waitForChangeSetCreation,
       getCreateChangeSetParams,
-      getExecuteChangeSetParams
+      getExecuteChangeSetParams,
+      getCreateStackParams,
+      getUpdateStackParams,
+      getSharedStackActionParams
     );
 
     this.hooks = {

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -342,6 +342,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
         StackName: awsNaming.getStackName(),
         Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
         Parameters: [],
+        NotificationARNs: [],
         Tags: [{ Key: 'STAGE', Value: 'dev' }],
         TemplateBody: JSON.stringify({
           Resources: serverless.service.provider.coreCloudFormationTemplate.Resources,

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -21,379 +21,1115 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
     },
   };
 
-  it('with nonexistent stack - first deploy with custom deployment bucket', async () => {
-    const describeStacksStub = sinon
-      .stub()
-      .onFirstCall()
-      .throws('error', 'stack does not exist')
-      .onSecondCall()
-      .resolves({ Stacks: [{}] });
-    const createChangeSetStub = sinon.stub().resolves({});
-    const executeChangeSetStub = sinon.stub().resolves({});
-    const s3UploadStub = sinon.stub().resolves();
-    const deleteObjectsStub = sinon.stub().resolves({});
-    const awsRequestStubMap = {
-      ...baseAwsRequestStubMap,
-      ECR: {
-        describeRepositories: sinon.stub().throws({
-          providerError: { code: 'RepositoryNotFoundException' },
-        }),
-      },
-      S3: {
-        deleteObjects: deleteObjectsStub,
-        listObjectsV2: { Contents: [] },
-        upload: s3UploadStub,
-        headBucket: {},
-        getBucketLocation: () => {
-          return {
-            LocationConstraint: 'us-east-1',
-          };
+  describe('with direct create/update calls', () => {
+    it('with nonexistent stack - first deploy', async () => {
+      const describeStacksStub = sinon
+        .stub()
+        .onFirstCall()
+        .throws('error', 'stack does not exist')
+        .onSecondCall()
+        .resolves({ Stacks: [{}] });
+      const createStackStub = sinon.stub().resolves({});
+      const updateStackStub = sinon.stub().resolves({});
+      const s3UploadStub = sinon.stub().resolves();
+      const deleteObjectsStub = sinon.stub().resolves({});
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
         },
-      },
-      CloudFormation: {
-        describeStacks: describeStacksStub,
-        createChangeSet: createChangeSetStub,
-        executeChangeSet: executeChangeSetStub,
-        deleteChangeSet: {},
-        describeChangeSet: {
-          ChangeSetName: 'new-service-dev-change-set',
-          ChangeSetId: 'some-change-set-id',
-          StackName: 'new-service-dev',
-          Status: 'CREATE_COMPLETE',
+        S3: {
+          deleteObjects: deleteObjectsStub,
+          listObjectsV2: { Contents: [] },
+          upload: s3UploadStub,
+          headBucket: {},
         },
-        describeStackEvents: {
-          StackEvents: [
-            {
-              EventId: '1e2f3g4h',
-              StackName: 'new-service-dev',
-              LogicalResourceId: 'new-service-dev',
-              ResourceType: 'AWS::CloudFormation::Stack',
-              Timestamp: new Date(),
-              ResourceStatus: 'CREATE_COMPLETE',
-            },
-          ],
-        },
-        validateTemplate: {},
-        listStackResources: {},
-      },
-    };
-
-    await runServerless({
-      fixture: 'function',
-      command: 'deploy',
-      awsRequestStubMap,
-      configExt: {
-        provider: {
-          deploymentBucket: 'existing-s3-bucket',
-        },
-      },
-    });
-
-    expect(createChangeSetStub).to.be.calledOnce;
-    expect(createChangeSetStub.getCall(0).args[0].ChangeSetType).to.equal('CREATE');
-    expect(executeChangeSetStub).to.be.calledOnce;
-    const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
-      call[0].Key.endsWith('compiled-cloudformation-template.json')
-    );
-    expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
-    expect(deleteObjectsStub).not.to.be.called;
-  });
-
-  it('with nonexistent stack - first deploy', async () => {
-    const describeStacksStub = sinon
-      .stub()
-      .onFirstCall()
-      .throws('error', 'stack does not exist')
-      .onSecondCall()
-      .resolves({ Stacks: [{}] });
-    const createChangeSetStub = sinon.stub().resolves({});
-    const executeChangeSetStub = sinon.stub().resolves({});
-    const s3UploadStub = sinon.stub().resolves();
-    const deleteObjectsStub = sinon.stub().resolves({});
-    const awsRequestStubMap = {
-      ...baseAwsRequestStubMap,
-      ECR: {
-        describeRepositories: sinon.stub().throws({
-          providerError: { code: 'RepositoryNotFoundException' },
-        }),
-      },
-      S3: {
-        deleteObjects: deleteObjectsStub,
-        listObjectsV2: { Contents: [] },
-        upload: s3UploadStub,
-        headBucket: {},
-      },
-      CloudFormation: {
-        describeStacks: describeStacksStub,
-        createChangeSet: createChangeSetStub,
-        executeChangeSet: executeChangeSetStub,
-        deleteChangeSet: {},
-        describeChangeSet: {
-          ChangeSetName: 'new-service-dev-change-set',
-          ChangeSetId: 'some-change-set-id',
-          StackName: 'new-service-dev',
-          Status: 'CREATE_COMPLETE',
-        },
-        describeStackEvents: {
-          StackEvents: [
-            {
-              EventId: '1e2f3g4h',
-              StackName: 'new-service-dev',
-              LogicalResourceId: 'new-service-dev',
-              ResourceType: 'AWS::CloudFormation::Stack',
-              Timestamp: new Date(),
-              ResourceStatus: 'CREATE_COMPLETE',
-            },
-          ],
-        },
-        describeStackResource: {
-          StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
-        },
-        validateTemplate: {},
-        listStackResources: {},
-      },
-    };
-
-    await runServerless({
-      fixture: 'function',
-      command: 'deploy',
-      awsRequestStubMap,
-    });
-
-    expect(createChangeSetStub).to.be.calledTwice;
-    expect(createChangeSetStub.getCall(0).args[0].ChangeSetType).to.equal('CREATE');
-    expect(createChangeSetStub.getCall(1).args[0].ChangeSetType).to.equal('UPDATE');
-    expect(executeChangeSetStub).to.be.calledTwice;
-    const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
-      call[0].Key.endsWith('compiled-cloudformation-template.json')
-    );
-    expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
-    expect(deleteObjectsStub).not.to.be.called;
-  });
-
-  it('with existing stack - subsequent deploy', async () => {
-    const s3BucketPrefix = 'serverless/test-aws-deploy-with-existing-stack/dev';
-    const s3UploadStub = sinon.stub().resolves();
-    const createChangeSetStub = sinon.stub().resolves({});
-    const executeChangeSetStub = sinon.stub().resolves({});
-    const listObjectsV2Stub = sinon
-      .stub()
-      .onFirstCall()
-      .resolves({ Contents: [] })
-      .onSecondCall()
-      .resolves({
-        Contents: [
-          {
-            Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
+        CloudFormation: {
+          describeStacks: describeStacksStub,
+          createStack: createStackStub,
+          updateStack: updateStackStub,
+          describeStackEvents: {
+            StackEvents: [
+              {
+                EventId: '1e2f3g4h',
+                StackName: 'new-service-dev',
+                LogicalResourceId: 'new-service-dev',
+                ResourceType: 'AWS::CloudFormation::Stack',
+                Timestamp: new Date(),
+                ResourceStatus: 'CREATE_COMPLETE',
+              },
+            ],
           },
-          {
-            Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/artifact.zip`,
+          describeStackResource: {
+            StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
           },
-          {
-            Key: `${s3BucketPrefix}/1589988704352-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
-          },
-          {
-            Key: `${s3BucketPrefix}/1589988704352-2020-05-20T15:31:44.359Z/artifact.zip`,
-          },
-        ],
-      });
-    const deleteObjectsStub = sinon.stub().resolves();
-    const awsRequestStubMap = {
-      ...baseAwsRequestStubMap,
-      ECR: {
-        describeRepositories: sinon.stub().throws({
-          providerError: { code: 'RepositoryNotFoundException' },
-        }),
-      },
-      S3: {
-        deleteObjects: deleteObjectsStub,
-        listObjectsV2: listObjectsV2Stub,
-        upload: s3UploadStub,
-        headBucket: {},
-      },
-      CloudFormation: {
-        describeStacks: { Stacks: [{}] },
-        deleteChangeSet: {},
-        createChangeSet: createChangeSetStub,
-        executeChangeSet: executeChangeSetStub,
-        describeChangeSet: {
-          ChangeSetName: 'new-service-dev-change-set',
-          ChangeSetId: 'some-change-set-id',
-          StackName: 'new-service-dev',
-          Status: 'CREATE_COMPLETE',
+          validateTemplate: {},
+          listStackResources: {},
         },
-        describeStackEvents: {
-          StackEvents: [
-            {
-              EventId: '1e2f3g4h',
-              StackName: 'new-service-dev',
-              LogicalResourceId: 'new-service-dev',
-              ResourceType: 'AWS::CloudFormation::Stack',
-              Timestamp: new Date(),
-              ResourceStatus: 'UPDATE_COMPLETE',
-            },
-          ],
-        },
-        describeStackResource: {
-          StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
-        },
-        validateTemplate: {},
-        listStackResources: {},
-      },
-    };
+      };
 
-    await runServerless({
-      fixture: 'function',
-      command: 'deploy',
-      awsRequestStubMap,
-      configExt: {
-        // Default, non-deterministic service-name invalidates this test as S3 Bucket cleanup relies on it
-        service: 'test-aws-deploy-with-existing-stack',
-        provider: {
-          deploymentBucket: {
-            maxPreviousDeploymentArtifacts: 1,
-          },
-        },
-      },
-    });
-
-    expect(createChangeSetStub).to.be.calledOnce;
-    expect(createChangeSetStub.getCall(0).args[0].ChangeSetType).to.equal('UPDATE');
-    expect(executeChangeSetStub).to.be.calledOnce;
-    const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
-      call[0].Key.endsWith('compiled-cloudformation-template.json')
-    );
-    expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
-    expect(deleteObjectsStub).to.be.calledWithExactly({
-      Bucket: 's3-bucket-resource',
-      Delete: {
-        Objects: [
-          {
-            Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
-          },
-          { Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/artifact.zip` },
-        ],
-      },
-    });
-  });
-
-  it('with existing stack - subsequent deploy with empty changeset', async () => {
-    const createChangeSetStub = sinon.stub().resolves({});
-    const executeChangeSetStub = sinon.stub().resolves({});
-    const deleteChangeSetStub = sinon.stub().resolves();
-    const deleteObjectsStub = sinon.stub().resolves();
-    let objectsToRemove;
-    const listObjectsV2Stub = sinon
-      .stub()
-      .onFirstCall()
-      .resolves({ Contents: [] })
-      .onSecondCall()
-      .callsFake((params) => {
-        objectsToRemove = [
-          {
-            Key: `${params.Prefix}/compiled-cloudformation-template.json`,
-          },
-          {
-            Key: `${params.Prefix}/artifact.zip`,
-          },
-        ];
-        return {
-          Contents: objectsToRemove,
-        };
-      });
-    const awsRequestStubMap = {
-      ...baseAwsRequestStubMap,
-      ECR: {
-        describeRepositories: sinon.stub().throws({
-          providerError: { code: 'RepositoryNotFoundException' },
-        }),
-      },
-      S3: {
-        deleteObjects: deleteObjectsStub,
-        listObjectsV2: listObjectsV2Stub,
-        upload: {},
-        headBucket: {},
-      },
-      CloudFormation: {
-        describeStacks: { Stacks: [{}] },
-        deleteChangeSet: deleteChangeSetStub,
-        createChangeSet: createChangeSetStub,
-        executeChangeSet: executeChangeSetStub,
-        describeChangeSet: {
-          ChangeSetName: 'new-service-dev-change-set',
-          ChangeSetId: 'some-change-set-id',
-          StackName: 'new-service-dev',
-          Status: 'FAILED',
-          StatusReason: 'No updates are to be performed.',
-        },
-        describeStackResource: {
-          StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
-        },
-        validateTemplate: {},
-        listStackResources: {},
-      },
-    };
-
-    await runServerless({
-      fixture: 'function',
-      command: 'deploy',
-      awsRequestStubMap,
-    });
-
-    expect(createChangeSetStub).to.be.calledOnce;
-    expect(createChangeSetStub.getCall(0).args[0].ChangeSetType).to.equal('UPDATE');
-    expect(executeChangeSetStub).not.to.be.called;
-    expect(deleteChangeSetStub).to.be.calledTwice;
-    expect(deleteObjectsStub).to.be.calledWithExactly({
-      Bucket: 's3-bucket-resource',
-      Delete: { Objects: objectsToRemove },
-    });
-  });
-
-  it('should fail if cannot create a change set', async () => {
-    const awsRequestStubMap = {
-      ...baseAwsRequestStubMap,
-      ECR: {
-        describeRepositories: sinon.stub().throws({
-          providerError: { code: 'RepositoryNotFoundException' },
-        }),
-      },
-      S3: {
-        deleteObjects: {},
-        listObjectsV2: { Contents: [] },
-        upload: {},
-        headBucket: {},
-      },
-      CloudFormation: {
-        describeStacks: { Stacks: [{}] },
-        deleteChangeSet: {},
-        createChangeSet: {},
-        executeChangeSet: {},
-        describeChangeSet: {
-          ChangeSetName: 'new-service-dev-change-set',
-          ChangeSetId: 'some-change-set-id',
-          StackName: 'new-service-dev',
-          Status: 'FAILED',
-          StatusReason: 'Some internal reason',
-        },
-        describeStackResource: {
-          StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
-        },
-        validateTemplate: {},
-        listStackResources: {},
-      },
-    };
-
-    await expect(
-      runServerless({
+      await runServerless({
         fixture: 'function',
         command: 'deploy',
         awsRequestStubMap,
-      })
-    ).to.have.been.eventually.rejected.with.property(
-      'code',
-      'AWS_CLOUD_FORMATION_CHANGE_SET_CREATION_FAILED'
-    );
+        configExt: {
+          provider: {
+            deploymentMethod: 'direct',
+          },
+        },
+      });
+
+      expect(createStackStub).to.be.calledOnce;
+      expect(updateStackStub).to.be.calledOnce;
+      const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
+        call[0].Key.endsWith('compiled-cloudformation-template.json')
+      );
+      expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
+      expect(deleteObjectsStub).not.to.be.called;
+    });
+
+    it('with nonexistent stack - first deploy with custom deployment bucket', async () => {
+      const describeStacksStub = sinon
+        .stub()
+        .onFirstCall()
+        .throws('error', 'stack does not exist')
+        .onSecondCall()
+        .resolves({ Stacks: [{}] });
+      const createStackStub = sinon.stub().resolves({});
+      const updateStackStub = sinon.stub().resolves({});
+      const s3UploadStub = sinon.stub().resolves();
+      const deleteObjectsStub = sinon.stub().resolves({});
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          deleteObjects: deleteObjectsStub,
+          listObjectsV2: { Contents: [] },
+          upload: s3UploadStub,
+          headBucket: {},
+          getBucketLocation: () => {
+            return {
+              LocationConstraint: 'us-east-1',
+            };
+          },
+        },
+        CloudFormation: {
+          describeStacks: describeStacksStub,
+          createStack: createStackStub,
+          updateStack: updateStackStub,
+          describeStackEvents: {
+            StackEvents: [
+              {
+                EventId: '1e2f3g4h',
+                StackName: 'new-service-dev',
+                LogicalResourceId: 'new-service-dev',
+                ResourceType: 'AWS::CloudFormation::Stack',
+                Timestamp: new Date(),
+                ResourceStatus: 'CREATE_COMPLETE',
+              },
+            ],
+          },
+          validateTemplate: {},
+          listStackResources: {},
+        },
+      };
+
+      await runServerless({
+        fixture: 'function',
+        command: 'deploy',
+        awsRequestStubMap,
+        configExt: {
+          provider: {
+            deploymentBucket: 'existing-s3-bucket',
+            deploymentMethod: 'direct',
+          },
+        },
+      });
+
+      expect(createStackStub).to.be.calledOnce;
+      expect(updateStackStub).not.to.be.called;
+      const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
+        call[0].Key.endsWith('compiled-cloudformation-template.json')
+      );
+      expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
+      expect(deleteObjectsStub).not.to.be.called;
+    });
+
+    it('with existing stack - subsequent deploy', async () => {
+      const s3BucketPrefix = 'serverless/test-aws-deploy-with-existing-stack/dev';
+      const s3UploadStub = sinon.stub().resolves();
+      const createStackStub = sinon.stub().resolves({});
+      const updateStackStub = sinon.stub().resolves({});
+      const listObjectsV2Stub = sinon
+        .stub()
+        .onFirstCall()
+        .resolves({ Contents: [] })
+        .onSecondCall()
+        .resolves({
+          Contents: [
+            {
+              Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
+            },
+            {
+              Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/artifact.zip`,
+            },
+            {
+              Key: `${s3BucketPrefix}/1589988704352-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
+            },
+            {
+              Key: `${s3BucketPrefix}/1589988704352-2020-05-20T15:31:44.359Z/artifact.zip`,
+            },
+          ],
+        });
+      const deleteObjectsStub = sinon.stub().resolves();
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          deleteObjects: deleteObjectsStub,
+          listObjectsV2: listObjectsV2Stub,
+          upload: s3UploadStub,
+          headBucket: {},
+        },
+        CloudFormation: {
+          describeStacks: { Stacks: [{}] },
+          createStack: createStackStub,
+          updateStack: updateStackStub,
+          describeChangeSet: {
+            ChangeSetName: 'new-service-dev-change-set',
+            ChangeSetId: 'some-change-set-id',
+            StackName: 'new-service-dev',
+            Status: 'CREATE_COMPLETE',
+          },
+          describeStackEvents: {
+            StackEvents: [
+              {
+                EventId: '1e2f3g4h',
+                StackName: 'new-service-dev',
+                LogicalResourceId: 'new-service-dev',
+                ResourceType: 'AWS::CloudFormation::Stack',
+                Timestamp: new Date(),
+                ResourceStatus: 'UPDATE_COMPLETE',
+              },
+            ],
+          },
+          describeStackResource: {
+            StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+          },
+          validateTemplate: {},
+          listStackResources: {},
+        },
+      };
+
+      await runServerless({
+        fixture: 'function',
+        command: 'deploy',
+        awsRequestStubMap,
+        configExt: {
+          // Default, non-deterministic service-name invalidates this test as S3 Bucket cleanup relies on it
+          service: 'test-aws-deploy-with-existing-stack',
+          provider: {
+            deploymentMethod: 'direct',
+            deploymentBucket: {
+              maxPreviousDeploymentArtifacts: 1,
+            },
+          },
+        },
+      });
+
+      expect(createStackStub).not.to.be.called;
+      expect(updateStackStub).to.be.calledOnce;
+      const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
+        call[0].Key.endsWith('compiled-cloudformation-template.json')
+      );
+      expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
+      expect(deleteObjectsStub).to.be.calledWithExactly({
+        Bucket: 's3-bucket-resource',
+        Delete: {
+          Objects: [
+            {
+              Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
+            },
+            { Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/artifact.zip` },
+          ],
+        },
+      });
+    });
+
+    it('with existing stack - with deployment bucket resource missing from CloudFormation template', async () => {
+      const createStackStub = sinon.stub().resolves({});
+      const updateStackStub = sinon.stub().resolves({});
+      const describeStackResourceStub = sinon
+        .stub()
+        .onFirstCall()
+        .throws(() => {
+          const err = new Error('does not exist for stack');
+          err.providerError = {
+            code: 'ValidationError',
+          };
+          return err;
+        })
+        .onSecondCall()
+        .resolves({
+          StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+        });
+
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          listObjectsV2: { Contents: [] },
+          headBucket: () => {
+            const err = new Error();
+            err.code = 'AWS_S3_HEAD_BUCKET_NOT_FOUND';
+            throw err;
+          },
+        },
+        CloudFormation: {
+          describeStacks: { Stacks: [{}] },
+          validateTemplate: {},
+          createStack: createStackStub,
+          updateStack: updateStackStub,
+          getTemplate: () => {
+            return {
+              TemplateBody: JSON.stringify({}),
+            };
+          },
+          describeStackEvents: {
+            StackEvents: [
+              {
+                EventId: '1e2f3g4h',
+                StackName: 'new-service-dev',
+                LogicalResourceId: 'new-service-dev',
+                ResourceType: 'AWS::CloudFormation::Stack',
+                Timestamp: new Date(),
+                ResourceStatus: 'UPDATE_COMPLETE',
+              },
+            ],
+          },
+          describeStackResource: describeStackResourceStub,
+        },
+      };
+
+      const { serverless, awsNaming } = await runServerless({
+        fixture: 'function',
+        command: 'deploy',
+        awsRequestStubMap,
+        configExt: {
+          provider: {
+            deploymentMethod: 'direct',
+          },
+        },
+        lastLifecycleHookName: 'aws:deploy:deploy:checkForChanges',
+      });
+
+      expect(createStackStub).not.to.be.called;
+      expect(updateStackStub).to.be.calledWithExactly({
+        StackName: awsNaming.getStackName(),
+        Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+        Parameters: [],
+        Tags: [{ Key: 'STAGE', Value: 'dev' }],
+        TemplateBody: JSON.stringify({
+          Resources: serverless.service.provider.coreCloudFormationTemplate.Resources,
+          Outputs: serverless.service.provider.coreCloudFormationTemplate.Outputs,
+        }),
+      });
+    });
+
+    describe('custom deployment-related properties', () => {
+      let createStackStub;
+      let updateStackStub;
+      const deploymentRole = 'arn:xxx';
+      const notificationArns = ['arn:xxx', 'arn:yyy'];
+      const stackParameters = [
+        {
+          ParameterKey: 'key',
+          ParameterValue: 'val',
+        },
+        {
+          ParameterKey: 'key2',
+          ParameterValue: 'val2',
+        },
+      ];
+
+      const stackPolicy = [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: ['Update:*'],
+          Resource: '*',
+        },
+      ];
+
+      const rollbackConfiguration = {
+        MonitoringTimeInMinutes: 20,
+      };
+
+      const disableRollback = true;
+      const stackTags = {
+        TAG: 'value',
+        ANOTHERTAG: 'anotherval',
+      };
+
+      before(async () => {
+        const describeStacksStub = sinon
+          .stub()
+          .onFirstCall()
+          .throws('error', 'stack does not exist')
+          .onSecondCall()
+          .resolves({ Stacks: [{}] });
+        createStackStub = sinon.stub().resolves({});
+        updateStackStub = sinon.stub().resolves({});
+        const awsRequestStubMap = {
+          ...baseAwsRequestStubMap,
+          ECR: {
+            describeRepositories: sinon.stub().throws({
+              providerError: { code: 'RepositoryNotFoundException' },
+            }),
+          },
+          S3: {
+            deleteObjects: {},
+            listObjectsV2: { Contents: [] },
+            upload: {},
+            headBucket: {},
+          },
+          CloudFormation: {
+            describeStacks: describeStacksStub,
+            createStack: createStackStub,
+            updateStack: updateStackStub,
+            describeStackEvents: {
+              StackEvents: [
+                {
+                  EventId: '1e2f3g4h',
+                  StackName: 'new-service-dev',
+                  LogicalResourceId: 'new-service-dev',
+                  ResourceType: 'AWS::CloudFormation::Stack',
+                  Timestamp: new Date(),
+                  ResourceStatus: 'CREATE_COMPLETE',
+                },
+              ],
+            },
+            describeStackResource: {
+              StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+            },
+            validateTemplate: {},
+            listStackResources: {},
+          },
+        };
+
+        await runServerless({
+          fixture: 'function',
+          command: 'deploy',
+          awsRequestStubMap,
+          configExt: {
+            provider: {
+              deploymentMethod: 'direct',
+              notificationArns,
+              rollbackConfiguration,
+              stackParameters,
+              stackPolicy,
+              stackTags,
+              disableRollback,
+              iam: {
+                deploymentRole,
+              },
+            },
+          },
+        });
+      });
+
+      it('should support custom deployment role', () => {
+        expect(createStackStub.getCall(0).args[0].RoleARN).to.equal(deploymentRole);
+        expect(updateStackStub.getCall(0).args[0].RoleARN).to.equal(deploymentRole);
+      });
+
+      it('should support `notificationsArns`', () => {
+        expect(createStackStub.getCall(0).args[0].NotificationARNs).to.deep.equal(notificationArns);
+        expect(updateStackStub.getCall(0).args[0].NotificationARNs).to.deep.equal(notificationArns);
+      });
+
+      it('should support `stackParameters`', () => {
+        expect(createStackStub.getCall(0).args[0].Parameters).to.deep.equal(stackParameters);
+        expect(updateStackStub.getCall(0).args[0].Parameters).to.deep.equal(stackParameters);
+      });
+
+      it('should support `stackPolicy`', () => {
+        expect(updateStackStub.getCall(0).args[0].StackPolicyBody).to.deep.equal(
+          JSON.stringify({ Statement: stackPolicy })
+        );
+      });
+
+      it('should support `rollbackConfiguration`', () => {
+        expect(updateStackStub.getCall(0).args[0].RollbackConfiguration).to.deep.equal(
+          rollbackConfiguration
+        );
+      });
+
+      it('should support `disableRollback`', () => {
+        expect(createStackStub.getCall(0).args[0].DisableRollback).to.be.true;
+        expect(updateStackStub.getCall(0).args[0].DisableRollback).to.be.true;
+      });
+
+      it('should support `stackTags`', () => {
+        expect(createStackStub.getCall(0).args[0].Tags).to.deep.equal([
+          { Key: 'STAGE', Value: 'dev' },
+          { Key: 'TAG', Value: 'value' },
+          { Key: 'ANOTHERTAG', Value: 'anotherval' },
+        ]);
+        expect(updateStackStub.getCall(0).args[0].Tags).to.deep.equal([
+          { Key: 'STAGE', Value: 'dev' },
+          { Key: 'TAG', Value: 'value' },
+          { Key: 'ANOTHERTAG', Value: 'anotherval' },
+        ]);
+      });
+    });
+  });
+
+  describe('with change-sets', () => {
+    it('with nonexistent stack - first deploy with custom deployment bucket', async () => {
+      const describeStacksStub = sinon
+        .stub()
+        .onFirstCall()
+        .throws('error', 'stack does not exist')
+        .onSecondCall()
+        .resolves({ Stacks: [{}] });
+      const createChangeSetStub = sinon.stub().resolves({});
+      const executeChangeSetStub = sinon.stub().resolves({});
+      const s3UploadStub = sinon.stub().resolves();
+      const deleteObjectsStub = sinon.stub().resolves({});
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          deleteObjects: deleteObjectsStub,
+          listObjectsV2: { Contents: [] },
+          upload: s3UploadStub,
+          headBucket: {},
+          getBucketLocation: () => {
+            return {
+              LocationConstraint: 'us-east-1',
+            };
+          },
+        },
+        CloudFormation: {
+          describeStacks: describeStacksStub,
+          createChangeSet: createChangeSetStub,
+          executeChangeSet: executeChangeSetStub,
+          deleteChangeSet: {},
+          describeChangeSet: {
+            ChangeSetName: 'new-service-dev-change-set',
+            ChangeSetId: 'some-change-set-id',
+            StackName: 'new-service-dev',
+            Status: 'CREATE_COMPLETE',
+          },
+          describeStackEvents: {
+            StackEvents: [
+              {
+                EventId: '1e2f3g4h',
+                StackName: 'new-service-dev',
+                LogicalResourceId: 'new-service-dev',
+                ResourceType: 'AWS::CloudFormation::Stack',
+                Timestamp: new Date(),
+                ResourceStatus: 'CREATE_COMPLETE',
+              },
+            ],
+          },
+          validateTemplate: {},
+          listStackResources: {},
+        },
+      };
+
+      await runServerless({
+        fixture: 'function',
+        command: 'deploy',
+        awsRequestStubMap,
+        configExt: {
+          provider: {
+            deploymentBucket: 'existing-s3-bucket',
+          },
+        },
+      });
+
+      expect(createChangeSetStub).to.be.calledOnce;
+      expect(createChangeSetStub.getCall(0).args[0].ChangeSetType).to.equal('CREATE');
+      expect(executeChangeSetStub).to.be.calledOnce;
+      const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
+        call[0].Key.endsWith('compiled-cloudformation-template.json')
+      );
+      expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
+      expect(deleteObjectsStub).not.to.be.called;
+    });
+
+    it('with nonexistent stack - first deploy', async () => {
+      const describeStacksStub = sinon
+        .stub()
+        .onFirstCall()
+        .throws('error', 'stack does not exist')
+        .onSecondCall()
+        .resolves({ Stacks: [{}] });
+      const createChangeSetStub = sinon.stub().resolves({});
+      const executeChangeSetStub = sinon.stub().resolves({});
+      const s3UploadStub = sinon.stub().resolves();
+      const deleteObjectsStub = sinon.stub().resolves({});
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          deleteObjects: deleteObjectsStub,
+          listObjectsV2: { Contents: [] },
+          upload: s3UploadStub,
+          headBucket: {},
+        },
+        CloudFormation: {
+          describeStacks: describeStacksStub,
+          createChangeSet: createChangeSetStub,
+          executeChangeSet: executeChangeSetStub,
+          deleteChangeSet: {},
+          describeChangeSet: {
+            ChangeSetName: 'new-service-dev-change-set',
+            ChangeSetId: 'some-change-set-id',
+            StackName: 'new-service-dev',
+            Status: 'CREATE_COMPLETE',
+          },
+          describeStackEvents: {
+            StackEvents: [
+              {
+                EventId: '1e2f3g4h',
+                StackName: 'new-service-dev',
+                LogicalResourceId: 'new-service-dev',
+                ResourceType: 'AWS::CloudFormation::Stack',
+                Timestamp: new Date(),
+                ResourceStatus: 'CREATE_COMPLETE',
+              },
+            ],
+          },
+          describeStackResource: {
+            StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+          },
+          validateTemplate: {},
+          listStackResources: {},
+        },
+      };
+
+      await runServerless({
+        fixture: 'function',
+        command: 'deploy',
+        awsRequestStubMap,
+      });
+
+      expect(createChangeSetStub).to.be.calledTwice;
+      expect(createChangeSetStub.getCall(0).args[0].ChangeSetType).to.equal('CREATE');
+      expect(createChangeSetStub.getCall(1).args[0].ChangeSetType).to.equal('UPDATE');
+      expect(executeChangeSetStub).to.be.calledTwice;
+      const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
+        call[0].Key.endsWith('compiled-cloudformation-template.json')
+      );
+      expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
+      expect(deleteObjectsStub).not.to.be.called;
+    });
+
+    it('with existing stack - subsequent deploy', async () => {
+      const s3BucketPrefix = 'serverless/test-aws-deploy-with-existing-stack/dev';
+      const s3UploadStub = sinon.stub().resolves();
+      const createChangeSetStub = sinon.stub().resolves({});
+      const executeChangeSetStub = sinon.stub().resolves({});
+      const listObjectsV2Stub = sinon
+        .stub()
+        .onFirstCall()
+        .resolves({ Contents: [] })
+        .onSecondCall()
+        .resolves({
+          Contents: [
+            {
+              Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
+            },
+            {
+              Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/artifact.zip`,
+            },
+            {
+              Key: `${s3BucketPrefix}/1589988704352-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
+            },
+            {
+              Key: `${s3BucketPrefix}/1589988704352-2020-05-20T15:31:44.359Z/artifact.zip`,
+            },
+          ],
+        });
+      const deleteObjectsStub = sinon.stub().resolves();
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          deleteObjects: deleteObjectsStub,
+          listObjectsV2: listObjectsV2Stub,
+          upload: s3UploadStub,
+          headBucket: {},
+        },
+        CloudFormation: {
+          describeStacks: { Stacks: [{}] },
+          deleteChangeSet: {},
+          createChangeSet: createChangeSetStub,
+          executeChangeSet: executeChangeSetStub,
+          describeChangeSet: {
+            ChangeSetName: 'new-service-dev-change-set',
+            ChangeSetId: 'some-change-set-id',
+            StackName: 'new-service-dev',
+            Status: 'CREATE_COMPLETE',
+          },
+          describeStackEvents: {
+            StackEvents: [
+              {
+                EventId: '1e2f3g4h',
+                StackName: 'new-service-dev',
+                LogicalResourceId: 'new-service-dev',
+                ResourceType: 'AWS::CloudFormation::Stack',
+                Timestamp: new Date(),
+                ResourceStatus: 'UPDATE_COMPLETE',
+              },
+            ],
+          },
+          describeStackResource: {
+            StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+          },
+          validateTemplate: {},
+          listStackResources: {},
+        },
+      };
+
+      await runServerless({
+        fixture: 'function',
+        command: 'deploy',
+        awsRequestStubMap,
+        configExt: {
+          // Default, non-deterministic service-name invalidates this test as S3 Bucket cleanup relies on it
+          service: 'test-aws-deploy-with-existing-stack',
+          provider: {
+            deploymentBucket: {
+              maxPreviousDeploymentArtifacts: 1,
+            },
+          },
+        },
+      });
+
+      expect(createChangeSetStub).to.be.calledOnce;
+      expect(createChangeSetStub.getCall(0).args[0].ChangeSetType).to.equal('UPDATE');
+      expect(executeChangeSetStub).to.be.calledOnce;
+      const wasCloudFormationTemplateUploadInitiated = s3UploadStub.args.some((call) =>
+        call[0].Key.endsWith('compiled-cloudformation-template.json')
+      );
+      expect(wasCloudFormationTemplateUploadInitiated).to.be.true;
+      expect(deleteObjectsStub).to.be.calledWithExactly({
+        Bucket: 's3-bucket-resource',
+        Delete: {
+          Objects: [
+            {
+              Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json`,
+            },
+            { Key: `${s3BucketPrefix}/1589988704351-2020-05-20T15:31:44.359Z/artifact.zip` },
+          ],
+        },
+      });
+    });
+
+    it('with existing stack - subsequent deploy with empty changeset', async () => {
+      const createChangeSetStub = sinon.stub().resolves({});
+      const executeChangeSetStub = sinon.stub().resolves({});
+      const deleteChangeSetStub = sinon.stub().resolves();
+      const deleteObjectsStub = sinon.stub().resolves();
+      let objectsToRemove;
+      const listObjectsV2Stub = sinon
+        .stub()
+        .onFirstCall()
+        .resolves({ Contents: [] })
+        .onSecondCall()
+        .callsFake((params) => {
+          objectsToRemove = [
+            {
+              Key: `${params.Prefix}/compiled-cloudformation-template.json`,
+            },
+            {
+              Key: `${params.Prefix}/artifact.zip`,
+            },
+          ];
+          return {
+            Contents: objectsToRemove,
+          };
+        });
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          deleteObjects: deleteObjectsStub,
+          listObjectsV2: listObjectsV2Stub,
+          upload: {},
+          headBucket: {},
+        },
+        CloudFormation: {
+          describeStacks: { Stacks: [{}] },
+          deleteChangeSet: deleteChangeSetStub,
+          createChangeSet: createChangeSetStub,
+          executeChangeSet: executeChangeSetStub,
+          describeChangeSet: {
+            ChangeSetName: 'new-service-dev-change-set',
+            ChangeSetId: 'some-change-set-id',
+            StackName: 'new-service-dev',
+            Status: 'FAILED',
+            StatusReason: 'No updates are to be performed.',
+          },
+          describeStackResource: {
+            StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+          },
+          validateTemplate: {},
+          listStackResources: {},
+        },
+      };
+
+      await runServerless({
+        fixture: 'function',
+        command: 'deploy',
+        awsRequestStubMap,
+      });
+
+      expect(createChangeSetStub).to.be.calledOnce;
+      expect(createChangeSetStub.getCall(0).args[0].ChangeSetType).to.equal('UPDATE');
+      expect(executeChangeSetStub).not.to.be.called;
+      expect(deleteChangeSetStub).to.be.calledTwice;
+      expect(deleteObjectsStub).to.be.calledWithExactly({
+        Bucket: 's3-bucket-resource',
+        Delete: { Objects: objectsToRemove },
+      });
+    });
+
+    it('should fail if cannot create a change set', async () => {
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          deleteObjects: {},
+          listObjectsV2: { Contents: [] },
+          upload: {},
+          headBucket: {},
+        },
+        CloudFormation: {
+          describeStacks: { Stacks: [{}] },
+          deleteChangeSet: {},
+          createChangeSet: {},
+          executeChangeSet: {},
+          describeChangeSet: {
+            ChangeSetName: 'new-service-dev-change-set',
+            ChangeSetId: 'some-change-set-id',
+            StackName: 'new-service-dev',
+            Status: 'FAILED',
+            StatusReason: 'Some internal reason',
+          },
+          describeStackResource: {
+            StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+          },
+          validateTemplate: {},
+          listStackResources: {},
+        },
+      };
+
+      await expect(
+        runServerless({
+          fixture: 'function',
+          command: 'deploy',
+          awsRequestStubMap,
+        })
+      ).to.have.been.eventually.rejected.with.property(
+        'code',
+        'AWS_CLOUD_FORMATION_CHANGE_SET_CREATION_FAILED'
+      );
+    });
+
+    it('with existing stack - with deployment bucket resource missing from CloudFormation template', async () => {
+      const createChangeSetStub = sinon.stub().resolves({});
+      const executeChangeSetStub = sinon.stub().resolves({});
+      const describeStackResourceStub = sinon
+        .stub()
+        .onFirstCall()
+        .throws(() => {
+          const err = new Error('does not exist for stack');
+          err.providerError = {
+            code: 'ValidationError',
+          };
+          return err;
+        })
+        .onSecondCall()
+        .resolves({
+          StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+        });
+
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          listObjectsV2: { Contents: [] },
+          headBucket: () => {
+            const err = new Error();
+            err.code = 'AWS_S3_HEAD_BUCKET_NOT_FOUND';
+            throw err;
+          },
+        },
+        CloudFormation: {
+          describeStacks: { Stacks: [{}] },
+          validateTemplate: {},
+          deleteChangeSet: {},
+          createChangeSet: createChangeSetStub,
+          executeChangeSet: executeChangeSetStub,
+          describeChangeSet: {
+            ChangeSetName: 'new-service-dev-change-set',
+            ChangeSetId: 'some-change-set-id',
+            StackName: 'new-service-dev',
+            Status: 'CREATE_COMPLETE',
+          },
+          getTemplate: () => {
+            return {
+              TemplateBody: JSON.stringify({}),
+            };
+          },
+          describeStackEvents: {
+            StackEvents: [
+              {
+                EventId: '1e2f3g4h',
+                StackName: 'new-service-dev',
+                LogicalResourceId: 'new-service-dev',
+                ResourceType: 'AWS::CloudFormation::Stack',
+                Timestamp: new Date(),
+                ResourceStatus: 'UPDATE_COMPLETE',
+              },
+            ],
+          },
+          describeStackResource: describeStackResourceStub,
+        },
+      };
+
+      const { serverless, awsNaming } = await runServerless({
+        fixture: 'function',
+        command: 'deploy',
+        awsRequestStubMap,
+        lastLifecycleHookName: 'aws:deploy:deploy:checkForChanges',
+      });
+
+      expect(createChangeSetStub).to.be.calledWithExactly({
+        StackName: awsNaming.getStackName(),
+        ChangeSetName: awsNaming.getStackChangeSetName(),
+        ChangeSetType: 'UPDATE',
+        Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+        Parameters: [],
+        NotificationARNs: [],
+        Tags: [{ Key: 'STAGE', Value: 'dev' }],
+        TemplateBody: JSON.stringify({
+          Resources: serverless.service.provider.coreCloudFormationTemplate.Resources,
+          Outputs: serverless.service.provider.coreCloudFormationTemplate.Outputs,
+        }),
+      });
+      expect(executeChangeSetStub).to.be.calledWithExactly({
+        StackName: awsNaming.getStackName(),
+        ChangeSetName: awsNaming.getStackChangeSetName(),
+      });
+    });
+
+    describe('custom deployment-related properties', () => {
+      let createChangeSetStub;
+      let executeChangeSetStub;
+      let setStackPolicyStub;
+      const deploymentRole = 'arn:xxx';
+      const notificationArns = ['arn:xxx', 'arn:yyy'];
+      const stackParameters = [
+        {
+          ParameterKey: 'key',
+          ParameterValue: 'val',
+        },
+        {
+          ParameterKey: 'key2',
+          ParameterValue: 'val2',
+        },
+      ];
+
+      const stackPolicy = [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: ['Update:*'],
+          Resource: '*',
+        },
+      ];
+
+      const rollbackConfiguration = {
+        MonitoringTimeInMinutes: 20,
+      };
+
+      const disableRollback = true;
+      const stackTags = {
+        TAG: 'value',
+        ANOTHERTAG: 'anotherval',
+      };
+
+      before(async () => {
+        const describeStacksStub = sinon
+          .stub()
+          .onFirstCall()
+          .throws('error', 'stack does not exist')
+          .onSecondCall()
+          .resolves({ Stacks: [{}] });
+        createChangeSetStub = sinon.stub().resolves({});
+        executeChangeSetStub = sinon.stub().resolves({});
+        setStackPolicyStub = sinon.stub().resolves({});
+        const awsRequestStubMap = {
+          ...baseAwsRequestStubMap,
+          ECR: {
+            describeRepositories: sinon.stub().throws({
+              providerError: { code: 'RepositoryNotFoundException' },
+            }),
+          },
+          S3: {
+            deleteObjects: {},
+            listObjectsV2: { Contents: [] },
+            upload: {},
+            headBucket: {},
+          },
+          CloudFormation: {
+            describeStacks: describeStacksStub,
+            createChangeSet: createChangeSetStub,
+            executeChangeSet: executeChangeSetStub,
+            deleteChangeSet: {},
+            describeChangeSet: {
+              ChangeSetName: 'new-service-dev-change-set',
+              ChangeSetId: 'some-change-set-id',
+              StackName: 'new-service-dev',
+              Status: 'CREATE_COMPLETE',
+            },
+            setStackPolicy: setStackPolicyStub,
+            describeStackEvents: {
+              StackEvents: [
+                {
+                  EventId: '1e2f3g4h',
+                  StackName: 'new-service-dev',
+                  LogicalResourceId: 'new-service-dev',
+                  ResourceType: 'AWS::CloudFormation::Stack',
+                  Timestamp: new Date(),
+                  ResourceStatus: 'CREATE_COMPLETE',
+                },
+              ],
+            },
+            describeStackResource: {
+              StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+            },
+            validateTemplate: {},
+            listStackResources: {},
+          },
+        };
+
+        await runServerless({
+          fixture: 'function',
+          command: 'deploy',
+          awsRequestStubMap,
+          configExt: {
+            provider: {
+              notificationArns,
+              rollbackConfiguration,
+              stackParameters,
+              stackPolicy,
+              stackTags,
+              disableRollback,
+              iam: {
+                deploymentRole,
+              },
+            },
+          },
+        });
+      });
+
+      it('should support custom deployment role', () => {
+        expect(createChangeSetStub.getCall(0).args[0].RoleARN).to.equal(deploymentRole);
+        expect(createChangeSetStub.getCall(1).args[0].RoleARN).to.equal(deploymentRole);
+      });
+
+      it('should support `notificationsArns`', () => {
+        expect(createChangeSetStub.getCall(0).args[0].NotificationARNs).to.deep.equal(
+          notificationArns
+        );
+        expect(createChangeSetStub.getCall(1).args[0].NotificationARNs).to.deep.equal(
+          notificationArns
+        );
+      });
+
+      it('should support `stackParameters`', () => {
+        expect(createChangeSetStub.getCall(1).args[0].Parameters).to.deep.equal(stackParameters);
+      });
+
+      it('should support `stackPolicy`', () => {
+        expect(setStackPolicyStub.getCall(0).args[0].StackPolicyBody).to.equal(
+          JSON.stringify({ Statement: stackPolicy })
+        );
+      });
+
+      it('should only set `stackPolicy` after applying change set', () => {
+        expect(setStackPolicyStub).to.not.be.calledBefore(executeChangeSetStub);
+      });
+
+      it('should support `rollbackConfiguration`', () => {
+        expect(createChangeSetStub.getCall(1).args[0].RollbackConfiguration).to.deep.equal(
+          rollbackConfiguration
+        );
+      });
+
+      it('should support `disableRollback`', () => {
+        expect(executeChangeSetStub.getCall(0).args[0].DisableRollback).to.be.true;
+        expect(executeChangeSetStub.getCall(1).args[0].DisableRollback).to.be.true;
+      });
+
+      it('should support `stackTags`', () => {
+        expect(createChangeSetStub.getCall(0).args[0].Tags).to.deep.equal([
+          { Key: 'STAGE', Value: 'dev' },
+          { Key: 'TAG', Value: 'value' },
+          { Key: 'ANOTHERTAG', Value: 'anotherval' },
+        ]);
+        expect(createChangeSetStub.getCall(1).args[0].Tags).to.deep.equal([
+          { Key: 'STAGE', Value: 'dev' },
+          { Key: 'TAG', Value: 'value' },
+          { Key: 'ANOTHERTAG', Value: 'anotherval' },
+        ]);
+      });
+    });
   });
 
   it('with existing stack - should skip deploy if nothing changed', async () => {
@@ -603,261 +1339,5 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
       'code',
       'DEPLOYMENT_BUCKET_REMOVED_MANUALLY'
     );
-  });
-
-  it('with existing stack - with deployment bucket resource missing from CloudFormation template', async () => {
-    const createChangeSetStub = sinon.stub().resolves({});
-    const executeChangeSetStub = sinon.stub().resolves({});
-    const describeStackResourceStub = sinon
-      .stub()
-      .onFirstCall()
-      .throws(() => {
-        const err = new Error('does not exist for stack');
-        err.providerError = {
-          code: 'ValidationError',
-        };
-        return err;
-      })
-      .onSecondCall()
-      .resolves({
-        StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
-      });
-
-    const awsRequestStubMap = {
-      ...baseAwsRequestStubMap,
-      ECR: {
-        describeRepositories: sinon.stub().throws({
-          providerError: { code: 'RepositoryNotFoundException' },
-        }),
-      },
-      S3: {
-        listObjectsV2: { Contents: [] },
-        headBucket: () => {
-          const err = new Error();
-          err.code = 'AWS_S3_HEAD_BUCKET_NOT_FOUND';
-          throw err;
-        },
-      },
-      CloudFormation: {
-        describeStacks: { Stacks: [{}] },
-        validateTemplate: {},
-        deleteChangeSet: {},
-        createChangeSet: createChangeSetStub,
-        executeChangeSet: executeChangeSetStub,
-        describeChangeSet: {
-          ChangeSetName: 'new-service-dev-change-set',
-          ChangeSetId: 'some-change-set-id',
-          StackName: 'new-service-dev',
-          Status: 'CREATE_COMPLETE',
-        },
-        getTemplate: () => {
-          return {
-            TemplateBody: JSON.stringify({}),
-          };
-        },
-        describeStackEvents: {
-          StackEvents: [
-            {
-              EventId: '1e2f3g4h',
-              StackName: 'new-service-dev',
-              LogicalResourceId: 'new-service-dev',
-              ResourceType: 'AWS::CloudFormation::Stack',
-              Timestamp: new Date(),
-              ResourceStatus: 'UPDATE_COMPLETE',
-            },
-          ],
-        },
-        describeStackResource: describeStackResourceStub,
-      },
-    };
-
-    const { serverless, awsNaming } = await runServerless({
-      fixture: 'function',
-      command: 'deploy',
-      awsRequestStubMap,
-      lastLifecycleHookName: 'aws:deploy:deploy:checkForChanges',
-    });
-
-    expect(createChangeSetStub).to.be.calledWithExactly({
-      StackName: awsNaming.getStackName(),
-      ChangeSetName: awsNaming.getStackChangeSetName(),
-      ChangeSetType: 'UPDATE',
-      Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
-      Parameters: [],
-      NotificationARNs: [],
-      Tags: [{ Key: 'STAGE', Value: 'dev' }],
-      TemplateBody: JSON.stringify({
-        Resources: serverless.service.provider.coreCloudFormationTemplate.Resources,
-        Outputs: serverless.service.provider.coreCloudFormationTemplate.Outputs,
-      }),
-    });
-    expect(executeChangeSetStub).to.be.calledWithExactly({
-      StackName: awsNaming.getStackName(),
-      ChangeSetName: awsNaming.getStackChangeSetName(),
-    });
-  });
-
-  describe('custom deployment-related properties', () => {
-    let createChangeSetStub;
-    let executeChangeSetStub;
-    let setStackPolicyStub;
-    const deploymentRole = 'arn:xxx';
-    const notificationArns = ['arn:xxx', 'arn:yyy'];
-    const stackParameters = [
-      {
-        ParameterKey: 'key',
-        ParameterValue: 'val',
-      },
-      {
-        ParameterKey: 'key2',
-        ParameterValue: 'val2',
-      },
-    ];
-
-    const stackPolicy = [
-      {
-        Effect: 'Allow',
-        Principal: '*',
-        Action: ['Update:*'],
-        Resource: '*',
-      },
-    ];
-
-    const rollbackConfiguration = {
-      MonitoringTimeInMinutes: 20,
-    };
-
-    const disableRollback = true;
-    const stackTags = {
-      TAG: 'value',
-      ANOTHERTAG: 'anotherval',
-    };
-
-    before(async () => {
-      const describeStacksStub = sinon
-        .stub()
-        .onFirstCall()
-        .throws('error', 'stack does not exist')
-        .onSecondCall()
-        .resolves({ Stacks: [{}] });
-      createChangeSetStub = sinon.stub().resolves({});
-      executeChangeSetStub = sinon.stub().resolves({});
-      setStackPolicyStub = sinon.stub().resolves({});
-      const awsRequestStubMap = {
-        ...baseAwsRequestStubMap,
-        ECR: {
-          describeRepositories: sinon.stub().throws({
-            providerError: { code: 'RepositoryNotFoundException' },
-          }),
-        },
-        S3: {
-          deleteObjects: {},
-          listObjectsV2: { Contents: [] },
-          upload: {},
-          headBucket: {},
-        },
-        CloudFormation: {
-          describeStacks: describeStacksStub,
-          createChangeSet: createChangeSetStub,
-          executeChangeSet: executeChangeSetStub,
-          deleteChangeSet: {},
-          describeChangeSet: {
-            ChangeSetName: 'new-service-dev-change-set',
-            ChangeSetId: 'some-change-set-id',
-            StackName: 'new-service-dev',
-            Status: 'CREATE_COMPLETE',
-          },
-          setStackPolicy: setStackPolicyStub,
-          describeStackEvents: {
-            StackEvents: [
-              {
-                EventId: '1e2f3g4h',
-                StackName: 'new-service-dev',
-                LogicalResourceId: 'new-service-dev',
-                ResourceType: 'AWS::CloudFormation::Stack',
-                Timestamp: new Date(),
-                ResourceStatus: 'CREATE_COMPLETE',
-              },
-            ],
-          },
-          describeStackResource: {
-            StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
-          },
-          validateTemplate: {},
-          listStackResources: {},
-        },
-      };
-
-      await runServerless({
-        fixture: 'function',
-        command: 'deploy',
-        awsRequestStubMap,
-        configExt: {
-          provider: {
-            notificationArns,
-            rollbackConfiguration,
-            stackParameters,
-            stackPolicy,
-            stackTags,
-            disableRollback,
-            iam: {
-              deploymentRole,
-            },
-          },
-        },
-      });
-    });
-
-    it('should support custom deployment role', () => {
-      expect(createChangeSetStub.getCall(0).args[0].RoleARN).to.equal(deploymentRole);
-      expect(createChangeSetStub.getCall(1).args[0].RoleARN).to.equal(deploymentRole);
-    });
-
-    it('should support `notificationsArns`', () => {
-      expect(createChangeSetStub.getCall(0).args[0].NotificationARNs).to.deep.equal(
-        notificationArns
-      );
-      expect(createChangeSetStub.getCall(1).args[0].NotificationARNs).to.deep.equal(
-        notificationArns
-      );
-    });
-
-    it('should support `stackParameters`', () => {
-      expect(createChangeSetStub.getCall(1).args[0].Parameters).to.deep.equal(stackParameters);
-    });
-
-    it('should support `stackPolicy`', () => {
-      expect(setStackPolicyStub.getCall(0).args[0].StackPolicyBody).to.equal(
-        JSON.stringify({ Statement: stackPolicy })
-      );
-    });
-
-    it('should only set `stackPolicy` after applying change set', () => {
-      expect(setStackPolicyStub).to.not.be.calledBefore(executeChangeSetStub);
-    });
-
-    it('should support `rollbackConfiguration`', () => {
-      expect(createChangeSetStub.getCall(1).args[0].RollbackConfiguration).to.deep.equal(
-        rollbackConfiguration
-      );
-    });
-
-    it('should support `disableRollback`', () => {
-      expect(executeChangeSetStub.getCall(0).args[0].DisableRollback).to.be.true;
-      expect(executeChangeSetStub.getCall(1).args[0].DisableRollback).to.be.true;
-    });
-
-    it('should support `stackTags`', () => {
-      expect(createChangeSetStub.getCall(0).args[0].Tags).to.deep.equal([
-        { Key: 'STAGE', Value: 'dev' },
-        { Key: 'TAG', Value: 'value' },
-        { Key: 'ANOTHERTAG', Value: 'anotherval' },
-      ]);
-      expect(createChangeSetStub.getCall(1).args[0].Tags).to.deep.equal([
-        { Key: 'STAGE', Value: 'dev' },
-        { Key: 'TAG', Value: 'value' },
-        { Key: 'ANOTHERTAG', Value: 'anotherval' },
-      ]);
-    });
   });
 });


### PR DESCRIPTION
Re-introduce the ability to use direct stack updates instead of changeset based deployments.

Addresses: https://github.com/serverless/serverless/issues/10815