### PR TITLE
docs: Remove incorrect default value for shouldStartNameWithService

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -286,7 +286,7 @@ provider:
       - '*/*'
     # Optional detailed Cloud Watch Metrics
     metrics: false
-    # Use `${service}-${stage}` naming for API Gateway. Will be `true` by default in v3.
+    # Use `${service}-${stage}` naming for API Gateway.
     shouldStartNameWithService: false
     resourcePolicy:
       - Effect: Allow


### PR DESCRIPTION
The plan was to make the default `shouldStartNameWithService` to be true in v3, but that decision was reverted in
https://github.com/serverless/serverless/pull/9160#issuecomment-805608103 and the default value in v3 is still actually false.

This caused my team issues today after we removed `shouldStartNameWithService: true` from our `serverless.yml` thinking that as its the default it isn't needed to be explicitly defined (we're using v3), but when we deployed the change it created a new API gateway resource which was totally unexpected and caused us some headaches. I believe this is because contrary to what the docs say, the default `shouldStartNameWithService` in v3 is still actually false.