### PR TITLE
fix: Changed Map for runtimeManagementMap

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -27,7 +27,7 @@ const defaultCors = {
 };
 const runtimeManagementMap = new Map([
   ['auto', 'Auto'],
-  ['onFunctionUpdate', 'Function update'],
+  ['onFunctionUpdate', 'FunctionUpdate'],
   ['manual', 'Manual'],
 ]);
 

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1351,7 +1351,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       const { UpdateRuntimeOn } =
         cfResources[naming.getLambdaLogicalId('foo')].Properties.RuntimeManagementConfig;
 
-      expect(UpdateRuntimeOn).to.equal('Function update');
+      expect(UpdateRuntimeOn).to.equal('FunctionUpdate');
     });
 
     it('should support `provider.versionFunctions: false`', () => {


### PR DESCRIPTION
It was not in sync with Cloudformation, could be Cloudformation is wrong, just syncing this with CF. Here's the link to the documentation:- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-runtimemanagementconfig.html#cfn-lambda-function-runtimemanagementconfig-updateruntimeon

Fix for PR #11715
