### PR TITLE
CLI & variable resolution issues

### DIFF
--- a/lib/cli/commands-schema/resolve-final.js
+++ b/lib/cli/commands-schema/resolve-final.js
@@ -61,6 +61,7 @@ module.exports = (loadedPlugins, { providerName, configuration }) => {
 
   const missingOptionTypes = new Map();
   const commonOptions = providerName === 'aws' ? awsServiceOptions : serviceOptions;
+  commands.commonOptions = commonOptions;
   const resolveCommands = (loadedPlugin, config, commandPrefix = '') => {
     if (!config.commands) return;
     for (const [commandName, commandConfig] of Object.entries(config.commands)) {

--- a/lib/cli/commands-schema/resolve-final.js
+++ b/lib/cli/commands-schema/resolve-final.js
@@ -60,6 +60,7 @@ module.exports = (loadedPlugins, { providerName, configuration }) => {
   }
 
   const missingOptionTypes = new Map();
+  const commonOptions = providerName === 'aws' ? awsServiceOptions : serviceOptions;
   const resolveCommands = (loadedPlugin, config, commandPrefix = '') => {
     if (!config.commands) return;
     for (const [commandName, commandConfig] of Object.entries(config.commands)) {
@@ -91,8 +92,6 @@ module.exports = (loadedPlugins, { providerName, configuration }) => {
             }
           }
         }
-
-        const commonOptions = providerName === 'aws' ? awsServiceOptions : serviceOptions;
 
         // Put common options to end of index
         for (const optionName of Object.keys(commonOptions)) delete schema.options[optionName];

--- a/lib/configuration/variables/resolve-unresolved-source-types.js
+++ b/lib/configuration/variables/resolve-unresolved-source-types.js
@@ -1,29 +1,22 @@
 'use strict';
 
 const processVariables = (propertyPath, variablesMeta, resultMap) => {
-  let hasUnresolvedSources = false;
-  if (!variablesMeta.variables) return hasUnresolvedSources;
+  if (!variablesMeta.variables) return;
   for (const variableMeta of variablesMeta.variables) {
     if (!variableMeta.sources) continue;
     const sourceData = variableMeta.sources[0];
     if (!sourceData.type) continue;
     if (sourceData.params) {
       for (const paramData of sourceData.params) {
-        if (processVariables(propertyPath, paramData, resultMap)) hasUnresolvedSources = true;
+        processVariables(propertyPath, paramData, resultMap);
       }
-      if (hasUnresolvedSources) continue;
     }
     if (sourceData.address) {
-      if (processVariables(propertyPath, sourceData.address, resultMap)) {
-        hasUnresolvedSources = true;
-        continue;
-      }
+      processVariables(propertyPath, sourceData.address, resultMap);
     }
-    hasUnresolvedSources = true;
     if (!resultMap.has(sourceData.type)) resultMap.set(sourceData.type, new Set());
     resultMap.get(sourceData.type).add(propertyPath);
   }
-  return hasUnresolvedSources;
 };
 
 module.exports = (propertiesVariablesMeta) => {

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -721,6 +721,7 @@ processSpanPromise = (async () => {
         // Do not confirm on unresolved sources with partially resolved configuration
         if (resolverConfiguration.propertyPathsToResolve) return;
 
+        processLog.debug('uresolved variables meta: %o', variablesMeta);
         // Report unrecognized variable sources found in variables configured in service config
         const unresolvedSources =
           require('../lib/configuration/variables/resolve-unresolved-source-types')(variablesMeta);

--- a/test/unit/lib/configuration/variables/resolve-unresolved-source-types.test.js
+++ b/test/unit/lib/configuration/variables/resolve-unresolved-source-types.test.js
@@ -50,33 +50,48 @@ describe('test/unit/lib/configuration/variables/resolve-unresolved-source-types.
   });
 
   it('should resolve all not resolved sources', () => {
-    expect(resultMap).to.deep.equal(
-      new Map([
+    expect(
+      Array.from(resultMap).map(([name, set]) => [name, Array.from(set).sort()])
+    ).to.deep.equal([
+      [
+        'unrecognized',
         [
           'unrecognized',
-          new Set([
-            'unrecognized',
-            'unrecognizedInParens',
-            'unrecognizedInAddress',
-            'unrecognizedInParensAndAddress',
-            'otherUnrecognizedFallback',
-            'deep\0unrecognized',
-            'deep\0unrecognizedInParens',
-            'deep\0unrecognizedInAddress',
-            'deep\0unrecognizedInParensAndAddress',
-            'deep\0otherUnrecognizedFallback',
-          ]),
-        ],
+          'unrecognizedInParens',
+          'unrecognizedInAddress',
+          'unrecognizedInParensAndAddress',
+          'otherUnrecognizedFallback',
+          'deep\0unrecognized',
+          'deep\0unrecognizedInParens',
+          'deep\0unrecognizedInAddress',
+          'deep\0unrecognizedInParensAndAddress',
+          'deep\0otherUnrecognizedFallback',
+        ].sort(),
+      ],
+      [
+        'unrecognized2',
         [
-          'unrecognized2',
-          new Set([
-            'unrecognizedInParens',
-            'unrecognizedInParensAndAddress',
-            'deep\0unrecognizedInParens',
-            'deep\0unrecognizedInParensAndAddress',
-          ]),
-        ],
-      ])
-    );
+          'unrecognizedInParens',
+          'unrecognizedInParensAndAddress',
+          'deep\0unrecognizedInParens',
+          'deep\0unrecognizedInParensAndAddress',
+        ].sort(),
+      ],
+      [
+        'recognized',
+        [
+          'unrecognizedInAddress',
+          'unrecognizedInParens',
+          'unrecognizedInParensAndAddress',
+          'deep\0unrecognizedInAddress',
+          'deep\0unrecognizedInParens',
+          'deep\0unrecognizedInParensAndAddress',
+        ].sort(),
+      ],
+      [
+        'unrecognized3',
+        ['unrecognizedInParensAndAddress', 'deep\0unrecognizedInParensAndAddress'].sort(),
+      ],
+    ]);
   });
 });

--- a/test/unit/lib/configuration/variables/resolve.test.js
+++ b/test/unit/lib/configuration/variables/resolve.test.js
@@ -62,6 +62,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
           '${sourceDirect:}|${sourceUnrecognized:}|${sourceDirect(${sourceUnrecognized:})}' +
           '${sourceDirect:${sourceUnrecognized:}}',
       },
+      recognizedInUnrecognized: '${sourceUnrecognized(${sourceDirect:})}',
       erroredParam: '${sourceDirect(${sourceError:})}',
       nestErrored: {
         erroredAddress: '${sourceDirect:${sourceError:}}',
@@ -382,6 +383,11 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
       expect(valueMeta).to.have.property('variables');
     });
 
+    it('should not resolve dependencies of unrecognized source', () => {
+      const valueMeta = variablesMeta.get('recognizedInUnrecognized');
+      expect(valueMeta.variables[0].sources[0].params[0]).to.have.property('variables');
+    });
+
     it('should mark dependency on errored property with error', () => {
       const valueMeta = variablesMeta.get('deepPropertyErrored');
       expect(valueMeta).to.not.have.property('variables');
@@ -437,6 +443,7 @@ describe('test/unit/lib/configuration/variables/resolve.test.js', () => {
         'missing',
         'nonStringStringPart',
         'nestUnrecognized\0unrecognized',
+        'recognizedInUnrecognized',
         'erroredParam',
         'nestErrored\0erroredAddress',
         'erroredSourceServerlessError',

--- a/test/unit/scripts/serverless.test.js
+++ b/test/unit/scripts/serverless.test.js
@@ -241,6 +241,19 @@ describe('test/unit/scripts/serverless.test.js', () => {
     }
   });
 
+  it('should throw meaningful error on unrecognized command for custom provider', async () => {
+    try {
+      await spawn('node', [serverlessPath, 'foo'], {
+        cwd: (await programmaticFixturesEngine.setup('custom-provider')).servicePath,
+      });
+      throw new Error('Unexpected');
+    } catch (error) {
+      if (!error.code) throw error;
+      expect(error.code).to.equal(1);
+      expect(String(error.stdoutBuffer)).to.include('command "foo" not found');
+    }
+  });
+
   it('should show help when requested and in context of invalid service configuration', async () => {
     const output = String(
       (


### PR DESCRIPTION
When investigating https://github.com/serverless/serverless/issues/11068 I've discovered two bugs, which this PR fixes.

1. Trying to run unrecognized command in context of custom provider resulted with programmer error as `TypeError: Cannot convert undefined or null to object`. It's due to regression introduced with https://github.com/serverless/serverless/pull/10846 where dependency on newly added `.commonOptions` was introduced, yet this property was not secured at final schema resolution.

2. Configuring property with not recognized variable source but which used recognized variable source for _param_ or _address_ (e.g. `${unrecognized(${self:service})}`, resulted with error message as `Unrecognized configuration variable sources: ""`. It's because unresolved source resolver was programmed to pick just the most nested unresolved sources, and while resolver (for valid reasons) was not attempting to resolve `self:service`, it's `self` that surfaced  as _unresolved_ source. As `self` is by all means the recognized source, it was not shown in error message. To have that working well, I've updated the unresolved sources retriever to return information on all sources

