### PR TITLE
Issue template:  Improve latest version requirement

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -17,10 +17,10 @@ body:
           required: true
   - type: checkboxes
     attributes:
-      label: Are you using the latest version?
+      label: Are you using the latest v3 release?
       description: Latest version can be checked at https://github.com/serverless/serverless/releases/latest
       options:
-        - label: Yes, I'm using the latest version
+        - label: Yes, I'm using the latest v3 release
           required: true
   - type: checkboxes
     attributes:


### PR DESCRIPTION
Users are repeatedly reporting issues with v2, marking they're relying on the latest version.

Either they intentionally mark the checkmark with false information, or they do not have a good understanding of what the latest version is (even though we provide a link under the question to verify that).

This update should reduce such reports, and push users to upgrade to v3 before reporting v2 issues to us.