### PR TITLE
Console: Rely on Console ready layers pre-published to AWS

### DIFF
--- a/lib/classes/console.js
+++ b/lib/classes/console.js
@@ -4,24 +4,13 @@ const _ = require('lodash');
 const d = require('d');
 const lazy = require('d/lazy');
 const path = require('path');
-const os = require('os');
-const fsp = require('fs').promises;
-const fse = require('fs-extra');
-const fetch = require('node-fetch');
-const tar = require('tar');
-const filesize = require('filesize');
-const provisionTmpDir = require('process-utils/tmpdir/provision');
-const resolvePackageVersionMetadata = require('npm-registry-utilities/resolve-version-metadata');
+const semver = require('semver');
 const log = require('@serverless/utils/log').log.get('console');
 const resolveAuthMode = require('@serverless/utils/auth/resolve-mode');
 const urls = require('@serverless/utils/lib/auth/urls');
 const apiRequest = require('@serverless/utils/api-request');
 
 const ServerlessError = require('../serverless-error');
-const ensureExists = require('../utils/ensure-exists');
-const safeMoveFile = require('../utils/fs/safe-move-file');
-const { setBucketName } = require('../plugins/aws/lib/set-bucket-name');
-const { uploadZipFile } = require('../plugins/aws/lib/upload-zip-file');
 
 const supportedCommands = new Set([
   'deploy',
@@ -31,15 +20,12 @@ const supportedCommands = new Set([
   'remove',
   'rollback',
 ]);
-const devVersionTimeBase = new Date(2022, 1, 17).getTime();
-const extensionCachePath = path.resolve(os.homedir(), '.serverless/aws-lambda-otel-extension');
-const ingestionServerUrl = `${urls.backend}/ingestion/kinesis`;
 
 class Console {
   constructor(serverless) {
     this.serverless = serverless;
     // Used to confirm that we obtained compatible console state data for deployment
-    this.stateSchemaVersion = '1';
+    this.stateSchemaVersion = '2';
   }
 
   async initialize() {
@@ -166,192 +152,79 @@ class Console {
     });
   }
 
-  overrideSettings({ otelIngestionToken, extensionLayerVersionPostfix, service, stage, region }) {
-    // Store at "_usedExtensionLayerVersionPostfix" for telemetry purposes
-    this._usedExtensionLayerVersionPostfix = extensionLayerVersionPostfix;
+  overrideSettings({ otelIngestionToken, layerVersion, service, stage, region }) {
+    this.layerVersion = layerVersion;
     Object.defineProperties(this, {
       deferredOtelIngestionToken: d(Promise.resolve(otelIngestionToken)),
-      deferredExtensionLayerVersionPostfix: d(Promise.resolve(extensionLayerVersionPostfix)),
       service: d('cew', service),
       stage: d('cew', stage),
       region: d('cew', region),
     });
-  }
-
-  async compileOtelExtensionLayer() {
-    const layerName = await this.deferredExtensionLayerName;
-    log.debug('compile extension resource (%s)', layerName);
-    this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
-      this.provider.naming.getConsoleExtensionLayerLogicalId()
-    ] = {
-      Type: 'AWS::Lambda::LayerVersion',
-      Properties: {
-        Content: {
-          S3Bucket: this.serverless.service.package.deploymentBucket || {
-            Ref: this.provider.naming.getDeploymentBucketLogicalId(),
-          },
-          S3Key: `${this.serverless.service.package.artifactsS3KeyDirname}/${await this
-            .deferredExtensionLayerBasename}`,
-        },
-        LayerName: layerName,
-      },
-    };
-  }
-
-  async packageOtelExtensionLayer() {
-    const layerFilename = await this.deferredExtensionLayerFilename;
-    log.debug('copy extension file (%s) to package directory', layerFilename);
-    await fse.ensureDir(path.join(this.serverless.serviceDir, '.serverless'));
-    await fsp.copyFile(
-      layerFilename,
-      path.join(
-        this.serverless.serviceDir,
-        '.serverless',
-        await this.deferredExtensionLayerBasename
-      )
-    );
-  }
-
-  async ensureLayerVersion() {
-    const layerName = await this.deferredExtensionLayerName;
-    let layerVersionMeta = (
-      await this.provider.request('Lambda', 'listLayerVersions', {
-        LayerName: layerName,
-      })
-    ).LayerVersions[0];
-    if (!layerVersionMeta) {
-      log.debug('publish layer version (%s)', layerName);
-      await this.uploadOtelExtensionLayer({ readFromTheSource: true });
-      await this.provider.request('Lambda', 'publishLayerVersion', {
-        LayerName: layerName,
-        Content: {
-          S3Bucket: await this.deferredBucketName,
-          S3Key: `${this.serverless.service.package.artifactsS3KeyDirname}/${await this
-            .deferredExtensionLayerBasename}`,
-        },
-      });
-      layerVersionMeta = (
-        await this.provider.request('Lambda', 'listLayerVersions', {
-          LayerName: layerName,
-        })
-      ).LayerVersions[0];
-    } else {
-      log.debug('layer version already published (%s)', layerName);
-    }
-    log.debug('retrieved layer version arn (%s)', layerVersionMeta.LayerVersionArn);
-    return layerVersionMeta.LayerVersionArn;
-  }
-
-  async uploadOtelExtensionLayer(options = {}) {
-    const layerBasename = await this.deferredExtensionLayerBasename;
-    const bucketName = await this.deferredBucketName;
-    const key = `${this.serverless.service.package.artifactsS3KeyDirname}/${layerBasename}`;
-    log.debug(
-      'check if extension file (%s) is already uploaded to S3 (%s/%s)',
-      layerBasename,
-      bucketName,
-      key
-    );
-    try {
-      await this.provider.request('S3', 'headObject', {
-        Bucket: bucketName,
-        Key: key,
-      });
-      // Extension layer is already available at S3, skip
-      log.debug('extension file is already uploaded to S3');
-      return;
-    } catch (error) {
-      if (error.code !== 'AWS_S3_HEAD_OBJECT_NOT_FOUND') throw error;
-      const filename = options.readFromTheSource
-        ? await this.deferredExtensionLayerFilename
-        : path.join(this.packagePath, layerBasename);
-      const stats = await fsp.stat(filename);
-      log.info(`Uploading console otel extension file to S3 (${filesize(stats.size)})`);
-      // bucketName is accessed by uploadZipFile
-      this.bucketName = await this.deferredBucketName;
-      await uploadZipFile.call(this, {
-        filename,
-        s3KeyDirname: this.serverless.service.package.artifactsS3KeyDirname,
-        basename: layerBasename,
-      });
-    }
   }
 }
 
 Object.defineProperties(
   Console.prototype,
   lazy({
-    deferredBucketName: d(async function () {
-      const tmpObject = { provider: this.provider };
-      await setBucketName.call(tmpObject);
-      return tmpObject.bucketName;
+    deferredLayerArn: d(async function () {
+      if (process.env.SLS_OTEL_LAYER_ARN) {
+        if (!process.env.SLS_OTEL_LAYER_ARN.includes(':layer:sls-otel-extension-')) {
+          throw new ServerlessError(
+            'Cannot rely on custom extension layer ARN: ' +
+              'For compatibility reasons layer name must be prefixed with "sls-otel-extension-"',
+            'CONSOLE_INCOMPATIBLE_CUSTOM_LAYER_ARN'
+          );
+        }
+        this.layerVersion = 'custom';
+        return process.env.SLS_OTEL_LAYER_ARN;
+      }
+      const data = JSON.parse(
+        String(
+          (
+            await this.provider.request('S3', 'getObject', {
+              Bucket: 'sls-layers-registry',
+              Key: 'sls-otel-extension-node.json',
+            })
+          ).Body
+        )
+      );
+      if (!data[this.region]) {
+        throw new ServerlessError(
+          `Region "${this.region} is not supported by the Console"`,
+          'CONSOLE_UNSUPPORTED_REGION'
+        );
+      }
+      const version = semver.maxSatisfying(Object.keys(data[this.region]), '^0.5.0');
+      if (!version) {
+        throw new ServerlessError(
+          `Region "${this.region} is not supported by the Console"`,
+          'CONSOLE_UNSUPPORTED_VERSION_IN_REGION'
+        );
+      }
+      this.layerVersion = version;
+      return data[this.region][version];
     }),
     deferredFunctionEnvironmentVariables: d(function () {
       return this.deferredOtelIngestionToken.then((otelIngestionToken) => {
         const userSettings = _.merge({}, this.config.monitoring, {
-          common: { destination: { requestHeaders: `serverless_token=${otelIngestionToken}` } },
-          logs: { destination: `${ingestionServerUrl}/v1/logs` },
-          metrics: { destination: `${ingestionServerUrl}/v1/metrics` },
-          request: { destination: `${ingestionServerUrl}/v1/request-response` },
-          response: { destination: `${ingestionServerUrl}/v1/request-response` },
-          traces: { destination: `${ingestionServerUrl}/v1/traces` },
+          ingestToken: otelIngestionToken,
+          orgId: this.orgId,
+          namespace: this.service,
+          environment: this.stage,
         });
         const result = {
-          OTEL_RESOURCE_ATTRIBUTES:
-            `sls_service_name=${this.service},sls_stage=${this.stage},` +
-            `sls_org_id=${this.orgId}`,
           AWS_LAMBDA_EXEC_WRAPPER: '/opt/otel-extension-internal-node/exec-wrapper.sh',
-          SLS_OTEL_USER_SETTINGS: JSON.stringify(userSettings),
+          SLS_EXTENSION: JSON.stringify(userSettings),
         };
-        if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.DEBUG_SLS_OTEL_LAYER = '1';
+        if (process.env.SERVERLESS_PLATFORM_STAGE) {
+          result.SERVERLESS_PLATFORM_STAGE = process.env.SERVERLESS_PLATFORM_STAGE;
+        }
+        if (process.env.SLS_OTEL_LAYER_DEV_BUILD) result.SLS_DEBUG_EXTENSION = '1';
         return result;
       });
     }),
     deferredOtelIngestionToken: d(function () {
       return this.createOtelIngestionToken();
-    }),
-    deferredExtensionLayerFilename: d(async () => {
-      if (process.env.SLS_OTEL_LAYER_FILENAME) {
-        log.debug('target extension filename (overriden): %s', process.env.SLS_OTEL_LAYER_FILENAME);
-        return process.env.SLS_OTEL_LAYER_FILENAME;
-      }
-      const extensionVersionMetadata = await resolvePackageVersionMetadata(
-        '@serverless/aws-lambda-otel-extension-dist',
-        '^0.4'
-      );
-      log.debug('target extension version: %s', extensionVersionMetadata.version);
-      const extensionArtifactFilename = path.resolve(
-        extensionCachePath,
-        `${extensionVersionMetadata.version}.zip`
-      );
-      await ensureExists(extensionArtifactFilename, async () => {
-        log.debug('resolving extension layer from npm registry');
-        const tmpDir = await provisionTmpDir();
-        const response = await fetch(extensionVersionMetadata.dist.tarball);
-        await new Promise((resolve, reject) => {
-          const stream = response.body.pipe(tar.x({ cwd: tmpDir, strip: 1 }));
-          stream.on('error', reject);
-          stream.on('end', resolve);
-        });
-        await safeMoveFile(path.resolve(tmpDir, 'extension.zip'), extensionArtifactFilename);
-      });
-      return extensionArtifactFilename;
-    }),
-    deferredExtensionLayerName: d(async function () {
-      return `sls-console-otel-extension-${(
-        await this.deferredExtensionLayerVersionPostfix
-      ).replace(/\./g, '-')}`;
-    }),
-    deferredExtensionLayerBasename: d(async function () {
-      return `sls-otel.${await this.deferredExtensionLayerVersionPostfix}.zip`;
-    }),
-    deferredExtensionLayerVersionPostfix: d(async function () {
-      const extensionLayerVersionPostfix = process.env.SLS_OTEL_LAYER_FILENAME
-        ? (Date.now() - devVersionTimeBase).toString(32)
-        : path.basename(await this.deferredExtensionLayerFilename, '.zip');
-      // Store at "_usedExtensionLayerVersionPostfix" for telemetry purposes
-      this._usedExtensionLayerVersionPostfix = extensionLayerVersionPostfix;
-      return extensionLayerVersionPostfix;
     }),
     url: d(function () {
       return (

--- a/lib/plugins/aws/deploy-function.js
+++ b/lib/plugins/aws/deploy-function.js
@@ -267,9 +267,13 @@ class AwsDeployFunction {
     } else if (isConsoleEnabled) {
       params.Layers = (remoteFunctionConfiguration.Layers || [])
         .map((layer) => layer.Arn)
-        .filter((layerArn) => !layerArn.includes('layer:sls-console-otel-extension-'));
+        .filter(
+          (layerArn) =>
+            !layerArn.includes('layer:sls-console-otel-extension-') &&
+            !layerArn.includes('layer:sls-otel-extension-')
+        );
     }
-    if (isConsoleEnabled) params.Layers.push(await this.console.ensureLayerVersion());
+    if (isConsoleEnabled) params.Layers.push(await this.console.deferredLayerArn);
     if (
       params.Layers &&
       remoteFunctionConfiguration.Layers &&

--- a/lib/plugins/aws/deploy/index.js
+++ b/lib/plugins/aws/deploy/index.js
@@ -173,7 +173,7 @@ class AwsDeploy {
           }
           this.console.overrideSettings({
             otelIngestionToken: this.state.console.otelIngestionToken,
-            extensionLayerVersionPostfix: this.state.console.extensionLayerVersionPostfix,
+            layerVersion: this.state.console.layerVersion,
             service: this.state.console.service,
             stage: this.state.console.stage,
             region: this.state.console.region,

--- a/lib/plugins/aws/deploy/lib/upload-artifacts.js
+++ b/lib/plugins/aws/deploy/lib/upload-artifacts.js
@@ -202,9 +202,6 @@ module.exports = {
         s3KeyDirname: this.serverless.service.package.artifactDirectoryName,
       })
     );
-    if (this.console.isEnabled) {
-      uploadPromises.push(this.console.uploadOtelExtensionLayer());
-    }
     await Promise.all(uploadPromises);
   },
 

--- a/lib/plugins/aws/info/get-stack-info.js
+++ b/lib/plugins/aws/info/get-stack-info.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const _ = require('lodash');
 const resolveCfImportValue = require('../utils/resolve-cf-import-value');
 const ServerlessError = require('../../../serverless-error');
 
@@ -98,21 +97,6 @@ module.exports = {
           }
           this.gatheredData.info.layers.push(layerInfo);
         });
-        // In Framework `this.console` is guranteed, still there are plugins adapting
-        // this method, and then `this.console` is undefined
-        if (_.get(this.console, 'isEnabled')) {
-          const layerMeta = (
-            await this.provider.request('Lambda', 'listLayerVersions', {
-              LayerName: await this.console.deferredExtensionLayerName,
-            })
-          ).LayerVersions[0];
-          if (layerMeta) {
-            this.gatheredData.info.layers.push({
-              name: '<console extension>',
-              arn: layerMeta.LayerVersionArn,
-            });
-          }
-        }
 
         // CloudFront
         const cloudFrontDomainName = outputs.find(

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -715,9 +715,4 @@ module.exports = {
     // TODO: Remove that with next major, assuming that issue #7056 (https://github.com/serverless/serverless/issues/7056) has been addressed
     return `serverless-${serviceName}-${stage}`.toLowerCase().replace(/-+/g, '-').replace(/-$/, '');
   },
-
-  // Console
-  getConsoleExtensionLayerLogicalId() {
-    return 'SlsConsoleOtelExtension';
-  },
 };

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -447,9 +447,7 @@ class AwsCompileFunctions {
         functionResource.Properties.Environment.Variables,
         await this.console.deferredFunctionEnvironmentVariables
       );
-      functionResource.Properties.Layers.push({
-        Ref: this.provider.naming.getConsoleExtensionLayerLogicalId(),
-      });
+      functionResource.Properties.Layers.push(await this.console.deferredLayerArn);
     }
 
     const functionLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
@@ -492,21 +490,7 @@ class AwsCompileFunctions {
       }
       // Include all referenced layer code in the version id hash
       const layerArtifactPaths = [];
-      const consoleExtensionLayerName =
-        this.console.isEnabled && (await this.console.deferredExtensionLayerName);
-      const consoleExtensionBasename =
-        this.console.isEnabled && (await this.console.deferredExtensionLayerBasename);
       layerConfigurations.forEach((layer) => {
-        if (
-          !layer.name &&
-          consoleExtensionLayerName &&
-          layer.properties.LayerName === consoleExtensionLayerName
-        ) {
-          layerArtifactPaths.push(
-            path.join(this.serverless.serviceDir, '.serverless', consoleExtensionBasename)
-          );
-          return;
-        }
         const layerArtifactPath = this.provider.resolveLayerArtifactName(layer.name);
         layerArtifactPaths.push(layerArtifactPath);
       });

--- a/lib/plugins/aws/package/compile/layers.js
+++ b/lib/plugins/aws/package/compile/layers.js
@@ -170,9 +170,6 @@ class AwsCompileLayers {
         this.compileLayer(layerName).then(() => this.compareWithLastLayer(layerName))
       )
     );
-    if (this.serverless.console.isEnabled) {
-      await this.serverless.console.compileOtelExtensionLayer();
-    }
   }
 
   cfLambdaLayerTemplate() {

--- a/lib/plugins/aws/package/lib/save-service-state.js
+++ b/lib/plugins/aws/package/lib/save-service-state.js
@@ -38,7 +38,7 @@ module.exports = {
       state.console = {
         schemaVersion: this.console.stateSchemaVersion,
         otelIngestionToken: await this.console.deferredOtelIngestionToken,
-        extensionLayerVersionPostfix: await this.console.deferredExtensionLayerVersionPostfix,
+        layerVersion: this.console.layerVersion,
         service: this.console.service,
         stage: this.console.stage,
         region: this.console.region,

--- a/lib/plugins/aws/package/lib/validate-template.js
+++ b/lib/plugins/aws/package/lib/validate-template.js
@@ -17,7 +17,7 @@ module.exports = {
         const layers = functionResource.Properties.Layers;
         if (!layers || layers.length <= 5) continue;
         const nonConsoleLayers = layers.filter(
-          (layer) => layer.Ref !== this.provider.naming.getConsoleExtensionLayerLogicalId()
+          (layer) => typeof layer !== 'string' || !layer.includes('layer:sls-otel-extension-')
         );
         throw new ServerlessError(
           `${

--- a/lib/plugins/aws/rollback.js
+++ b/lib/plugins/aws/rollback.js
@@ -180,7 +180,7 @@ class AwsRollback {
       }
       this.console.overrideSettings({
         otelIngestionToken: state.console.otelIngestionToken,
-        extensionLayerVersionPostfix: state.console.extensionLayerVersionPostfix,
+        layerVersion: state.console.layerVersion,
         service: state.console.service,
         stage: state.console.stage,
       });

--- a/lib/plugins/package/lib/package-service.js
+++ b/lib/plugins/package/lib/package-service.js
@@ -110,7 +110,6 @@ module.exports = {
         await this.packageLayer(layerName);
       })
     );
-    if (this.console.isEnabled) await this.console.packageOtelExtensionLayer();
 
     await Promise.all(packagePromises);
     if (shouldPackageService) {

--- a/lib/utils/telemetry/generate-payload.js
+++ b/lib/utils/telemetry/generate-payload.js
@@ -263,7 +263,7 @@ module.exports = ({
       serverless && serverless.isDashboardEnabled ? serverless.service.orgUid : undefined;
     if (_.get(serverless, 'console.isEnabled')) {
       payload.console.orgUid = serverless.console.orgId;
-      payload.console.extensionVersion = serverless.console._usedExtensionLayerVersionPostfix;
+      payload.console.extensionVersion = serverless.console.layerVersion;
     }
     if (isAwsProvider && serverless && commandsReportingProjectId.has(command)) {
       const serviceName = isObject(configuration.service)


### PR DESCRIPTION
Since v0.5 release of extension layers. The extension layers are setup as made specifically for Serverless Console (they're no longer observability tool agnostic) and are pre-published to our AWS accounts into all regions (so there's no longer need to upload them to user account and reference from there)

This PR ensures we rely on those layers and upgrade to v0.5