### PR TITLE
refactor(AWS Lambda): Recognize all supported log retention days

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -621,7 +621,11 @@ class AwsProvider {
           },
           awsLogRetentionInDays: {
             type: 'number',
-            enum: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653],
+            // https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html#API_PutRetentionPolicy_RequestSyntax
+            enum: [
+              1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 2192, 2557, 2922,
+              3288, 3653,
+            ],
           },
           awsResourceCondition: { type: 'string' },
           awsResourceDependsOn: { type: 'array', items: { type: 'string' } },


### PR DESCRIPTION
The [current list of supported log retention days](https://github.com/serverless/serverless/blob/main/lib/plugins/aws/provider.js#L622-L625) for AWS CloudWatch Logs is not inclusive of the [supported list by AWS](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutRetentionPolicy.html#API_PutRetentionPolicy_RequestSyntax).

Missing supported options are: 2192, 2557, 2922, and 3288. This change adds those options.

Closes: https://github.com/serverless/serverless/issues/11075