### PR TITLE
feat(AWS Local Invocation): Support Node handlers with `.cjs` extension

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -810,7 +810,27 @@ class AwsInvokeLocal {
         this.options.extraServicePath || '',
         handlerPath
       );
-      const handlersContainer = require(pathToHandler);
+      let handlersContainer;
+      try {
+        handlersContainer = require(pathToHandler);
+      } catch (e) {
+        if (e.code === 'MODULE_NOT_FOUND') {
+          // Attempt to require handler with `.cjs` extension
+          pathToHandler = `${pathToHandler}.cjs`;
+          try {
+            handlersContainer = require(pathToHandler);
+          } catch (innerError) {
+            if (innerError.code === 'MODULE_NOT_FOUND') {
+              // Throw original error as not finding module with `.cjs` might be confusing
+              throw e;
+            }
+            throw innerError;
+          }
+        } else {
+          throw e;
+        }
+      }
+
       lambda = handlersContainer[handlerName];
     } catch (error) {
       log.error(inspect(error));

--- a/test/fixtures/programmatic/invocation/async-cjs.cjs
+++ b/test/fixtures/programmatic/invocation/async-cjs.cjs
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports.handler = async (event, context) => {
+  if (event && event.shouldFail) throw new Error('Failed on request');
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Invoked',
+      event,
+      clientContext: context.clientContext,
+      env: process.env,
+    }),
+  };
+};

--- a/test/fixtures/programmatic/invocation/serverless.yml
+++ b/test/fixtures/programmatic/invocation/serverless.yml
@@ -12,6 +12,8 @@ functions:
     handler: callback.handler
   async:
     handler: async.handler
+  asyncCjs:
+    handler: async-cjs.handler
   contextDone:
     handler: context-done.handler
   contextSucceed:

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -1175,6 +1175,16 @@ describe('test/unit/lib/plugins/aws/invokeLocal/index.test.js', () => {
       expect(secondRemainingMs).to.be.lte(2910);
       expect(thirdRemainingMs).to.be.lte(secondRemainingMs);
     });
+
+    it('should support handlers with `.cjs` extension', async () => {
+      const { output } = await runServerless({
+        fixture: 'invocation',
+        command: 'invoke local',
+        options: { function: 'asyncCjs' },
+      });
+
+      expect(output).to.include('Invoked');
+    });
   });
 
   describe('Python', () => {


### PR DESCRIPTION
Found out about this problem internally when working on https://github.com/serverless/dashboard-plugin/pull/692

Adds support for `.cjs` extension for handlers in local invoke for Node
