### PR TITLE
Add block Deployment method to Upgrade guide

### DIFF
--- a/docs/guides/upgrading-v3.md
+++ b/docs/guides/upgrading-v3.md
@@ -137,6 +137,19 @@ service: my-service
 
 All options that used to be defined inside the `service` key have been moved to other sections (mentioned below in that document). This change clears up confusion that existed between the `service` and `provider` sections.
 
+### Deployment method
+
+Since Serverless Framework v3, deployments are done using [CloudFormation change sets](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html). It is possible to use [CloudFormation direct deployments](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-direct.html) instead.
+
+Direct deployments **are faster** and have no downsides (unless you specifically use the generated change sets). They will become the default in Serverless Framework 4.
+
+You are encouraged to enable direct deployments via the deploymentMethod option:
+
+```yaml
+provider:	
+  deploymentMethod: direct
+```
+
 ### API Gateway
 
 When configuring API Gateway, some configuration options have moved to a dedicated sub-section of `provider`. That will help clear up confusion with similar `httpApi` settings.


### PR DESCRIPTION
I feel like this deserves a spot in the upgrade guide, as many people (including me) have noticed slower deploys when upgrading to serverless 3. See https://github.com/serverless/serverless/issues/10815

Copied from https://github.com/serverless/serverless/blob/main/docs/providers/aws/guide/deploying.md#deployment-method