### PR TITLE
Lambda alias events

### DIFF
--- a/lib/plugins/aws/package/compile/events/activemq.js
+++ b/lib/plugins/aws/package/compile/events/activemq.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
+const _ = require('lodash');
+
 class AwsCompileActiveMQEvents {
   constructor(serverless) {
     this.serverless = serverless;
@@ -106,16 +109,17 @@ class AwsCompileActiveMQEvents {
           functionName,
           queue
         );
-        const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-        const dependsOn = this.provider.resolveFunctionIamRoleResourceName(functionObj) || [];
+
+        const dependsOn = _.compact([
+          this.provider.resolveFunctionIamRoleResourceName(functionObj),
+          _.get(functionObj.targetAlias, 'logicalId'),
+        ]);
 
         const mqResource = {
           Type: 'AWS::Lambda::EventSourceMapping',
           DependsOn: dependsOn,
           Properties: {
-            FunctionName: {
-              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-            },
+            FunctionName: resolveLambdaTarget(functionName, functionObj),
             EventSourceArn: arn,
             Queues: [queue],
             SourceAccessConfigurations: [

--- a/lib/plugins/aws/package/compile/events/activemq.js
+++ b/lib/plugins/aws/package/compile/events/activemq.js
@@ -110,10 +110,10 @@ class AwsCompileActiveMQEvents {
           queue
         );
 
-        const dependsOn = _.compact([
+        const dependsOn = [
           this.provider.resolveFunctionIamRoleResourceName(functionObj),
           _.get(functionObj.targetAlias, 'logicalId'),
-        ]);
+        ].filter(Boolean);
 
         const mqResource = {
           Type: 'AWS::Lambda::EventSourceMapping',

--- a/lib/plugins/aws/package/compile/events/alb/lib/target-groups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/target-groups.js
@@ -87,7 +87,7 @@ module.exports = {
         DependsOn: [
           registerTargetPermissionLogicalId,
           _.get(functionObj.targetAlias, 'logicalId'),
-        ].filter((d) => d),
+        ].filter(Boolean),
       };
       Object.assign(TargetGroup.Properties, healthCheckProperties);
       Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {

--- a/lib/plugins/aws/package/compile/events/alb/lib/target-groups.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/target-groups.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const resolveLambdaTarget = require('../../../../../utils/resolve-lambda-target');
+const _ = require('lodash');
 
 const healthCheckDefaults = {
   HealthCheckEnabled: false,
@@ -83,7 +84,10 @@ module.exports = {
             },
           ],
         },
-        DependsOn: [registerTargetPermissionLogicalId],
+        DependsOn: [
+          registerTargetPermissionLogicalId,
+          _.get(functionObj.targetAlias, 'logicalId'),
+        ].filter((d) => d),
       };
       Object.assign(TargetGroup.Properties, healthCheckProperties);
       Object.assign(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {

--- a/lib/plugins/aws/package/compile/events/alexa-skill.js
+++ b/lib/plugins/aws/package/compile/events/alexa-skill.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 class AwsCompileAlexaSkillEvents {
   constructor(serverless) {
@@ -58,14 +59,11 @@ class AwsCompileAlexaSkillEvents {
           }
           alexaSkillNumberInFunction++;
 
-          const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-
           const permissionTemplate = {
             Type: 'AWS::Lambda::Permission',
+            DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
             Properties: {
-              FunctionName: {
-                'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-              },
+              FunctionName: resolveLambdaTarget(functionName, functionObj),
               Action: enabled ? 'lambda:InvokeFunction' : 'lambda:DisableInvokeFunction',
               Principal: 'alexa-appkit.amazon.com',
             },

--- a/lib/plugins/aws/package/compile/events/alexa-smart-home.js
+++ b/lib/plugins/aws/package/compile/events/alexa-smart-home.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 class AwsCompileAlexaSmartHomeEvents {
   constructor(serverless) {
@@ -49,14 +50,12 @@ class AwsCompileAlexaSmartHomeEvents {
               EventSourceToken = event.alexaSmartHome;
               Action = 'lambda:InvokeFunction';
             }
-            const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
 
             const permissionTemplate = {
               Type: 'AWS::Lambda::Permission',
+              DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
               Properties: {
-                FunctionName: {
-                  'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                },
+                FunctionName: resolveLambdaTarget(functionName, functionObj),
                 Action: Action.replace(/\\n|\\r/g, ''),
                 Principal: 'alexa-connectedhome.amazon.com',
                 EventSourceToken: EventSourceToken.replace(/\\n|\\r/g, ''),

--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/authorizers.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/authorizers.js
@@ -51,6 +51,7 @@ module.exports = {
         _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
           [authorizerLogicalId]: {
             Type: 'AWS::ApiGateway::Authorizer',
+            DependsOn: authorizer.logicalId,
             Properties: authorizerProperties,
           },
         });

--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/method/authorization.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/method/authorization.js
@@ -57,7 +57,7 @@ module.exports = {
             AuthorizationType: authorizationType,
             AuthorizerId: { Ref: authorizerLogicalId },
           },
-          DependsOn: authorizerLogicalId,
+          DependsOn: [authorizerLogicalId],
         };
         if (http.authorizer.scopes && http.authorizer.scopes.length) {
           cognitoReturn.Properties.AuthorizationScopes = http.authorizer.scopes;
@@ -70,7 +70,7 @@ module.exports = {
           AuthorizationType: authorizationType,
           AuthorizerId: { Ref: authorizerLogicalId },
         },
-        DependsOn: authorizerLogicalId,
+        DependsOn: [authorizerLogicalId],
       };
     }
 

--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/method/index.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/method/index.js
@@ -61,6 +61,10 @@ module.exports = {
       };
       this.permissionMapping.push(singlePermissionMapping);
 
+      if (lambdaAliasLogicalId) {
+        template.DependsOn.push(lambdaAliasLogicalId);
+      }
+
       _.merge(
         template,
         this.getMethodAuthorization(event.http),

--- a/lib/plugins/aws/package/compile/events/cloud-watch-event.js
+++ b/lib/plugins/aws/package/compile/events/cloud-watch-event.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const ServerlessError = require('../../../../../serverless-error');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 class AwsCompileCloudWatchEventEvents {
   constructor(serverless) {
@@ -86,7 +87,6 @@ class AwsCompileCloudWatchEventEvents {
               InputTransformer = this.formatInputTransformer(InputTransformer);
             }
 
-            const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             const cloudWatchLogicalId = this.provider.naming.getCloudWatchEventLogicalId(
               functionName,
               cloudWatchEventNumberInFunction
@@ -98,9 +98,12 @@ class AwsCompileCloudWatchEventEvents {
               );
             const cloudWatchId = this.provider.naming.getCloudWatchEventId(functionName);
 
+            const dependsOn = _.get(functionObj.targetAlias, 'logicalId');
+
             const cloudWatchEventRuleTemplate = `
               {
                 "Type": "AWS::Events::Rule",
+                ${dependsOn ? `"DependsOn": "${dependsOn}",` : ''}
                 "Properties": {
                   "EventPattern": ${EventPattern.replace(/\\n|\\r/g, '')},
                   "State": "${State}",
@@ -110,7 +113,7 @@ class AwsCompileCloudWatchEventEvents {
                     ${Input ? `"Input": "${Input.replace(/\\n|\\r/g, '')}",` : ''}
                     ${InputPath ? `"InputPath": "${InputPath.replace(/\r?\n/g, '')}",` : ''}
                     ${InputTransformer ? `"InputTransformer": ${InputTransformer},` : ''}
-                    "Arn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
+                    "Arn": ${JSON.stringify(resolveLambdaTarget(functionName, functionObj))},
                     "Id": "${cloudWatchId}"
                   }]
                 }
@@ -120,8 +123,9 @@ class AwsCompileCloudWatchEventEvents {
             const permissionTemplate = `
               {
                 "Type": "AWS::Lambda::Permission",
+                ${dependsOn ? `"DependsOn": "${dependsOn}",` : ''}
                 "Properties": {
-                  "FunctionName": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
+                  "FunctionName": ${JSON.stringify(resolveLambdaTarget(functionName, functionObj))},
                   "Action": "lambda:InvokeFunction",
                   "Principal": "events.amazonaws.com",
                   "SourceArn": { "Fn::GetAtt": ["${cloudWatchLogicalId}", "Arn"] }

--- a/lib/plugins/aws/package/compile/events/cloud-watch-log.js
+++ b/lib/plugins/aws/package/compile/events/cloud-watch-log.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const ServerlessError = require('../../../../../serverless-error');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 class AwsCompileCloudWatchLogEvents {
   constructor(serverless) {
@@ -73,7 +74,6 @@ class AwsCompileCloudWatchLogEvents {
             }
             logGroupNamesThisFunction.push(LogGroupName);
 
-            const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             const cloudWatchLogLogicalId = this.provider.naming.getCloudWatchLogLogicalId(
               functionName,
               cloudWatchLogNumberInFunction
@@ -88,14 +88,21 @@ class AwsCompileCloudWatchLogEvents {
               FilterPattern = FilterPattern.replace(/\\("|\\|')/g, (match, g) => g);
             }
 
+            const dependsOn = _.compact([
+              lambdaPermissionLogicalId,
+              _.get(functionObj.targetAlias, 'logicalId'),
+            ]);
+
             const cloudWatchLogRuleTemplate = `
               {
                 "Type": "AWS::Logs::SubscriptionFilter",
-                "DependsOn": "${lambdaPermissionLogicalId}",
+                ${dependsOn.length ? `"DependsOn": ${JSON.stringify(dependsOn)},` : ''}
                 "Properties": {
                   "LogGroupName": "${LogGroupName}",
                   "FilterPattern": ${JSON.stringify(FilterPattern)},
-                  "DestinationArn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] }
+                  "DestinationArn": ${JSON.stringify(
+                    resolveLambdaTarget(functionName, functionObj)
+                  )}
                 }
               }
             `;
@@ -105,8 +112,9 @@ class AwsCompileCloudWatchLogEvents {
             const permissionTemplate = `
             {
               "Type": "AWS::Lambda::Permission",
+              ${dependsOn.length ? `"DependsOn": ${JSON.stringify(dependsOn)},` : ''}
               "Properties": {
-                "FunctionName": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
+                "FunctionName": ${JSON.stringify(resolveLambdaTarget(functionName, functionObj))},
                 "Action": "lambda:InvokeFunction",
                 "Principal": {
                   "Fn::Join": [ "", [

--- a/lib/plugins/aws/package/compile/events/cloud-watch-log.js
+++ b/lib/plugins/aws/package/compile/events/cloud-watch-log.js
@@ -88,10 +88,10 @@ class AwsCompileCloudWatchLogEvents {
               FilterPattern = FilterPattern.replace(/\\("|\\|')/g, (match, g) => g);
             }
 
-            const dependsOn = _.compact([
+            const dependsOn = [
               lambdaPermissionLogicalId,
               _.get(functionObj.targetAlias, 'logicalId'),
-            ]);
+            ].filter(Boolean);
 
             const cloudWatchLogRuleTemplate = `
               {

--- a/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const { addCustomResourceToService } = require('../../../custom-resources');
 const ServerlessError = require('../../../../../serverless-error');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 const customSenderSources = ['CustomSMSSender', 'CustomEmailSender'];
 const validTriggerSources = [
@@ -85,16 +86,19 @@ class AwsCompileCognitoUserPoolEvents {
               const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(
                 cognitoUserPoolTriggerFunction.poolName
               );
-              const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(
+
+              const triggerFunctionObj = service.getFunction(
                 cognitoUserPoolTriggerFunction.functionName
               );
 
               const permissionTemplate = {
                 Type: 'AWS::Lambda::Permission',
+                DependsOn: _.get(triggerFunctionObj.targetAlias, 'logicalId'),
                 Properties: {
-                  FunctionName: {
-                    'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                  },
+                  FunctionName: resolveLambdaTarget(
+                    cognitoUserPoolTriggerFunction.functionName,
+                    triggerFunctionObj
+                  ),
                   Action: 'lambda:InvokeFunction',
                   Principal: 'cognito-idp.amazonaws.com',
                   SourceArn: {
@@ -343,15 +347,13 @@ class AwsCompileCognitoUserPoolEvents {
   generateTemplateForPool(poolName, currentPoolTriggerFunctions) {
     const poolKmsIdMap = new Map();
     const lambdaConfig = currentPoolTriggerFunctions.reduce((result, value) => {
-      const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(value.functionName);
+      const functionObj = this.serverless.service.getFunction(value.functionName);
 
       let triggerObject;
       if (customSenderSources.includes(value.triggerSource)) {
         triggerObject = {
           [value.triggerSource]: {
-            LambdaArn: {
-              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-            },
+            LambdaArn: resolveLambdaTarget(value.functionName, functionObj),
             LambdaVersion: value.lambdaVersion || validLambdaVersions[0],
           },
         };
@@ -359,9 +361,7 @@ class AwsCompileCognitoUserPoolEvents {
         triggerObject.KMSKeyID = value.kmsKeyId;
       } else {
         triggerObject = {
-          [value.triggerSource]: {
-            'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-          },
+          [value.triggerSource]: resolveLambdaTarget(value.functionName, functionObj),
         };
       }
 
@@ -372,9 +372,13 @@ class AwsCompileCognitoUserPoolEvents {
     const userPoolLogicalId = this.provider.naming.getCognitoUserPoolLogicalId(poolName);
 
     // Attach `DependsOn` for any relevant Lambdas
-    const DependsOn = currentPoolTriggerFunctions.map((value) =>
-      this.provider.naming.getLambdaLogicalId(value.functionName)
-    );
+    const DependsOn = currentPoolTriggerFunctions.map((value) => {
+      const functionObj = this.serverless.service.getFunction(value.functionName);
+      return (
+        _.get(functionObj.targetAlias, 'logicalId') ||
+        this.provider.naming.getLambdaLogicalId(value.functionName)
+      );
+    });
 
     return {
       [userPoolLogicalId]: {

--- a/lib/plugins/aws/package/compile/events/event-bridge/index.js
+++ b/lib/plugins/aws/package/compile/events/event-bridge/index.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const { addCustomResourceToService } = require('../../../../custom-resources');
 const ServerlessError = require('../../../../../../serverless-error');
 const { makeAndHashRuleName, makeEventBusTargetId, makeRuleName } = require('./utils');
+const resolveLambdaTarget = require('../../../../utils/resolve-lambda-target');
 
 class AwsCompileEventBridgeEvents {
   constructor(serverless, options) {
@@ -404,10 +405,9 @@ class AwsCompileEventBridgeEvents {
       ] = eventBusResource;
     }
 
+    const functionObj = this.serverless.service.getFunction(functionName);
     const targetBase = {
-      Arn: {
-        'Fn::GetAtt': [this.provider.naming.getLambdaLogicalId(functionName), 'Arn'],
-      },
+      Arn: resolveLambdaTarget(functionName, functionObj),
       Id: makeEventBusTargetId(RuleName),
     };
 
@@ -423,6 +423,7 @@ class AwsCompileEventBridgeEvents {
     // Create a rule
     const eventRuleResource = {
       Type: 'AWS::Events::Rule',
+      DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
       Properties: {
         // default event bus is used when EventBusName is not set
         EventBusName: eventBusName === 'default' ? undefined : eventBusName,
@@ -451,11 +452,10 @@ class AwsCompileEventBridgeEvents {
     const ruleNameArnPath = eventBusName ? [eventBusName, RuleName] : [RuleName];
     const lambdaPermissionResource = {
       Type: 'AWS::Lambda::Permission',
+      DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
       Properties: {
         Action: 'lambda:InvokeFunction',
-        FunctionName: {
-          Ref: this.provider.naming.getLambdaLogicalId(functionName),
-        },
+        FunctionName: resolveLambdaTarget(functionName, functionObj),
         Principal: 'events.amazonaws.com',
         SourceArn: {
           'Fn::Join': [

--- a/lib/plugins/aws/package/compile/events/http-api.js
+++ b/lib/plugins/aws/package/compile/events/http-api.js
@@ -237,6 +237,10 @@ class HttpApiEvents {
             ],
           ],
         };
+        authorizerResource.DependsOn = _.get(
+          _.get(authorizer.functionObject, 'targetAlias'),
+          'logicalId'
+        );
 
         // If authorizer is not managed externally, we need to make sure the correct permission is created that
         // allows API Gateway to invoke authorizer function

--- a/lib/plugins/aws/package/compile/events/http-api.js
+++ b/lib/plugins/aws/package/compile/events/http-api.js
@@ -635,6 +635,7 @@ Object.defineProperties(
         this.provider.naming.getHttpApiIntegrationLogicalId(routeTargetData.functionName)
       ] = {
         Type: 'AWS::ApiGatewayV2::Integration',
+        DependsOn: _.get(routeTargetData.functionAlias, 'logicalId'),
         Properties: properties,
       };
     }),

--- a/lib/plugins/aws/package/compile/events/iot-fleet-provisioning.js
+++ b/lib/plugins/aws/package/compile/events/iot-fleet-provisioning.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const ServerlessError = require('../../../../../serverless-error');
+const _ = require('lodash');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 class AwsCompileIotFleetProvisioningEvents {
   constructor(serverless) {
@@ -41,7 +43,6 @@ class AwsCompileIotFleetProvisioningEvents {
         const provisioningRoleArn = event.iotFleetProvisioning.provisioningRoleArn;
         const templateBody = event.iotFleetProvisioning.templateBody;
 
-        const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
         const iotFleetProvisioningLogicalId =
           this.provider.naming.getIotFleetProvisioningLogicalId(functionName);
         const lambdaPermissionLogicalId =
@@ -52,14 +53,15 @@ class AwsCompileIotFleetProvisioningEvents {
           Properties: {
             Enabled: true,
             PreProvisioningHook: {
-              TargetArn: {
-                'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-              },
+              TargetArn: resolveLambdaTarget(functionName, functionObj),
             },
             ProvisioningRoleArn: provisioningRoleArn,
             TemplateBody: JSON.stringify(templateBody),
           },
-          DependsOn: [lambdaPermissionLogicalId],
+          DependsOn: _.compact([
+            lambdaPermissionLogicalId,
+            _.get(functionObj.targetAlias, 'logicalId'),
+          ]),
         };
 
         if (event.iotFleetProvisioning.enabled !== undefined) {
@@ -73,10 +75,9 @@ class AwsCompileIotFleetProvisioningEvents {
 
         const permissionResource = {
           Type: 'AWS::Lambda::Permission',
+          DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
           Properties: {
-            FunctionName: {
-              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-            },
+            FunctionName: resolveLambdaTarget(functionName, functionObj),
             Action: 'lambda:InvokeFunction',
             Principal: 'iot.amazonaws.com',
           },

--- a/lib/plugins/aws/package/compile/events/iot-fleet-provisioning.js
+++ b/lib/plugins/aws/package/compile/events/iot-fleet-provisioning.js
@@ -58,10 +58,10 @@ class AwsCompileIotFleetProvisioningEvents {
             ProvisioningRoleArn: provisioningRoleArn,
             TemplateBody: JSON.stringify(templateBody),
           },
-          DependsOn: _.compact([
+          DependsOn: [
             lambdaPermissionLogicalId,
             _.get(functionObj.targetAlias, 'logicalId'),
-          ]),
+          ].filter(Boolean),
         };
 
         if (event.iotFleetProvisioning.enabled !== undefined) {

--- a/lib/plugins/aws/package/compile/events/iot.js
+++ b/lib/plugins/aws/package/compile/events/iot.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 class AwsCompileIoTEvents {
   constructor(serverless) {
@@ -56,7 +57,6 @@ class AwsCompileIoTEvents {
             const sql = event.iot.sql.replace(/\r?\n/g, '');
             const ruleDisabled = event.iot.enabled === false;
 
-            const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             const iotLogicalId = this.provider.naming.getIotLogicalId(
               functionName,
               iotNumberInFunction
@@ -68,6 +68,7 @@ class AwsCompileIoTEvents {
 
             const topicRuleResource = {
               Type: 'AWS::IoT::TopicRule',
+              DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
               Properties: {
                 TopicRulePayload: {
                   RuleDisabled: ruleDisabled,
@@ -75,9 +76,7 @@ class AwsCompileIoTEvents {
                   Actions: [
                     {
                       Lambda: {
-                        FunctionArn: {
-                          'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                        },
+                        FunctionArn: resolveLambdaTarget(functionName, functionObj),
                       },
                     },
                   ],
@@ -99,10 +98,9 @@ class AwsCompileIoTEvents {
 
             const permissionResource = {
               Type: 'AWS::Lambda::Permission',
+              DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
               Properties: {
-                FunctionName: {
-                  'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                },
+                FunctionName: resolveLambdaTarget(functionName, functionObj),
                 Action: 'lambda:InvokeFunction',
                 Principal: 'iot.amazonaws.com',
                 SourceArn: {

--- a/lib/plugins/aws/package/compile/events/kafka.js
+++ b/lib/plugins/aws/package/compile/events/kafka.js
@@ -168,10 +168,10 @@ class AwsCompileKafkaEvents {
           functionName,
           topic
         );
-        const dependsOn = _.compact([
+        const dependsOn = [
           this.provider.resolveFunctionIamRoleResourceName(functionObj),
           _.get(functionObj.targetAlias, 'logicalId'),
-        ]);
+        ].filter(Boolean);
 
         const kafkaResource = {
           Type: 'AWS::Lambda::EventSourceMapping',

--- a/lib/plugins/aws/package/compile/events/kafka.js
+++ b/lib/plugins/aws/package/compile/events/kafka.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const ServerlessError = require('../../../../../serverless-error');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
+const _ = require('lodash');
 
 class AwsCompileKafkaEvents {
   constructor(serverless) {
@@ -166,16 +168,16 @@ class AwsCompileKafkaEvents {
           functionName,
           topic
         );
-        const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-        const dependsOn = this.provider.resolveFunctionIamRoleResourceName(functionObj) || [];
+        const dependsOn = _.compact([
+          this.provider.resolveFunctionIamRoleResourceName(functionObj),
+          _.get(functionObj.targetAlias, 'logicalId'),
+        ]);
 
         const kafkaResource = {
           Type: 'AWS::Lambda::EventSourceMapping',
           DependsOn: dependsOn,
           Properties: {
-            FunctionName: {
-              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-            },
+            FunctionName: resolveLambdaTarget(functionName, functionObj),
             StartingPosition: startingPosition,
             SelfManagedEventSource: {
               Endpoints: { KafkaBootstrapServers: event.kafka.bootstrapServers },

--- a/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/lib/plugins/aws/package/compile/events/msk/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const getMskClusterNameToken = require('./get-msk-cluster-name-token');
+const resolveLambdaTarget = require('../../../../utils/resolve-lambda-target');
+const _ = require('lodash');
 
 class AwsCompileMSKEvents {
   constructor(serverless) {
@@ -97,18 +99,17 @@ class AwsCompileMSKEvents {
             topic
           );
 
-          const dependsOn = this.provider.resolveFunctionIamRoleResourceName(functionObj) || [];
-
-          const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
+          const dependsOn = _.compact([
+            this.provider.resolveFunctionIamRoleResourceName(functionObj),
+            _.get(functionObj.targetAlias, 'logicalId'),
+          ]);
 
           const mskResource = {
             Type: 'AWS::Lambda::EventSourceMapping',
             DependsOn: dependsOn,
             Properties: {
               EventSourceArn: eventSourceArn,
-              FunctionName: {
-                'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-              },
+              FunctionName: resolveLambdaTarget(functionName, functionObj),
               StartingPosition: startingPosition,
               Topics: [topic],
             },

--- a/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/lib/plugins/aws/package/compile/events/msk/index.js
@@ -99,10 +99,10 @@ class AwsCompileMSKEvents {
             topic
           );
 
-          const dependsOn = _.compact([
+          const dependsOn = [
             this.provider.resolveFunctionIamRoleResourceName(functionObj),
             _.get(functionObj.targetAlias, 'logicalId'),
-          ]);
+          ].filter(Boolean);
 
           const mskResource = {
             Type: 'AWS::Lambda::EventSourceMapping',

--- a/lib/plugins/aws/package/compile/events/rabbitmq.js
+++ b/lib/plugins/aws/package/compile/events/rabbitmq.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const _ = require('lodash');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
+
 class AwsCompileRabbitMQEvents {
   constructor(serverless) {
     this.serverless = serverless;
@@ -110,8 +113,10 @@ class AwsCompileRabbitMQEvents {
           functionName,
           queue
         );
-        const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-        const dependsOn = this.provider.resolveFunctionIamRoleResourceName(functionObj) || [];
+        const dependsOn = _.compact([
+          this.provider.resolveFunctionIamRoleResourceName(functionObj),
+          _.get(functionObj.targetAlias, 'logicalId'),
+        ]);
 
         const sourceAccessConfigurations = [
           {
@@ -131,9 +136,7 @@ class AwsCompileRabbitMQEvents {
           Type: 'AWS::Lambda::EventSourceMapping',
           DependsOn: dependsOn,
           Properties: {
-            FunctionName: {
-              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-            },
+            FunctionName: resolveLambdaTarget(functionName, functionObj),
             EventSourceArn: arn,
             Queues: [queue],
             SourceAccessConfigurations: sourceAccessConfigurations,

--- a/lib/plugins/aws/package/compile/events/rabbitmq.js
+++ b/lib/plugins/aws/package/compile/events/rabbitmq.js
@@ -113,10 +113,10 @@ class AwsCompileRabbitMQEvents {
           functionName,
           queue
         );
-        const dependsOn = _.compact([
+        const dependsOn = [
           this.provider.resolveFunctionIamRoleResourceName(functionObj),
           _.get(functionObj.targetAlias, 'logicalId'),
-        ]);
+        ].filter(Boolean);
 
         const sourceAccessConfigurations = [
           {

--- a/lib/plugins/aws/package/compile/events/s3/index.js
+++ b/lib/plugins/aws/package/compile/events/s3/index.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const BbPromise = require('bluebird');
 const { addCustomResourceToService } = require('../../../../custom-resources');
 const ServerlessError = require('../../../../../../serverless-error');
+const resolveLambdaTarget = require('../../../../utils/resolve-lambda-target');
 
 class AwsCompileS3Events {
   constructor(serverless, options) {
@@ -100,7 +101,6 @@ class AwsCompileS3Events {
               bucketRef = event.s3;
             }
 
-            const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
             let bucketName;
             if (providerS3[bucketRef]) {
               bucketName = providerS3[bucketRef].name || bucketRef;
@@ -127,9 +127,7 @@ class AwsCompileS3Events {
               // in another S3 event in the service
               let newLambdaConfiguration = {
                 Event: notificationEvent,
-                Function: {
-                  'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                },
+                Function: resolveLambdaTarget(functionName, functionObj),
               };
 
               // Assign 'filter' if not empty
@@ -139,9 +137,7 @@ class AwsCompileS3Events {
               bucketsLambdaConfigurations[bucketName] = [
                 {
                   Event: notificationEvent,
-                  Function: {
-                    'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-                  },
+                  Function: resolveLambdaTarget(functionName, functionObj),
                 },
               ];
               // Assign 'filter' if not empty
@@ -210,6 +206,12 @@ class AwsCompileS3Events {
           );
 
           bucketTemplate.DependsOn.push(lambdaPermissionLogicalId);
+
+          const functionObj = this.serverless.service.getFunction(item.functionName);
+          const dependsOn = _.get(functionObj.targetAlias, 'logicalId');
+          if (dependsOn) {
+            bucketTemplate.DependsOn.push(dependsOn);
+          }
         });
 
         const bucketLogicalId =
@@ -229,15 +231,13 @@ class AwsCompileS3Events {
     // and give S3 permission to invoke them all
     // by adding Lambda::Permission resource for each
     s3EnabledFunctions.forEach((s3EnabledFunction) => {
-      const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(
-        s3EnabledFunction.functionName
-      );
+      const functionObj = this.serverless.service.getFunction(s3EnabledFunction.functionName);
+
       const permissionTemplate = {
         Type: 'AWS::Lambda::Permission',
+        DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
         Properties: {
-          FunctionName: {
-            'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-          },
+          FunctionName: resolveLambdaTarget(s3EnabledFunction.functionName, functionObj),
           Action: 'lambda:InvokeFunction',
           Principal: 's3.amazonaws.com',
           SourceArn: {

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const ServerlessError = require('../../../../../serverless-error');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 const rateSyntax = '^rate\\((?:1 (?:minute|hour|day)|(?:1\\d+|[2-9]\\d*) (?:minute|hour|day)s)\\)$';
 const cronSyntax = '^cron\\(\\S+ \\S+ \\S+ \\S+ \\S+ \\S+\\)$';
@@ -136,7 +137,12 @@ class AwsCompileScheduledEvents {
               State = 'ENABLED';
             }
 
-            const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
+            const lambdaTarget = JSON.stringify(resolveLambdaTarget(functionName, functionObj));
+            const dependsOn =
+              functionObj && functionObj.targetAlias
+                ? functionObj.targetAlias.logicalId
+                : undefined;
+
             const scheduleId = this.provider.naming.getScheduleId(functionName);
 
             for (const ScheduleExpression of ScheduleExpressions) {
@@ -162,6 +168,7 @@ class AwsCompileScheduledEvents {
               const scheduleTemplate = `
               {
                 "Type": "AWS::Events::Rule",
+                ${dependsOn ? `"DependsOn": "${dependsOn}",` : ''}
                 "Properties": {
                   "ScheduleExpression": ${templateScheduleExpression},
                   "State": "${State}",
@@ -171,7 +178,7 @@ class AwsCompileScheduledEvents {
                     ${Input ? `"Input": "${Input}",` : ''}
                     ${InputPath ? `"InputPath": "${InputPath}",` : ''}
                     ${InputTransformer ? `"InputTransformer": ${InputTransformer},` : ''}
-                    "Arn": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
+                    "Arn": ${lambdaTarget},
                     "Id": "${scheduleId}"
                   }]
                 }
@@ -181,8 +188,9 @@ class AwsCompileScheduledEvents {
               const permissionTemplate = `
               {
                 "Type": "AWS::Lambda::Permission",
+                ${dependsOn ? `"DependsOn": "${dependsOn}",` : ''}
                 "Properties": {
-                  "FunctionName": { "Fn::GetAtt": ["${lambdaLogicalId}", "Arn"] },
+                  "FunctionName": ${lambdaTarget},
                   "Action": "lambda:InvokeFunction",
                   "Principal": "events.amazonaws.com",
                   "SourceArn": { "Fn::GetAtt": ["${scheduleLogicalId}", "Arn"] }

--- a/lib/plugins/aws/package/compile/events/sns.js
+++ b/lib/plugins/aws/package/compile/events/sns.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const ServerlessError = require('../../../../../serverless-error');
+const resolveLambdaTarget = require('../../../utils/resolve-lambda-target');
 
 class AwsCompileSNSEvents {
   constructor(serverless, options) {
@@ -177,11 +178,7 @@ class AwsCompileSNSEvents {
               });
             }
 
-            const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(functionName);
-
-            const endpoint = {
-              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-            };
+            const endpoint = resolveLambdaTarget(functionName, functionObj);
 
             const subscriptionLogicalId = this.provider.naming.getLambdaSnsSubscriptionLogicalId(
               functionName,
@@ -192,6 +189,7 @@ class AwsCompileSNSEvents {
               _.merge(template.Resources, {
                 [subscriptionLogicalId]: {
                   Type: 'AWS::SNS::Subscription',
+                  DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
                   Properties: {
                     TopicArn: topicArn,
                     Protocol: 'lambda',
@@ -235,6 +233,7 @@ class AwsCompileSNSEvents {
                 _.merge(template.Resources, {
                   [topicLogicalId]: {
                     Type: 'AWS::SNS::Topic',
+                    DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
                     Properties: topicResourceProperties,
                   },
                 });
@@ -270,6 +269,7 @@ class AwsCompileSNSEvents {
             _.merge(template.Resources, {
               [lambdaPermissionLogicalId]: {
                 Type: 'AWS::Lambda::Permission',
+                DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
                 Properties: {
                   FunctionName: endpoint,
                   Action: 'lambda:InvokeFunction',

--- a/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.js
@@ -8,6 +8,7 @@ module.exports = {
       if (!event.authorizer) {
         return;
       }
+      const functionObj = this.serverless.service.getFunction(event.authorizer.name);
       const websocketsAuthorizerLogicalId = this.provider.naming.getWebsocketsAuthorizerLogicalId(
         event.authorizer.name
       );
@@ -15,6 +16,7 @@ module.exports = {
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [websocketsAuthorizerLogicalId]: {
           Type: 'AWS::ApiGatewayV2::Authorizer',
+          DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
           Properties: {
             ApiId: this.provider.getApiGatewayWebsocketApiId(),
             Name: event.authorizer.name,

--- a/lib/plugins/aws/package/compile/events/websockets/lib/integrations.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/integrations.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const resolveLambdaTarget = require('../../../../../utils/resolve-lambda-target');
 
 module.exports = {
   compileIntegrations() {
@@ -8,11 +9,12 @@ module.exports = {
       const websocketsIntegrationLogicalId = this.provider.naming.getWebsocketsIntegrationLogicalId(
         event.functionName
       );
+      const functionObj = this.serverless.service.getFunction(event.functionName);
 
-      const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(event.functionName);
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [websocketsIntegrationLogicalId]: {
           Type: 'AWS::ApiGatewayV2::Integration',
+          DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
           Properties: {
             ApiId: this.provider.getApiGatewayWebsocketApiId(),
             IntegrationType: 'AWS_PROXY',
@@ -25,7 +27,7 @@ module.exports = {
                   ':apigateway:',
                   { Ref: 'AWS::Region' },
                   ':lambda:path/2015-03-31/functions/',
-                  { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] },
+                  resolveLambdaTarget(event.functionName, functionObj),
                   '/invocations',
                 ],
               ],

--- a/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
@@ -1,12 +1,15 @@
 'use strict';
 
 const _ = require('lodash');
+const resolveLambdaTarget = require('../../../../../utils/resolve-lambda-target');
 
 module.exports = {
   compilePermissions() {
     this.validated.events.forEach((event) => {
       const websocketApiId = this.provider.getApiGatewayWebsocketApiId();
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(event.functionName);
+      const functionObj = this.serverless.service.getFunction(event.functionName);
+      const aliasDependsOn = _.get(functionObj.targetAlias, 'logicalId');
 
       const websocketsPermissionLogicalId =
         this.provider.naming.getLambdaWebsocketsPermissionLogicalId(event.functionName);
@@ -14,11 +17,9 @@ module.exports = {
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [websocketsPermissionLogicalId]: {
           Type: 'AWS::Lambda::Permission',
-          DependsOn: websocketApiId.Ref ? [websocketApiId.Ref, lambdaLogicalId] : [lambdaLogicalId],
+          DependsOn: _.compact([websocketApiId.Ref, aliasDependsOn || lambdaLogicalId]),
           Properties: {
-            FunctionName: {
-              'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
-            },
+            FunctionName: resolveLambdaTarget(event.functionName, functionObj),
             Action: 'lambda:InvokeFunction',
             Principal: 'apigateway.amazonaws.com',
           },
@@ -45,15 +46,25 @@ module.exports = {
             websocketsAuthorizerPermissionLogicalId
           ].Properties.FunctionName = event.authorizer.permission;
         } else {
+          const permissionFunctionObj = this.serverless.service.getFunction(event.authorizer.name);
+          const permissionAliasDependsOn = _.get(permissionFunctionObj.targetAlias, 'logicalId');
+
           authorizerPermissionTemplate[
             websocketsAuthorizerPermissionLogicalId
-          ].Properties.FunctionName = {
-            'Fn::GetAtt': [event.authorizer.permission, 'Arn'],
-          };
+          ].Properties.FunctionName = resolveLambdaTarget(
+            event.authorizer.name,
+            permissionFunctionObj
+          );
 
           authorizerPermissionTemplate[websocketsAuthorizerPermissionLogicalId].DependsOn.push(
             event.authorizer.permission
           );
+
+          if (permissionAliasDependsOn) {
+            authorizerPermissionTemplate[websocketsAuthorizerPermissionLogicalId].DependsOn.push(
+              permissionAliasDependsOn
+            );
+          }
         }
 
         _.merge(

--- a/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
@@ -17,7 +17,7 @@ module.exports = {
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [websocketsPermissionLogicalId]: {
           Type: 'AWS::Lambda::Permission',
-          DependsOn: _.compact([websocketApiId.Ref, aliasDependsOn || lambdaLogicalId]),
+          DependsOn: [websocketApiId.Ref, aliasDependsOn || lambdaLogicalId].filter(Boolean),
           Properties: {
             FunctionName: resolveLambdaTarget(event.functionName, functionObj),
             Action: 'lambda:InvokeFunction',

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const ServerlessError = require('../../../../../../../serverless-error');
+const resolveLambdaTarget = require('../../../../../utils/resolve-lambda-target');
 
 module.exports = {
   validate() {
@@ -56,6 +57,7 @@ module.exports = {
                 const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(
                   event.websocket.authorizer
                 );
+                const functionObj = this.serverless.service.getFunction(event.websocket.authorizer);
                 websocketObj.authorizer = {
                   name: event.websocket.authorizer,
                   uri: {
@@ -67,7 +69,7 @@ module.exports = {
                         ':apigateway:',
                         { Ref: 'AWS::Region' },
                         ':lambda:path/2015-03-31/functions/',
-                        { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] },
+                        resolveLambdaTarget(event.websocket.authorizer, functionObj),
                         '/invocations',
                       ],
                     ],
@@ -109,6 +111,9 @@ module.exports = {
                 websocketObj.authorizer.permission = event.websocket.authorizer.arn;
               } else if (event.websocket.authorizer.name) {
                 websocketObj.authorizer.name = event.websocket.authorizer.name;
+                const functionObj = this.serverless.service.getFunction(
+                  event.websocket.authorizer.name
+                );
                 const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(
                   event.websocket.authorizer.name
                 );
@@ -121,7 +126,7 @@ module.exports = {
                       ':apigateway:',
                       { Ref: 'AWS::Region' },
                       ':lambda:path/2015-03-31/functions/',
-                      { 'Fn::GetAtt': [lambdaLogicalId, 'Arn'] },
+                      resolveLambdaTarget(event.websocket.authorizer.name, functionObj),
                       '/invocations',
                     ],
                   ],

--- a/test/unit/lib/plugins/aws/package/compile/events/activemq.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/activemq.test.js
@@ -98,8 +98,8 @@ describe('test/unit/lib/plugins/aws/package/compile/events/activemq.test.js', ()
     });
 
     it('should correctly compile EventSourceMapping resource DependsOn ', () => {
-      expect(minimalEventSourceMappingResource.DependsOn).to.equal('IamRoleLambdaExecution');
-      expect(allParamsEventSourceMappingResource.DependsOn).to.equal('IamRoleLambdaExecution');
+      expect(minimalEventSourceMappingResource.DependsOn).to.include('IamRoleLambdaExecution');
+      expect(allParamsEventSourceMappingResource.DependsOn).to.include('IamRoleLambdaExecution');
     });
 
     it('should correctly compile EventSourceMapping resource with all parameters', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/alias.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alias.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const runServerless = require('../../../../../../../utils/run-serverless');
+const { use: chaiUse, expect } = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const naming = require('../../../../../../../../lib/plugins/aws/lib/naming');
+
+chaiUse(chaiAsPromised);
+describe('test/unit/lib/plugins/aws/package/compile/events/alias.test.js', () => {
+  let lambdaResourceCount = 0;
+
+  before(async () => {
+    const events = (index) => {
+      return [
+        {
+          activemq: {
+            queue: 'TestingQueue',
+            arn: 'arn:aws:mq:us-east-1:0000:broker:ExampleMQBroker:b-xxx-xxx',
+            basicAuthArn: 'arn:aws:secretsmanager:us-east-1:01234567890:secret:MyBrokerSecretName',
+          },
+        },
+        {
+          rabbitmq: {
+            queue: 'TestingQueue',
+            arn: 'arn:aws:mq:us-east-1:0000:broker:ExampleMQBroker:b-xxx-xxx',
+            basicAuthArn: 'arn:aws:secretsmanager:us-east-1:01234567890:secret:MyBrokerSecretName',
+          },
+        },
+        {
+          alb: {
+            listenerArn:
+              'arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-load-balancer/50dc6c495c0c9188/f2f7dc8efc522ab2',
+            priority: index,
+            conditions: { path: '/' },
+          },
+        },
+        { httpApi: `POST /users/create${index}` },
+        { http: { path: '/{proxy+}', method: 'any' } },
+        { schedule: { rate: 'rate(10 minutes)' } },
+        { sns: `Topic${index}` },
+        {
+          msk: {
+            topic: 'TestingTopic',
+            arn: 'arn:aws:kafka:us-east-1:111111111111:cluster/ClusterName/a1a1a1a1a1a1a1a1a',
+          },
+        },
+        {
+          iotFleetProvisioning: {
+            templateBody: {},
+            provisioningRoleArn: 'arn:aws:iam::123456789:role/provisioning-role',
+          },
+        },
+        { iot: { sql: 'SELECT * FROM topic_1' } },
+        { s3: `first-function-bucket-${index}` },
+        { alexaSkill: 'amzn1.ask.skill.xx-xx-xx-xx' },
+        { alexaSmartHome: { appId: 'amzn1.ask.skill.xx-xx-xx-xx' } },
+        {
+          cloudFront: {
+            eventType: 'viewer-request',
+            origin: 's3://bucketname.s3.amazonaws.com/files',
+            pathPattern: `/files/${index}/*`,
+          },
+        },
+        { sqs: 'arn:aws:sqs:region:account:MyQueue' },
+        {
+          cloudwatchEvent: {
+            event: {
+              'source': ['aws.ec2'],
+              'detail-type': ['EC2 Instance State-change Notification'],
+              'detail': { state: ['pending'] },
+            },
+          },
+        },
+        { cloudwatchLog: { logGroup: `/aws/lambda/hello${index}` } },
+        {
+          cognitoUserPool: {
+            pool: `Test${index}`,
+            trigger: 'CustomSMSSender',
+            kmsKeyId: 'arn:aws:kms:eu-west-1:111111111111:key/11111111-9abc-def0-1234-56789abcdef1',
+          },
+        },
+        { websocket: { route: '$connect', authorizer: 'ProvisionedFn' } },
+        { websocket: { route: '$disconnect', authorizer: 'SnapStartFn' } },
+        { websocket: { route: '$default', authorizer: 'NoAliasFn' } },
+        { stream: 'arn:aws:dynamodb:region:account:table/foo/stream/1' },
+        {
+          kafka: {
+            topic: 'TestingTopic',
+            bootstrapServers: ['abc.xyz:9092'],
+            accessConfigurations: {
+              saslScram256Auth:
+                'arn:aws:secretsmanager:us-east-1:01234567890:secret:SaslScram256Auth',
+            },
+          },
+        },
+        {
+          eventBridge: {
+            eventBus: 'arn:aws:events:us-east-1:12345:event-bus/default',
+            schedule: 'rate(10 minutes)',
+          },
+        },
+      ];
+    };
+    const { cfTemplate } = await runServerless({
+      fixture: 'function',
+      configExt: {
+        functions: {
+          ProvisionedFn: {
+            handler: 'index.handler',
+            provisionedConcurrency: 1,
+            events: events(1),
+          },
+          SnapStartFn: {
+            handler: 'index.handler',
+            snapStart: true,
+            events: events(2),
+          },
+          NoAliasFn: {
+            handler: 'index.handler',
+            events: events(3),
+          },
+        },
+      },
+      command: 'package',
+    });
+
+    const resources = cfTemplate.Resources;
+
+    const unwrapApiGateway = (uri) => {
+      if (
+        uri['Fn::Join'] &&
+        uri['Fn::Join'][0] === '' &&
+        uri['Fn::Join'][1][2] === ':apigateway:'
+      ) {
+        return uri['Fn::Join'][1][5];
+      }
+      return uri;
+    };
+
+    const resourceTypeToLambdaLookup = {
+      'AWS::Lambda::Version': false,
+      'AWS::Lambda::Alias': false,
+      'AWS::Lambda::Permission': (r) => r.Properties.FunctionName,
+      'AWS::Lambda::EventSourceMapping': (r) => r.Properties.FunctionName,
+      'AWS::Events::Rule': (r) => r.Properties.Targets[0].Arn,
+      'AWS::ApiGatewayV2::Integration': (r) => unwrapApiGateway(r.Properties.IntegrationUri),
+      'AWS::ApiGatewayV2::Authorizer': (r) => r.Properties.AuthorizerUri['Fn::Join'][1][5],
+      'AWS::ElasticLoadBalancingV2::TargetGroup': (r) => r.Properties.Targets[0].Id,
+      'AWS::IoT::ProvisioningTemplate': (r) => r.Properties.PreProvisioningHook.TargetArn,
+      'AWS::Logs::SubscriptionFilter': (r) => r.Properties.DestinationArn,
+      'AWS::S3::Bucket': (r) =>
+        r.Properties.NotificationConfiguration.LambdaConfigurations[0].Function,
+      'AWS::SNS::Topic': (r) => r.Properties.Subscription[0].Endpoint,
+      'AWS::Cognito::UserPool': (r) => r.Properties.LambdaConfig.CustomSMSSender.LambdaArn,
+      'AWS::ApiGateway::Method': (r) => unwrapApiGateway(r.Properties.Integration.Uri),
+      'AWS::IoT::TopicRule': (r) => r.Properties.TopicRulePayload.Actions[0].Lambda.FunctionArn,
+    };
+
+    const functionsToCheck = [
+      {
+        functionName: 'ProvisionedFn',
+        aliasName: 'provisioned',
+        aliasLogicalId: naming.getLambdaProvisionedConcurrencyAliasLogicalId('ProvisionedFn'),
+      },
+      {
+        functionName: 'SnapStartFn',
+        aliasName: 'snapstart',
+        aliasLogicalId: naming.getLambdaSnapStartAliasLogicalId('SnapStartFn'),
+      },
+      { functionName: 'NoAliasFn', aliasName: null, aliasLogicalId: null },
+    ];
+
+    functionsToCheck.forEach((check) => {
+      const lambdaLogicalId = naming.getLambdaLogicalId(check.functionName);
+      describe(`test/unit/lib/plugins/aws/package/compile/events/alias.test.js - ${check.functionName}`, () => {
+        Object.keys(resources).forEach((r) => {
+          const resource = resources[r];
+          const lookup = resourceTypeToLambdaLookup[resource.Type];
+          if (JSON.stringify(resource).includes(naming.getLambdaLogicalId(check.functionName))) {
+            lambdaResourceCount++;
+            if (lookup == null) {
+              it(`${r} - should be a known type`, () => {
+                expect(Object.keys(resourceTypeToLambdaLookup)).to.include(resource.Type);
+              });
+            } else if (lookup) {
+              const lambdaReference = lookup(resource);
+              if (check.aliasName) {
+                it(`${r} - should reference lambda alias '${check.aliasName}'`, () => {
+                  expect(lambdaReference).to.deep.equal({
+                    'Fn::Join': [
+                      ':',
+                      [
+                        {
+                          'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+                        },
+                        check.aliasName,
+                      ],
+                    ],
+                  });
+                });
+                it(`${r} - should depend on lambda alias '${check.aliasName}'`, () => {
+                  expect(resource.DependsOn).to.include(check.aliasLogicalId);
+                });
+              } else {
+                it(`${r} - should not reference lambda alias`, () => {
+                  expect(lambdaReference).to.deep.equal({
+                    'Fn::GetAtt': [lambdaLogicalId, 'Arn'],
+                  });
+                });
+              }
+            }
+          }
+        });
+      });
+    });
+  });
+  it('Check resource count', () => {
+    expect(lambdaResourceCount).to.gte(1);
+  });
+});

--- a/test/unit/lib/plugins/aws/package/compile/events/http-api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/http-api.test.js
@@ -460,6 +460,7 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
     it('should configure authorizer resource that references function from service', () => {
       expect(cfResources[naming.getHttpApiAuthorizerLogicalId('someAuthorizer')]).to.deep.equal({
         Type: 'AWS::ApiGatewayV2::Authorizer',
+        DependsOn: undefined,
         Properties: {
           ApiId: { Ref: naming.getHttpApiLogicalId() },
           AuthorizerPayloadFormatVersion: '2.0',
@@ -534,6 +535,7 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
         cfResources[naming.getHttpApiAuthorizerLogicalId('authorizerWithExternalFunction')]
       ).to.deep.equal({
         Type: 'AWS::ApiGatewayV2::Authorizer',
+        DependsOn: undefined,
         Properties: {
           ApiId: { Ref: naming.getHttpApiLogicalId() },
           AuthorizerPayloadFormatVersion: '2.0',

--- a/test/unit/lib/plugins/aws/package/compile/events/iot-fleet-provisioning/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/iot-fleet-provisioning/index.test.js
@@ -97,6 +97,7 @@ describe('lib/plugins/aws/package/compile/events/iotFleetProvisioning/index.test
         cfResources[naming.getLambdaIotFleetProvisioningPermissionLogicalId(functionName)];
       expect(lambdaPermissionResource).to.deep.equal({
         Type: 'AWS::Lambda::Permission',
+        DependsOn: undefined,
         Properties: {
           FunctionName: {
             'Fn::GetAtt': [naming.getLambdaLogicalId(functionName), 'Arn'],

--- a/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
@@ -102,8 +102,8 @@ describe('test/unit/lib/plugins/aws/package/compile/events/kafka.test.js', () =>
     });
 
     it('should correctly compile EventSourceMapping resource DependsOn ', () => {
-      expect(minimalEventSourceMappingResource.DependsOn).to.equal('IamRoleLambdaExecution');
-      expect(allParamsEventSourceMappingResource.DependsOn).to.equal('IamRoleLambdaExecution');
+      expect(minimalEventSourceMappingResource.DependsOn).to.contain('IamRoleLambdaExecution');
+      expect(allParamsEventSourceMappingResource.DependsOn).to.contain('IamRoleLambdaExecution');
     });
 
     it('should correctly compile EventSourceMapping resource with all parameters', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
@@ -110,8 +110,8 @@ describe('AwsCompileMSKEvents', () => {
     });
 
     it('should correctly compile EventSourceMapping resource DependsOn ', () => {
-      expect(minimalEventSourceMappingResource.DependsOn).to.equal('IamRoleLambdaExecution');
-      expect(allParamsEventSourceMappingResource.DependsOn).to.equal('IamRoleLambdaExecution');
+      expect(minimalEventSourceMappingResource.DependsOn).to.include('IamRoleLambdaExecution');
+      expect(allParamsEventSourceMappingResource.DependsOn).to.include('IamRoleLambdaExecution');
     });
 
     it('should correctly complie EventSourceMapping resource with all parameters', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/rabbitmq.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/rabbitmq.test.js
@@ -100,8 +100,8 @@ describe('test/unit/lib/plugins/aws/package/compile/events/rabbitmq.test.js', ()
     });
 
     it('should correctly compile EventSourceMapping resource DependsOn ', () => {
-      expect(minimalEventSourceMappingResource.DependsOn).to.equal('IamRoleLambdaExecution');
-      expect(allParamsEventSourceMappingResource.DependsOn).to.equal('IamRoleLambdaExecution');
+      expect(minimalEventSourceMappingResource.DependsOn).to.include('IamRoleLambdaExecution');
+      expect(allParamsEventSourceMappingResource.DependsOn).to.include('IamRoleLambdaExecution');
     });
 
     it('should correctly compile EventSourceMapping resource with all parameters', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.test.js
@@ -13,7 +13,9 @@ describe('#compileAuthorizers()', () => {
       const serverless = new Serverless({ commands: [], options: {} });
       serverless.setProvider('aws', new AwsProvider(serverless));
       serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-
+      serverless.service.functions = {
+        auth: {},
+      };
       awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
 
       awsCompileWebsocketsEvents.websocketsApiLogicalId =
@@ -55,6 +57,7 @@ describe('#compileAuthorizers()', () => {
 
       expect(resources).to.deep.equal({
         AuthWebsocketsAuthorizer: {
+          DependsOn: undefined,
           Type: 'AWS::ApiGatewayV2::Authorizer',
           Properties: {
             ApiId: {

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
@@ -15,7 +15,6 @@ describe('#compileIntegrations()', () => {
     serverless.service.functions = {
       First: {},
       Second: {},
-      // 'AuthLambdaPermissionWebsockets':{}
     };
     awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/integrations.test.js
@@ -12,7 +12,11 @@ describe('#compileIntegrations()', () => {
     const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
-
+    serverless.service.functions = {
+      First: {},
+      Second: {},
+      // 'AuthLambdaPermissionWebsockets':{}
+    };
     awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
 
     awsCompileWebsocketsEvents.websocketsApiLogicalId =
@@ -41,6 +45,7 @@ describe('#compileIntegrations()', () => {
     expect(resources).to.deep.equal({
       FirstWebsocketsIntegration: {
         Type: 'AWS::ApiGatewayV2::Integration',
+        DependsOn: undefined,
         Properties: {
           ApiId: {
             Ref: 'WebsocketsApi',
@@ -70,6 +75,7 @@ describe('#compileIntegrations()', () => {
       },
       SecondWebsocketsIntegration: {
         Type: 'AWS::ApiGatewayV2::Integration',
+        DependsOn: undefined,
         Properties: {
           ApiId: {
             Ref: 'WebsocketsApi',

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/permissions.test.js
@@ -12,6 +12,11 @@ describe('#compilePermissions()', () => {
     const serverless = new Serverless({ commands: [], options: {} });
     serverless.setProvider('aws', new AwsProvider(serverless));
     serverless.service.provider.compiledCloudFormationTemplate = { Resources: {} };
+    serverless.service.functions = {
+      First: {},
+      Second: {},
+      auth: {},
+    };
 
     awsCompileWebsocketsEvents = new AwsCompileWebsocketsEvents(serverless);
 
@@ -72,7 +77,7 @@ describe('#compilePermissions()', () => {
           route: '$connect',
           authorizer: {
             name: 'auth',
-            permission: 'AuthLambdaPermissionWebsockets',
+            permission: 'AuthLambdaFunction',
           },
         },
       ],
@@ -97,10 +102,10 @@ describe('#compilePermissions()', () => {
       },
       AuthLambdaPermissionWebsockets: {
         Type: 'AWS::Lambda::Permission',
-        DependsOn: ['WebsocketsApi', 'AuthLambdaPermissionWebsockets'],
+        DependsOn: ['WebsocketsApi', 'AuthLambdaFunction'],
         Properties: {
           FunctionName: {
-            'Fn::GetAtt': ['AuthLambdaPermissionWebsockets', 'Arn'],
+            'Fn::GetAtt': ['AuthLambdaFunction', 'Arn'],
           },
           Action: 'lambda:InvokeFunction',
           Principal: 'apigateway.amazonaws.com',

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/validate.test.js
@@ -62,6 +62,9 @@ describe('#validate()', () => {
 
   it('should add authorizer config when authorizer is specified as a string', () => {
     awsCompileWebsocketsEvents.serverless.service.functions = {
+      auth: {
+        events: [],
+      },
       first: {
         events: [
           {
@@ -144,6 +147,9 @@ describe('#validate()', () => {
 
   it('should add authorizer config when authorizer is specified as an object', () => {
     awsCompileWebsocketsEvents.serverless.service.functions = {
+      auth: {
+        events: [],
+      },
       first: {
         events: [
           {
@@ -271,11 +277,13 @@ describe('#validate()', () => {
 describe('#validate() using runServerless util', () => {
   it('should use provided authorizer name when name field is supplied', async () => {
     const nameField = 'authName';
-
     const { cfTemplate, awsNaming } = await runServerless({
       fixture: 'function',
       configExt: {
         functions: {
+          [nameField]: {
+            handler: 'index.handler',
+          },
           first: {
             handler: 'index.handler',
             events: [


### PR DESCRIPTION
Most events were not using the lambda alias when calling the lambda when using the provisionedConcurrency or snapStart options, meaning these features weren't being used.  I've created a new unit test alias.test.js which checks the following for all resources which have a reference to a provisionedConcurrency or snapStart lambda:
* Make sure the alias is configured in the ARN
* Make sure the alias is the DependsOn

Closes: #11662
Closes: #11246
Closes: #11484
Closes: #10764
Closes: #10167