### PR TITLE
Fixed docs as `yarn-*.log` is the default exclude file for `package.patterns`

### DIFF
--- a/docs/providers/aws/guide/packaging.md
+++ b/docs/providers/aws/guide/packaging.md
@@ -45,6 +45,7 @@ By default, serverless will exclude the following patterns:
 - .gitignore
 - .DS_Store
 - npm-debug.log
+- yarn-\*.log
 - .serverless/\*\*
 - .serverless_plugins/\*\*
 


### PR DESCRIPTION
The implementation includes `yarn-*.log` in the default exclusion list in `package.patterns`:

https://github.com/serverless/serverless/blob/bb37f4fe75ff5234fae48ada433cd52ddf51cb91/lib/plugins/package/lib/package-service.js#L18

However, the documentation did not include `yarn-*.log`, so I fixed this.