### PR TITLE
feat(CLI): Do not run `compose` for non-service commands

### DIFF
--- a/lib/cli/triage.js
+++ b/lib/cli/triage.js
@@ -47,21 +47,50 @@ module.exports = async () => {
     return resolvePlatformCli();
   }
 
-  if (
-    (
-      await Promise.all(
-        ['yml', 'yaml', 'json', 'js', 'ts'].map(async (extension) => {
-          try {
-            await fsp.access(`serverless-compose.${extension}`);
-            return true;
-          } catch {
-            return false;
-          }
-        })
-      )
-    ).some(Boolean)
-  ) {
-    return '@serverless/compose';
+  const isComposeIgnoredCommand = (() => {
+    const args = process.argv.slice(2);
+    // Simplified check - if arg starts with `-` then we consider it to be
+    // a param and everything before it to be a command
+    const firstParamIndex = args.findIndex((element) => element.startsWith('-'));
+
+    const commands = args.slice(0, firstParamIndex === -1 ? Infinity : firstParamIndex);
+    const command = commands.join(' ');
+
+    const composeIgnoredCommands = new Set([
+      '',
+      'config',
+      'config credentials',
+      'create',
+      'generate-event',
+      'install',
+      'login',
+      'logout',
+      'plugin list',
+      'plugin search',
+      'upgrade',
+      'uninstall',
+    ]);
+
+    return composeIgnoredCommands.has(command);
+  })();
+
+  if (!isComposeIgnoredCommand) {
+    if (
+      (
+        await Promise.all(
+          ['yml', 'yaml', 'json', 'js', 'ts'].map(async (extension) => {
+            try {
+              await fsp.access(`serverless-compose.${extension}`);
+              return true;
+            } catch {
+              return false;
+            }
+          })
+        )
+      ).some(Boolean)
+    ) {
+      return '@serverless/compose';
+    }
   }
 
   // Detect eventual service configuration

--- a/test/unit/lib/cli/triage/index.test.js
+++ b/test/unit/lib/cli/triage/index.test.js
@@ -96,4 +96,21 @@ describe('test/unit/lib/cli/triage/index.test.js', () => {
       }
     }
   });
+
+  describe('Service configuration with CLI params', () => {
+    let restoreArgv;
+    before(() => {
+      ({ restoreArgv } = overrideArgv({ args: ['sls', 'login'] }));
+    });
+    after(() => restoreArgv());
+
+    it('should not resolve to `@serverless/compose` with compose config present when command should be ignored', async () => {
+      await overrideCwd(
+        path.resolve(fixturesDirname, '@serverless/compose', 'yml', 'project'),
+        async () => {
+          expect(await triage()).to.equal('serverless');
+        }
+      );
+    });
+  });
 });


### PR DESCRIPTION
Improve triage process to do not run `compose` engine when command is not service specific. Reported internally
