### PR TITLE
feat(AWS Local Invocation): Support Node handlers that are ECMAScript modules

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -810,27 +810,7 @@ class AwsInvokeLocal {
         this.options.extraServicePath || '',
         handlerPath
       );
-      let handlersContainer;
-      try {
-        handlersContainer = require(pathToHandler);
-      } catch (e) {
-        if (e.code === 'MODULE_NOT_FOUND') {
-          // Attempt to require handler with `.cjs` extension
-          pathToHandler = `${pathToHandler}.cjs`;
-          try {
-            handlersContainer = require(pathToHandler);
-          } catch (innerError) {
-            if (innerError.code === 'MODULE_NOT_FOUND') {
-              // Throw original error as not finding module with `.cjs` might be confusing
-              throw e;
-            }
-            throw innerError;
-          }
-        } else {
-          throw e;
-        }
-      }
-
+      const handlersContainer = await loadModule(pathToHandler);
       lambda = handlersContainer[handlerName];
     } catch (error) {
       log.error(inspect(error));
@@ -845,6 +825,28 @@ class AwsInvokeLocal {
         `Lambda handler "${handlerPath}" does not point function property`,
         'INVALID_LAMBDA_HANDLER_PATH'
       );
+    }
+
+    async function loadModule(modulePath) {
+      try {
+        return require(modulePath);
+      } catch (error) {
+        if (error.code === 'ERR_REQUIRE_ESM') {
+          return await import(`${modulePath}.js`);
+        } else if (error.code === 'MODULE_NOT_FOUND') {
+          // Attempt to require handler with `.cjs` extension
+          pathToHandler = `${pathToHandler}.cjs`;
+          try {
+            return require(pathToHandler);
+          } catch (innerError) {
+            // Throw original error if still "MODULE_NOT_FOUND", as not finding module with `.cjs` might be confusing
+            if (innerError.code !== 'MODULE_NOT_FOUND') {
+              throw innerError;
+            }
+          }
+        }
+        throw error;
+      }
     }
 
     function handleError(err) {

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -832,7 +832,7 @@ class AwsInvokeLocal {
         return require(modulePath);
       } catch (error) {
         if (error.code === 'ERR_REQUIRE_ESM') {
-          return await import(`${modulePath}.js`);
+          return await import(`file:///${modulePath}.js`);
         } else if (error.code === 'MODULE_NOT_FOUND') {
           // Attempt to require handler with `.cjs` extension
           pathToHandler = `${pathToHandler}.cjs`;

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
       {
         "files": [
           "test/fixtures/programmatic/plugin/local-esm-plugin/**",
-          "test/fixtures/programmatic/plugin/node_modules/esm-plugin/**"
+          "test/fixtures/programmatic/plugin/node_modules/esm-plugin/**",
+          "test/fixtures/programmatic/invocation/esm/**"
         ],
         "parserOptions": {
           "sourceType": "module"
@@ -131,7 +132,8 @@
       },
       {
         "files": [
-          "lib/utils/import-module.js"
+          "lib/utils/import-module.js",
+          "lib/plugins/aws/invoke-local/index.js"
         ],
         "parserOptions": {
           "ecmaVersion": 2020

--- a/test/fixtures/programmatic/invocation/esm/async-esm.js
+++ b/test/fixtures/programmatic/invocation/esm/async-esm.js
@@ -1,0 +1,14 @@
+export const handler = async (event, context) => {
+  if (event && event.shouldFail) throw new Error('Failed on request');
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      message: 'Invoked',
+      event,
+      clientContext: context.clientContext,
+      env: process.env,
+    }),
+  };
+};
+
+export default handler;

--- a/test/fixtures/programmatic/invocation/esm/package.json
+++ b/test/fixtures/programmatic/invocation/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/fixtures/programmatic/invocation/serverless.yml
+++ b/test/fixtures/programmatic/invocation/serverless.yml
@@ -14,6 +14,8 @@ functions:
     handler: async.handler
   asyncCjs:
     handler: async-cjs.handler
+  asyncEsm:
+    handler: esm/async-esm.handler
   contextDone:
     handler: context-done.handler
   contextSucceed:

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -1185,6 +1185,15 @@ describe('test/unit/lib/plugins/aws/invokeLocal/index.test.js', () => {
 
       expect(output).to.include('Invoked');
     });
+    it('should support handlers that are ES modules', async () => {
+      const { output } = await runServerless({
+        fixture: 'invocation',
+        command: 'invoke local',
+        options: { function: 'asyncEsm' },
+      });
+
+      expect(output).to.include('Invoked');
+    });
   });
 
   describe('Python', () => {


### PR DESCRIPTION
- fallback to dynamic import if require fails and errorcode says 'ERR_REQUIRE_ESM'

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #11143
