### PR TITLE
fix: Allow S3 event rule prefix and suffix to use CF functions

### DIFF
--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -31,8 +31,12 @@ class AwsCompileS3Events {
               items: {
                 type: 'object',
                 properties: {
-                  prefix: { type: 'string' },
-                  suffix: { type: 'string' },
+                  prefix: {
+                    anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfFunction' }],
+                  },
+                  suffix: {
+                    anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfFunction' }],
+                  },
                 },
                 maxProperties: 1,
                 additionalProperties: false,

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -883,6 +883,30 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
               },
             ],
           },
+          prefixSuffixWithCfFunction: {
+            handler: 'basic.handler',
+            events: [
+              {
+                s3: {
+                  bucket: 'TestBucket',
+                  event: 's3:ObjectCreated:*',
+                  existing: true,
+                  rules: [
+                    {
+                      prefix: {
+                        'Fn::Join': ['-', ['test', 'join']],
+                      },
+                    },
+                    {
+                      suffix: {
+                        'Fn::Join': ['-', ['test', 'join']],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
         },
       },
       command: 'package',
@@ -951,6 +975,43 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
           'Fn::If': ['isFirstBucketEmtpy', { Ref: 'FirstBucket' }, { Ref: 'SecondBucket' }],
         },
         BucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
+      },
+    });
+  });
+
+  it('should support `prefix` and `suffix` provided as CF function', () => {
+    expect(
+      cfResources[naming.getCustomResourceS3ResourceLogicalId('prefixSuffixWithCfFunction')]
+    ).to.deep.equal({
+      Type: 'Custom::S3',
+      Version: 1,
+      DependsOn: [
+        'PrefixSuffixWithCfFunctionLambdaFunction',
+        'CustomDashresourceDashexistingDashs3LambdaFunction',
+      ],
+      Properties: {
+        ServiceToken: {
+          'Fn::GetAtt': ['CustomDashresourceDashexistingDashs3LambdaFunction', 'Arn'],
+        },
+        FunctionName: `${serverlessInstance.service.service}-dev-prefixSuffixWithCfFunction`,
+        BucketName: 'TestBucket',
+        BucketConfigs: [
+          {
+            Event: 's3:ObjectCreated:*',
+            Rules: [
+              {
+                Prefix: {
+                  'Fn::Join': ['-', ['test', 'join']],
+                },
+              },
+              {
+                Suffix: {
+                  'Fn::Join': ['-', ['test', 'join']],
+                },
+              },
+            ],
+          },
+        ],
       },
     });
   });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #11013 
