### PR TITLE
docs: Mention `patterns` instead of `exclude` in layers.md

### DIFF
--- a/docs/providers/aws/guide/layers.md
+++ b/docs/providers/aws/guide/layers.md
@@ -74,7 +74,7 @@ provider:
 
 package:
   patterns:
-    - !layerSourceTarball.tar.gz
+    - '!layerSourceTarball.tar.gz'
 
 layers:
   layerOne:
@@ -95,7 +95,7 @@ layers:
     path: layerOne
     package:
       patterns:
-        - !layerSourceTarball.tar.gz
+        - '!layerSourceTarball.tar.gz'
 ```
 
 Keep in mind that all patterns (even when inherited from the service config) are resolved against the layer's `path` and not the service `path`.

--- a/docs/providers/aws/guide/layers.md
+++ b/docs/providers/aws/guide/layers.md
@@ -73,8 +73,8 @@ provider:
   name: aws
 
 package:
-  exclude:
-    - layerSourceTarball.tar.gz
+  patterns:
+    - !layerSourceTarball.tar.gz
 
 layers:
   layerOne:
@@ -94,11 +94,11 @@ layers:
   layerOne:
     path: layerOne
     package:
-      exclude:
-        - layerSourceTarball.tar.gz
+      patterns:
+        - !layerSourceTarball.tar.gz
 ```
 
-Keep in mind that all `include` and `exclude` patterns (even when inherited from the service config) are resolved against the layer's `path` and not the service `path`.
+Keep in mind that all patterns (even when inherited from the service config) are resolved against the layer's `path` and not the service `path`.
 
 You can also specify a prebuilt archive to create your layer. When you do this, you do not need to specify the `path` element of your layer.
 


### PR DESCRIPTION
Support for "package.include" and "package.exclude" will be removed in the next major release. Please use "package.patterns" instead
More info: https://serverless.com/framework/docs/deprecations/#PACKAGE_PATTERNS
