### PR TITLE
set lint-staged to 12, as 13 drops support for node 12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ Welcome, and thanks in advance for your help!
 
 ## Setup
 
-Once you've cloned forked repository, all is needed is to run `npm install` at its root folder
+Once you've cloned forked repository, all is needed is to run `npm install` at its root folder.
+
+For best results use a \*nix development environment; If you're using Windows see: [Install Linux on Windows with WSL] (https://docs.microsoft.com/en-us/windows/wsl/install).
 
 ## When you propose a new feature or bug fix
 

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "github-release-from-cc-changelog": "^2.3.0",
     "husky": "^4.3.8",
     "jszip": "^3.10.0",
-    "lint-staged": "^13.0.3",
+    "lint-staged": "^12.5.0",
     "log": "^6.3.1",
     "log-node": "^8.0.3",
     "mocha": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "github-release-from-cc-changelog": "^2.3.0",
     "husky": "^4.3.8",
     "jszip": "^3.10.0",
-    "lint-staged": "^12.5.0",
+    "lint-staged": "^13.0.3",
     "log": "^6.3.1",
     "log-node": "^8.0.3",
     "mocha": "^9.2.2",


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #11249

Attempting a commit with lint-staged resulted in an error, as the current version of lint-staged dropped support for node 12. Changing to lint-staged@12 resolved the issue.
