### PR TITLE
docs: Default to nodejs14.x in AWS docs

### DIFF
--- a/docs/providers/aws/cli-reference/print.md
+++ b/docs/providers/aws/cli-reference/print.md
@@ -44,7 +44,9 @@ custom:
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
+
+.x
 
 functions:
   hello:
@@ -67,7 +69,7 @@ custom:
   bucketName: test
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   stage: dev # <-- Resolved
 functions:
   hello:

--- a/docs/providers/aws/cli-reference/print.md
+++ b/docs/providers/aws/cli-reference/print.md
@@ -46,8 +46,6 @@ provider:
   name: aws
   runtime: nodejs14.x
 
-.x
-
 functions:
   hello:
     handler: handler.hello

--- a/docs/providers/aws/events/apigateway.md
+++ b/docs/providers/aws/events/apigateway.md
@@ -1467,7 +1467,7 @@ service: my-api
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   stage: dev
   region: eu-west-2
 
@@ -1656,7 +1656,7 @@ Resource policies are policy documents that are used to control the invocation o
 ```yml
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
 
   apiGateway:
     resourcePolicy:

--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -75,7 +75,7 @@ service: serverless-ws-test
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   websocketsApiName: custom-websockets-api-name
   websocketsApiRouteSelectionExpression: $request.body.action # custom routes are selected by the value of the action property in the body
   websocketsDescription: Custom Serverless Websockets

--- a/docs/providers/aws/guide/credentials.md
+++ b/docs/providers/aws/guide/credentials.md
@@ -156,7 +156,7 @@ You can even set up different profiles for different accounts, which can be used
 service: new-service
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   stage: dev
   profile: devProfile
 ```
@@ -204,7 +204,7 @@ This example `serverless.yml` snippet will load the profile depending upon the s
 service: new-service
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   profile: ${self:custom.profiles.${sls:stage}}
 custom:
   profiles:

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -685,7 +685,6 @@ service: myService
 provider:
   name: aws
   runtime: nodejs14.x
-  
   tracing:
     lambda: true
 ```

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -133,7 +133,6 @@ service: myService
 provider:
   name: aws
   runtime: nodejs14.x
-
   iam:
     role:
       statements: # permissions for all of your functions can be set here

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -24,7 +24,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   memorySize: 512 # optional, in MB, default is 1024
   timeout: 10 # optional, in seconds, default is 6
   versionFunctions: false # optional, default is true
@@ -60,7 +60,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
 
 functions:
   functionOne:
@@ -80,7 +80,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   memorySize: 512 # will be inherited by all functions
 
 functions:
@@ -96,7 +96,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
 
 functions:
   functionOne:
@@ -132,7 +132,8 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
+
   iam:
     role:
       statements: # permissions for all of your functions can be set here
@@ -631,7 +632,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
 
 functions:
   hello:
@@ -684,7 +685,8 @@ service: myService
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
+  
   tracing:
     lambda: true
 ```

--- a/docs/providers/aws/guide/services.md
+++ b/docs/providers/aws/guide/services.md
@@ -176,7 +176,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   memorySize: 512
 
 …
@@ -193,7 +193,7 @@ service: users
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   memorySize: 512
 
 …

--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -210,7 +210,7 @@ You can add such custom output to CloudFormation stack. For example:
 service: another-service
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   region: ap-northeast-1
   memorySize: 512
 functions:

--- a/docs/providers/azure/guide/serverless.yml.md
+++ b/docs/providers/azure/guide/serverless.yml.md
@@ -25,7 +25,7 @@ frameworkVersion: '3'
 provider:
   name: azure
   region: West US 2
-  runtime: nodejs12.x
+  runtime: nodejs14.x
   prefix: sample # prefix of generated resource name
   subscriptionId: 00000000-0000-0000-0000-000000000000
   stage: dev # Default stage to be used


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Changes deafult nodejs version from 12.x to 14.x in docs for AWS provider.
AWS is ending support fon nodejs12.x during late 2022. Read more here: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy
