### PR TITLE
Add support for cloudformation functions for provisioned concurrency

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -582,7 +582,6 @@ class AwsCompileFunctions {
       if (functionObject.provisionedConcurrency) {
         if (!shouldVersionFunction) delete versionResource.DeletionPolicy;
 
-        const provisionedConcurrency = Number(functionObject.provisionedConcurrency);
         const aliasLogicalId =
           this.provider.naming.getLambdaProvisionedConcurrencyAliasLogicalId(functionName);
         const aliasName = this.provider.naming.getLambdaProvisionedConcurrencyAliasName();
@@ -596,7 +595,7 @@ class AwsCompileFunctions {
             FunctionVersion: { 'Fn::GetAtt': [versionLogicalId, 'Version'] },
             Name: aliasName,
             ProvisionedConcurrencyConfig: {
-              ProvisionedConcurrentExecutions: provisionedConcurrency,
+              ProvisionedConcurrentExecutions: functionObject.provisionedConcurrency,
             },
           },
           DependsOn: functionLogicalId,

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1443,7 +1443,7 @@ class AwsProvider {
               },
               additionalProperties: false,
             },
-            provisionedConcurrency: { type: 'integer', minimum: 0 },
+            provisionedConcurrency: cfValue({ type: 'integer', minimum: 0 }),
             reservedConcurrency: cfValue({ type: 'integer', minimum: 0 }),
             role: { $ref: '#/definitions/awsLambdaRole' },
             runtime: { $ref: '#/definitions/awsLambdaRuntime' },


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

I need to dynamically have provisioned concurrency turned on in some cases, but the current implementation doesn't support that scenario. This fix is similar to what I did for #10129 for reserved concurrency.
