### PR TITLE
test: Freeze version of `aws-iot-device-sdk-v2`

### DIFF
--- a/test/fixtures/programmatic/iot-fleet-provisioning/package.json
+++ b/test/fixtures/programmatic/iot-fleet-provisioning/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "aws-iot-device-sdk-v2": "^1.3.3"
+    "aws-iot-device-sdk-v2": "1.8.2"
   }
 }


### PR DESCRIPTION
We've observed a failing integration test for `iot-fleet-provisioning` and after investigation, it turns out that one of the dependencies really increased its size after the recent relates. Until the bug I reported them is fixed, we need to use previous version: https://github.com/aws/aws-iot-device-sdk-js-v2/issues/264

