### PR TITLE
docs: Remove incorrect note about google functions availability

### DIFF
--- a/docs/providers/google/guide/README.md
+++ b/docs/providers/google/guide/README.md
@@ -19,10 +19,3 @@ Get started with the [Introduction to the framework](./intro.md)
 If you have questions, join the [Slack community](https://serverless.com/slack) or [post over on the forums](http://forum.serverless.com/)
 
 **Note:** Before continuing [Google Cloud user credentials](./credentials.md) are required for using the CLI.
-
-**Note:** Google Cloud Functions is currently supported in only the following regions:
-
-- asia-northeast1
-- europe-west1
-- us-central1
-- us-east1


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Remove a old note about the availability of Google Functions. Seems like availability isn't an issue anymore 
 - [Locations](https://cloud.google.com/functions/docs/locations)
