### PR TITLE
feat(AWS Lambda): Add support for `nodejs16.x` runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -559,6 +559,7 @@ class AwsProvider {
               'java8.al2',
               'nodejs12.x',
               'nodejs14.x',
+              'nodejs16.x',
               'provided',
               'provided.al2',
               'python3.6',


### PR DESCRIPTION
AWS Lambda now supports nodejs16.x

https://github.com/aws/aws-lambda-base-images/issues/14#issuecomment-1120864028

Updated the validation so that serverless does not throw a warning when using in projects with nodejs16.