### PR TITLE
docs(AWS CloudFront): maximum function size limit

### DIFF
--- a/docs/providers/aws/events/cloudfront.md
+++ b/docs/providers/aws/events/cloudfront.md
@@ -37,6 +37,8 @@ Lambda@Edge has four options when the Lambda function is triggered
 
 **RUNTIME LIMITS:** According to [AWS Requirements on Lambda@Edge](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-requirements-limits.html) the runtimes supported by Lambda@Edge functions are: `Python 3.9`, `Python 3.8`, `Python 3.7`, `Node.js 16.x`, `Node.js 14.x`, `Node.js 12.x`, `Node.js 10.x`.
 
+**FUNCTION SIZE LIMITS:** According to [AWS Quotas on CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-functions), Lambda@Edge functions mustn't exceed the maximum size of 10KB. An easy way of reducing the size of a function is through bundling and minification via e.g. the plugin [serverless-esbuild](https://www.serverless.com/plugins/serverless-esbuild).
+
 ## Simple event definition
 
 This will enable your Lambda@Edge function to be called by a CloudFront.


### PR DESCRIPTION
This PR adds a note including a possible solution for CloudFront Functions, respectively Lambda@Edge. There's a function size limit of 10KB, which can easily get solved by bundling and minification.

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html#limits-functions
https://www.serverless.com/plugins/serverless-esbuild