### PR TITLE
fix(sec): upgrade com.google.code.gson:gson to 2.8.9

### DIFF
--- a/docs/providers/openwhisk/examples/hello-world/java/pom.xml
+++ b/docs/providers/openwhisk/examples/hello-world/java/pom.xml
@@ -10,7 +10,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <gson.version>2.8.2</gson.version>
+    <gson.version>2.8.9</gson.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.code.gson:gson 2.8.2
- [CVE-2022-25647](https://www.oscs1024.com/hd/CVE-2022-25647)


### What did I do？
Upgrade com.google.code.gson:gson from 2.8.2 to 2.8.9 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>