### PR TITLE
fix(AWS CloudFront): Do not define CachePolicyId if behavior includes ForwardedValues to support legacy cache configuration

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloud-front.js
+++ b/lib/plugins/aws/package/compile/events/cloud-front.js
@@ -138,6 +138,40 @@ class AwsCompileCloudFrontEvents {
             anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfRef' }],
           },
         },
+        MaxTTL: { type: 'number' },
+        MinTTL: { type: 'number' },
+        DefaultTTL: { type: 'number' },
+        ForwardedValues: {
+          type: 'object',
+          properties: {
+            Cookies: {
+              anyOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    Forward: { enum: ['all', 'none'] },
+                  },
+                  additionalProperties: false,
+                  required: ['Forward'],
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    Forward: { const: 'whitelist' },
+                    WhitelistedNames: { type: 'array', items: { type: 'string' } },
+                  },
+                  additionalProperties: false,
+                  required: ['Forward', 'WhitelistedNames'],
+                },
+              ],
+            },
+            Headers: { type: 'array', items: { type: 'string' } },
+            QueryString: { type: 'boolean' },
+            QueryStringCacheKeys: { type: 'array', items: { type: 'string' } },
+          },
+          additionalProperties: false,
+          required: ['QueryString'],
+        },
       },
       additionalProperties: false,
     };
@@ -388,6 +422,16 @@ class AwsCompileCloudFrontEvents {
               Object.assign(behavior, {
                 CachePolicyId: event.cloudFront.behavior.CachePolicyId,
               });
+              shouldAssignCachePolicy = false;
+            }
+
+            if (
+              event.cloudFront.behavior &&
+              (event.cloudFront.behavior.ForwardedValues ||
+                event.cloudFront.behavior.MaxTTL != null ||
+                event.cloudFront.behavior.MinTTL != null ||
+                event.cloudFront.behavior.DefaultTTL != null)
+            ) {
               shouldAssignCachePolicy = false;
             }
 

--- a/test/unit/lib/plugins/aws/package/compile/events/cloud-front.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloud-front.test.js
@@ -1910,6 +1910,29 @@ describe('test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js', 
                 },
               ],
             },
+            fnLegacyCacheSettings: {
+              handler: 'myLambdaAtEdge.handler',
+              events: [
+                {
+                  cloudFront: {
+                    origin: 's3://bucketname.s3.amazonaws.com',
+                    eventType: 'viewer-response',
+                    pathPattern: 'legacyCacheSettings',
+                    behavior: {
+                      MaxTTL: 0,
+                      MinTTL: 0,
+                      DefaultTTL: 0,
+                      ForwardedValues: {
+                        QueryString: true,
+                        Cookies: {
+                          Forward: 'none',
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+            },
           },
         },
       });
@@ -2052,6 +2075,18 @@ describe('test/unit/lib/plugins/aws/package/compile/events/cloudFront.test.js', 
       // Default Managed-CachingOptimized Cache Policy id
       const defaultCachePolicyId = '658327ea-f89d-4fab-a63d-7e88639e58f6';
       expect(getAssociatedCacheBehavior('noPolicy').CachePolicyId).to.eq(defaultCachePolicyId);
+    });
+
+    it('Should use legacy cache settings', () => {
+      expect(getAssociatedCacheBehavior('legacyCacheSettings')).not.to.contain.keys(
+        'CachePolicyId'
+      );
+      expect(getAssociatedCacheBehavior('legacyCacheSettings')).to.contain.keys(
+        'MinTTL',
+        'MaxTTL',
+        'DefaultTTL',
+        'ForwardedValues'
+      );
     });
   });
 });


### PR DESCRIPTION
https://github.com/serverless/serverless/issues/11410

Ignore `CachePolicyId` default assignation if `ForwardedValues` is defined.

```diff
          "DefaultCacheBehavior": {
            "ViewerProtocolPolicy": "allow-all",
            "MaxTTL": 0,
            "MinTTL": 0,
            "DefaultTTL": 0,
++          "ForwardedValues": {
++            "QueryString": true,
++            "Cookies": {
++              "Forward": "none"
++            }
++          },
---        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
            "TargetOriginId": "custom/google.com",
            "LambdaFunctionAssociations": [
              {
                "EventType": "origin-request",
                "LambdaFunctionARN": {
                  "Ref": "PassThroughLambdaVersion28byJfevyEHabjRi2s8Ymoq4ZN5ReW4oOg85Ai1yfiw"
                }
              }
            ]
          }
```