### PR TITLE
Change endpoint type to uppercase in documentation

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -239,7 +239,7 @@ provider:
   # Use a custom name for the API Gateway API
   apiName: custom-api-name
   # Endpoint type for API Gateway REST API: edge or regional (default: edge)
-  endpointType: regional
+  endpointType: REGIONAL
   # Use a custom name for the websockets API
   websocketsApiName: custom-websockets-api-name
   # custom route selection expression


### PR DESCRIPTION
This pull request changes the case of the `endpointType` value in the documentation, while case [doesn't matter](https://github.com/serverless/serverless/blob/38fe02ef81ac60967852dd4489e5f6dfec3ce3b3/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js#L18-L31) this makes it consistent with the use elsewhere in Serverless and AWS.