### PR TITLE
feat: Add support for `nodejs18.x` runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -607,6 +607,7 @@ class AwsProvider {
               'nodejs12.x',
               'nodejs14.x',
               'nodejs16.x',
+              'nodejs18.x',
               'provided',
               'provided.al2',
               'python3.6',


### PR DESCRIPTION
Node 18 is now officially supported by AWS Lambda. I could not find a corresponding issue.

Reference: https://aws.amazon.com/blogs/compute/node-js-18-x-runtime-now-available-in-aws-lambda/