### PR TITLE
Add bucket name to exception

### DIFF
--- a/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
+++ b/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
@@ -31,7 +31,7 @@ module.exports = {
         });
       } catch (err) {
         throw new ServerlessError(
-          `Could not locate deployment bucket. Error: ${err.message}`,
+          `Could not locate deployment bucket: "${this.bucketName}". Error: ${err.message}`,
           'DEPLOYMENT_BUCKET_NOT_FOUND'
         );
       }


### PR DESCRIPTION
When the deployment bucket is not found, add the bucket name to the exception so that it is easier to determine what is wrong.

This is especially useful when the specified bucket name is an interpolated string and confirming variables are properly being set is useful.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #11387.

Thanks!
