### PR TITLE
feat(AWS Cognito): Add Support for Custom Sender Triggers

### DIFF
--- a/docs/providers/aws/events/cognito-user-pool.md
+++ b/docs/providers/aws/events/cognito-user-pool.md
@@ -93,8 +93,6 @@ functions:
           # Required with CustomSMSSender and CustomEmailSender Triggers
           # Can either be KMS Key ARN string or reference to KMS Key Resource ARN (see customEmailSenderFunction below)
           kmsKeyId: 'arn:aws:kms:eu-west-1:111111111111:key/12345678-9abc-def0-1234-56789abcdef1'
-          # Optional, defaults to 'V1_0'
-          lambdaVersion: 'V1_0'
   customEmailSenderFunction:
     handler: customEmailSender.handler
     events:
@@ -104,9 +102,9 @@ functions:
           kmsKeyId:
             Fn::GetAtt: ['kmsKey', 'Arn']
 
-# Used to show use in supplying kmsKeyId in customEmailSenderFunction, not needed when kmsKeyId is a string as shown in customSMSSenderFunction
 resources:
   Resources:
+    # Used to show use in supplying kmsKeyId in customEmailSenderFunction, not needed when kmsKeyId is a string as shown in customSMSSenderFunction
     kmsKey:
       Type: AWS::KMS::Key
       Properties:
@@ -123,6 +121,19 @@ resources:
             Effect: Allow
             Action: kms:*
             Resource: '*'
+
+    # Used to show how CustomSenderSources can be used with overriding the generated User Pool, as described below
+    # This makes it such that when a user signs up, they are automatically sent a verification email, triggering our
+    # CustomEmailSender
+    CognitoUserPoolMyUserPool2:
+      Type: AWS::Cognito::UserPool
+      Properties:
+        UsernameAttributes:
+          - 'email'
+        AutoVerifiedAttributes:
+          - 'email'
+        EmailVerificationMessage: 'email message: {####}'
+        EmailVerificationSubject: 'email subject: {####}'
 ```
 
 **NOTE:** The only supported value for lambdaVersion is `V1_0`, as documented [by AWS](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customsmssender.html).

--- a/docs/providers/aws/events/cognito-user-pool.md
+++ b/docs/providers/aws/events/cognito-user-pool.md
@@ -74,6 +74,91 @@ functions:
           trigger: PreSignUp
 ```
 
+## Special Trigger Considerations
+
+### Custom Sender Triggers
+
+There are two types of Custom Sender Triggers, `CustomSMSSender` and `CustomEmailSender`, both [documented by AWS](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-sender-triggers.html).
+
+In order to use these triggers, you must supply a `kmsKeyId` and (optionally) the `lambdaVersion` of the function. Only 1 `kmsKeyId` can be supplied per Cognito User Pool.
+
+```yml
+functions:
+  customSMSSenderFunction:
+    handler: customSMSSender.handler
+    events:
+      - cognitoUserPool:
+          pool: MyUserPool1
+          trigger: CustomSMSSender
+          # Required with CustomSMSSender and CustomEmailSender Triggers
+          # Can either be KMS Key ARN string or reference to KMS Key Resource ARN (see customEmailSenderFunction below)
+          kmsKeyId: 'arn:aws:kms:eu-west-1:111111111111:key/12345678-9abc-def0-1234-56789abcdef1'
+          # Optional, defaults to 'V1_0'
+          lambdaVersion: 'V1_0'
+  customEmailSenderFunction:
+    handler: customEmailSender.handler
+    events:
+      - cognitoUserPool:
+          pool: MyUserPool2
+          trigger: CustomEmailSender
+          kmsKeyId:
+            Fn::GetAtt: ['kmsKey', 'Arn']
+
+# Used to show use in supplying kmsKeyId in customEmailSenderFunction, not needed when kmsKeyId is a string as shown in customSMSSenderFunction
+resources:
+  Resources:
+    kmsKey:
+      Type: AWS::KMS::Key
+      Properties:
+        Description: MyKMSKey
+        Enabled: true
+        KeyPolicy:
+          Version: '2012-10-17'
+          Id: my-kms-key
+          Statement:
+            Sid: Enable IAM User Permissions
+            Principal:
+              AWS:
+                - Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+            Effect: Allow
+            Action: kms:*
+            Resource: '*'
+```
+
+**NOTE:** The only supported value for lambdaVersion is `V1_0`, as documented [by AWS](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customsmssender.html).
+
+### Custom Sender Triggers Handlers
+
+For custom senders, the `event.triggerSource` type does not get populated by the type of custom sender, rather may be populated by another trigger source. Instead, `event.request.type` is populated with either `customEmailSenderRequestV1` or `customSMSSenderRequestV1`, respectively documented by AWS [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-email-sender.html) and [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-sms-sender.html)
+
+```js
+// customSender.js
+function handler(event, context, callback) {
+  if (event.request.type === 'customEmailSenderRequestV1') {
+    // ...
+  }
+  if (event.request.type === 'customSMSSenderRequestV1') {
+    // ...
+  }
+}
+```
+
+### Custom Message Trigger Handlers
+
+For custom messages, you will need to check `event.triggerSource` type inside your handler function:
+
+```js
+// customMessage.js
+function handler(event, context, callback) {
+  if (event.triggerSource === 'CustomMessage_AdminCreateUser') {
+    // ...
+  }
+  if (event.triggerSource === 'CustomMessage_ResendCode') {
+    // ...
+  }
+}
+```
+
 ## Using existing pools
 
 Sometimes you might want to attach Lambda functions to existing Cognito User Pools. In that case you just need to set the `existing` event configuration property to `true`. All the other config parameters can also be used on existing user pools:
@@ -91,22 +176,6 @@ functions:
           pool: legacy-user-pool
           trigger: CustomMessage
           existing: true
-```
-
-## Custom message trigger handlers
-
-For custom messages, you will need to check `event.triggerSource` type inside your handler function:
-
-```js
-// customMessage.js
-function handler(event, context, callback) {
-  if (event.triggerSource === 'CustomMessage_AdminCreateUser') {
-    // ...
-  }
-  if (event.triggerSource === 'CustomMessage_ResendCode') {
-    // ...
-  }
-}
 ```
 
 ## Overriding a generated User Pool

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -1142,6 +1142,14 @@ functions:
           existing: true
           # Optional, for forcing deployment of triggers on existing User Pools
           forceDeploy: true
+      - cognitoUserPool:
+          pool: MyUserPool
+          trigger: CustomEmailSender
+          # Required, if you're using the CustomSMSSender or CustomEmailSender triggers
+          # Can either be KMS Key ARN string or reference to KMS Key Resource ARN
+          kmsKeyId: 'arn:aws:kms:eu-west-1:111111111111:key/12345678-9abc-def0-1234-56789abcdef1'
+          existing: true
+          forceDeploy: true
 ```
 
 ### ALB

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
@@ -82,7 +82,7 @@ async function updateConfiguration(config) {
           LambdaArn: lambdaArn,
           LambdaVersion: poolConfig.LambdaVersion,
         };
-        LambdaConfig[KMSKeyID] = poolConfig.KmsKeyId;
+        LambdaConfig.KMSKeyID = poolConfig.KMSKeyID;
       } else {
         LambdaConfig[poolConfig.Trigger] = lambdaArn;
       }
@@ -134,7 +134,7 @@ function removeExistingLambdas(lambdaConfig, lambdaArn) {
       );
     })
   );
-  // if there are no customSenderSources delete also KMSKeyId
+  // if there are no customSenderSources also delete KMSKeyId
   if (KMSKeyID in res && customSenderSources.every((source) => !(source in res))) {
     delete res[KMSKeyID];
   }

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
@@ -2,6 +2,10 @@
 
 const { awsRequest } = require('../../utils');
 
+const customSenderSources = ['CustomSMSSender', 'CustomEmailSender'];
+
+const KMSKeyID = 'KMSKeyID';
+
 function getUpdateConfigFromCurrentSetup(currentSetup) {
   const updatedConfig = Object.assign({}, currentSetup);
   delete updatedConfig.Id;
@@ -68,14 +72,20 @@ async function updateConfiguration(config) {
   return getConfiguration(config).then((res) => {
     const UserPoolId = res.UserPool.Id;
     let { LambdaConfig } = res.UserPool;
+
     // remove configurations for this specific function
-    LambdaConfig = Object.keys(LambdaConfig).reduce((accum, key) => {
-      if (LambdaConfig[key] === lambdaArn) delete accum[key];
-      return accum;
-    }, LambdaConfig);
+    LambdaConfig = removeExistingLambdas(LambdaConfig, lambdaArn);
 
     userPoolConfigs.forEach((poolConfig) => {
-      LambdaConfig[poolConfig.Trigger] = lambdaArn;
+      if (customSenderSources.includes(poolConfig.Trigger)) {
+        LambdaConfig[poolConfig.Trigger] = {
+          LambdaArn: lambdaArn,
+          LambdaVersion: poolConfig.LambdaVersion,
+        };
+        LambdaConfig[KMSKeyID] = poolConfig.KmsKeyId;
+      } else {
+        LambdaConfig[poolConfig.Trigger] = lambdaArn;
+      }
     });
 
     const updatedConfig = getUpdateConfigFromCurrentSetup(res.UserPool);
@@ -98,11 +108,9 @@ async function removeConfiguration(config) {
   return getConfiguration(config).then((res) => {
     const UserPoolId = res.UserPool.Id;
     let { LambdaConfig } = res.UserPool;
+
     // remove configurations for this specific function
-    LambdaConfig = Object.keys(LambdaConfig).reduce((accum, key) => {
-      if (LambdaConfig[key] === lambdaArn) delete accum[key];
-      return accum;
-    }, LambdaConfig);
+    LambdaConfig = removeExistingLambdas(LambdaConfig, lambdaArn);
 
     const updatedConfig = getUpdateConfigFromCurrentSetup(res.UserPool);
     Object.assign(updatedConfig, {
@@ -116,6 +124,21 @@ async function removeConfiguration(config) {
       updatedConfig
     );
   });
+}
+
+function removeExistingLambdas(lambdaConfig, lambdaArn) {
+  const res = Object.fromEntries(
+    Object.entries(lambdaConfig).filter(([key, value]) => {
+      return (
+        !(customSenderSources.includes(key) && value.LambdaArn === lambdaArn) && value !== lambdaArn
+      );
+    })
+  );
+  // if there are no customSenderSources delete also KMSKeyId
+  if (KMSKeyID in res && customSenderSources.every((source) => !(source in res))) {
+    delete res[KMSKeyID];
+  }
+  return res;
 }
 
 module.exports = {

--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -43,18 +43,8 @@ class AwsCompileCognitoUserPoolEvents {
         trigger: { enum: validTriggerSources },
         existing: { type: 'boolean' },
         forceDeploy: { type: 'boolean' },
-        kmsKeyId: {
-          anyOf: [
-            { $ref: '#/definitions/awsArn' },
-            {
-              type: 'string',
-              maxLength: 128,
-              pattern:
-                'arn:^[\\w+=/,.@-]+:[\\w+=/,.@-]+:([\\w+=/,.@-]*)?:[0-9]+:[\\w+=/,.@-]+(:[\\w+=/,.@-]+)?(:[\\w+=/,.@-]+)?',
-            },
-          ],
-        },
-        lambdaVersion: { enum: validLambdaVersions },
+        kmsKeyId: { $ref: '#/definitions/awsKmsArn' },
+        // lambdaVersion: { enum: validTriggerSources }, // Add this back in when more lambda versions are added by AWS
       },
       required: ['pool', 'trigger'],
       additionalProperties: false,
@@ -70,13 +60,6 @@ class AwsCompileCognitoUserPoolEvents {
           if (event.cognitoUserPool) {
             // return immediately if it's an existing Cognito User Pool event since we treat them differently
             if (event.cognitoUserPool.existing) return null;
-
-            if (!validTriggerSources.includes(event.cognitoUserPool.trigger)) {
-              throw new ServerlessError(
-                `Invalid trigger source. Valid trigger sources are: ${validTriggerSources}.`,
-                'COGNITO_INVALID_TRIGGER_SOURCE'
-              );
-            }
 
             const result = this.findUserPoolsAndFunctions();
             const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
@@ -164,13 +147,6 @@ class AwsCompileCognitoUserPoolEvents {
       if (functionObj.events) {
         functionObj.events.forEach((event) => {
           if (event.cognitoUserPool && event.cognitoUserPool.existing) {
-            if (!validTriggerSources.includes(event.cognitoUserPool.trigger)) {
-              throw new ServerlessError(
-                `Invalid trigger source. Valid trigger sources are: ${validTriggerSources}.`,
-                'COGNITO_INVALID_TRIGGER_SOURCE'
-              );
-            }
-
             numEventsForFunc++;
             const { pool, trigger, forceDeploy, kmsKeyId, lambdaVersion } = event.cognitoUserPool;
             usesExistingCognitoUserPool = funcUsesExistingCognitoUserPool = true;
@@ -204,15 +180,6 @@ class AwsCompileCognitoUserPoolEvents {
             let customCognitoUserPoolResource;
             const forceDeployProperty = forceDeploy ? Date.now() : undefined;
 
-            if (customSenderSources.includes(trigger)) {
-              this.checkCustomSenderConstraints(
-                kmsKeyId,
-                lambdaVersion,
-                poolKmsIdMap,
-                currentPoolName
-              );
-            }
-
             let userPoolConfig = {
               Trigger: trigger,
             };
@@ -220,14 +187,16 @@ class AwsCompileCognitoUserPoolEvents {
               userPoolConfig = {
                 ...userPoolConfig,
                 ...{
-                  KmsKeyId: kmsKeyId,
                   LambdaVersion: lambdaVersion || validLambdaVersions[0],
                 },
               };
+
+              this.checkKmsArn(kmsKeyId, poolKmsIdMap, pool);
+              userPoolConfig.KMSKeyID = kmsKeyId;
             }
 
             if (numEventsForFunc === 1) {
-              if (customSenderSources.includes(trigger)) {
+              if (customSenderSources.includes(trigger) && kmsKeyId) {
                 iamRoleStatements.push({
                   Effect: 'Allow',
                   Resource: kmsKeyId,
@@ -315,18 +284,12 @@ class AwsCompileCognitoUserPoolEvents {
     return null;
   }
 
-  checkCustomSenderConstraints(kmsKeyId, lambdaVersion, poolKmsIdMap, currentPoolName) {
-    if (lambdaVersion && !validLambdaVersions.includes(lambdaVersion)) {
-      throw new ServerlessError(
-        `Invalid Lambda version. Valid Lambda versions: ${validLambdaVersions}.`,
-        'COGNITO_INVALID_LAMBDA_VERSION'
-      );
-    }
-
+  checkKmsArn(kmsKeyId, poolKmsIdMap, currentPoolName) {
+    // KMSKeyId is only used (and is required) with Custom Sender Sources
     if (!kmsKeyId) {
       throw new ServerlessError(
-        `A KMS Key must be specified if using the following triggers: ${customSenderSources}.`,
-        'COGNITO_MISSING_KMS_KEY'
+        `KMS Key must be set when using a Custom Sender Source Trigger (CustomSMSSender and/or CustomEmailSender). Affected Cognito User Pool: "${currentPoolName}".`,
+        'COGNITO_KMS_KEY_NOT_SET'
       );
     }
 
@@ -385,21 +348,16 @@ class AwsCompileCognitoUserPoolEvents {
 
       let triggerObject;
       if (customSenderSources.includes(value.triggerSource)) {
-        this.checkCustomSenderConstraints(
-          value.kmsKeyId,
-          value.lambdaVersion,
-          poolKmsIdMap,
-          poolName
-        );
         triggerObject = {
           [value.triggerSource]: {
             LambdaArn: {
               'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
             },
-            LambdaVersion: value.lambdaVersion ? value.lambdaVersion : validLambdaVersions[0],
+            LambdaVersion: value.lambdaVersion || validLambdaVersions[0],
           },
-          KMSKeyID: value.kmsKeyId,
         };
+        this.checkKmsArn(value.kmsKeyId, poolKmsIdMap, poolName);
+        triggerObject.KMSKeyID = value.kmsKeyId;
       } else {
         triggerObject = {
           [value.triggerSource]: {

--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -44,7 +44,6 @@ class AwsCompileCognitoUserPoolEvents {
         existing: { type: 'boolean' },
         forceDeploy: { type: 'boolean' },
         kmsKeyId: { $ref: '#/definitions/awsKmsArn' },
-        // lambdaVersion: { enum: validTriggerSources }, // Add this back in when more lambda versions are added by AWS
       },
       required: ['pool', 'trigger'],
       additionalProperties: false,

--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -5,6 +5,7 @@ const BbPromise = require('bluebird');
 const { addCustomResourceToService } = require('../../../custom-resources');
 const ServerlessError = require('../../../../../serverless-error');
 
+const customSenderSources = ['CustomSMSSender', 'CustomEmailSender'];
 const validTriggerSources = [
   'PreSignUp',
   'PostConfirmation',
@@ -16,7 +17,9 @@ const validTriggerSources = [
   'CreateAuthChallenge',
   'VerifyAuthChallengeResponse',
   'UserMigration',
-];
+].concat(customSenderSources);
+
+const validLambdaVersions = ['V1_0'];
 
 class AwsCompileCognitoUserPoolEvents {
   constructor(serverless, options) {
@@ -40,6 +43,18 @@ class AwsCompileCognitoUserPoolEvents {
         trigger: { enum: validTriggerSources },
         existing: { type: 'boolean' },
         forceDeploy: { type: 'boolean' },
+        kmsKeyId: {
+          anyOf: [
+            { $ref: '#/definitions/awsArn' },
+            {
+              type: 'string',
+              maxLength: 128,
+              pattern:
+                'arn:^[\\w+=/,.@-]+:[\\w+=/,.@-]+:([\\w+=/,.@-]*)?:[0-9]+:[\\w+=/,.@-]+(:[\\w+=/,.@-]+)?(:[\\w+=/,.@-]+)?',
+            },
+          ],
+        },
+        lambdaVersion: { enum: validLambdaVersions },
       },
       required: ['pool', 'trigger'],
       additionalProperties: false,
@@ -55,6 +70,13 @@ class AwsCompileCognitoUserPoolEvents {
           if (event.cognitoUserPool) {
             // return immediately if it's an existing Cognito User Pool event since we treat them differently
             if (event.cognitoUserPool.existing) return null;
+
+            if (!validTriggerSources.includes(event.cognitoUserPool.trigger)) {
+              throw new ServerlessError(
+                `Invalid trigger source. Valid trigger sources are: ${validTriggerSources}.`,
+                'COGNITO_INVALID_TRIGGER_SOURCE'
+              );
+            }
 
             const result = this.findUserPoolsAndFunctions();
             const cognitoUserPoolTriggerFunctions = result.cognitoUserPoolTriggerFunctions;
@@ -130,6 +152,7 @@ class AwsCompileCognitoUserPoolEvents {
 
     // used to keep track of the custom resources created for each Cognito User Pool
     const poolResources = {};
+    const poolKmsIdMap = new Map();
 
     service.getAllFunctions().forEach((functionName) => {
       let numEventsForFunc = 0;
@@ -141,8 +164,15 @@ class AwsCompileCognitoUserPoolEvents {
       if (functionObj.events) {
         functionObj.events.forEach((event) => {
           if (event.cognitoUserPool && event.cognitoUserPool.existing) {
+            if (!validTriggerSources.includes(event.cognitoUserPool.trigger)) {
+              throw new ServerlessError(
+                `Invalid trigger source. Valid trigger sources are: ${validTriggerSources}.`,
+                'COGNITO_INVALID_TRIGGER_SOURCE'
+              );
+            }
+
             numEventsForFunc++;
-            const { pool, trigger, forceDeploy } = event.cognitoUserPool;
+            const { pool, trigger, forceDeploy, kmsKeyId, lambdaVersion } = event.cognitoUserPool;
             usesExistingCognitoUserPool = funcUsesExistingCognitoUserPool = true;
 
             if (!currentPoolName) {
@@ -173,7 +203,37 @@ class AwsCompileCognitoUserPoolEvents {
 
             let customCognitoUserPoolResource;
             const forceDeployProperty = forceDeploy ? Date.now() : undefined;
+
+            if (customSenderSources.includes(trigger)) {
+              this.checkCustomSenderConstraints(
+                kmsKeyId,
+                lambdaVersion,
+                poolKmsIdMap,
+                currentPoolName
+              );
+            }
+
+            let userPoolConfig = {
+              Trigger: trigger,
+            };
+            if (customSenderSources.includes(trigger)) {
+              userPoolConfig = {
+                ...userPoolConfig,
+                ...{
+                  KmsKeyId: kmsKeyId,
+                  LambdaVersion: lambdaVersion || validLambdaVersions[0],
+                },
+              };
+            }
+
             if (numEventsForFunc === 1) {
+              if (customSenderSources.includes(trigger)) {
+                iamRoleStatements.push({
+                  Effect: 'Allow',
+                  Resource: kmsKeyId,
+                  Action: ['kms:CreateGrant'],
+                });
+              }
               customCognitoUserPoolResource = {
                 [customPoolResourceLogicalId]: {
                   Type: 'Custom::CognitoUserPool',
@@ -185,11 +245,7 @@ class AwsCompileCognitoUserPoolEvents {
                     },
                     FunctionName,
                     UserPoolName: pool,
-                    UserPoolConfigs: [
-                      {
-                        Trigger: trigger,
-                      },
-                    ],
+                    UserPoolConfigs: [userPoolConfig],
                     ForceDeploy: forceDeployProperty,
                   },
                 },
@@ -205,9 +261,9 @@ class AwsCompileCognitoUserPoolEvents {
                 ],
               });
             } else {
-              Resources[customPoolResourceLogicalId].Properties.UserPoolConfigs.push({
-                Trigger: trigger,
-              });
+              Resources[customPoolResourceLogicalId].Properties.UserPoolConfigs.push(
+                userPoolConfig
+              );
             }
 
             _.merge(Resources, customCognitoUserPoolResource);
@@ -259,6 +315,35 @@ class AwsCompileCognitoUserPoolEvents {
     return null;
   }
 
+  checkCustomSenderConstraints(kmsKeyId, lambdaVersion, poolKmsIdMap, currentPoolName) {
+    if (lambdaVersion && !validLambdaVersions.includes(lambdaVersion)) {
+      throw new ServerlessError(
+        `Invalid Lambda version. Valid Lambda versions: ${validLambdaVersions}.`,
+        'COGNITO_INVALID_LAMBDA_VERSION'
+      );
+    }
+
+    if (!kmsKeyId) {
+      throw new ServerlessError(
+        `A KMS Key must be specified if using the following triggers: ${customSenderSources}.`,
+        'COGNITO_MISSING_KMS_KEY'
+      );
+    }
+
+    const previousKmsId = poolKmsIdMap.get(currentPoolName);
+    if (
+      previousKmsId !== undefined &&
+      previousKmsId !== kmsKeyId &&
+      JSON.stringify(previousKmsId) !== JSON.stringify(kmsKeyId)
+    ) {
+      throw new ServerlessError(
+        `Only one KMS Key for can be configured per Cognito User Pool. Affected Cognito User Pool: "${currentPoolName}".`,
+        'COGNITO_KMS_KEY_ID_NOT_SAME_FOR_SINGLE_USER_POOL'
+      );
+    }
+    poolKmsIdMap.set(currentPoolName, kmsKeyId);
+  }
+
   findUserPoolsAndFunctions() {
     const userPools = [];
     const cognitoUserPoolTriggerFunctions = [];
@@ -278,6 +363,8 @@ class AwsCompileCognitoUserPoolEvents {
               functionName,
               poolName: event.cognitoUserPool.pool,
               triggerSource: event.cognitoUserPool.trigger,
+              kmsKeyId: event.cognitoUserPool.kmsKeyId,
+              lambdaVersion: event.cognitoUserPool.lambdaVersion,
             });
 
             // Save user pools so we can use them to generate
@@ -292,15 +379,37 @@ class AwsCompileCognitoUserPoolEvents {
   }
 
   generateTemplateForPool(poolName, currentPoolTriggerFunctions) {
+    const poolKmsIdMap = new Map();
     const lambdaConfig = currentPoolTriggerFunctions.reduce((result, value) => {
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(value.functionName);
 
+      let triggerObject;
+      if (customSenderSources.includes(value.triggerSource)) {
+        this.checkCustomSenderConstraints(
+          value.kmsKeyId,
+          value.lambdaVersion,
+          poolKmsIdMap,
+          poolName
+        );
+        triggerObject = {
+          [value.triggerSource]: {
+            LambdaArn: {
+              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+            },
+            LambdaVersion: value.lambdaVersion ? value.lambdaVersion : validLambdaVersions[0],
+          },
+          KMSKeyID: value.kmsKeyId,
+        };
+      } else {
+        triggerObject = {
+          [value.triggerSource]: {
+            'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+          },
+        };
+      }
+
       // Return a new object to avoid lint errors
-      return Object.assign({}, result, {
-        [value.triggerSource]: {
-          'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-        },
-      });
+      return Object.assign({}, result, triggerObject);
     }, {});
 
     const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);

--- a/test/fixtures/programmatic/cognito-user-pool/core.js
+++ b/test/fixtures/programmatic/cognito-user-pool/core.js
@@ -29,4 +29,11 @@ function existingMulti(event, context, callback) {
   return callback(null, event);
 }
 
-module.exports = { basic, existingSimple, existingMulti };
+function existingCustomEmailSender(event, context, callback) {
+  const functionName = 'existingCustomEmailSender';
+
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
+module.exports = { basic, existingSimple, existingMulti, existingCustomEmailSender };

--- a/test/fixtures/programmatic/cognito-user-pool/core.js
+++ b/test/fixtures/programmatic/cognito-user-pool/core.js
@@ -13,6 +13,13 @@ function basic(event, context, callback) {
   return callback(null, nextEvent);
 }
 
+function customEmailSender(event, context, callback) {
+  const functionName = 'customEmailSender';
+
+  log(functionName, JSON.stringify(event));
+  return callback(null, event);
+}
+
 function existingSimple(event, context, callback) {
   const functionName = 'existingSimple';
   const nextEvent = Object.assign({}, event);
@@ -36,4 +43,10 @@ function existingCustomEmailSender(event, context, callback) {
   return callback(null, event);
 }
 
-module.exports = { basic, existingSimple, existingMulti, existingCustomEmailSender };
+module.exports = {
+  basic,
+  customEmailSender,
+  existingSimple,
+  existingMulti,
+  existingCustomEmailSender,
+};

--- a/test/fixtures/programmatic/cognito-user-pool/serverless.yml
+++ b/test/fixtures/programmatic/cognito-user-pool/serverless.yml
@@ -14,6 +14,18 @@ functions:
       - cognitoUserPool:
           pool: ${self:service} CUP Basic
           trigger: PreSignUp
+  customEmailSender:
+    handler: core.customEmailSender
+    events:
+      - cognitoUserPool:
+          # ${self:service} is purposefully omitted here. It causes the custom resource
+          # override below to select the wrong user pool when the resources get merged.
+          # The name is updated during the merge as defined in the resource below.
+          # This also allows us to include the resource merge operations in our integration tests.
+          pool: CUP CustomEmailSender
+          trigger: CustomEmailSender
+          kmsKeyId:
+            Fn::GetAtt: ['kmsKey', 'Arn']
   existingSimple:
     handler: core.existingSimple
     events:
@@ -45,6 +57,16 @@ functions:
 
 resources:
   Resources:
+    CognitoUserPoolCUPCustomEmailSender:
+      Type: AWS::Cognito::UserPool
+      Properties:
+        UserPoolName: ${self:service} CUP CustomEmailSender
+        UsernameAttributes:
+          - 'email'
+        AutoVerifiedAttributes:
+          - 'email'
+        EmailVerificationMessage: 'email message: {####}'
+        EmailVerificationSubject: 'email subject: {####}'
     kmsKey:
       Type: AWS::KMS::Key
       Properties:

--- a/test/fixtures/programmatic/cognito-user-pool/serverless.yml
+++ b/test/fixtures/programmatic/cognito-user-pool/serverless.yml
@@ -33,3 +33,31 @@ functions:
           pool: ${self:service} CUP Existing Multi
           trigger: PreAuthentication
           existing: true
+  existingCustomEmailSender:
+    handler: core.existingCustomEmailSender
+    events:
+      - cognitoUserPool:
+          pool: ${self:service} CUP Existing CustomEmailSender
+          trigger: CustomEmailSender
+          kmsKeyId:
+            Fn::GetAtt: ['kmsKey', 'Arn']
+          existing: true
+
+resources:
+  Resources:
+    kmsKey:
+      Type: AWS::KMS::Key
+      Properties:
+        Description: ServerlessIntegrationTestKMSKey
+        Enabled: true
+        KeyPolicy:
+          Version: '2012-10-17'
+          Id: cognito-user-pool-integration-test-key
+          Statement:
+            Sid: Enable IAM User Permissions
+            Principal:
+              AWS:
+                - Fn::Sub: arn:aws:iam::${AWS::AccountId}:root
+            Effect: Allow
+            Action: kms:*
+            Resource: '*'

--- a/test/integration/aws/cognito-user-pool.test.js
+++ b/test/integration/aws/cognito-user-pool.test.js
@@ -26,7 +26,9 @@ describe('AWS - Cognito User Pool Integration Test', function () {
   let poolBasicSetup;
   let poolExistingSimpleSetup;
   let poolExistingMultiSetup;
+  let poolExistingCustomEmailSenderSetup;
   let poolExistingSimpleSetupConfig;
+  let poolExistingCustomEmailSenderSetupConfig;
   const stage = 'dev';
 
   before(async () => {
@@ -38,18 +40,27 @@ describe('AWS - Cognito User Pool Integration Test', function () {
     poolBasicSetup = `${serviceName} CUP Basic`;
     poolExistingSimpleSetup = `${serviceName} CUP Existing Simple`;
     poolExistingMultiSetup = `${serviceName} CUP Existing Multi`;
+    poolExistingCustomEmailSenderSetup = `${serviceName} CUP Existing CustomEmailSender`;
 
     // create external Cognito User Pools
     // the simple pool setup has some additional configuration when we set it up
     poolExistingSimpleSetupConfig = {
       EmailVerificationMessage: 'email{####}message',
       EmailVerificationSubject: 'email{####}subject',
+      SmsVerificationMessage: 'sms{####}message',
+    };
+    poolExistingCustomEmailSenderSetupConfig = {
+      UsernameAttributes: ['email'],
+      AutoVerifiedAttributes: ['email'],
+      EmailVerificationMessage: 'email message: {####}',
+      EmailVerificationSubject: 'email subject: {####}',
     };
     // NOTE: deployment can only be done once the Cognito User Pools are created
     log.notice('Creating Cognito User Pools');
     await BbPromise.all([
       createUserPool(poolExistingSimpleSetup, poolExistingSimpleSetupConfig),
       createUserPool(poolExistingMultiSetup),
+      createUserPool(poolExistingCustomEmailSenderSetup, poolExistingCustomEmailSenderSetupConfig),
     ]);
     return deployService(serviceDir);
   });
@@ -64,6 +75,7 @@ describe('AWS - Cognito User Pool Integration Test', function () {
     return BbPromise.all([
       deleteUserPool(poolExistingSimpleSetup),
       deleteUserPool(poolExistingMultiSetup),
+      deleteUserPool(poolExistingCustomEmailSenderSetup),
     ]);
   });
 
@@ -92,7 +104,7 @@ describe('AWS - Cognito User Pool Integration Test', function () {
   });
 
   describe('Existing Setup', () => {
-    describe('single function / single pool setup', () => {
+    describe('single function / single trigger pool setup', () => {
       it('should invoke function when a user is created', async () => {
         const functionName = 'existingSimple';
 
@@ -105,7 +117,7 @@ describe('AWS - Cognito User Pool Integration Test', function () {
           {
             checkIsComplete: (soFarEvents) => {
               const logs = soFarEvents.reduce((data, event) => data + event.message, '');
-              return logs.includes('userName');
+              return logs.includes('PreSignUp_AdminCreateUser');
             },
           }
         );
@@ -128,7 +140,7 @@ describe('AWS - Cognito User Pool Integration Test', function () {
       });
     });
 
-    describe('single function / multi pool setup', () => {
+    describe('single function / multi trigger pool setup', () => {
       it('should invoke function when a user inits auth after being created', async () => {
         const functionName = 'existingMulti';
         const usernamePrefix = 'janedoe';
@@ -160,6 +172,37 @@ describe('AWS - Cognito User Pool Integration Test', function () {
         expect(logs).to.include(`"userName":"${usernamePrefix}`);
         expect(logs).to.include('"triggerSource":"PreSignUp_AdminCreateUser"');
         expect(logs).to.include('"triggerSource":"PreAuthentication_Authentication"');
+      });
+    });
+
+    describe('single function / custom sender triggers', () => {
+      it('should invoke function when a user is created and sent verification code via email', async () => {
+        const functionName = 'existingCustomEmailSender';
+
+        const { Id: userPoolId } = await findUserPoolByName(poolExistingCustomEmailSenderSetup);
+
+        let counter = 0;
+        const events = await confirmCloudWatchLogs(
+          `/aws/lambda/${stackName}-${functionName}`,
+          async () =>
+            createUser(
+              userPoolId,
+              `janedoe${++counter}@email.com`,
+              '!!!wAsD123456wAsD!!!',
+              'email'
+            ),
+          {
+            checkIsComplete: (soFarEvents) =>
+              soFarEvents
+                .reduce((data, event) => data + event.message, '')
+                .includes('customEmailSenderRequestV1'),
+          }
+        );
+        const logs = events.reduce((data, event) => data + event.message, '');
+
+        expect(logs).to.include(`"userPoolId":"${userPoolId}"`);
+        expect(logs).to.include('"userName":"janedoe');
+        expect(logs).to.include('"type":"customEmailSenderRequestV1"');
       });
     });
   });

--- a/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -953,7 +953,7 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
   });
 });
 
-describe('AwsCompileCognitoUserPoolEvents - runServerless', () => {
+describe('lib/plugins/aws/package/compile/events/cognito-user-pool.test.js', () => {
   let cfResources;
 
   before(async () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -167,18 +167,6 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
   let awsCompileCognitoUserPoolEvents;
   let addCustomResourceToServiceStub;
 
-  let cfResources;
-
-  before(() =>
-    runServerless({
-      fixture: 'function',
-      configExt: serverlessConfigurationExtension,
-      command: 'package',
-    }).then(({ cfTemplate }) => {
-      ({ Resources: cfResources } = cfTemplate);
-    })
-  );
-
   beforeEach(() => {
     addCustomResourceToServiceStub = sinon.stub().resolves();
     const AwsCompileCognitoUserPoolEvents = proxyquire(
@@ -963,17 +951,30 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
     });
   });
+});
+
+describe('AwsCompileCognitoUserPoolEvents - runServerless', () => {
+  let cfResources;
+
+  before(async () => {
+    const { cfTemplate } = await runServerless({
+      fixture: 'function',
+      configExt: serverlessConfigurationExtension,
+      command: 'package',
+    });
+
+    ({ Resources: cfResources } = cfTemplate);
+  });
 
   describe('Custom Sender Sources', () => {
     describe('Schema Issues', () => {
-      it('should throw if more than 1 KMS Key is configured per new Cognito User Pool', () => {
-        return expect(
+      it('should throw if more than 1 KMS Key is configured per new Cognito User Pool', async () => {
+        return await expect(
           runServerless({
             fixture: 'function',
             configExt: {
               functions: {
-                first: {
-                  handler: 'index.js',
+                basic: {
                   events: [
                     {
                       cognitoUserPool: {
@@ -1000,14 +1001,13 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
         ).to.eventually.be.rejectedWith('Only one KMS Key');
       });
 
-      it('should throw if more than 1 KMS Key is configured per existing Cognito User Pool', () => {
-        return expect(
+      it('should throw if more than 1 KMS Key is configured per existing Cognito User Pool', async () => {
+        return await expect(
           runServerless({
             fixture: 'function',
             configExt: {
               functions: {
-                first: {
-                  handler: 'index.js',
+                basic: {
                   events: [
                     {
                       cognitoUserPool: {


### PR DESCRIPTION
Hi all!

I saw that #10834 stalled, and I see a need for supporting Custom Sender Triggers for Cognito. I used #10834 as a guide to create my own implementation of the custom sender triggers.

This PR adds support for `CustomSMSSender` and `CustomEmailSender` as [documented by AWS](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-sender-triggers.html).

To address [a comment from the original pull request](https://github.com/serverless/serverless/pull/10834#issuecomment-1068027407), only 1 `kmsKeyId` can be configured per Cognito User Pool.

I have also added various unit tests, as well as an integration test. I did not make new files for these, rather updated the original tests for Cognito User Pools.

Thank you!

Closes: #8889