### PR TITLE
CLI Onboarding: Fix providers recognition

### DIFF
--- a/lib/cli/interactive-setup/aws-credentials.js
+++ b/lib/cli/interactive-setup/aws-credentials.js
@@ -338,37 +338,34 @@ module.exports = {
       return false;
     }
 
-    if (!configuration.console) {
-      const orgName = configuration.org;
-      if (orgName && isAuthenticated()) {
-        let providers;
-        try {
-          providers = await getProviders(orgName);
-        } catch (err) {
-          if (err.code === 'DASHBOARD_UNAVAILABLE') {
-            log.error();
-            log.error(err.message);
-            return false;
-          }
-          throw err;
-        }
-        const hasDefaultProvider = providers.some((provider) => provider.isDefault);
-
-        if (hasDefaultProvider) {
-          context.inapplicabilityReasonCode = 'DEFAULT_PROVIDER_CONFIGURED';
+    if (configuration.org && configuration.app && isAuthenticated()) {
+      let providers;
+      try {
+        providers = await getProviders(configuration.org);
+      } catch (err) {
+        if (err.code === 'DASHBOARD_UNAVAILABLE') {
+          log.error();
+          log.error(err.message);
           return false;
         }
+        throw err;
+      }
+      const hasDefaultProvider = providers.some((provider) => provider.isDefault);
 
-        // For situation where it is invoked for already existing service
-        // We need to check if service already has a linked provider
-        if (
-          providers &&
-          !history.has('service') &&
-          (await doesServiceInstanceHaveLinkedProvider({ configuration, options }))
-        ) {
-          context.inapplicabilityReasonCode = 'LINKED_PROVIDER_CONFIGURED';
-          return false;
-        }
+      if (hasDefaultProvider) {
+        context.inapplicabilityReasonCode = 'DEFAULT_PROVIDER_CONFIGURED';
+        return false;
+      }
+
+      // For situation where it is invoked for already existing service
+      // We need to check if service already has a linked provider
+      if (
+        providers &&
+        !history.has('service') &&
+        (await doesServiceInstanceHaveLinkedProvider({ configuration, options }))
+      ) {
+        context.inapplicabilityReasonCode = 'LINKED_PROVIDER_CONFIGURED';
+        return false;
       }
     }
 
@@ -379,7 +376,7 @@ module.exports = {
 
     // It is possible that user decides to not configure org for his service and
     // we still should allow setup of local credentials in such case
-    if (!context.configuration.console && context.configuration.org && isAuthenticated()) {
+    if (context.configuration.org && context.configuration.app && isAuthenticated()) {
       try {
         providers = await getProviders(context.configuration.org);
       } catch (err) {

--- a/lib/cli/interactive-setup/deploy.js
+++ b/lib/cli/interactive-setup/deploy.js
@@ -3,7 +3,6 @@
 const Serverless = require('../../serverless');
 const { writeText, style, log } = require('@serverless/utils/log');
 const promptWithHistory = require('@serverless/utils/inquirer/prompt-with-history');
-const isDashboardEnabled = require('../../configuration/is-dashboard-enabled');
 const { doesServiceInstanceHaveLinkedProvider } = require('./utils');
 const _ = require('lodash');
 const AWS = require('aws-sdk');
@@ -40,7 +39,8 @@ module.exports = {
 
     // We want to proceed if the service instance has a linked provider
     if (
-      isDashboardEnabled(context) &&
+      configuration.org &&
+      configuration.app &&
       isAuthenticated() &&
       (await doesServiceInstanceHaveLinkedProvider({ configuration, options }))
     ) {

--- a/test/unit/lib/cli/interactive-setup/aws-credentials.test.js
+++ b/test/unit/lib/cli/interactive-setup/aws-credentials.test.js
@@ -197,7 +197,7 @@ describe('test/unit/lib/cli/interactive-setup/aws-credentials.test.js', () => {
     ).to.be.true;
   });
 
-  it('Should be ineffective dashboard is not available', async () => {
+  it('Should be ineffective when dashboard is not available', async () => {
     const internalMockedSdk = {
       ...mockedSdk,
       getProviders: async () => {

--- a/test/unit/lib/cli/interactive-setup/deploy.test.js
+++ b/test/unit/lib/cli/interactive-setup/deploy.test.js
@@ -69,6 +69,29 @@ describe('test/unit/lib/cli/interactive-setup/deploy.test.js', () => {
     ).to.equal(true);
   });
 
+  it('Should be applied if service instance has a linked provider but disabled dashboard monitoring', async () => {
+    const mockedStep = proxyquire('../../../../../lib/cli/interactive-setup/deploy', {
+      '@serverless/dashboard-plugin/lib/is-authenticated': () => true,
+      './utils': {
+        doesServiceInstanceHaveLinkedProvider: () => true,
+      },
+    });
+
+    expect(
+      await mockedStep.isApplicable({
+        configuration: {
+          provider: { name: 'aws' },
+          org: 'someorg',
+          app: 'someapp',
+          dashboard: { disableMonitoring: true },
+        },
+        serviceDir: '/foo',
+        options: {},
+        history: new Map([['awsCredentials', []]]),
+      })
+    ).to.equal(true);
+  });
+
   describe('run', () => {
     it('should correctly handle skipping deployment for new service not configured with dashboard', async () => {
       configureInquirerStub(inquirer, {


### PR DESCRIPTION
PR addresses the following issues:
- With Console integration on, Dashboard providers were not handled as expected in the AWS credentials setup step
- In the Deployment step, providers check was skipped when `dashboard.disableMonitoring` was set (although this setting is meant to prevent deploying to dashboard but still allow to resolve providers)