### PR TITLE
docs: Fix Console link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,19 @@ Now that Serverless Framework is installed, here is what you can do next:
 
 <br>
 
-| <br>**Try Serverless Console**<br><br>Monitor, observe, and trace your serverless architectures.<br>Real-time dev mode provides streaming logs from your AWS Lambda Functions.<br><br>Get started instantly with `serverless --console`<br>-or-<br>[Visit the Docs](https://bit.ly/3kL8ACL)<br><br>![1800x1-ffffff7f](https://user-images.githubusercontent.com/3837103/167449348-bf254fca-9aec-4367-b166-aaa69178f98c.png) |
-| :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+<table>
+  <tr>
+    <td align="center">
+      <br><strong>Try <a href="https://www.serverless.com/console/">Serverless Console</a></strong><br><br>
+      Monitor, observe, and trace your serverless architectures.<br>
+      Real-time dev mode provides streaming logs from your AWS Lambda Functions.<br><br>
+      Get started instantly with <code>serverless --console</code><br>
+      -or-<br>
+      <a href="https://bit.ly/3kL8ACL">Register</a>
+      <img src="https://user-images.githubusercontent.com/3837103/167449348-bf254fca-9aec-4367-b166-aaa69178f98c.png">
+    </td>
+  </tr>
+</table>
 
 <br>
 


### PR DESCRIPTION
The Console ad in the README incorrectly says "View docs": the short URL was changed to point to the register page. That creates a very confusing and poor experience for visitors.

This PR adds a link to the console home page (for those looking to learn _what_ Console is), and rewords the link to "Register" to set expectations to visitors.

I also took the opportunity to fix the "bold" style caused by the table heading.