### PR TITLE
11034 extend configuration

### DIFF
--- a/docs/guides/plugins/custom-configuration.md
+++ b/docs/guides/plugins/custom-configuration.md
@@ -1,8 +1,8 @@
 <!--
 title: Serverless Framework - Plugins - Extending the configuration
-menuText: Extending the configuration
+menuText: Extending the configuration schema
 menuOrder: 5
-description: How to extend the serverless.yml syntax with custom configuration via a plugin
+description: How to extend the serverless.yml schema with custom configuration via a plugin
 layout: Doc
 -->
 
@@ -12,7 +12,7 @@ layout: Doc
 
 <!-- DOCS-SITE-LINK:END -->
 
-# Extending the configuration
+# Extending the configuration schema
 
 Plugin can extend the `serverless.yml` syntax with custom configuration:
 

--- a/docs/guides/plugins/extending-configuration.md
+++ b/docs/guides/plugins/extending-configuration.md
@@ -1,0 +1,70 @@
+<!--
+title: Serverless Framework - Plugins - Extending and overriding the configuration
+menuText: Extending and overriding configuration
+menuOrder: 6
+description: How to extend and override configuration via a plugin
+layout: Doc
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/plugins/extending-configuration)
+
+<!-- DOCS-SITE-LINK:END -->
+
+# Extending and overriding configuration
+
+Plugins can extend and override the internal configuration.
+
+To do so, plugins may use the `serverless.extendConfiguration(...)` method.
+This is only allowed at pre-init stage of serverless.
+The method also takes care of resolving all variables in the given value. But it **does not validate you input** nor the target. Improper usage can cause serverless to fail.
+
+The `serverless.extendConfiguration(configurationPathKeys, value)` method takes two arguments.
+
+| Argument                | Type                      | Description                                                        |
+| ----------------------- | ------------------------- | ------------------------------------------------------------------ |
+| `configurationPathKeys` | string[]                  | Path of the configuration property to set; must not be empty       |
+| `value`                 | string \| object \| array | New value of the configuration property in `configurationPathKeys` |
+
+If configuration in `configurationPathKeys` **does exist** the value will be overwritten.  
+If configuration in `configurationPathKeys` **does not exist** the whole path will be created.
+
+You can use it in the `asyncInit()` method of your plugin.
+
+```js
+class MyPlugin {
+  constructor(serverless) {
+    this.serverless = serverless;
+  }
+
+  async asyncInit() {
+    const value = {
+      myKey: 'myValue',
+    };
+    this.serverless.extendConfiguration(['custom', 'myPlugin'], value);
+  }
+}
+
+module.exports = MyPlugin;
+```
+
+If your plugin needs merging you need to take care of it yourself.
+
+```js
+class MyPlugin {
+  constructor(serverless) {
+    this.serverless = serverless;
+  }
+
+  async asyncInit() {
+    const currentConfig = this.serverless.configurationInput.custom.myPlugin;
+    const value = Object.assign(currentConfig, {
+      myKey: 'myValue',
+    });
+    this.serverless.extendConfiguration(['custom', 'myPlugin'], value);
+  }
+}
+
+module.exports = MyPlugin;
+```

--- a/docs/guides/plugins/extending-configuration.md
+++ b/docs/guides/plugins/extending-configuration.md
@@ -30,15 +30,13 @@ The `serverless.extendConfiguration(configurationPathKeys, value)` method takes 
 If configuration in `configurationPathKeys` **does exist** the value will be overwritten.  
 If configuration in `configurationPathKeys` **does not exist** the whole path will be created.
 
-You can use it in the `asyncInit()` method of your plugin.
+You can use it in plugin constructor, or if for some reason configuration extension is resolved asynchronously you may resort to `asyncInit()` method
 
 ```js
 class MyPlugin {
   constructor(serverless) {
     this.serverless = serverless;
-  }
 
-  async asyncInit() {
     const value = {
       myKey: 'myValue',
     };
@@ -55,9 +53,7 @@ If your plugin needs merging you need to take care of it yourself.
 class MyPlugin {
   constructor(serverless) {
     this.serverless = serverless;
-  }
 
-  async asyncInit() {
     const currentConfig = this.serverless.configurationInput.custom.myPlugin;
     const value = Object.assign(currentConfig, {
       myKey: 'myValue',

--- a/docs/menu.json
+++ b/docs/menu.json
@@ -50,7 +50,8 @@
       "CLI Output": "guides/plugins/cli-output",
       "Custom Commands": "guides/plugins/custom-commands",
       "Custom Variables": "guides/plugins/custom-variables",
-      "Extending the Configuration": "guides/plugins/custom-configuration"
+      "Extending the Configuration schema": "guides/plugins/custom-configuration",
+      "Extending and overriding configuration": "guides/plugins/extending-configuration"
     }
   },
   "Examples and Tutorials": "examples-and-tutorials",

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const os = require('os');
+const _ = require('lodash');
 const ensureString = require('type/string/ensure');
 const ensureValue = require('type/value/ensure');
 const ensureArray = require('type/array/ensure');
@@ -23,6 +24,7 @@ const eventuallyUpdate = require('./utils/eventually-update');
 const commmandsSchema = require('./cli/commands-schema');
 const resolveCliInput = require('./cli/resolve-input');
 const isDashboardEnabled = require('./configuration/is-dashboard-enabled');
+const { parseEntries } = require('./configuration/variables/resolve-meta');
 
 // Old local fallback is triggered in older versions by Serverless constructor directly
 const isStackFromOldLocalFallback = RegExp.prototype.test.bind(
@@ -215,6 +217,27 @@ class Serverless {
   // To be used by external plugins
   logDeprecation(code, message) {
     return this._logDeprecation(`EXT_${ensureString(code)}`, ensureString(message));
+  }
+
+  extendConfiguration(configurationPathKeys, value) {
+    const oldConfig = _.get(configurationPathKeys, this.configurationInput);
+    if (oldConfig === undefined) {
+      _.set(this.configurationInput, configurationPathKeys, value);
+    } else {
+      const mergedConfig = _.merge(oldConfig, value);
+      _.set(this.configurationInput, configurationPathKeys, mergedConfig);
+    }
+
+    const metaPathPrefix = configurationPathKeys.replace('.', '\0');
+    const filteredEntries = Object.entries(this.variablesMeta).filter(
+      (entry) => !entry[0].startsWith(metaPathPrefix)
+    );
+    this.variablesMeta = Object.fromEntries(filteredEntries);
+    parseEntries(this.configurationInput, configurationPathKeys.split('.'), new Map()).forEach(
+      (entryValue, key) => {
+        this.variablesMeta.set(key, entryValue);
+      }
+    );
   }
 }
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -238,7 +238,7 @@ class Serverless {
 
     if (!this.isConfigurationExtendable) {
       throw new ServerlessError(
-        'ExtendConfiguration cannot be used after init.',
+        'Cannot extend configuration: It can only be extended during initialization phase.',
         'INVALID_EXTEND_AFTER_INIT'
       );
     }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -101,6 +101,10 @@ class Serverless {
     // Old variables resolver is dropped, yet some plugins access service properties through
     // `variables` class. Below patch ensures those plugins won't get broken
     this.variables = { service: this.service };
+
+    // `config.variablesMeta` will not be provided if the initial resolution of variables failed.
+    // We're ensuring it locally not to disrupt configuration extensions as eventually done by
+    // the plugins (which are still loaded in spite of the error, if e.g. help output was requested)
     this.variablesMeta = config.variablesMeta || new Map([]);
     this.pluginManager = new PluginManager(this);
     this.configSchemaHandler = new ConfigSchemaHandler(this);

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -221,7 +221,7 @@ class Serverless {
     return this._logDeprecation(`EXT_${ensureString(code)}`, ensureString(message));
   }
 
-  extendConfiguration(configurationPath, value) {
+  extendConfiguration(configurationPathKeys, value) {
     if (!this.isConfigurationExtendable) {
       throw new ServerlessError(
         'ExtendConfiguration cannot be used after init.',
@@ -240,6 +240,8 @@ class Serverless {
     const isObject = (obj) => {
       return typeof obj === 'object' && !Array.isArray(obj) && obj !== null;
     };
+
+    const configurationPath = configurationPathKeys.join('.');
 
     const oldConfig = _.get(this.configurationInput, configurationPath);
     if (oldConfig === undefined) {
@@ -267,11 +269,7 @@ class Serverless {
     }
 
     const mergedConfig = _.get(this.configurationInput, configurationPath);
-    parseEntries(Object.entries(mergedConfig), configurationPath.split('.'), new Map()).forEach(
-      (entryValue, key) => {
-        this.variablesMeta.set(key, entryValue);
-      }
-    );
+    parseEntries(Object.entries(mergedConfig), configurationPathKeys, this.variablesMeta);
   }
 }
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -251,7 +251,7 @@ class Serverless {
 
     const metaPathPrefix = configurationPathKeys.join('\0');
     for (const key of this.variablesMeta.keys()) {
-      if (key.startsWith(metaPathPrefix)) {
+      if (key === metaPathPrefix || key.startsWith(`${metaPathPrefix}\0`)) {
         this.variablesMeta.delete(key);
       }
     }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -223,6 +223,12 @@ class Serverless {
 
   extendConfiguration(configurationPathKeys, value) {
     ensureArray(configurationPathKeys, { ensureItem: ensureString });
+    if (configurationPathKeys.length < 1) {
+      throw new ServerlessError(
+        'ExtendConfiguration cannot be used at root. ConfigurationPathKeys needs to contain at least one element.',
+        'INVALID_EXTEND_AFTER_INIT'
+      );
+    }
 
     if (!this.isConfigurationExtendable) {
       throw new ServerlessError(
@@ -245,17 +251,16 @@ class Serverless {
 
     const configurationPath = configurationPathKeys.join('.');
 
+    let newConfig;
     const oldConfig = _.get(this.configurationInput, configurationPath);
     if (oldConfig === undefined) {
-      _.set(this.configurationInput, configurationPath, value);
+      newConfig = value;
     } else if (Array.isArray(oldConfig) && Array.isArray(value)) {
-      const mergedConfig = oldConfig.concat(value);
-      _.set(this.configurationInput, configurationPath, mergedConfig);
+      newConfig = oldConfig.concat(value);
     } else if (isObject(oldConfig) && isObject(value)) {
-      const mergedConfig = _.merge(oldConfig, value);
-      _.set(this.configurationInput, configurationPath, mergedConfig);
+      newConfig = _.merge(oldConfig, value);
     } else if (typeof oldConfig === typeof value && typeof oldConfig !== 'object') {
-      _.set(this.configurationInput, configurationPath, value);
+      newConfig = value;
     } else {
       throw new ServerlessError(
         `Configuration cannot be extended at ${configurationPath}. Expected: ${typeof oldConfig}, Received: ${typeof value}`,
@@ -263,15 +268,20 @@ class Serverless {
       );
     }
 
+    _.set(this.configurationInput, configurationPath, newConfig);
+
     const metaPathPrefix = configurationPath.replace(/\./g, '\0');
     for (const key of this.variablesMeta.keys()) {
       if (key.startsWith(metaPathPrefix)) {
         this.variablesMeta.delete(key);
       }
     }
-
-    const mergedConfig = _.get(this.configurationInput, configurationPath);
-    parseEntries(Object.entries(mergedConfig), configurationPathKeys, this.variablesMeta);
+    if (typeof newConfig !== 'object') {
+      const lastKey = configurationPathKeys.pop();
+      parseEntries({ [lastKey]: newConfig }, configurationPathKeys, this.variablesMeta);
+    } else {
+      parseEntries(Object.entries(newConfig), configurationPathKeys, this.variablesMeta);
+    }
   }
 }
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -230,24 +230,19 @@ class Serverless {
       ensureItem: ensureString,
     });
     if (configurationPathKeys.length < 1) {
-      throw new Error(
-        'ConfigurationPathKeys needs to contain at least one element.',
-        'INVALID_EXTEND_AT_ROOT'
-      );
+      throw new Error('ConfigurationPathKeys needs to contain at least one element.');
     }
 
     if (!this.isConfigurationExtendable) {
       throw new Error(
-        'Cannot extend configuration: It can only be extended during initialization phase.',
-        'INVALID_EXTEND_AFTER_INIT'
+        'Cannot extend configuration: It can only be extended during initialization phase.'
       );
     }
     try {
       value = JSON.parse(JSON.stringify(value));
     } catch (error) {
       throw new Error(
-        'ExtendConfiguration called with invalid data. Value is not json-serializable. Error: ${error}',
-        'INVALID_EXTEND_VALUE'
+        'ExtendConfiguration called with invalid data. Value is not json-serializable. Error: ${error}'
       );
     }
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -101,7 +101,7 @@ class Serverless {
     // Old variables resolver is dropped, yet some plugins access service properties through
     // `variables` class. Below patch ensures those plugins won't get broken
     this.variables = { service: this.service };
-    this.variablesMeta = config.variablesMeta;
+    this.variablesMeta = config.variablesMeta || new Map([]);
     this.pluginManager = new PluginManager(this);
     this.configSchemaHandler = new ConfigSchemaHandler(this);
 
@@ -228,7 +228,7 @@ class Serverless {
     if (configurationPathKeys.length < 1) {
       throw new ServerlessError(
         'ConfigurationPathKeys needs to contain at least one element.',
-        'INVALID_EXTEND_AFTER_INIT'
+        'INVALID_EXTEND_AT_ROOT'
       );
     }
 
@@ -248,7 +248,6 @@ class Serverless {
     }
 
     _.set(this.configurationInput, configurationPathKeys, value);
-
     const metaPathPrefix = configurationPathKeys.join('\0');
     for (const key of this.variablesMeta.keys()) {
       if (key === metaPathPrefix || key.startsWith(`${metaPathPrefix}\0`)) {
@@ -257,10 +256,9 @@ class Serverless {
     }
     if (!_.isObject(value)) {
       const lastKey = configurationPathKeys.pop();
-      parseEntries({ [lastKey]: value }, configurationPathKeys, this.variablesMeta);
-    } else {
-      parseEntries(Object.entries(value), configurationPathKeys, this.variablesMeta);
+      value = { [lastKey]: value };
     }
+    parseEntries(Object.entries(value), configurationPathKeys, this.variablesMeta);
   }
 }
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -228,7 +228,14 @@ class Serverless {
         'INVALID_EXTEND_AFTER_INIT'
       );
     }
-    value = JSON.parse(JSON.stringify(value));
+    try {
+      value = JSON.parse(JSON.stringify(value));
+    } catch (error) {
+      throw new ServerlessError(
+        'ExtendConfiguration called with invalid data. Value is not json-serializable. Error: ${error}',
+        'INVALID_EXTEND_VALUE'
+      );
+    }
 
     const isObject = (obj) => {
       return typeof obj === 'object' && !Array.isArray(obj) && obj !== null;

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -222,7 +222,7 @@ class Serverless {
   }
 
   extendConfiguration(configurationPathKeys, value) {
-    ensureArray(configurationPathKeys, {
+    configurationPathKeys = ensureArray(configurationPathKeys, {
       ensureItem: ensureString,
     });
     if (configurationPathKeys.length < 1) {
@@ -247,8 +247,7 @@ class Serverless {
       );
     }
 
-    const configurationPath = configurationPathKeys.join('.');
-    _.set(this.configurationInput, configurationPath, value);
+    _.set(this.configurationInput, configurationPathKeys, value);
 
     const metaPathPrefix = configurationPathKeys.join('\0');
     for (const key of this.variablesMeta.keys()) {
@@ -256,7 +255,7 @@ class Serverless {
         this.variablesMeta.delete(key);
       }
     }
-    if (typeof value !== 'object') {
+    if (!_.isObject(value)) {
       const lastKey = configurationPathKeys.pop();
       parseEntries({ [lastKey]: value }, configurationPathKeys, this.variablesMeta);
     } else {

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -230,7 +230,9 @@ class Serverless {
       ensureItem: ensureString,
     });
     if (configurationPathKeys.length < 1) {
-      throw new Error('ConfigurationPathKeys needs to contain at least one element.');
+      throw new Error(
+        'Cannot extend configuration: ConfigurationPathKeys needs to contain at least one element.'
+      );
     }
 
     if (!this.isConfigurationExtendable) {
@@ -241,9 +243,7 @@ class Serverless {
     try {
       value = JSON.parse(JSON.stringify(value));
     } catch (error) {
-      throw new Error(
-        'ExtendConfiguration called with invalid data. Value is not json-serializable. Error: ${error}'
-      );
+      throw new Error(`Cannot extend configuration: Received non JSON value: ${value}`);
     }
 
     _.set(this.configurationInput, configurationPathKeys, value);

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -99,6 +99,7 @@ class Serverless {
     // Old variables resolver is dropped, yet some plugins access service properties through
     // `variables` class. Below patch ensures those plugins won't get broken
     this.variables = { service: this.service };
+    this.variablesMeta = config.variablesMeta;
     this.pluginManager = new PluginManager(this);
     this.configSchemaHandler = new ConfigSchemaHandler(this);
 

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -220,12 +220,23 @@ class Serverless {
   }
 
   extendConfiguration(configurationPathKeys, value) {
-    const oldConfig = _.get(configurationPathKeys, this.configurationInput);
+    this.cli.consoleLog(`Extending configuration at ${configurationPathKeys}`)
+
+    const isObject = (obj) => {
+      return typeof obj === 'object' && !Array.isArray(obj) && obj !== null
+    }
+
+    const oldConfig = _.get(this.configurationInput, configurationPathKeys);
     if (oldConfig === undefined) {
       _.set(this.configurationInput, configurationPathKeys, value);
-    } else {
+    } else if ( Array.isArray(oldConfig) && Array.isArray(value) ) {
+      const mergedConfig = oldConfig.concat(value);
+      _.set(this.configurationInput, configurationPathKeys, mergedConfig);
+    } else if ( isObject(oldConfig) && isObject(value) ) {
       const mergedConfig = _.merge(oldConfig, value);
       _.set(this.configurationInput, configurationPathKeys, mergedConfig);
+    } else {
+      throw Error('Cannot extend without matching types.')
     }
 
     const metaPathPrefix = configurationPathKeys.replace('.', '\0');

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -222,10 +222,12 @@ class Serverless {
   }
 
   extendConfiguration(configurationPathKeys, value) {
-    ensureArray(configurationPathKeys, { ensureItem: ensureString });
+    ensureArray(configurationPathKeys, {
+      ensureItem: ensureString,
+    });
     if (configurationPathKeys.length < 1) {
       throw new ServerlessError(
-        'ExtendConfiguration cannot be used at root. ConfigurationPathKeys needs to contain at least one element.',
+        'ConfigurationPathKeys needs to contain at least one element.',
         'INVALID_EXTEND_AFTER_INIT'
       );
     }
@@ -245,42 +247,20 @@ class Serverless {
       );
     }
 
-    const isObject = (obj) => {
-      return typeof obj === 'object' && !Array.isArray(obj) && obj !== null;
-    };
-
     const configurationPath = configurationPathKeys.join('.');
+    _.set(this.configurationInput, configurationPath, value);
 
-    let newConfig;
-    const oldConfig = _.get(this.configurationInput, configurationPath);
-    if (oldConfig === undefined) {
-      newConfig = value;
-    } else if (Array.isArray(oldConfig) && Array.isArray(value)) {
-      newConfig = oldConfig.concat(value);
-    } else if (isObject(oldConfig) && isObject(value)) {
-      newConfig = _.merge(oldConfig, value);
-    } else if (typeof oldConfig === typeof value && typeof oldConfig !== 'object') {
-      newConfig = value;
-    } else {
-      throw new ServerlessError(
-        `Configuration cannot be extended at ${configurationPath}. Expected: ${typeof oldConfig}, Received: ${typeof value}`,
-        'INVALID_EXTEND_WITH_TYPE_MISMATCH'
-      );
-    }
-
-    _.set(this.configurationInput, configurationPath, newConfig);
-
-    const metaPathPrefix = configurationPath.replace(/\./g, '\0');
+    const metaPathPrefix = configurationPathKeys.join('\0');
     for (const key of this.variablesMeta.keys()) {
       if (key.startsWith(metaPathPrefix)) {
         this.variablesMeta.delete(key);
       }
     }
-    if (typeof newConfig !== 'object') {
+    if (typeof value !== 'object') {
       const lastKey = configurationPathKeys.pop();
-      parseEntries({ [lastKey]: newConfig }, configurationPathKeys, this.variablesMeta);
+      parseEntries({ [lastKey]: value }, configurationPathKeys, this.variablesMeta);
     } else {
-      parseEntries(Object.entries(newConfig), configurationPathKeys, this.variablesMeta);
+      parseEntries(Object.entries(value), configurationPathKeys, this.variablesMeta);
     }
   }
 }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -220,31 +220,34 @@ class Serverless {
   }
 
   extendConfiguration(configurationPathKeys, value) {
-    this.cli.consoleLog(`Extending configuration at ${configurationPathKeys}`)
+    this.cli.consoleLog(`Extending configuration at ${configurationPathKeys}`);
 
     const isObject = (obj) => {
-      return typeof obj === 'object' && !Array.isArray(obj) && obj !== null
-    }
+      return typeof obj === 'object' && !Array.isArray(obj) && obj !== null;
+    };
 
     const oldConfig = _.get(this.configurationInput, configurationPathKeys);
     if (oldConfig === undefined) {
       _.set(this.configurationInput, configurationPathKeys, value);
-    } else if ( Array.isArray(oldConfig) && Array.isArray(value) ) {
+    } else if (Array.isArray(oldConfig) && Array.isArray(value)) {
       const mergedConfig = oldConfig.concat(value);
       _.set(this.configurationInput, configurationPathKeys, mergedConfig);
-    } else if ( isObject(oldConfig) && isObject(value) ) {
+    } else if (isObject(oldConfig) && isObject(value)) {
       const mergedConfig = _.merge(oldConfig, value);
       _.set(this.configurationInput, configurationPathKeys, mergedConfig);
     } else {
-      throw Error('Cannot extend without matching types.')
+      throw Error('Cannot extend without matching types.');
     }
 
     const metaPathPrefix = configurationPathKeys.replace('.', '\0');
-    const filteredEntries = Object.entries(this.variablesMeta).filter(
-      (entry) => !entry[0].startsWith(metaPathPrefix)
-    );
-    this.variablesMeta = Object.fromEntries(filteredEntries);
-    parseEntries(this.configurationInput, configurationPathKeys.split('.'), new Map()).forEach(
+    for (const key of this.variablesMeta.keys()) {
+      if (key.startsWith(metaPathPrefix)) {
+        this.variablesMeta.delete(key);
+      }
+    }
+
+    const mergedConfig = _.get(this.configurationInput, configurationPathKeys);
+    parseEntries(Object.entries(mergedConfig), configurationPathKeys.split('.'), new Map()).forEach(
       (entryValue, key) => {
         this.variablesMeta.set(key, entryValue);
       }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -222,6 +222,8 @@ class Serverless {
   }
 
   extendConfiguration(configurationPathKeys, value) {
+    ensureArray(configurationPathKeys, { ensureItem: ensureString });
+
     if (!this.isConfigurationExtendable) {
       throw new ServerlessError(
         'ExtendConfiguration cannot be used after init.',

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -24,7 +24,7 @@ const eventuallyUpdate = require('./utils/eventually-update');
 const commmandsSchema = require('./cli/commands-schema');
 const resolveCliInput = require('./cli/resolve-input');
 const isDashboardEnabled = require('./configuration/is-dashboard-enabled');
-const { parseEntries } = require('./configuration/variables/resolve-meta');
+const parseEntries = require('./configuration/variables/resolve-meta').parseEntries;
 
 // Old local fallback is triggered in older versions by Serverless constructor directly
 const isStackFromOldLocalFallback = RegExp.prototype.test.bind(
@@ -119,6 +119,7 @@ class Serverless {
     this.serverlessDirPath = path.join(os.homedir(), '.serverless');
     this.isStandaloneExecutable = isStandaloneExecutable;
     this.triggeredDeprecations = logDeprecation.triggeredDeprecations;
+    this.isConfigurationExtendable = true;
 
     // TODO: Remove once "@serverless/dashboard-plugin" is integrated into this repository
     this._commandsSchema = commmandsSchema;
@@ -139,6 +140,7 @@ class Serverless {
     await this.service.load(this.processedInput.options);
     // load all plugins
     await this.pluginManager.loadAllPlugins(this.service.plugins);
+    this.isConfigurationExtendable = false;
     // give the CLI the plugins and commands so that it can print out
     // information such as options when the user enters --help
     this.cli.setLoadedPlugins(this.pluginManager.getPlugins());
@@ -219,35 +221,46 @@ class Serverless {
     return this._logDeprecation(`EXT_${ensureString(code)}`, ensureString(message));
   }
 
-  extendConfiguration(configurationPathKeys, value) {
-    this.cli.consoleLog(`Extending configuration at ${configurationPathKeys}`);
+  extendConfiguration(configurationPath, value) {
+    if (!this.isConfigurationExtendable) {
+      throw new ServerlessError(
+        'ExtendConfiguration cannot be used after init.',
+        'INVALID_EXTEND_AFTER_INIT'
+      );
+    }
+    value = JSON.parse(JSON.stringify(value));
 
     const isObject = (obj) => {
       return typeof obj === 'object' && !Array.isArray(obj) && obj !== null;
     };
 
-    const oldConfig = _.get(this.configurationInput, configurationPathKeys);
+    const oldConfig = _.get(this.configurationInput, configurationPath);
     if (oldConfig === undefined) {
-      _.set(this.configurationInput, configurationPathKeys, value);
+      _.set(this.configurationInput, configurationPath, value);
     } else if (Array.isArray(oldConfig) && Array.isArray(value)) {
       const mergedConfig = oldConfig.concat(value);
-      _.set(this.configurationInput, configurationPathKeys, mergedConfig);
+      _.set(this.configurationInput, configurationPath, mergedConfig);
     } else if (isObject(oldConfig) && isObject(value)) {
       const mergedConfig = _.merge(oldConfig, value);
-      _.set(this.configurationInput, configurationPathKeys, mergedConfig);
+      _.set(this.configurationInput, configurationPath, mergedConfig);
+    } else if (typeof oldConfig === typeof value && typeof oldConfig !== 'object') {
+      _.set(this.configurationInput, configurationPath, value);
     } else {
-      throw Error('Cannot extend without matching types.');
+      throw new ServerlessError(
+        `Configuration cannot be extended at ${configurationPath}. Expected: ${typeof oldConfig}, Received: ${typeof value}`,
+        'INVALID_EXTEND_WITH_TYPE_MISMATCH'
+      );
     }
 
-    const metaPathPrefix = configurationPathKeys.replace('.', '\0');
+    const metaPathPrefix = configurationPath.replace(/\./g, '\0');
     for (const key of this.variablesMeta.keys()) {
       if (key.startsWith(metaPathPrefix)) {
         this.variablesMeta.delete(key);
       }
     }
 
-    const mergedConfig = _.get(this.configurationInput, configurationPathKeys);
-    parseEntries(Object.entries(mergedConfig), configurationPathKeys.split('.'), new Map()).forEach(
+    const mergedConfig = _.get(this.configurationInput, configurationPath);
+    parseEntries(Object.entries(mergedConfig), configurationPath.split('.'), new Map()).forEach(
       (entryValue, key) => {
         this.variablesMeta.set(key, entryValue);
       }

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -230,14 +230,14 @@ class Serverless {
       ensureItem: ensureString,
     });
     if (configurationPathKeys.length < 1) {
-      throw new ServerlessError(
+      throw new Error(
         'ConfigurationPathKeys needs to contain at least one element.',
         'INVALID_EXTEND_AT_ROOT'
       );
     }
 
     if (!this.isConfigurationExtendable) {
-      throw new ServerlessError(
+      throw new Error(
         'Cannot extend configuration: It can only be extended during initialization phase.',
         'INVALID_EXTEND_AFTER_INIT'
       );
@@ -245,7 +245,7 @@ class Serverless {
     try {
       value = JSON.parse(JSON.stringify(value));
     } catch (error) {
-      throw new ServerlessError(
+      throw new Error(
         'ExtendConfiguration called with invalid data. Value is not json-serializable. Error: ${error}',
         'INVALID_EXTEND_VALUE'
       );

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -664,7 +664,7 @@ processSpanPromise = (async () => {
             fulfilledSources: new Set(['env', 'file', 'self', 'strToBool']),
             propertyPathsToResolve:
               commands[0] === 'plugin'
-                ? new Set(['plugin', 'provider\0name', 'provider\0stage', 'useDotenv'])
+                ? new Set(['plugins', 'provider\0name', 'provider\0stage', 'useDotenv'])
                 : null,
             variableSourcesInConfig,
           };

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -644,7 +644,7 @@ processSpanPromise = (async () => {
         // Validate result command and options
         if (hasFinalCommandSchema) require('../lib/cli/ensure-supported-command')(configuration);
         if (isHelpRequest) return;
-        if (!_.get(serverless.variablesMeta, 'size')) return;
+        if (!_.get(variablesMeta, 'size')) return;
 
         if (commandSchema) {
           resolverConfiguration.options = filterSupportedOptions(options, {
@@ -679,12 +679,12 @@ processSpanPromise = (async () => {
           // Pre-resolve to eventually pick not yet resolved AWS auth related properties
           processLog.debug('resolve variables');
           await resolveVariables(resolverConfiguration);
-          if (!serverless.variablesMeta.size) return;
+          if (!variablesMeta.size) return;
           if (
             eventuallyReportVariableResolutionErrors(
               configurationPath,
               configuration,
-              serverless.variablesMeta
+              variablesMeta
             )
           ) {
             return;
@@ -728,13 +728,9 @@ processSpanPromise = (async () => {
         // Having all source resolvers configured, resolve variables
         processLog.debug('resolve all variables');
         await resolveVariables(resolverConfiguration);
-        if (!serverless.variablesMeta.size) return;
+        if (!variablesMeta.size) return;
         if (
-          eventuallyReportVariableResolutionErrors(
-            configurationPath,
-            configuration,
-            serverless.variablesMeta
-          )
+          eventuallyReportVariableResolutionErrors(configurationPath, configuration, variablesMeta)
         ) {
           return;
         }
@@ -742,12 +738,10 @@ processSpanPromise = (async () => {
         // Do not confirm on unresolved sources with partially resolved configuration
         if (resolverConfiguration.propertyPathsToResolve) return;
 
-        processLog.debug('uresolved variables meta: %o', serverless.variablesMeta);
+        processLog.debug('uresolved variables meta: %o', variablesMeta);
         // Report unrecognized variable sources found in variables configured in service config
         const unresolvedSources =
-          require('../lib/configuration/variables/resolve-unresolved-source-types')(
-            serverless.variablesMeta
-          );
+          require('../lib/configuration/variables/resolve-unresolved-source-types')(variablesMeta);
         const recognizedSourceNames = new Set(Object.keys(resolverConfiguration.sources));
 
         const unrecognizedSourceNames = Array.from(unresolvedSources.keys()).filter(

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -598,6 +598,7 @@ processSpanPromise = (async () => {
         commands[0] === 'plugin' || Boolean(variablesMeta && !variablesMeta.size),
       commands,
       options,
+      variablesMeta,
     });
 
     try {
@@ -643,7 +644,7 @@ processSpanPromise = (async () => {
         // Validate result command and options
         if (hasFinalCommandSchema) require('../lib/cli/ensure-supported-command')(configuration);
         if (isHelpRequest) return;
-        if (!_.get(variablesMeta, 'size')) return;
+        if (!_.get(serverless.variablesMeta, 'size')) return;
 
         if (commandSchema) {
           resolverConfiguration.options = filterSupportedOptions(options, {
@@ -678,12 +679,12 @@ processSpanPromise = (async () => {
           // Pre-resolve to eventually pick not yet resolved AWS auth related properties
           processLog.debug('resolve variables');
           await resolveVariables(resolverConfiguration);
-          if (!variablesMeta.size) return;
+          if (!serverless.variablesMeta.size) return;
           if (
             eventuallyReportVariableResolutionErrors(
               configurationPath,
               configuration,
-              variablesMeta
+              serverless.variablesMeta
             )
           ) {
             return;
@@ -727,9 +728,13 @@ processSpanPromise = (async () => {
         // Having all source resolvers configured, resolve variables
         processLog.debug('resolve all variables');
         await resolveVariables(resolverConfiguration);
-        if (!variablesMeta.size) return;
+        if (!serverless.variablesMeta.size) return;
         if (
-          eventuallyReportVariableResolutionErrors(configurationPath, configuration, variablesMeta)
+          eventuallyReportVariableResolutionErrors(
+            configurationPath,
+            configuration,
+            serverless.variablesMeta
+          )
         ) {
           return;
         }
@@ -737,10 +742,12 @@ processSpanPromise = (async () => {
         // Do not confirm on unresolved sources with partially resolved configuration
         if (resolverConfiguration.propertyPathsToResolve) return;
 
-        processLog.debug('uresolved variables meta: %o', variablesMeta);
+        processLog.debug('uresolved variables meta: %o', serverless.variablesMeta);
         // Report unrecognized variable sources found in variables configured in service config
         const unresolvedSources =
-          require('../lib/configuration/variables/resolve-unresolved-source-types')(variablesMeta);
+          require('../lib/configuration/variables/resolve-unresolved-source-types')(
+            serverless.variablesMeta
+          );
         const recognizedSourceNames = new Set(Object.keys(resolverConfiguration.sources));
 
         const unrecognizedSourceNames = Array.from(unresolvedSources.keys()).filter(

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -594,8 +594,6 @@ processSpanPromise = (async () => {
       configuration,
       serviceDir,
       configurationFilename,
-      isConfigurationResolved:
-        commands[0] === 'plugin' || Boolean(variablesMeta && !variablesMeta.size),
       commands,
       options,
       variablesMeta,

--- a/scripts/serverless.js
+++ b/scripts/serverless.js
@@ -296,30 +296,29 @@ processSpanPromise = (async () => {
           }
 
           let envVarNamesNeededForDotenvResolution;
-          resolverConfiguration = {
-            serviceDir,
-            configuration,
-            variablesMeta,
-            sources: {
-              env: require('../lib/configuration/variables/sources/env'),
-              file: require('../lib/configuration/variables/sources/file'),
-              opt: require('../lib/configuration/variables/sources/opt'),
-              self: require('../lib/configuration/variables/sources/self'),
-              strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
-              sls: require('../lib/configuration/variables/sources/instance-dependent/get-sls')(),
-            },
-            options: filterSupportedOptions(options, { commandSchema, providerName }),
-            fulfilledSources: new Set(['file', 'self', 'strToBool']),
-            propertyPathsToResolve: new Set(['provider\0name', 'provider\0stage', 'useDotenv']),
-            variableSourcesInConfig,
-          };
-
           if (variablesMeta.size) {
             processLog.debug('resolve variables in core properties');
             // Some properties are configured with variables
 
             // Resolve eventual variables in `provider.stage` and `useDotEnv`
             // (required for reliable .env resolution)
+            resolverConfiguration = {
+              serviceDir,
+              configuration,
+              variablesMeta,
+              sources: {
+                env: require('../lib/configuration/variables/sources/env'),
+                file: require('../lib/configuration/variables/sources/file'),
+                opt: require('../lib/configuration/variables/sources/opt'),
+                self: require('../lib/configuration/variables/sources/self'),
+                strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
+                sls: require('../lib/configuration/variables/sources/instance-dependent/get-sls')(),
+              },
+              options: filterSupportedOptions(options, { commandSchema, providerName }),
+              fulfilledSources: new Set(['file', 'self', 'strToBool']),
+              propertyPathsToResolve: new Set(['provider\0name', 'provider\0stage', 'useDotenv']),
+              variableSourcesInConfig,
+            };
 
             if (isInteractiveSetup) resolverConfiguration.fulfilledSources.add('opt');
             await resolveVariables(resolverConfiguration);
@@ -591,10 +590,6 @@ processSpanPromise = (async () => {
       }
     }
 
-    const isConfigurationExtended = function (oldSize) {
-      return oldSize < variablesMeta.size;
-    }.bind(null, variablesMeta.size);
-
     processLog.debug('construct Serverless instance');
     serverless = new Serverless({
       configuration,
@@ -610,11 +605,6 @@ processSpanPromise = (async () => {
       serverless.invocationId = uuid.v4();
       processLog.debug('initialize Serverless instance');
       await serverless.init();
-
-      if (isConfigurationExtended() && resolverConfiguration.propertyPathsToResolve) {
-        processLog.debug('resolve variables in all properties');
-        delete resolverConfiguration.propertyPathsToResolve;
-      }
 
       // IIFE for maintenance convenience
       await (async () => {
@@ -654,6 +644,31 @@ processSpanPromise = (async () => {
         if (hasFinalCommandSchema) require('../lib/cli/ensure-supported-command')(configuration);
         if (isHelpRequest) return;
         if (!_.get(variablesMeta, 'size')) return;
+        if (!resolverConfiguration) {
+          // There were no variables in the initial configuration, yet it was extended by
+          // the plugins with ones.
+          // In this case we need to ensure `resolverConfiguration` which initially was not setup
+          resolverConfiguration = {
+            serviceDir,
+            configuration,
+            variablesMeta,
+            sources: {
+              env: require('../lib/configuration/variables/sources/env'),
+              file: require('../lib/configuration/variables/sources/file'),
+              opt: require('../lib/configuration/variables/sources/opt'),
+              self: require('../lib/configuration/variables/sources/self'),
+              strToBool: require('../lib/configuration/variables/sources/str-to-bool'),
+              sls: require('../lib/configuration/variables/sources/instance-dependent/get-sls')(),
+            },
+            options: filterSupportedOptions(options, { commandSchema, providerName }),
+            fulfilledSources: new Set(['env', 'file', 'self', 'strToBool']),
+            propertyPathsToResolve:
+              commands[0] === 'plugin'
+                ? new Set(['plugin', 'provider\0name', 'provider\0stage', 'useDotenv'])
+                : null,
+            variableSourcesInConfig,
+          };
+        }
 
         if (commandSchema) {
           resolverConfiguration.options = filterSupportedOptions(options, {

--- a/test/fixtures/programmatic/plugin/extend-config-plugin/index.js
+++ b/test/fixtures/programmatic/plugin/extend-config-plugin/index.js
@@ -31,6 +31,12 @@ module.exports = class TestPlugin {
     } catch (error) {
       // ignore this
     }
+
+    try {
+      this.serverless.extendConfiguration('custom.target.invalid', {});
+    } catch (error) {
+      // ignore this
+    }
   }
 
   extendAfterInit() {

--- a/test/fixtures/programmatic/plugin/extend-config-plugin/index.js
+++ b/test/fixtures/programmatic/plugin/extend-config-plugin/index.js
@@ -1,5 +1,12 @@
 'use strict';
 
+const pluginConfig = {
+  targetValuePath: ['custom', 'extend', 'value'],
+  overwriteValuePath: ['custom', 'extend', 'overwrite'],
+  afterInitValuePath: ['custom', 'extend', 'afterInit'],
+  refValuePath: ['custom', 'extend', 'ref'],
+};
+
 module.exports = class TestPlugin {
   constructor(serverless, options, utils) {
     this.serverless = serverless;
@@ -15,9 +22,9 @@ module.exports = class TestPlugin {
     const configExt = {
       var: 'value',
     };
-    this.serverless.extendConfiguration(['custom', 'extend', 'value'], configExt);
-    this.serverless.extendConfiguration(['custom', 'extend', 'preexist'], configExt);
-    this.serverless.extendConfiguration(['custom', 'extend', 'ref'], '${self:custom.extend.value}');
+    this.serverless.extendConfiguration(pluginConfig.targetValuePath, configExt);
+    this.serverless.extendConfiguration(pluginConfig.overwriteValuePath, configExt);
+    this.serverless.extendConfiguration(pluginConfig.refValuePath, '${self:custom.extend.value}');
 
     try {
       this.serverless.extendConfiguration([], { custom: {} });
@@ -28,9 +35,11 @@ module.exports = class TestPlugin {
 
   extendAfterInit() {
     try {
-      this.serverless.extendConfiguration(['custom', 'extend', 'afterInit'], 'value');
+      this.serverless.extendConfiguration(pluginConfig.afterInitValuePath, 'value');
     } catch (error) {
       // ignore this
     }
   }
 };
+
+module.exports.pluginConfig = pluginConfig;

--- a/test/fixtures/programmatic/plugin/extend-config-plugin/index.js
+++ b/test/fixtures/programmatic/plugin/extend-config-plugin/index.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = class TestPlugin {
+  constructor(serverless, options, utils) {
+    this.serverless = serverless;
+    this.options = options;
+    this.utils = utils;
+
+    this.target = this.serverless.configurationInput.custom.extendConfig.target;
+    this.value = this.serverless.configurationInput.custom.extendConfig.value;
+    if (typeof this.value === 'string') {
+      this.value = this.value.replace(/%/g, '$');
+    }
+
+    this.hook = this.serverless.configurationInput.custom.extendConfig.hook;
+    if (this.hook !== undefined) {
+      this.hooks = {
+        [this.hook]: () => this.extend(),
+      };
+    } else {
+      this.hook = 'async init';
+    }
+  }
+
+  async asyncInit() {
+    if (this.hooks === undefined) {
+      this.extend();
+    }
+  }
+
+  extend() {
+    this.utils.log(`Excuting "${this.hook}" for extension of "${this.target}" with: ${this.value}`);
+    this.serverless.extendConfiguration(this.target, this.value);
+  }
+};

--- a/test/fixtures/programmatic/plugin/extend-config-plugin/index.js
+++ b/test/fixtures/programmatic/plugin/extend-config-plugin/index.js
@@ -6,30 +6,31 @@ module.exports = class TestPlugin {
     this.options = options;
     this.utils = utils;
 
-    this.target = this.serverless.configurationInput.custom.extendConfig.target;
-    this.value = this.serverless.configurationInput.custom.extendConfig.value;
-    if (typeof this.value === 'string') {
-      this.value = this.value.replace(/%/g, '$');
-    }
-
-    this.hook = this.serverless.configurationInput.custom.extendConfig.hook;
-    if (this.hook !== undefined) {
-      this.hooks = {
-        [this.hook]: () => this.extend(),
-      };
-    } else {
-      this.hook = 'async init';
-    }
+    this.hooks = {
+      initialize: () => this.extendAfterInit(),
+    };
   }
 
   async asyncInit() {
-    if (this.hooks === undefined) {
-      this.extend();
+    const configExt = {
+      var: 'value',
+    };
+    this.serverless.extendConfiguration(['custom', 'extend', 'value'], configExt);
+    this.serverless.extendConfiguration(['custom', 'extend', 'preexist'], configExt);
+    this.serverless.extendConfiguration(['custom', 'extend', 'ref'], '${self:custom.extend.value}');
+
+    try {
+      this.serverless.extendConfiguration([], { custom: {} });
+    } catch (error) {
+      // ignore this
     }
   }
 
-  extend() {
-    this.utils.log(`Excuting "${this.hook}" for extension of "${this.target}" with: ${this.value}`);
-    this.serverless.extendConfiguration(this.target, this.value);
+  extendAfterInit() {
+    try {
+      this.serverless.extendConfiguration(['custom', 'extend', 'afterInit'], 'value');
+    } catch (error) {
+      // ignore this
+    }
   }
 };

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -205,8 +205,6 @@ describe('test/unit/lib/serverless.test.js', () => {
       });
       const configuration = yaml.load(String(serverlessProcess.stdoutBuffer));
 
-      expect(configuration).to.be.an('object', configuration);
-
       const targetValue = _.get(configuration, pluginConfig.targetValuePath);
       expect(targetValue, 'Target value should not be undefined').to.not.be.undefined;
 

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -295,7 +295,10 @@ describe('test/unit/lib/serverless.test.js', () => {
       const configuration = await runFixture(extendConfig, {});
       expect(configuration).to.be.a('string', configuration);
 
-      expect(configuration).to.include('cannot be used after init', configuration);
+      expect(configuration).to.include(
+        'It can only be extended during initialization phase',
+        configuration
+      );
     });
   });
 });

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -200,16 +200,10 @@ describe('test/unit/lib/serverless.test.js', () => {
       const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin', {
         configExt,
       });
-      let configuration;
-      try {
-        const serverlessProcess = await spawn('node', [serverlessPath, 'print'], {
-          cwd: serviceDir,
-        });
-        configuration = yaml.load(String(serverlessProcess.stdoutBuffer));
-      } catch (error) {
-        const errorMessage = String(error.stdoutBuffer);
-        throw Error(errorMessage);
-      }
+      const serverlessProcess = await spawn('node', [serverlessPath, 'print'], {
+        cwd: serviceDir,
+      });
+      const configuration = yaml.load(String(serverlessProcess.stdoutBuffer));
 
       expect(configuration).to.be.an('object', configuration);
 

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -222,7 +222,7 @@ describe('test/unit/lib/serverless.test.js', () => {
         newKey: 'value',
       };
       serverless.configurationInput = JSON.parse(JSON.stringify(initialConfig));
-      serverless.extendConfiguration(path, value);
+      serverless.extendConfiguration(path.split('.'), value);
 
       expect(serverless.configurationInput).to.deep.include(initialConfig);
       expect(serverless.configurationInput).to.deep.nested.include({ [path]: value });
@@ -240,7 +240,7 @@ describe('test/unit/lib/serverless.test.js', () => {
         newKey: 'value',
       };
       serverless.configurationInput = JSON.parse(JSON.stringify(initialConfig));
-      serverless.extendConfiguration(path, value);
+      serverless.extendConfiguration(path.split('.'), value);
 
       expect(serverless.configurationInput[path]).to.deep.include(
         Object.assign(initialConfig[path], value)
@@ -255,7 +255,7 @@ describe('test/unit/lib/serverless.test.js', () => {
 
       const value = [4, 5, 6];
       serverless.configurationInput = JSON.parse(JSON.stringify(initialConfig));
-      serverless.extendConfiguration(path, value);
+      serverless.extendConfiguration(path.split('.'), value);
 
       expect(serverless.configurationInput[path])
         .to.be.an('array')
@@ -273,7 +273,7 @@ describe('test/unit/lib/serverless.test.js', () => {
       };
       const value = 'other string';
       serverless.configurationInput = JSON.parse(JSON.stringify(initialConfig));
-      serverless.extendConfiguration(path, value);
+      serverless.extendConfiguration(path.split('.'), value);
       expect(serverless.configurationInput[path]).to.equal(value);
     });
 
@@ -287,7 +287,7 @@ describe('test/unit/lib/serverless.test.js', () => {
         [subpath]: subvalue,
       };
       serverless.configurationInput = {};
-      serverless.extendConfiguration(path, value);
+      serverless.extendConfiguration(path.split('.'), value);
 
       expect(serverless.configurationInput[path]).to.not.equal(value);
       expect(serverless.configurationInput[path][subpath]).to.not.equal(subvalue);
@@ -301,7 +301,9 @@ describe('test/unit/lib/serverless.test.js', () => {
       const value = {};
       serverless.configurationInput = JSON.parse(JSON.stringify(initialConfig));
 
-      expect(() => serverless.extendConfiguration(path, value)).to.throw(ServerlessError);
+      expect(() => serverless.extendConfiguration(path.split('.'), value)).to.throw(
+        ServerlessError
+      );
     });
 
     it('Should throw if called after init', async () => {
@@ -324,7 +326,7 @@ describe('test/unit/lib/serverless.test.js', () => {
 
       const deleteStub = sinon.stub(serverless.variablesMeta, 'delete');
 
-      serverless.extendConfiguration(path, value);
+      serverless.extendConfiguration(path.split('.'), value);
 
       metaToDelete.forEach((meta) => {
         expect(deleteStub).to.have.been.calledWith(meta);
@@ -347,7 +349,7 @@ describe('test/unit/lib/serverless.test.js', () => {
 
       const setStub = sinon.stub(serverless.variablesMeta, 'set');
 
-      serverless.extendConfiguration(path, value);
+      serverless.extendConfiguration(path.split('.'), value);
 
       Object.getOwnPropertyNames(resolvedVariables).forEach((varName) => {
         expect(setStub).to.have.been.calledWith(varName, sinon.match.any);

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -182,11 +182,8 @@ describe('test/unit/lib/serverless.test.js', () => {
 
   describe('Extend configuration', () => {
     let awsRegion;
-    // see fixture plugin in ./test/fixtures/programmatic/plugin/extend-config-plugin/index.js
-    const targetValuePath = ['custom', 'extend', 'value'];
-    const targetValuePreexistPath = ['custom', 'extend', 'preexist'];
-    const targetValueAfterInitPath = ['custom', 'extend', 'afterInit'];
-    const targetRefPath = ['custom', 'extend', 'ref'];
+    const pluginConfig =
+      require('../../fixtures/programmatic/plugin/extend-config-plugin').pluginConfig;
 
     const serverlessPath = path.resolve(__dirname, '../../../scripts/serverless.js');
 
@@ -208,7 +205,7 @@ describe('test/unit/lib/serverless.test.js', () => {
         },
         custom: {},
       };
-      _.set(customExt, targetValuePreexistPath, 'test_value');
+      _.set(customExt, pluginConfig.overwriteValuePath, 'test_value');
 
       const { servicePath: serviceDir } = await programmaticFixturesEngine.setup('plugin', {
         configExt,
@@ -226,17 +223,17 @@ describe('test/unit/lib/serverless.test.js', () => {
 
       expect(configuration).to.be.an('object', configuration);
 
-      const targetValue = _.get(configuration, targetValuePath);
-      expect(targetValue).to.not.be.undefined;
+      const targetValue = _.get(configuration, pluginConfig.targetValuePath);
+      expect(targetValue, 'Target value should not be undefined').to.not.be.undefined;
 
-      const targetValueAfterInit = _.get(configuration, targetValueAfterInitPath);
-      expect(targetValueAfterInit).to.be.undefined;
+      const afterInitValue = _.get(configuration, pluginConfig.afterInitValuePath);
+      expect(afterInitValue, 'afterInitValue should be undefined').to.be.undefined;
 
-      const refValue = _.get(configuration, targetRefPath);
-      expect(refValue).to.deep.equal(targetValue);
+      const refValue = _.get(configuration, pluginConfig.refValuePath);
+      expect(refValue).to.deep.equal(targetValue, 'refValue should equal targetValue');
 
-      const preexistValue = _.get(configuration, targetValuePreexistPath);
-      expect(preexistValue).to.deep.equal(targetValue);
+      const overwriteValue = _.get(configuration, pluginConfig.overwriteValuePath);
+      expect(overwriteValue).to.deep.equal(targetValue, 'overwriteValue should equal targetValue');
     });
   });
 });

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -284,7 +284,7 @@ describe('test/unit/lib/serverless.test.js', () => {
         newKey: 'value',
       };
       serverless.configurationInput = {};
-      const metaToKeep = ['path.to.keep'].map((_) => _.replace(/\./g, '\0'));
+      const metaToKeep = ['path.to.keep', `${path}suffix`].map((_) => _.replace(/\./g, '\0'));
       const metaToDelete = [path, `${path}.child`, `${path}.zero\0`].map((_) =>
         _.replace(/\./g, '\0')
       );

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -285,7 +285,9 @@ describe('test/unit/lib/serverless.test.js', () => {
       };
       serverless.configurationInput = {};
       const metaToKeep = ['path.to.keep'].map((_) => _.replace(/\./g, '\0'));
-      const metaToDelete = [path, `${path}.child`].map((_) => _.replace(/\./g, '\0'));
+      const metaToDelete = [path, `${path}.child`, `${path}.zero\0`].map((_) =>
+        _.replace(/\./g, '\0')
+      );
       const variablesMeta = metaToKeep.concat(metaToDelete);
 
       const keyStub = sinon.stub(serverless.variablesMeta, 'keys');

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 chai.use(require('chai-as-promised'));
 
-const { expect, assert } = chai;
+const { expect } = chai;
 
 const Serverless = require('../../../lib/serverless');
 const semverRegex = require('semver-regex');
@@ -218,7 +218,7 @@ describe('test/unit/lib/serverless.test.js', () => {
         configuration = yaml.load(String(serverlessProcess.stdoutBuffer));
       } catch (error) {
         const errorMessage = String(error.stdoutBuffer);
-        assert.fail(errorMessage);
+        throw Error(errorMessage);
       }
 
       expect(configuration).to.be.an('object', configuration);

--- a/test/unit/lib/serverless.test.js
+++ b/test/unit/lib/serverless.test.js
@@ -181,20 +181,10 @@ describe('test/unit/lib/serverless.test.js', () => {
   });
 
   describe('Extend configuration', () => {
-    let awsRegion;
     const pluginConfig =
       require('../../fixtures/programmatic/plugin/extend-config-plugin').pluginConfig;
 
     const serverlessPath = path.resolve(__dirname, '../../../scripts/serverless.js');
-
-    before(() => {
-      awsRegion = process.env.AWS_REGION;
-      process.env.AWS_REGION = 'us-east-1';
-    });
-
-    after(() => {
-      process.env.AWS_REGION = awsRegion;
-    });
 
     it('Extends configuration with given values', async () => {
       const customExt = { custom: {} };


### PR DESCRIPTION
Adds a new method in serverless-object for extending the internal configuration. This method extends variablesMeta with the newly added and parsed configuration.

VariablesMeta is now exposed via serverless-object.

Addresses the issue discussed in https://github.com/serverless/serverless/issues/11034.

Closes: #11034
