### PR TITLE
fix: Set API gateway timeout to 30 seconds by default

### DIFF
--- a/lib/plugins/aws/package/compile/events/http-api.js
+++ b/lib/plugins/aws/package/compile/events/http-api.js
@@ -624,6 +624,7 @@ Object.defineProperties(
         IntegrationType: 'AWS_PROXY',
         IntegrationUri: resolveTargetConfig(routeTargetData),
         PayloadFormatVersion: funcHttpApi.payload || providerHttpApi.payload || '2.0',
+        TimeoutInMillis: 30000,
       };
       this.cfTemplate.Resources[
         this.provider.naming.getHttpApiIntegrationLogicalId(routeTargetData.functionName)

--- a/test/unit/lib/plugins/aws/package/compile/events/http-api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/http-api.test.js
@@ -129,9 +129,9 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
       expect(resource.Properties.RouteKey).to.equal(routeKey);
     });
 
-    it('should let the default api gateway timeout by not setting the TimeoutInMillis property', () => {
+    it('should set the default api gateway timeout by setting the TimeoutInMillis property', () => {
       const resource = cfResources[naming.getHttpApiIntegrationLogicalId('foo')];
-      expect(resource.Properties.TimeoutInMillis).to.be.undefined;
+      expect(resource.Properties.TimeoutInMillis).to.equal(30000);
     });
 
     it('should configure lambda permissions', () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #11423 
