### PR TITLE
docs: Replace Gitter links with Slack

### DIFF
--- a/docs/providers/aliyun/README.md
+++ b/docs/providers/aliyun/README.md
@@ -15,7 +15,7 @@ layout: Doc
 
 Welcome to the Serverless Alibaba Cloud Function Compute documentation!
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)
 
 **Note:** [Alibaba Cloud AccessKeys](./guide/credentials.md) are required for using the CLI.
 

--- a/docs/providers/aliyun/cli-reference/README.md
+++ b/docs/providers/aliyun/cli-reference/README.md
@@ -14,6 +14,6 @@ layout: Doc
 
 Welcome to the Serverless Alibaba Cloud Function Compute CLI Reference! Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/).
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/).
 
 **Note:** Before continuing [Alibaba Cloud system credentials](../guide/credentials.md) are required for using the CLI.

--- a/docs/providers/aliyun/events/README.md
+++ b/docs/providers/aliyun/events/README.md
@@ -16,6 +16,6 @@ Welcome to the Serverless Alibaba Cloud Function Compute Events Glossary!
 
 Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)
 
 **Note:** Before continuing [Alibaba Cloud system credentials](../guide/credentials.md) are required for using the CLI.

--- a/docs/providers/aliyun/guide/README.md
+++ b/docs/providers/aliyun/guide/README.md
@@ -16,6 +16,6 @@ Welcome to the Serverless Alibaba Cloud Function Compute Guide!
 
 Get started with the **[Introduction to the framework](./intro.md)**
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)
 
 **Note:** Before continuing [Alibaba Cloud user credentials](./credentials.md) are required for using the CLI.

--- a/docs/providers/aws/cli-reference/README.md
+++ b/docs/providers/aws/cli-reference/README.md
@@ -14,4 +14,4 @@ layout: Doc
 
 Welcome to the Serverless CLI Reference for AWS. Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/aws/events/README.md
+++ b/docs/providers/aws/events/README.md
@@ -18,4 +18,4 @@ Please select a section on the left to get started, or see the [user
 guide](../guide/events.md) for general information regarding Lambda Events in
 Serverless.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/aws/examples/README.md
+++ b/docs/providers/aws/examples/README.md
@@ -16,4 +16,4 @@ Search for AWS Serverless Examples using our [Example Explorer](https://serverle
 
 Have an example? Submit a PR or [open an issue](https://github.com/serverless/examples/issues). ⚡️
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/azure/cli-reference/README.md
+++ b/docs/providers/azure/cli-reference/README.md
@@ -15,4 +15,4 @@ layout: Doc
 Welcome to the Serverless Azure Functions CLI Reference! Please select a section
 on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/).
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/).

--- a/docs/providers/azure/events/README.md
+++ b/docs/providers/azure/events/README.md
@@ -16,6 +16,6 @@ Welcome to the Serverless Azure Functions Events Glossary!
 
 Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)
 
 **Note:** Before continuing [Azure Functions system credentials](../guide/credentials.md) are required for using the CLI.

--- a/docs/providers/azure/examples/README.md
+++ b/docs/providers/azure/examples/README.md
@@ -28,4 +28,4 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 
 ## Get Help
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/azure/guide/README.md
+++ b/docs/providers/azure/guide/README.md
@@ -16,6 +16,6 @@ Welcome to the Serverless Azure Functions Guide!
 
 Get started with the [Introduction to the framework](./intro.md)
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless), [post over on the forums](http://forum.serverless.com/) or [post issues in the plugin repo](https://github.com/serverless/serverless-azure-functions/issues)
+If you have questions, join the [Slack community](https://serverless.com/slack), [post over on the forums](http://forum.serverless.com/) or [post issues in the plugin repo](https://github.com/serverless/serverless-azure-functions/issues)
 
 **Note:** Before continuing [Azure user credentials](./credentials.md) are required for using the CLI.

--- a/docs/providers/cloudflare/cli-reference/README.md
+++ b/docs/providers/cloudflare/cli-reference/README.md
@@ -14,4 +14,4 @@ layout: Doc
 
 Welcome to the Serverless Cloudflare Workers CLI Reference! Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/).
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/).

--- a/docs/providers/cloudflare/events/README.md
+++ b/docs/providers/cloudflare/events/README.md
@@ -16,4 +16,4 @@ Welcome to the Serverless Cloudflare Workers Events Glossary!
 
 Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)

--- a/docs/providers/cloudflare/guide/README.md
+++ b/docs/providers/cloudflare/guide/README.md
@@ -16,4 +16,4 @@ Welcome to the Serverless Cloudflare Workers Guide!
 
 Get started with the [Introduction to the Serverless framework](./intro.md)
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)

--- a/docs/providers/fn/cli-reference/README.md
+++ b/docs/providers/fn/cli-reference/README.md
@@ -14,4 +14,4 @@ layout: Doc
 
 Welcome to the Serverless Fn CLI Reference! Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/).
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/).

--- a/docs/providers/fn/events/README.md
+++ b/docs/providers/fn/events/README.md
@@ -16,4 +16,4 @@ Welcome to the Serverless Fn Events Glossary!
 
 Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)

--- a/docs/providers/fn/guide/README.md
+++ b/docs/providers/fn/guide/README.md
@@ -16,4 +16,4 @@ Welcome to the Serverless Fn Guide!
 
 Get started with the [Introduction to the Serverless framework](./intro.md)
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)

--- a/docs/providers/google/cli-reference/README.md
+++ b/docs/providers/google/cli-reference/README.md
@@ -14,6 +14,6 @@ layout: Doc
 
 Welcome to the Serverless Google Cloud Functions CLI Reference! Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/).
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/).
 
 **Note:** Before continuing [Google Cloud system credentials](../guide/credentials.md) are required for using the CLI.

--- a/docs/providers/google/events/README.md
+++ b/docs/providers/google/events/README.md
@@ -16,6 +16,6 @@ Welcome to the Serverless Google Cloud Functions Events Glossary!
 
 Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)
 
 **Note:** Before continuing [Google Cloud system credentials](../guide/credentials.md) are required for using the CLI.

--- a/docs/providers/google/examples/README.md
+++ b/docs/providers/google/examples/README.md
@@ -19,4 +19,4 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 | [Google Node Simple](https://serverless.com/examples/google-node-simple-http-endpoint/) <br/> Boilerplate project repository for Google Cloud provider with Serverless Framework.     | nodeJS  |
 | [Google Python Simple](https://serverless.com/examples/google-python-simple-http-endpoint/) <br/> Boilerplate project repository for Google Cloud provider with Serverless Framework. | Python  |
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/google/guide/README.md
+++ b/docs/providers/google/guide/README.md
@@ -16,7 +16,7 @@ Welcome to the Serverless Google Cloud Functions Guide!
 
 Get started with the [Introduction to the framework](./intro.md)
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)
 
 **Note:** Before continuing [Google Cloud user credentials](./credentials.md) are required for using the CLI.
 

--- a/docs/providers/kubeless/cli-reference/README.md
+++ b/docs/providers/kubeless/cli-reference/README.md
@@ -14,4 +14,4 @@ layout: Doc
 
 Welcome to the Serverless Kubeless CLI Reference! Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/).
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/).

--- a/docs/providers/kubeless/events/README.md
+++ b/docs/providers/kubeless/events/README.md
@@ -16,4 +16,4 @@ Welcome to the Serverless Kubeless Events Glossary!
 
 Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)

--- a/docs/providers/kubeless/guide/README.md
+++ b/docs/providers/kubeless/guide/README.md
@@ -16,4 +16,4 @@ Welcome to the Serverless Kubeless Guide!
 
 Get started with the [Introduction to the Serverless framework](./intro.md)
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)

--- a/docs/providers/kubeless/guide/debugging.md
+++ b/docs/providers/kubeless/guide/debugging.md
@@ -98,7 +98,6 @@ Serverless: Calling function: bikesearch...
      Docs:          docs.serverless.com
      Bugs:          github.com/serverless/serverless/issues
      Forums:        forum.serverless.com
-     Chat:          gitter.im/serverless/serverless
 
   Your Environment Information -----------------------------
      OS:                     darwin

--- a/docs/providers/openwhisk/cli-reference/README.md
+++ b/docs/providers/openwhisk/cli-reference/README.md
@@ -16,4 +16,4 @@ Welcome to the Serverless Apache OpenWhisk CLI Reference! Please select a sectio
 
 **Note:** Before continuing [Apache OpenWhisk system credentials](../guide/credentials.md) are required for using the CLI.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/).
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/).

--- a/docs/providers/openwhisk/events/README.md
+++ b/docs/providers/openwhisk/events/README.md
@@ -16,6 +16,6 @@ Welcome to the Serverless Apache OpenWhisk Events Glossary!
 
 Please select a section on the left to get started.
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)
 
 **Note:** Before continuing [Apache OpenWhisk system credentials](../guide/credentials.md) are required for using the CLI.

--- a/docs/providers/openwhisk/examples/README.md
+++ b/docs/providers/openwhisk/examples/README.md
@@ -23,4 +23,4 @@ Have an example? Submit a PR or [open an issue](https://github.com/serverless/ex
 | [OpenWhisk Swift Simple](https://serverless.com/examples/openwhisk-swift-simple/) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework.   | swift   |
 | [OpenWhisk Java Simple](https://serverless.com/examples/openwhisk-java-simple/) <br/> Boilerplate project repository for OpenWhisk provider with Serverless Framework.     | java    |
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)

--- a/docs/providers/openwhisk/guide/README.md
+++ b/docs/providers/openwhisk/guide/README.md
@@ -16,6 +16,6 @@ Welcome to the Serverless Apache OpenWhisk Guide!
 
 Get started with the [Introduction to the framework](./intro.md)
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](http://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)
 
 **Note:** Before continuing [Apache OpenWhisk user credentials](./credentials.md) are required for using the CLI.

--- a/docs/providers/spotinst/guide/README.md
+++ b/docs/providers/spotinst/guide/README.md
@@ -17,7 +17,7 @@ Welcome to the Serverless Spotinst Functions Guide!
 
 Get started with the [Introduction to the framework](./intro.md)
 
-If you have questions, join the [chat in gitter](https://gitter.im/serverless/serverless) or [post over on the forums](https://forum.serverless.com/)
+If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](https://forum.serverless.com/)
 
 ## Enjoy Spotinst Functions' Core Benefits
 


### PR DESCRIPTION
Replace Gitter links with Slack links.