### PR TITLE
feat(AWS S3): Support `forceDeploy` setting

### DIFF
--- a/docs/providers/aws/events/s3.md
+++ b/docs/providers/aws/events/s3.md
@@ -132,3 +132,22 @@ functions:
             - suffix: .jpg
           existing: true
 ```
+
+## Forcing deploying of triggers
+
+An S3 bucket with triggers attached may not be correctly updated by AWS Cloudformation on subsequent deployments. To circumvent this issue you can use the `forceDeploy` flag which will try to force Cloudformation to update the triggers no matter what. This has to be used in conjuction with the `existing: true` flag.
+
+```yml
+functions:
+  users:
+    handler: users.handler
+    events:
+      - s3:
+          bucket: legacy-photos
+          event: s3:ObjectCreated:*
+          rules:
+            - prefix: uploads/
+            - suffix: .jpg
+          existing: true
+          forceDeploy: true
+```

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -843,6 +843,8 @@ functions:
           # Set to 'true' when using an existing bucket
           # Else the bucket will be automatically created
           existing: true
+          # Optional, for forcing deployment of triggers on existing User Pools
+          forceDeploy: true
 ```
 
 ### Schedule

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -843,7 +843,7 @@ functions:
           # Set to 'true' when using an existing bucket
           # Else the bucket will be automatically created
           existing: true
-          # Optional, for forcing deployment of triggers on existing User Pools
+          # Optional, for forcing deployment of triggers on existing S3 buckets
           forceDeploy: true
 ```
 

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -350,7 +350,7 @@ class AwsCompileS3Events {
                         Rules: rules,
                       },
                     ],
-                    ForceDeploy: forceDeployProperty,
+                    ...(forceDeployProperty && { ForceDeploy: forceDeployProperty }),
                   },
                 },
               };

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -26,6 +26,7 @@ class AwsCompileS3Events {
             },
             event: { type: 'string', pattern: '^s3:.+$' },
             existing: { type: 'boolean' },
+            forceDeploy: { type: 'boolean' },
             rules: {
               type: 'array',
               items: {
@@ -286,6 +287,7 @@ class AwsCompileS3Events {
           if (event.s3 && _.isObject(event.s3) && event.s3.existing) {
             numEventsForFunc++;
             let rules = null;
+            const { forceDeploy } = event.s3;
             const bucket = event.s3.bucket;
             // In order to property use it as key and during comparisons below,
             const stringifiedBucket = _.isObject(bucket) ? JSON.stringify(bucket) : bucket;
@@ -329,6 +331,7 @@ class AwsCompileS3Events {
             }
 
             let customS3Resource;
+            const forceDeployProperty = forceDeploy ? Date.now() : undefined;
             if (numEventsForFunc === 1) {
               customS3Resource = {
                 [customS3ResourceLogicalId]: {
@@ -347,6 +350,7 @@ class AwsCompileS3Events {
                         Rules: rules,
                       },
                     ],
+                    ForceDeploy: forceDeployProperty,
                   },
                 },
               };

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "prettify:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml --base=main -- prettier --write",
     "test": "mocha \"test/unit/**/*.test.js\"",
     "test:ci": "npm run prettier-check:updated && npm run lint:updated && npm run test:isolated",
-    "test:isolated": "mocha-isolated \"test/unit/**/*.test.js\""
+    "test:isolated": "mocha-isolated \"test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js\""
   },
   "engines": {
     "node": ">=12.0"

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "prettify:updated": "pipe-git-updated --ext=css --ext=html --ext=js --ext=json --ext=md --ext=yaml --ext=yml --base=main -- prettier --write",
     "test": "mocha \"test/unit/**/*.test.js\"",
     "test:ci": "npm run prettier-check:updated && npm run lint:updated && npm run test:isolated",
-    "test:isolated": "mocha-isolated \"test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js\""
+    "test:isolated": "mocha-isolated \"test/unit/**/*.test.js\""
   },
   "engines": {
     "node": ">=12.0"

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -433,7 +433,6 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'first',
             BucketName: 'existing-s3-bucket',
-            ForceDeploy: undefined,
             BucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
           },
         });
@@ -518,7 +517,6 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'second',
             BucketName: 'existing-s3-bucket',
-            ForceDeploy: undefined,
             BucketConfigs: [
               {
                 Event: 's3:ObjectCreated:Put',
@@ -653,7 +651,6 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'second',
             BucketName: 'existing-s3-bucket',
-            ForceDeploy: undefined,
             BucketConfigs: [
               {
                 Event: 's3:ObjectCreated:Put',
@@ -788,7 +785,6 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'first',
             BucketName: 'existing-s3-bucket',
-            ForceDeploy: undefined,
             BucketConfigs: [
               {
                 Event: 's3:ObjectCreated:*',
@@ -820,7 +816,6 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'second',
             BucketName: 'existing-s3-bucket',
-            ForceDeploy: undefined,
             BucketConfigs: [
               {
                 Event: 's3:ObjectRemoved:*',
@@ -990,7 +985,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
         },
         FunctionName: `${serverlessInstance.service.service}-dev-other`,
         BucketName: { Ref: 'SomeBucket' },
-        ForceDeploy: undefined,
         BucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
       },
     });
@@ -1009,7 +1003,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
         BucketName: {
           'Fn::If': ['isFirstBucketEmtpy', { Ref: 'FirstBucket' }, { Ref: 'SecondBucket' }],
         },
-        ForceDeploy: undefined,
         BucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
       },
     });
@@ -1031,7 +1024,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
         },
         FunctionName: `${serverlessInstance.service.service}-dev-prefixSuffixWithCfFunction`,
         BucketName: 'TestBucket',
-        ForceDeploy: undefined,
         BucketConfigs: [
           {
             Event: 's3:ObjectCreated:*',

--- a/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js
@@ -433,6 +433,7 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'first',
             BucketName: 'existing-s3-bucket',
+            ForceDeploy: undefined,
             BucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
           },
         });
@@ -517,6 +518,7 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'second',
             BucketName: 'existing-s3-bucket',
+            ForceDeploy: undefined,
             BucketConfigs: [
               {
                 Event: 's3:ObjectCreated:Put',
@@ -526,6 +528,35 @@ describe('AwsCompileS3Events', () => {
           },
         });
       });
+    });
+
+    it('should support `forceDeploy` setting', async () => {
+      const result = await runServerless({
+        fixture: 'function',
+        configExt: {
+          functions: {
+            basic: {
+              events: [
+                {
+                  s3: {
+                    bucket: 'existing-s3-bucket',
+                    forceDeploy: true,
+                    existing: true,
+                  },
+                },
+              ],
+            },
+          },
+        },
+        command: 'package',
+      });
+
+      const { Resources } = result.cfTemplate;
+      const { awsNaming } = result;
+
+      const customResource = Resources[awsNaming.getCustomResourceS3ResourceLogicalId('basic')];
+
+      expect(typeof customResource.Properties.ForceDeploy).to.equal('number');
     });
 
     it('should create the necessary resources for a service using multiple event definitions', () => {
@@ -622,6 +653,7 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'second',
             BucketName: 'existing-s3-bucket',
+            ForceDeploy: undefined,
             BucketConfigs: [
               {
                 Event: 's3:ObjectCreated:Put',
@@ -756,6 +788,7 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'first',
             BucketName: 'existing-s3-bucket',
+            ForceDeploy: undefined,
             BucketConfigs: [
               {
                 Event: 's3:ObjectCreated:*',
@@ -787,6 +820,7 @@ describe('AwsCompileS3Events', () => {
             },
             FunctionName: 'second',
             BucketName: 'existing-s3-bucket',
+            ForceDeploy: undefined,
             BucketConfigs: [
               {
                 Event: 's3:ObjectRemoved:*',
@@ -956,6 +990,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
         },
         FunctionName: `${serverlessInstance.service.service}-dev-other`,
         BucketName: { Ref: 'SomeBucket' },
+        ForceDeploy: undefined,
         BucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
       },
     });
@@ -974,6 +1009,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
         BucketName: {
           'Fn::If': ['isFirstBucketEmtpy', { Ref: 'FirstBucket' }, { Ref: 'SecondBucket' }],
         },
+        ForceDeploy: undefined,
         BucketConfigs: [{ Event: 's3:ObjectCreated:*', Rules: [] }],
       },
     });
@@ -995,6 +1031,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/s3/index.test.js', ()
         },
         FunctionName: `${serverlessInstance.service.service}-dev-prefixSuffixWithCfFunction`,
         BucketName: 'TestBucket',
+        ForceDeploy: undefined,
         BucketConfigs: [
           {
             Event: 's3:ObjectCreated:*',


### PR DESCRIPTION
I have added a forceDeploy flag to the s3 bucket event trigger. The same logic has been used as in [#10435](https://github.com/serverless/serverless/pull/10435). I have tested this locally and it seems to work.

Closes: [issue 10939](https://github.com/serverless/serverless/issues/10939)

