### PR TITLE
Variables: Fix handling of parallel resolution of same variable

### DIFF
--- a/lib/configuration/variables/resolve.js
+++ b/lib/configuration/variables/resolve.js
@@ -175,12 +175,14 @@ class VariablesResolver {
   async resolveVariable(resolutionBatchId, propertyPath, variableMeta) {
     // Resolve a single variable, which could be configured with multiple
     // (first-choice, and fallback) sources
-    for (const source of variableMeta.sources) {
-      if (source.type) {
-        this.variableSourcesInConfig.add(source.type);
-      }
+
+    // Work on a copy, as with mulitple resolution batches, there's a rare possibility of same
+    // variable being resolved multiple times at once
+    const sources = Array.from(variableMeta.sources);
+    for (const source of sources) {
+      if (source.type) this.variableSourcesInConfig.add(source.type);
     }
-    let sourceData = variableMeta.sources[0];
+    let sourceData = sources[0];
     do {
       const sourceMeta = this.sources[sourceData.type];
       if (!sourceMeta) {
@@ -207,6 +209,7 @@ class VariablesResolver {
         if (error.code === 'MISSING_VARIABLE_DEPENDENCY') {
           // Resolution internally depends on unknown source, silently abort
           // (it'll leave variable as not resolved)
+          variableMeta.sources = sources;
           return;
         }
         // Resolution error, which signals configuration error
@@ -225,11 +228,12 @@ class VariablesResolver {
         // Source resolved with "null", but is marked as not yet fulfilled
         // (not having all data available at this point)
         // Silently abort (it'll leave variable as not resolved)
+        variableMeta.sources = sources;
         return;
       }
-      variableMeta.sources.shift();
+      sources.shift();
       const previousSourceData = sourceData;
-      sourceData = variableMeta.sources[0];
+      sourceData = sources[0];
       if (!sourceData) {
         // Last source reported no value and there's no further fallback, we treat it as an error
         // In further processing ideally it should be surfaced and prevent command from continuing


### PR DESCRIPTION
In specific scenarios, there can be multiple resolution batches which attempt to resolve same variable. Resolver internally was doing modifications on variables meta, which could result in breaking flow for other resolution that's done in parallel. 
This patch ensures it's no longer the case

Closes: #11286