### PR TITLE
feat(AWS Lambda): Add support for consumer group ID to kafka event

### DIFF
--- a/docs/providers/aws/events/kafka.md
+++ b/docs/providers/aws/events/kafka.md
@@ -21,6 +21,10 @@ In order to configure lambda to trigger via `kafka` events, you must provide thr
 - `topic` to consume messages from
 - `bootstrapServers` - an array of bootstrap server addresses for your Kafka cluster
 
+Optionally, you can provide the following properties:
+
+- `consumerGroupId` - the consumer group id to use for consuming messages
+
 ## Authentication
 
 You must authenticate your Lambda with a self-managed Apache Kafka cluster using one of;
@@ -72,6 +76,7 @@ functions:
           accessConfigurations:
             saslScram512Auth: arn:aws:secretsmanager:us-east-1:01234567890:secret:MyBrokerSecretName
           topic: MySelfManagedKafkaTopic
+          consumerGroupId: MyConsumerGroupId
           bootstrapServers:
             - abc3.xyz.com:9092
             - abc2.xyz.com:9092
@@ -91,6 +96,7 @@ functions:
             clientCertificateTlsAuth: arn:aws:secretsmanager:us-east-1:01234567890:secret:ClientCertificateTLS
             serverRootCaCertificate: arn:aws:secretsmanager:us-east-1:01234567890:secret:ServerRootCaCertificate
           topic: MySelfManagedMTLSKafkaTopic
+          consumerGroupId: MyConsumerGroupId
           bootstrapServers:
             - abc3.xyz.com:9092
             - abc2.xyz.com:9092

--- a/docs/providers/aws/events/msk.md
+++ b/docs/providers/aws/events/msk.md
@@ -64,6 +64,26 @@ functions:
           startingPosition: LATEST
 ```
 
+Optionally, you can provide the following properties:
+
+- `consumerGroupId` - the consumer group id to use for consuming messages
+
+For example:
+
+```yml
+functions:
+  compute:
+    handler: handler.compute
+    events:
+      - msk:
+          arn: arn:aws:kafka:region:XXXXXX:cluster/MyCluster/xxxx-xxxxx-xxxx
+          topic: mytopic
+          batchSize: 1000
+          maximumBatchingWindow: 30
+          startingPosition: LATEST
+          consumerGroupId: MyConsumerGroupId
+```
+
 ## Enabling and disabling MSK event
 
 The `msk` event also supports `enabled` parameter, which is used to control if the event source mapping is active. Setting it to `false` will pause polling for and processing new messages.

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -970,6 +970,8 @@ functions:
           enabled: false
           # Optional, arn of the secret key for authenticating with the brokers in your MSK cluster.
           saslScram512: arn:aws:secretsmanager:region:XXXXXX:secret:AmazonMSK_xxxxxx
+          # Optional, specifies the consumer group ID to be used when consuming from Kafka. If not provided, a random UUID will be generated
+          consumerGroupId: MyConsumerGroupId
 ```
 
 ### ActiveMQ
@@ -1025,6 +1027,8 @@ functions:
           startingPosition: LATEST
           # (default: true)
           enabled: false
+          # Optional, specifies the consumer group ID to be used when consuming from Kafka. If not provided, a random UUID will be generated
+          consumerGroupId: MyConsumerGroupId
 ```
 
 ### RabbitMQ

--- a/lib/plugins/aws/package/compile/events/kafka.js
+++ b/lib/plugins/aws/package/compile/events/kafka.js
@@ -89,6 +89,11 @@ class AwsCompileKafkaEvents {
         topic: {
           type: 'string',
         },
+        consumerGroupId: {
+          type: 'string',
+          maxLength: 200,
+          pattern: '[a-zA-Z0-9-\/*:_+=.@-]*'
+        }
       },
       additionalProperties: false,
       required: ['accessConfigurations', 'bootstrapServers', 'topic'],
@@ -142,7 +147,7 @@ class AwsCompileKafkaEvents {
         }
 
         hasKafkaEvent = true;
-        const { topic, batchSize, maximumBatchingWindow, enabled } = event.kafka;
+        const { topic, batchSize, maximumBatchingWindow, enabled, consumerGroupId } = event.kafka;
         const startingPosition = event.kafka.startingPosition || 'TRIM_HORIZON';
 
         const kafkaEventLogicalId = this.provider.naming.getKafkaEventLogicalId(
@@ -163,7 +168,7 @@ class AwsCompileKafkaEvents {
             SelfManagedEventSource: {
               Endpoints: { KafkaBootstrapServers: event.kafka.bootstrapServers },
             },
-            Topics: [topic],
+            Topics: [topic]
           },
         };
 
@@ -230,6 +235,15 @@ class AwsCompileKafkaEvents {
 
         if (enabled != null) {
           kafkaResource.Properties.Enabled = enabled;
+        }
+
+        if (consumerGroupId) {
+          kafkaResource.Properties.SelfManagedKafkaEventSourceConfig = {
+            ConsumerGroupId: consumerGroupId,
+          };
+          kafkaResource.Properties.AmazonManagedKafkaEventSourceConfig = {
+            ConsumerGroupId: consumerGroupId,
+          };
         }
 
         cfTemplate.Resources[kafkaEventLogicalId] = kafkaResource;

--- a/lib/plugins/aws/package/compile/events/kafka.js
+++ b/lib/plugins/aws/package/compile/events/kafka.js
@@ -92,8 +92,8 @@ class AwsCompileKafkaEvents {
         consumerGroupId: {
           type: 'string',
           maxLength: 200,
-          pattern: '[a-zA-Z0-9-\/*:_+=.@-]*'
-        }
+          pattern: '[a-zA-Z0-9-/*:_+=.@-]*',
+        },
       },
       additionalProperties: false,
       required: ['accessConfigurations', 'bootstrapServers', 'topic'],
@@ -168,7 +168,7 @@ class AwsCompileKafkaEvents {
             SelfManagedEventSource: {
               Endpoints: { KafkaBootstrapServers: event.kafka.bootstrapServers },
             },
-            Topics: [topic]
+            Topics: [topic],
           },
         };
 

--- a/lib/plugins/aws/package/compile/events/kafka.js
+++ b/lib/plugins/aws/package/compile/events/kafka.js
@@ -241,9 +241,6 @@ class AwsCompileKafkaEvents {
           kafkaResource.Properties.SelfManagedKafkaEventSourceConfig = {
             ConsumerGroupId: consumerGroupId,
           };
-          kafkaResource.Properties.AmazonManagedKafkaEventSourceConfig = {
-            ConsumerGroupId: consumerGroupId,
-          };
         }
 
         cfTemplate.Resources[kafkaEventLogicalId] = kafkaResource;

--- a/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/lib/plugins/aws/package/compile/events/msk/index.js
@@ -42,6 +42,11 @@ class AwsCompileMSKEvents {
           type: 'string',
         },
         saslScram512: { $ref: '#/definitions/awsArnString' },
+        consumerGroupId: {
+          type: 'string',
+          maxLength: 200,
+          pattern: '[a-zA-Z0-9-/*:_+=.@-]*',
+        },
       },
       additionalProperties: false,
       required: ['arn', 'topic'],
@@ -81,6 +86,7 @@ class AwsCompileMSKEvents {
           const enabled = event.msk.enabled;
           const startingPosition = event.msk.startingPosition || 'TRIM_HORIZON';
           const saslScram512 = event.msk.saslScram512;
+          const consumerGroupId = event.msk.consumerGroupId;
 
           const mskClusterNameToken = getMskClusterNameToken(eventSourceArn);
           const mskEventLogicalId = this.provider.naming.getMSKEventLogicalId(
@@ -112,6 +118,12 @@ class AwsCompileMSKEvents {
 
           if (maximumBatchingWindow) {
             mskResource.Properties.MaximumBatchingWindowInSeconds = maximumBatchingWindow;
+          }
+
+          if (consumerGroupId) {
+            mskResource.Properties.AmazonManagedKafkaEventSourceConfig = {
+              ConsumerGroupId: consumerGroupId,
+            };
           }
 
           if (enabled != null) {

--- a/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
@@ -518,6 +518,46 @@ describe('test/unit/lib/plugins/aws/package/compile/events/kafka.test.js', () =>
         command: 'package',
       });
 
+      it('should correctly compile EventSourceMapping resource properties for ConsumerGroupId', async () => {
+        const eventConfig = {
+          event: {
+            topic,
+            bootstrapServers: ['abc.xyz:9092'],
+            accessConfigurations: {
+              clientCertificateTlsAuth: clientCertificateTlsAuthArn,
+            },
+            consumerGroupId: 'my-consumer-group-id',
+          },
+          resource: (awsNaming) => {
+            return {
+              SelfManagedEventSource: {
+                Endpoints: {
+                  KafkaBootstrapServers: ['abc.xyz:9092'],
+                },
+              },
+              SourceAccessConfigurations: [
+                {
+                  Type: 'CLIENT_CERTIFICATE_TLS_AUTH',
+                  URI: clientCertificateTlsAuthArn,
+                },
+              ],
+              StartingPosition: 'TRIM_HORIZON',
+              Topics: [topic],
+              FunctionName: {
+                'Fn::GetAtt': [awsNaming.getLambdaLogicalId('basic'), 'Arn'],
+              },
+              SelfManagedKafkaEventSourceConfig: {
+                ConsumerGroupId: 'my-consumer-group-id',
+              },
+              AmazonManagedKafkaEventSourceConfig: {
+                ConsumerGroupId: 'my-consumer-group-id',
+              },
+            };
+          },
+        };
+        await runCompileEventSourceMappingTest(eventConfig);
+      });
+
       const eventSourceMappingResource =
         cfTemplate.Resources[awsNaming.getKafkaEventLogicalId('basic', 'TestingTopic')];
       expect(eventSourceMappingResource.DependsOn).to.deep.equal([]);

--- a/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
@@ -457,6 +457,46 @@ describe('test/unit/lib/plugins/aws/package/compile/events/kafka.test.js', () =>
         await runCompileEventSourceMappingTest(eventConfig);
       });
 
+      it('should correctly compile EventSourceMapping resource properties for ConsumerGroupId', async () => {
+        const eventConfig = {
+          event: {
+            topic,
+            bootstrapServers: ['abc.xyz:9092'],
+            accessConfigurations: {
+              clientCertificateTlsAuth: clientCertificateTlsAuthArn,
+            },
+            consumerGroupId: 'my-consumer-group-id',
+          },
+          resource: (awsNaming) => {
+            return {
+              SelfManagedEventSource: {
+                Endpoints: {
+                  KafkaBootstrapServers: ['abc.xyz:9092'],
+                },
+              },
+              SourceAccessConfigurations: [
+                {
+                  Type: 'CLIENT_CERTIFICATE_TLS_AUTH',
+                  URI: clientCertificateTlsAuthArn,
+                },
+              ],
+              StartingPosition: 'TRIM_HORIZON',
+              Topics: [topic],
+              FunctionName: {
+                'Fn::GetAtt': [awsNaming.getLambdaLogicalId('basic'), 'Arn'],
+              },
+              SelfManagedKafkaEventSourceConfig: {
+                ConsumerGroupId: 'my-consumer-group-id',
+              },
+              AmazonManagedKafkaEventSourceConfig: {
+                ConsumerGroupId: 'my-consumer-group-id',
+              },
+            };
+          },
+        };
+        await runCompileEventSourceMappingTest(eventConfig);
+      });
+
       it('should update default IAM role with EC2 statement when VPC accessConfiguration is provided', async () => {
         const { cfTemplate } = await runServerless({
           fixture: 'function',
@@ -516,46 +556,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/kafka.test.js', () =>
           },
         },
         command: 'package',
-      });
-
-      it('should correctly compile EventSourceMapping resource properties for ConsumerGroupId', async () => {
-        const eventConfig = {
-          event: {
-            topic,
-            bootstrapServers: ['abc.xyz:9092'],
-            accessConfigurations: {
-              clientCertificateTlsAuth: clientCertificateTlsAuthArn,
-            },
-            consumerGroupId: 'my-consumer-group-id',
-          },
-          resource: (awsNaming) => {
-            return {
-              SelfManagedEventSource: {
-                Endpoints: {
-                  KafkaBootstrapServers: ['abc.xyz:9092'],
-                },
-              },
-              SourceAccessConfigurations: [
-                {
-                  Type: 'CLIENT_CERTIFICATE_TLS_AUTH',
-                  URI: clientCertificateTlsAuthArn,
-                },
-              ],
-              StartingPosition: 'TRIM_HORIZON',
-              Topics: [topic],
-              FunctionName: {
-                'Fn::GetAtt': [awsNaming.getLambdaLogicalId('basic'), 'Arn'],
-              },
-              SelfManagedKafkaEventSourceConfig: {
-                ConsumerGroupId: 'my-consumer-group-id',
-              },
-              AmazonManagedKafkaEventSourceConfig: {
-                ConsumerGroupId: 'my-consumer-group-id',
-              },
-            };
-          },
-        };
-        await runCompileEventSourceMappingTest(eventConfig);
       });
 
       const eventSourceMappingResource =

--- a/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
@@ -488,9 +488,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/kafka.test.js', () =>
               SelfManagedKafkaEventSourceConfig: {
                 ConsumerGroupId: 'my-consumer-group-id',
               },
-              AmazonManagedKafkaEventSourceConfig: {
-                ConsumerGroupId: 'my-consumer-group-id',
-              },
             };
           },
         };

--- a/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
@@ -16,6 +16,7 @@ describe('AwsCompileMSKEvents', () => {
   const maximumBatchingWindow = 10;
   const saslScram512 =
     'arn:aws:secretsmanager:us-east-1:111111111111:secret:AmazonMSK_a1a1a1a1a1a1a1a1';
+  const consumerGroupId = 'TestConsumerGroupId';
   const sourceAccessConfigurations = [
     {
       Type: 'SASL_SCRAM_512_AUTH',
@@ -55,6 +56,7 @@ describe('AwsCompileMSKEvents', () => {
                     enabled,
                     startingPosition,
                     saslScram512,
+                    consumerGroupId,
                   },
                 },
               ],
@@ -121,6 +123,9 @@ describe('AwsCompileMSKEvents', () => {
         Topics: [topic],
         FunctionName: {
           'Fn::GetAtt': [naming.getLambdaLogicalId('other'), 'Arn'],
+        },
+        AmazonManagedKafkaEventSourceConfig: {
+          ConsumerGroupId: consumerGroupId,
         },
       });
     });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Context: this has just been added to the event trigger as a feature and is an extremely useful missing feature: https://aws.amazon.com/about-aws/whats-new/2022/08/aws-lambda-consumer-group-ids-msk-kafka-event-sources/

Closes: (No issue created yet for this)
