### PR TITLE
feat: support custom timeout option when downloading templates #11224

### DIFF
--- a/lib/cli/commands-schema/no-service.js
+++ b/lib/cli/commands-schema/no-service.js
@@ -30,6 +30,10 @@ commands.set('', {
       usage: 'Enable Serverless Console integration. See: http://slss.io/console',
       type: 'boolean',
     },
+    'timeout': {
+      usage:
+        'Set the timeout for downloading templates in milliseconds. The default timeout is 30000 milliseconds.',
+    },
   },
   lifecycleEvents: ['initializeService', 'setupAws', 'autoUpdate', 'end'],
 });
@@ -101,6 +105,10 @@ commands.set('create', {
       usage: 'Name for the service. Overwrites the default name of the created service.',
       shortcut: 'n',
     },
+    'timeout': {
+      usage:
+        'Set the timeout for downloading templates in milliseconds. The default timeout is 30000 milliseconds.',
+    },
   },
   lifecycleEvents: ['create'],
 });
@@ -150,6 +158,10 @@ commands.set('install', {
     name: {
       usage: 'Name for the service',
       shortcut: 'n',
+    },
+    timeout: {
+      usage:
+        'Set the timeout for downloading templates in milliseconds. The default timeout is 30000 milliseconds.',
     },
   },
   lifecycleEvents: ['install'],

--- a/lib/cli/interactive-setup/service.js
+++ b/lib/cli/interactive-setup/service.js
@@ -168,7 +168,7 @@ module.exports = {
       const downloadProgress = progress.get('template-download');
       downloadProgress.notice(`Downloading template from provided url: ${templateUrl}`);
       try {
-        await downloadTemplateFromRepo(templateUrl, null, projectName);
+        await downloadTemplateFromRepo(templateUrl, null, projectName, context.options.timeout);
       } catch (err) {
         if (err.constructor.name !== 'ServerlessError') throw err;
 
@@ -204,7 +204,12 @@ module.exports = {
       const downloadProgress = progress.get('template-download');
       downloadProgress.notice(`Downloading "${projectType}" template`);
       try {
-        await downloadTemplateFromRepo(templateUrl, projectType, projectName);
+        await downloadTemplateFromRepo(
+          templateUrl,
+          projectType,
+          projectName,
+          context.options.timeout
+        );
       } catch (err) {
         if (err.code === 'ENOENT' && context.options.template) {
           throw new ServerlessError(

--- a/lib/plugins/create/create.js
+++ b/lib/plugins/create/create.js
@@ -51,6 +51,7 @@ class Create {
         name: this.options.name,
         path: this.options.path,
         isLegacy: true,
+        timeout: this.options.timeout,
       });
 
       log.notice();
@@ -81,7 +82,8 @@ class Create {
         .downloadTemplateFromRepo(
           this.options['template-url'],
           this.options.name,
-          this.options.path
+          this.options.path,
+          this.options.timeout
         )
         .then((serviceName) => {
           log.notice();

--- a/lib/plugins/install.js
+++ b/lib/plugins/install.js
@@ -27,7 +27,9 @@ class Install {
     progress.get('main').notice(`Downloading service from provided url: ${this.options.url}`);
     const serviceName = await download.downloadTemplateFromRepo(
       this.options.url,
-      this.options.name
+      this.options.name,
+      null,
+      this.options.timeout
     );
     const message = [
       `Successfully installed "${serviceName}" `,

--- a/lib/utils/download-template-from-examples.js
+++ b/lib/utils/download-template-from-examples.js
@@ -20,7 +20,13 @@ const resolveServiceName = (serviceDir) => {
   return serviceName;
 };
 
-async function downloadTemplateFromExamples({ template, name, path: projectPath, isLegacy }) {
+async function downloadTemplateFromExamples({
+  template,
+  name,
+  path: projectPath,
+  isLegacy,
+  timeout,
+}) {
   const downloadUrl = 'https://github.com/serverless/examples/archive/v3.zip';
   let pathToDirectory;
   if (isLegacy) {
@@ -44,7 +50,7 @@ async function downloadTemplateFromExamples({ template, name, path: projectPath,
   }
 
   const downloadOptions = {
-    timeout: 30000,
+    timeout: +timeout || 30000,
     extract: true,
     strip: 1,
     mode: '755',

--- a/lib/utils/download-template-from-repo.js
+++ b/lib/utils/download-template-from-repo.js
@@ -261,9 +261,10 @@ async function parseRepoURL(inputUrl) {
  * @param {string} inputUrl
  * @param {string} [templateName]
  * @param {string} [path]
+ * @param {(string|number)} [timeout]
  * @returns {Promise}
  */
-async function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
+async function downloadTemplateFromRepo(inputUrl, templateName, downloadPath, timeout) {
   return parseRepoURL(inputUrl).then((repoInformation) => {
     let serviceName;
     let dirName;
@@ -297,7 +298,7 @@ async function downloadTemplateFromRepo(inputUrl, templateName, downloadPath) {
     }
 
     const downloadOptions = {
-      timeout: 30000,
+      timeout: +timeout || 30000,
       extract: true,
       strip: 1,
       mode: '755',


### PR DESCRIPTION
When `server create` encounters the problem of downloading template timeout, you can avoid it by customizing the timeout setting.

```
Error:
RequestError: Timeout awaiting 'request' for 30000ms
    at ClientRequest.<anonymous> (/Users/TechBirds/code/hundsun/severless/sc/serverless/node_modules/got/dist/source/core/index.js:970:65)
    at Object.onceWrapper (node:events:640:26)
    at ClientRequest.emit (node:events:532:35)
    at ClientRequest.emit (node:domain:475:12)
    at ClientRequest.origin.emit (/Users/TechBirds/code/hundsun/severless/sc/serverless/node_modules/@szmarczak/http-timer/dist/source/index.js:43:20)
    at TLSSocket.socketErrorListener (node:_http_client:442:9)
    at TLSSocket.emit (node:events:520:28)
    at TLSSocket.emit (node:domain:475:12)
    at emitErrorNT (node:internal/streams/destroy:157:8)
    at emitErrorCloseNT (node:internal/streams/destroy:122:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
    at Timeout.timeoutHandler [as _onTimeout] (/Users/TechBirds/code/h
```

use case :

````
serverless create --template knative-docker --path my-service2 --debug="*" --timeout 60000
````

Closes: #11224 
