### PR TITLE
docs: remove `http: path` in Google Provider function config examples

### DIFF
--- a/docs/providers/google/examples/hello-world/node/serverless.yml
+++ b/docs/providers/google/examples/hello-world/node/serverless.yml
@@ -20,4 +20,4 @@ functions:
   helloWorld:
     handler: http
     events:
-      - http: path
+      - http: true

--- a/docs/providers/google/examples/hello-world/python/serverless.yml
+++ b/docs/providers/google/examples/hello-world/python/serverless.yml
@@ -20,4 +20,4 @@ functions:
   helloWorld:
     handler: http
     events:
-      - http: path
+      - http: true

--- a/docs/providers/google/guide/events.md
+++ b/docs/providers/google/guide/events.md
@@ -32,7 +32,7 @@ functions:
   first: # Function name
     handler: http # Reference to file index.js & exported function 'http'
     events: # All events associated with this function
-      - http: path
+      - http: true
 ```
 
 **Note:** Currently only one event definition per function is supported.

--- a/docs/providers/google/guide/functions.md
+++ b/docs/providers/google/guide/functions.md
@@ -34,7 +34,7 @@ functions:
   first:
     handler: http
     events:
-      - http: path
+      - http: true
 ```
 
 You can specify an array of functions, which is useful if you separate your functions in to different files:
@@ -163,13 +163,13 @@ functions:
   first:
     handler: httpFirst
     events:
-      - http: path
+      - http: true
     labels:
       team: gcf-team
   second:
     handler: httpSecond
     events:
-      - http: path
+      - http: true
     labels:
       application: serverless-example_documentation
 ```


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Unlike AWS, Google Cloud Function cannot manually specify the URL to use for HTTP endpoints. This is explained on this page: https://www.serverless.com/framework/docs/providers/google/events/http

Having an example value of `path` may erroneously suggest to the reader that you can specify a url path, however the actual value is ignored & only the presence of the `http` key is checked. The value `true` can better communicate this
