### PR TITLE
feat(AWS HTTP API): Use the default API Gateway timeout of 30s

### DIFF
--- a/docs/providers/aws/events/http-api.md
+++ b/docs/providers/aws/events/http-api.md
@@ -73,7 +73,7 @@ functions:
 
 ### Endpoints timeout
 
-Framework ensures that function timeout setting (which defaults to 6 seconds) is respected in HTTP API endpoint configuration. Still note that maximum possible timeout for an endpoint is 29 seconds. Ensure to keep function timeout below that. Otherwise you may observe successful lambda invocations reported with `503` status code.
+The default and maximal API Gateway timeout is used: 30s. Ensure to keep function timeout below 29s. Otherwise, you may observe successful lambda invocations reported with `503` status code.
 
 ### CORS Setup
 

--- a/lib/plugins/aws/package/compile/events/http-api.js
+++ b/lib/plugins/aws/package/compile/events/http-api.js
@@ -611,11 +611,6 @@ Object.defineProperties(
               'for a successful lambda invocation.'
           );
         }
-        // Ensure endpoint has slightly larger timeout than a function,
-        // It's a margin needed for some side processing time on AWS side.
-        // Otherwise there's a risk of observing 503 status for successfully resolved invocation
-        // (which just fit function timeout setting)
-        routeTargetData.timeout = Math.min(functionTimeout + 0.5, 30);
       }
     }),
     compileIntegration: d(function (routeTargetData) {
@@ -630,9 +625,6 @@ Object.defineProperties(
         IntegrationUri: resolveTargetConfig(routeTargetData),
         PayloadFormatVersion: funcHttpApi.payload || providerHttpApi.payload || '2.0',
       };
-      if (routeTargetData.timeout) {
-        properties.TimeoutInMillis = Math.round(routeTargetData.timeout * 1000);
-      }
       this.cfTemplate.Resources[
         this.provider.naming.getHttpApiIntegrationLogicalId(routeTargetData.functionName)
       ] = {

--- a/test/unit/lib/plugins/aws/package/compile/events/http-api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/http-api.test.js
@@ -129,19 +129,9 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
       expect(resource.Properties.RouteKey).to.equal(routeKey);
     });
 
-    it('should ensure higher timeout than function default value', () => {
+    it('should let the default api gateway timeout by not setting the TimeoutInMillis property', () => {
       const resource = cfResources[naming.getHttpApiIntegrationLogicalId('foo')];
-      expect(resource.Properties.TimeoutInMillis).to.equal(6500);
-    });
-
-    it('should provide 0.5s time margin to custom function integration timeout', () => {
-      const resource = cfResources[naming.getHttpApiIntegrationLogicalId('customTimeout')];
-      expect(resource.Properties.TimeoutInMillis).to.equal(29500);
-    });
-
-    it('should limit function maximum integration timeout to 30s', () => {
-      const resource = cfResources[naming.getHttpApiIntegrationLogicalId('maxTimeout')];
-      expect(resource.Properties.TimeoutInMillis).to.equal(30000);
+      expect(resource.Properties.TimeoutInMillis).to.be.undefined;
     });
 
     it('should configure lambda permissions', () => {


### PR DESCRIPTION


<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: https://github.com/serverless/serverless/issues/11222

This is already the behavior with the REST API Gateway. The previous computation didn't consider the cold start of the functions. More details in the issue