### PR TITLE
Add ability to create AWS::Scheduler::Schedule triggers

### DIFF
--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -90,3 +90,27 @@ functions:
             key1: value1
             key2: value2
 ```
+
+## Use AWS::Scheduler::Schedule instead of AWS::Event::Rule
+
+**Note**: `scheduler` does not accept the `inputPath` or `inputTransformer` options. If you need these, use the default `eventBus` option
+
+AWS has account-wide limits on the number of `AWS::Event::Rule` triggers per bus (300 events), and all Lambda schedules go into a single bus with no way to override it.
+This can lead to a situation where large projects hit the limit with no ability to schedule more events.
+
+However, `AWS::Scheduler::Schedule` has much higher limits (1,000,000 events), and is configured identically.
+`method` can be set in order to migrate to this trigger type seamlessly. The default is `eventBus`, which configures an `AWS::Event::Rule`.
+
+```yaml
+functions:
+  foo:
+    handler: foo.handler
+    events:
+      - schedule:
+          method: scheduler
+          rate:
+            - cron(0 0/4 ? * MON-FRI *)
+          input:
+            key1: value1
+            key2: value2
+```

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -199,6 +199,9 @@ class AwsCompileScheduledEvents {
                   ScheduleExpression,
                   State,
                   Target: targetObj,
+                  FlexibleTimeWindow: {
+                    Mode: 'OFF',
+                  },
                 };
                 if (Name) {
                   Object.assign(properties, { Name });
@@ -209,9 +212,6 @@ class AwsCompileScheduledEvents {
 
                 scheduleTemplate = {
                   Type: 'AWS::Scheduler::Schedule',
-                  FlexibleTimeWindow: {
-                    Mode: 'OFF',
-                  },
                   Properties: properties,
                 };
               } else {

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -73,9 +73,6 @@ class AwsCompileScheduledEvents {
               type: 'string',
               enum: ['eventBus', 'scheduler'],
             },
-            roleArn: {
-              type: 'string',
-            },
           },
           required: ['rate'],
           additionalProperties: false,
@@ -88,6 +85,7 @@ class AwsCompileScheduledEvents {
     this.serverless.service.getAllFunctions().forEach((functionName) => {
       const functionObj = this.serverless.service.getFunction(functionName);
       let scheduleNumberInFunction = 0;
+      const functionRole = this.provider.naming.getRoleName();
 
       if (functionObj.events) {
         functionObj.events.forEach((event) => {
@@ -114,7 +112,9 @@ class AwsCompileScheduledEvents {
               InputTransformer = event.schedule.inputTransformer;
               Name = event.schedule.name;
               Description = event.schedule.description;
-              roleArn = event.schedule.roleArn;
+              roleArn = {
+                'Fn::GetAtt': [functionRole, 'Arn'],
+              };
 
               method = 'eventBus';
               if (event.schedule.method === 'scheduler') {
@@ -125,13 +125,6 @@ class AwsCompileScheduledEvents {
                 throw new ServerlessError(
                   'You cannot specify a name when defining more than one rate expression',
                   'SCHEDULE_NAME_NOT_ALLOWED_MULTIPLE_RATES'
-                );
-              }
-
-              if (method === 'scheduler' && !roleArn) {
-                throw new ServerlessError(
-                  'Cannot setup "schedule" event: parameter "roleArn" is required',
-                  'SCHEDULE_PARAMETER_NOT_FOUND'
                 );
               }
 

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -96,7 +96,7 @@ class AwsCompileScheduledEvents {
             let InputTransformer;
             let Name;
             let Description;
-            let Method;
+            let method;
 
             if (typeof event.schedule === 'object') {
               ScheduleExpressions = event.schedule.rate;
@@ -111,9 +111,9 @@ class AwsCompileScheduledEvents {
               Name = event.schedule.name;
               Description = event.schedule.description;
 
-              Method = 'eventBus';
+              method = 'eventBus';
               if (event.schedule.method === 'scheduler') {
-                Method = 'scheduler';
+                method = 'scheduler';
               }
 
               if (ScheduleExpressions.length > 1 && Name) {
@@ -129,30 +129,29 @@ class AwsCompileScheduledEvents {
                 }
                 Input = JSON.stringify(Input);
               }
-              if (Input && typeof Input === 'string') {
+              if (Input && typeof Input === 'string' && method !== 'scheduler') {
                 // escape quotes to favor JSON.parse
                 Input = Input.replace(/"/g, '\\"');
               }
               if (InputTransformer) {
-                if (Method === 'scheduler') {
+                if (method === 'scheduler') {
                   throw new ServerlessError(
-                    'InputTransformer is not supported for Scheduler::Schedule resources',
+                    'Cannot setup "schedule" event: "inputTransformer" is not supported with "scheduler" mode',
                     'SCHEDULE_PARAMETER_NOT_SUPPORTED'
                   );
                 } else {
                   InputTransformer = this.formatInputTransformer(InputTransformer);
                 }
               }
-              if (InputPath && Method === 'scheduler') {
+              if (InputPath && method === 'scheduler') {
                 throw new ServerlessError(
-                  'InputPath is not supported for Scheduler::Schedule resources',
+                  'Cannot setup "schedule" event: "inputPath" is not supported with "scheduler" mode',
                   'SCHEDULE_PARAMETER_NOT_SUPPORTED'
                 );
               }
             } else {
               ScheduleExpressions = [event.schedule];
               State = 'ENABLED';
-              Method = 'eventBus';
             }
 
             const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
@@ -171,41 +170,55 @@ class AwsCompileScheduledEvents {
                   scheduleNumberInFunction
                 );
 
-              const eventBusScheduleTemplate = `
-              {
-                "Type": "AWS::Events::Rule",
-                "Properties": {
-                  "ScheduleExpression": "${ScheduleExpression}",
-                  "State": "${State}",
-                  ${Name ? `"Name": "${Name}",` : ''}
-                  ${Description ? `"Description": "${Description}",` : ''}
-                  "Targets": [{
-                    ${Input ? `"Input": "${Input}",` : ''}
-                    ${InputPath ? `"InputPath": "${InputPath}",` : ''}
-                    ${InputTransformer ? `"InputTransformer": ${InputTransformer},` : ''}
-                    "Arn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
-                    "Id": "${scheduleId}"
-                  }]
-                }
-              }
-            `;
+              let scheduleTemplate;
 
-              const schedulerScheduleTemplate = `
-              {
-                "Type": "AWS::Scheduler::Schedule",
-                "Properties": {
-                  "ScheduleExpression": "${ScheduleExpression}",
-                  "State": "${State}",
-                  ${Name ? `"Name": "${Name}",` : ''}
-                  ${Description ? `"Description": "${Description}",` : ''}
-                  "Target": {
-                    ${Input ? `"Input": "${Input}",` : ''}
-                    "Arn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
-                    "Id": "${scheduleId}"
-                  }
+              if (method === 'scheduler') {
+                const targetObj = {
+                  Arn: {
+                    'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+                  },
+                  Id: scheduleId,
+                };
+                if (Input) {
+                  Object.assign(targetObj, { Input });
                 }
+
+                const properties = {
+                  ScheduleExpression,
+                  State,
+                  Target: targetObj,
+                };
+                if (Name) {
+                  Object.assign(properties, { Name });
+                }
+                if (Description) {
+                  Object.assign(properties, { Description });
+                }
+
+                scheduleTemplate = {
+                  Type: 'AWS::Scheduler::Schedule',
+                  Properties: properties,
+                };
+              } else {
+                scheduleTemplate = `
+                  {
+                    "Type": "AWS::Events::Rule",
+                    "Properties": {
+                      "ScheduleExpression": "${ScheduleExpression}",
+                      "State": "${State}",
+                      ${Name ? `"Name": "${Name}",` : ''}
+                      ${Description ? `"Description": "${Description}",` : ''}
+                      "Targets": [{
+                        ${Input ? `"Input": "${Input}",` : ''}
+                        ${InputPath ? `"InputPath": "${InputPath}",` : ''}
+                        ${InputTransformer ? `"InputTransformer": ${InputTransformer},` : ''}
+                        "Arn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
+                        "Id": "${scheduleId}"
+                      }]
+                    }
+                  }
+                `;
               }
-            `;
 
               const permissionTemplate = `
               {
@@ -221,9 +234,7 @@ class AwsCompileScheduledEvents {
 
               const newScheduleObject = {
                 [scheduleLogicalId]:
-                  Method === 'scheduler'
-                    ? JSON.parse(schedulerScheduleTemplate)
-                    : JSON.parse(eventBusScheduleTemplate),
+                  method === 'scheduler' ? scheduleTemplate : JSON.parse(scheduleTemplate),
               };
 
               const newPermissionObject = {

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -69,6 +69,10 @@ class AwsCompileScheduledEvents {
               required: ['inputTemplate'],
               additionalProperties: false,
             },
+            method: {
+              type: 'string',
+              enum: ['eventBus', 'scheduler'],
+            },
           },
           required: ['rate'],
           additionalProperties: false,
@@ -92,6 +96,7 @@ class AwsCompileScheduledEvents {
             let InputTransformer;
             let Name;
             let Description;
+            let Method;
 
             if (typeof event.schedule === 'object') {
               ScheduleExpressions = event.schedule.rate;
@@ -105,6 +110,11 @@ class AwsCompileScheduledEvents {
               InputTransformer = event.schedule.inputTransformer;
               Name = event.schedule.name;
               Description = event.schedule.description;
+
+              Method = 'eventBus';
+              if (event.schedule.method === 'scheduler') {
+                Method = 'scheduler';
+              }
 
               if (ScheduleExpressions.length > 1 && Name) {
                 throw new ServerlessError(
@@ -124,11 +134,25 @@ class AwsCompileScheduledEvents {
                 Input = Input.replace(/"/g, '\\"');
               }
               if (InputTransformer) {
-                InputTransformer = this.formatInputTransformer(InputTransformer);
+                if (Method === 'scheduler') {
+                  throw new ServerlessError(
+                    'InputTransformer is not supported for Scheduler::Schedule resources',
+                    'SCHEDULE_PARAMETER_NOT_SUPPORTED'
+                  );
+                } else {
+                  InputTransformer = this.formatInputTransformer(InputTransformer);
+                }
+              }
+              if (InputPath && Method === 'scheduler') {
+                throw new ServerlessError(
+                  'InputPath is not supported for Scheduler::Schedule resources',
+                  'SCHEDULE_PARAMETER_NOT_SUPPORTED'
+                );
               }
             } else {
               ScheduleExpressions = [event.schedule];
               State = 'ENABLED';
+              Method = 'eventBus';
             }
 
             const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
@@ -147,7 +171,7 @@ class AwsCompileScheduledEvents {
                   scheduleNumberInFunction
                 );
 
-              const scheduleTemplate = `
+              const eventBusScheduleTemplate = `
               {
                 "Type": "AWS::Events::Rule",
                 "Properties": {
@@ -166,6 +190,23 @@ class AwsCompileScheduledEvents {
               }
             `;
 
+              const schedulerScheduleTemplate = `
+              {
+                "Type": "AWS::Scheduler::Schedule",
+                "Properties": {
+                  "ScheduleExpression": "${ScheduleExpression}",
+                  "State": "${State}",
+                  ${Name ? `"Name": "${Name}",` : ''}
+                  ${Description ? `"Description": "${Description}",` : ''}
+                  "Target": {
+                    ${Input ? `"Input": "${Input}",` : ''}
+                    "Arn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
+                    "Id": "${scheduleId}"
+                  }
+                }
+              }
+            `;
+
               const permissionTemplate = `
               {
                 "Type": "AWS::Lambda::Permission",
@@ -179,7 +220,10 @@ class AwsCompileScheduledEvents {
             `;
 
               const newScheduleObject = {
-                [scheduleLogicalId]: JSON.parse(scheduleTemplate),
+                [scheduleLogicalId]:
+                  Method === 'scheduler'
+                    ? JSON.parse(schedulerScheduleTemplate)
+                    : JSON.parse(eventBusScheduleTemplate),
               };
 
               const newPermissionObject = {

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -73,6 +73,9 @@ class AwsCompileScheduledEvents {
               type: 'string',
               enum: ['eventBus', 'scheduler'],
             },
+            roleArn: {
+              type: 'string',
+            },
           },
           required: ['rate'],
           additionalProperties: false,
@@ -97,6 +100,7 @@ class AwsCompileScheduledEvents {
             let Name;
             let Description;
             let method;
+            let roleArn;
 
             if (typeof event.schedule === 'object') {
               ScheduleExpressions = event.schedule.rate;
@@ -110,6 +114,7 @@ class AwsCompileScheduledEvents {
               InputTransformer = event.schedule.inputTransformer;
               Name = event.schedule.name;
               Description = event.schedule.description;
+              roleArn = event.schedule.roleArn;
 
               method = 'eventBus';
               if (event.schedule.method === 'scheduler') {
@@ -120,6 +125,13 @@ class AwsCompileScheduledEvents {
                 throw new ServerlessError(
                   'You cannot specify a name when defining more than one rate expression',
                   'SCHEDULE_NAME_NOT_ALLOWED_MULTIPLE_RATES'
+                );
+              }
+
+              if (method === 'scheduler' && !roleArn) {
+                throw new ServerlessError(
+                  'Cannot setup "schedule" event: parameter "roleArn" is required',
+                  'SCHEDULE_PARAMETER_NOT_FOUND'
                 );
               }
 
@@ -177,7 +189,7 @@ class AwsCompileScheduledEvents {
                   Arn: {
                     'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
                   },
-                  Id: scheduleId,
+                  RoleArn: roleArn,
                 };
                 if (Input) {
                   Object.assign(targetObj, { Input });
@@ -197,6 +209,9 @@ class AwsCompileScheduledEvents {
 
                 scheduleTemplate = {
                   Type: 'AWS::Scheduler::Schedule',
+                  FlexibleTimeWindow: {
+                    Mode: 'OFF',
+                  },
                   Properties: properties,
                 };
               } else {

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -40,6 +40,7 @@ async function run(events) {
 
       const scheduleLogicalId = awsNaming.getScheduleLogicalId('test', index);
       const scheduleCfResource = cfResources[scheduleLogicalId];
+      scheduleCfResource.serviceName = awsNaming.provider.serverless.service.service;
 
       scheduleCfResources.push(scheduleCfResource);
     }
@@ -110,7 +111,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
           name: 'scheduler-scheduled-event',
           description: 'Scheduler Scheduled Event',
           input: '{"key":"array"}',
-          roleArn: 'arn:xxx',
         },
       },
       {
@@ -118,7 +118,6 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
           rate: 'cron(15 10 ? * SAT-SUN *)',
           enabled: false,
           method: 'scheduler',
-          roleArn: 'arn:xxx',
         },
       },
     ];
@@ -269,14 +268,12 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
           rate: 'rate(15 minutes)',
           method: 'scheduler',
           inputPath: '$.stageVariables',
-          roleArn: 'arn:xxx',
         },
       },
       {
         schedule: {
           rate: 'rate(15 minutes)',
           method: 'scheduler',
-          roleArn: 'arn:xxx',
           inputTransformer: {
             inputPathsMap: { eventTime: '$.time' },
             inputTemplate: '{"time": <eventTime>, "key": "value"}',
@@ -296,24 +293,43 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
     );
   });
 
-  it('should respect the roleArn variable for method:schedule resources', () => {
-    expect(scheduleCfResources[8].Properties.Target.RoleArn).to.equal('arn:xxx');
-    expect(scheduleCfResources[9].Properties.Target.RoleArn).to.equal('arn:xxx');
-  });
-
-  it('should throw when roleArn is not passed to method:schedule resources', async () => {
-    const event = {
-      schedule: {
-        rate: 'rate(15 minutes)',
-        method: 'scheduler',
-        inputPath: '$.stageVariables',
-      },
-    };
-
-    await expect(run([event])).to.be.eventually.rejectedWith(
-      ServerlessError,
-      'Cannot setup "schedule" event: parameter "roleArn" is required'
-    );
+  it('should pass the roleArn to method:schedule resources', () => {
+    expect(scheduleCfResources[8].Properties.Target.RoleArn).to.deep.equal({
+      'Fn::GetAtt': [
+        {
+          'Fn::Join': [
+            '-',
+            [
+              scheduleCfResources[8].serviceName,
+              'dev',
+              {
+                Ref: 'AWS::Region',
+              },
+              'lambdaRole',
+            ],
+          ],
+        },
+        'Arn',
+      ],
+    });
+    expect(scheduleCfResources[9].Properties.Target.RoleArn).to.deep.equal({
+      'Fn::GetAtt': [
+        {
+          'Fn::Join': [
+            '-',
+            [
+              scheduleCfResources[8].serviceName,
+              'dev',
+              {
+                Ref: 'AWS::Region',
+              },
+              'lambdaRole',
+            ],
+          ],
+        },
+        'Arn',
+      ],
+    });
   });
 
   it('should not create schedule resources when no scheduled event is given', async () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -283,12 +283,12 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
 
     await expect(run([events[0]])).to.be.eventually.rejectedWith(
       ServerlessError,
-      'InputPath is not supported for Scheduler::Schedule resources'
+      'Cannot setup "schedule" event: "inputPath" is not supported with "scheduler" mode'
     );
 
     await expect(run([events[1]])).to.be.eventually.rejectedWith(
       ServerlessError,
-      'InputTransformer is not supported for Scheduler::Schedule resources'
+      'Cannot setup "schedule" event: "inputTransformer" is not supported with "scheduler" mode'
     );
   });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -110,6 +110,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
           name: 'scheduler-scheduled-event',
           description: 'Scheduler Scheduled Event',
           input: '{"key":"array"}',
+          roleArn: 'arn:xxx',
         },
       },
       {
@@ -117,6 +118,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
           rate: 'cron(15 10 ? * SAT-SUN *)',
           enabled: false,
           method: 'scheduler',
+          roleArn: 'arn:xxx',
         },
       },
     ];
@@ -289,6 +291,28 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
     await expect(run([events[1]])).to.be.eventually.rejectedWith(
       ServerlessError,
       'Cannot setup "schedule" event: "inputTransformer" is not supported with "scheduler" mode'
+    );
+  });
+
+  it('should respect the roleArn variable for method:schedule resources', () => {
+    expect(scheduleCfResources[8].Properties.Target.RoleArn).to.equal('arn:xxx');
+    expect(scheduleCfResources[9].Properties.Target.RoleArn).to.equal('arn:xxx');
+  });
+
+  it('should throw when roleArn is not passed to method:schedule resources', async () => {
+    const event = {
+      schedule: {
+        schedule: {
+          rate: 'rate(15 minutes)',
+          method: 'scheduler',
+          inputPath: '$.stageVariables',
+        },
+      },
+    };
+
+    await expect(run([event])).to.be.eventually.rejectedWith(
+      ServerlessError,
+      'Cannot setup "schedule" event: parameter "roleArn" is required'
     );
   });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -269,12 +269,14 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
           rate: 'rate(15 minutes)',
           method: 'scheduler',
           inputPath: '$.stageVariables',
+          roleArn: 'arn:xxx',
         },
       },
       {
         schedule: {
           rate: 'rate(15 minutes)',
           method: 'scheduler',
+          roleArn: 'arn:xxx',
           inputTransformer: {
             inputPathsMap: { eventTime: '$.time' },
             inputTemplate: '{"time": <eventTime>, "key": "value"}',
@@ -302,11 +304,9 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
   it('should throw when roleArn is not passed to method:schedule resources', async () => {
     const event = {
       schedule: {
-        schedule: {
-          rate: 'rate(15 minutes)',
-          method: 'scheduler',
-          inputPath: '$.stageVariables',
-        },
+        rate: 'rate(15 minutes)',
+        method: 'scheduler',
+        inputPath: '$.stageVariables',
       },
     };
 


### PR DESCRIPTION
Adds the ability to create AWS::Scheduler::Schedule triggers as an alternative to AWS::Event::Rule, which may be preferable if hitting account-wide limits on number of AWS::Event::Rule triggers per bus (Lambdas are only able to be triggered from the default bus).

Unless they need to use `inputPath` or `inputTransformer`, developers should be able to just add the `method` config option and seamlessly migrate to use Scheduler if the devs find themselves up against the account quotas.

Closes: [#11680 ](https://github.com/serverless/serverless/issues/11680)
