### PR TITLE
fix: Ensure lambda ecr image region matches the provider region

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -2179,7 +2179,16 @@ Object.defineProperties(
         }
 
         const [repositoryName, imageTag] = image.slice(image.indexOf('/') + 1).split(':');
-        const registryId = image.split('.')[0];
+        const parts = image.split('.');
+        const registryId = parts[0];
+        const region = parts[3];
+        const serviceRegion = this.getRegion();
+        if (region !== serviceRegion) {
+          throw new ServerlessError(
+            `The region "${region}" of the ECR image "${image}" must match provider region "${serviceRegion}".`,
+            'LAMBDA_ECR_REGION_MISMATCH_ERROR'
+          );
+        }
         const describeImagesResponse = await this.request('ECR', 'describeImages', {
           imageIds: [
             {

--- a/test/unit/lib/plugins/aws/provider.test.js
+++ b/test/unit/lib/plugins/aws/provider.test.js
@@ -1034,7 +1034,7 @@ aws_secret_access_key = CUSTOMSECRET
       let naming;
       let serviceConfig;
       const imageSha = '6bb600b4d6e1d7cf521097177dd0c4e9ea373edb91984a505333be8ac9455d38';
-      const imageWithSha = `000000000000.dkr.ecr.sa-east-1.amazonaws.com/test-lambda-docker@sha256:${imageSha}`;
+      const imageWithSha = `000000000000.dkr.ecr.us-east-1.amazonaws.com/test-lambda-docker@sha256:${imageSha}`;
       const imageDigestFromECR =
         'sha256:2e6b10a4b1ca0f6d3563a8a1f034dde7c4d7c93b50aa91f24311765d0822186b';
       const describeImagesStub = sinon
@@ -1066,11 +1066,11 @@ aws_secret_access_key = CUSTOMSECRET
                 image: imageWithSha,
               },
               fnImageWithTag: {
-                image: '000000000000.dkr.ecr.sa-east-1.amazonaws.com/test-lambda-docker:stable',
+                image: '000000000000.dkr.ecr.us-east-1.amazonaws.com/test-lambda-docker:stable',
               },
               fnImageWithTagAndRepoWithSlashes: {
                 image:
-                  '000000000000.dkr.ecr.sa-east-1.amazonaws.com/test-lambda/repo-docker:stable',
+                  '000000000000.dkr.ecr.us-east-1.amazonaws.com/test-lambda/repo-docker:stable',
               },
               fnImageWithExplicitUri: {
                 image: {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Throws a nice error when the ECR url region doesn't match the provider region. Also updates a related test case.

Closes: #10969
