### PR TITLE
Console: Support new user settings format

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -288,27 +288,22 @@ Object.defineProperties(
     }),
     deferredFunctionEnvironmentVariables: d(function () {
       return this.deferredOtelIngestionToken.then((otelIngestionToken) => {
-        const userSettings = {};
+        const userSettings = _.merge({}, this.config.monitoring, {
+          common: { destination: { requestHeaders: `serverless_token=${otelIngestionToken}` } },
+          logs: { destination: `${ingestionServerUrl}/v1/logs` },
+          metrics: { destination: `${ingestionServerUrl}/v1/metrics` },
+          request: { destination: `${ingestionServerUrl}/v1/request-response` },
+          response: { destination: `${ingestionServerUrl}/v1/request-response` },
+          traces: { destination: `${ingestionServerUrl}/v1/traces` },
+        });
         const result = {
-          SLS_OTEL_REPORT_REQUEST_HEADERS: `serverless_token=${otelIngestionToken}`,
-          SLS_OTEL_REPORT_METRICS_URL: `${ingestionServerUrl}/v1/metrics`,
-          SLS_OTEL_REPORT_TRACES_URL: `${ingestionServerUrl}/v1/traces`,
-          OTEL_RESOURCE_ATTRIBUTES: `sls_service_name=${this.service},sls_stage=${this.stage},sls_org_id=${this.orgId}`,
+          OTEL_RESOURCE_ATTRIBUTES:
+            `sls_service_name=${this.service},sls_stage=${this.stage},` +
+            `sls_org_id=${this.orgId}`,
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
+          SLS_OTEL_USER_SETTINGS: JSON.stringify(userSettings),
         };
-        if (this.config.disableLogsCollection) {
-          userSettings.disableLogsMonitoring = true;
-        } else {
-          result.SLS_OTEL_REPORT_LOGS_URL = `${ingestionServerUrl}/v1/logs`;
-        }
-        if (this.config.disableRequestResponseCollection) {
-          userSettings.disableRequestResponseMonitoring = true;
-        } else {
-          result.SLS_OTEL_REPORT_REQUEST_RESPONSE_URL = `${ingestionServerUrl}/v1/request-response`;
-        }
         if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.DEBUG_SLS_OTEL_LAYER = '1';
-
-        result.SLS_OTEL_USER_SETTINGS = JSON.stringify(userSettings);
         return result;
       });
     }),
@@ -322,7 +317,7 @@ Object.defineProperties(
       }
       const extensionVersionMetadata = await resolvePackageVersionMetadata(
         '@serverless/aws-lambda-otel-extension-dist',
-        '^0.3'
+        '^0.4'
       );
       log.debug('target extension version: %s', extensionVersionMetadata.version);
       const extensionArtifactFilename = path.resolve(

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -21,8 +21,33 @@ const schema = {
         {
           type: 'object',
           properties: {
-            disableLogsCollection: { type: 'boolean' },
-            disableRequestResponseCollection: { type: 'boolean' },
+            monitoring: {
+              type: 'object',
+              properties: {
+                logs: {
+                  type: 'object',
+                  properties: {
+                    disabled: { type: 'boolean' },
+                  },
+                  additionalProperties: false,
+                },
+                request: {
+                  type: 'object',
+                  properties: {
+                    disabled: { type: 'boolean' },
+                  },
+                  additionalProperties: false,
+                },
+                response: {
+                  type: 'object',
+                  properties: {
+                    disabled: { type: 'boolean' },
+                  },
+                  additionalProperties: false,
+                },
+              },
+              additionalProperties: false,
+            },
             org: { type: 'string', pattern: '^[a-z0-9]{5,39}$' },
           },
           additionalProperties: false,


### PR DESCRIPTION
We've agreed internally to switch to a new user settings format (corresponding PR on runtime side: https://github.com/serverless/runtime/pull/57)

This technically is a  breaking change, but we consider this feature still experimental, so it's ok to push it that way.

Urls for logs and request/response collection are now propagated unconditionally as that's not harmful. Extension on it's own in response to user settings does not observe function logs, requests or responses.

--- 

Additionally reconfigured to support new format of `SLS_OTEL_USER_SETTINGS` as introduced with https://github.com/serverless/runtime/pull/62
