### PR TITLE
feat(AWS Local Invocation): Support loading ESModules with .mjs extensions

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -842,10 +842,18 @@ class AwsInvokeLocal {
           pathToHandler = `${pathToHandler}.cjs`;
           try {
             return require(pathToHandler);
-          } catch (innerError) {
-            // Throw original error if still "MODULE_NOT_FOUND", as not finding module with `.cjs` might be confusing
-            if (innerError.code !== 'MODULE_NOT_FOUND') {
-              throw innerError;
+          } catch (cjsInnerError) {
+            if (cjsInnerError.code !== 'MODULE_NOT_FOUND') {
+              throw cjsInnerError;
+            }
+            // Attempt to load `.mjs` extension
+            try {
+              return await import(`file:///${modulePath}.mjs`);
+            } catch (mjsInnerError) {
+              if (mjsInnerError.code !== 'MODULE_NOT_FOUND') {
+                throw mjsInnerError;
+                // Throw original error if still "MODULE_NOT_FOUND", as not finding module with `.cjs` might be confusing
+              }
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -122,6 +122,15 @@
       },
       {
         "files": [
+          "test/fixtures/programmatic/invocation/cjs/**"
+        ],
+        "parserOptions": {
+          "sourceType": "module",
+          "allowImportExportEverywhere": true
+        }
+      },
+      {
+        "files": [
           "test/fixtures/programmatic/plugin/local-esm-plugin/**",
           "test/fixtures/programmatic/plugin/node_modules/esm-plugin/**",
           "test/fixtures/programmatic/invocation/esm/**"

--- a/test/fixtures/programmatic/invocation/cjs/async-esm-mjs-in-commonjs-package-type.mjs
+++ b/test/fixtures/programmatic/invocation/cjs/async-esm-mjs-in-commonjs-package-type.mjs
@@ -1,0 +1,15 @@
+export const handler = async (event, context) => {
+    if (event && event.shouldFail) throw new Error('Failed on request');
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: 'Invoked',
+        event,
+        clientContext: context.clientContext,
+        env: process.env,
+      }),
+    };
+  };
+  
+  export default handler;
+  

--- a/test/fixtures/programmatic/invocation/cjs/package.json
+++ b/test/fixtures/programmatic/invocation/cjs/package.json
@@ -1,0 +1,4 @@
+{
+    "type": "commonjs"
+  }
+  

--- a/test/fixtures/programmatic/invocation/esm/async-esm-mjs-in-module-package-type.mjs
+++ b/test/fixtures/programmatic/invocation/esm/async-esm-mjs-in-module-package-type.mjs
@@ -1,0 +1,15 @@
+export const handler = async (event, context) => {
+    if (event && event.shouldFail) throw new Error('Failed on request');
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message: 'Invoked',
+        event,
+        clientContext: context.clientContext,
+        env: process.env,
+      }),
+    };
+  };
+  
+  export default handler;
+  

--- a/test/fixtures/programmatic/invocation/serverless.yml
+++ b/test/fixtures/programmatic/invocation/serverless.yml
@@ -16,6 +16,10 @@ functions:
     handler: async-cjs.handler
   asyncEsm:
     handler: esm/async-esm.handler
+  asyncEsmMjsInModulePackageType:
+    handler: esm/async-esm-mjs-in-module-package-type.handler
+  asyncEsmMjsInCommonjsPackageType:
+    handler: cjs/async-esm-mjs-in-commonjs-package-type.handler
   contextDone:
     handler: context-done.handler
   contextSucceed:

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -1194,6 +1194,24 @@ describe('test/unit/lib/plugins/aws/invokeLocal/index.test.js', () => {
 
       expect(output).to.include('Invoked');
     });
+    it('should support loading handlers that are ES modules with `.mjs` extension in packages of `module` type', async () => {
+      const { output } = await runServerless({
+        fixture: 'invocation',
+        command: 'invoke local',
+        options: { function: 'asyncEsmMjsInModulePackageType' },
+      });
+
+      expect(output).to.include('Invoked');
+    });
+    it('should support loading handlers that are ES modules with `.mjs` extension in packages of `commonjs` type', async () => {
+      const { output } = await runServerless({
+        fixture: 'invocation',
+        command: 'invoke local',
+        options: { function: 'asyncEsmMjsInCommonjsPackageType' },
+      });
+
+      expect(output).to.include('Invoked');
+    });
   });
 
   describe('Python', () => {


### PR DESCRIPTION
Q1: Provide a link to the corresponding issue

Closes https://github.com/serverless/serverless/pull/11212
