### PR TITLE
Update ambiguous logRetentionInDays documentation

### DIFF
--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -126,7 +126,8 @@ provider:
   # Function environment variables
   environment:
     APP_ENV_VARIABLE: FOOBAR
-  # Duration for CloudWatch log retention (default: forever)
+  # Duration for CloudWatch log retention (default: forever).
+  # Can be overridden for each function separately inside the functions block, see below on page.
   # Valid values: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html
   logRetentionInDays: 14
   # Policy defining how to monitor and mask sensitive data in CloudWatch logs
@@ -653,7 +654,7 @@ functions:
     snapStart: true
     # Disable the creation of the CloudWatch log group
     disableLogs: false
-    # Duration for CloudWatch log retention (default: forever).
+    # Duration for CloudWatch log retention (default: forever). Overrides provider setting.
     logRetentionInDays: 14
     tags: # Function specific tags
       foo: bar


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Updates the documentation on logRetentionInDays for CloudWatch log groups, as it wasn't mentioned anywhere that setting it for a function overrides the provider value (can be seen in `/lib/plugins/aws/package/lib/merge-iam-templates.js`):
```
const logRetentionInDays = functionObject.logRetentionInDays || this.provider.getLogRetentionInDays();
if (logRetentionInDays) {
    newLogGroup[logGroupLogicalId].Properties.RetentionInDays = logRetentionInDays;
}
```
