### PR TITLE
Console: Report command which originated login operation

### DIFF
--- a/commands/login.js
+++ b/commands/login.js
@@ -37,7 +37,7 @@ module.exports = async (context) => {
 
   switch (identityName) {
     case 'console':
-      await require('../lib/commands/login/console')();
+      await require('../lib/commands/login/console')({ clientOriginCommand: 'login' });
       break;
     case 'dashboard':
       await require('../lib/commands/login/dashboard')();

--- a/lib/cli/interactive-setup/console-login.js
+++ b/lib/cli/interactive-setup/console-login.js
@@ -25,7 +25,7 @@ const steps = {
   loginOrRegister: async (context) => {
     const shouldLoginOrRegister =
       context.options.org || context.configuration.org || (await loginOrRegisterQuestion(context));
-    if (shouldLoginOrRegister) await login(context);
+    if (shouldLoginOrRegister) await login({ clientOriginCommand: 'onboarding' });
   },
 };
 

--- a/lib/commands/login/console.js
+++ b/lib/commands/login/console.js
@@ -3,9 +3,10 @@
 const { log, style } = require('@serverless/utils/log');
 const login = require('@serverless/utils/auth/login');
 
-module.exports = async () => {
+module.exports = async (options = {}) => {
   log.notice('Logging into the Serverless Console via the browser');
   await login({
+    ...options,
     clientName: 'cli:serverless',
     clientVersion: require('../../../package').version,
     onLoginUrl: (loginUrl) => {


### PR DESCRIPTION
For telemetry purposes, we want to send information on what command originated the login.

Technically there are two commands (`` (onboarding) and `login`) which originate the login. As onboarding is command-less CLI invocation, I've decide to cover it under `onboarding` name (empty string won't work well here)

Proposed change here is ineffective until we have https://github.com/serverless/utils/pull/183 merged and published (yet it's safe to be merged earlier)