### PR TITLE
docs: Add missing line in Shared Authorizer example

### DIFF
--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1627,10 +1627,11 @@ functions:
       - http:
           path: /users/{userId}
           ...
-          # Provide both type and authorizerId
-          type: COGNITO_USER_POOLS # TOKEN or REQUEST or COGNITO_USER_POOLS, same as AWS Cloudformation documentation
-          authorizerId:
-            Ref: ApiGatewayAuthorizer # or hard-code Authorizer ID
+          authorizer:
+            # Provide both type and authorizerId
+            type: COGNITO_USER_POOLS # TOKEN or REQUEST or COGNITO_USER_POOLS, same as AWS Cloudformation documentation
+            authorizerId:
+              Ref: ApiGatewayAuthorizer # or hard-code Authorizer ID
 
 resources:
   Resources:


### PR DESCRIPTION
The documentation on using shared authorizer seemed misleading, as in one of the two examples the authorizer specifiers (`type` and `authorizerId` properties) were not nested under the `authorizer` property.

Added a missing line specifying the 'authorizer' property as a parent for `authorizerId` and `type` properties.
