### PR TITLE
Improves error message when pool missing

### DIFF
--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/handler.js
@@ -21,7 +21,11 @@ async function create(event, context) {
 
   const lambdaArn = getLambdaArn(Partition, Region, AccountId, FunctionName);
 
-  return findUserPoolByName({ userPoolName: UserPoolName, region: Region }).then((userPool) =>
+  return findUserPoolByName({ userPoolName: UserPoolName, region: Region }).then((userPool) => {
+    if (userPool === undefined) {
+      throw new Error(`Unable to find a Cognito user pool named ${userPoolName}`);
+    }
+    
     addPermission({
       functionName: FunctionName,
       userPoolName: UserPoolName,
@@ -37,7 +41,7 @@ async function create(event, context) {
         region: Region,
       })
     )
-  );
+  });
 }
 
 async function update(event, context) {


### PR DESCRIPTION
I accidentally miss-spelled the name of a Cognito user pool and got a very cryptic error message about `Id` not being a property of undefined and to check CloudWatch Logs for details but it didn't say which log group.

Anyway, hopefully this makes it easier to tell what's wrong.

So far this is an untested, quick and dirty submission from GitHub's web UI.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}
