### PR TITLE
refactor: Ignore `doctor` in Compose triage

### DIFF
--- a/lib/cli/triage.js
+++ b/lib/cli/triage.js
@@ -63,6 +63,7 @@ module.exports = async () => {
     'config',
     'config credentials',
     'create',
+    'doctor',
     'generate-event',
     'install',
     'login',


### PR DESCRIPTION
Addresses: https://github.com/serverless/compose/issues/151
