### PR TITLE
Items in `package.patterns` are enclosed in `''`

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -67,7 +67,7 @@ Exclude all files but `handler.js`
 package:
   patterns:
     - '!src/**'
-    - src/function/handler.js
+    - 'src/function/handler.js'
 ```
 
 **Note:** Don't forget to use the correct glob syntax if you want to exclude directories


### PR DESCRIPTION
This is a small style fix. Items in `package.patterns` are enclosed in `''`.
