### PR TITLE
Sanitize null Properties for AWS resources

### DIFF
--- a/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.js
+++ b/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.js
@@ -15,11 +15,10 @@ module.exports = {
     const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
     for (const resource of Object.values(resources)) {
-      if (resource.Properties !== undefined && resource.Properties === null) {
-        delete resource.Properties;
-      }
       if (resource.Properties) {
         stripNullPropsFromObj(resource.Properties);
+      } else {
+        delete resource.Properties;
       }
     }
   },

--- a/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.js
+++ b/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.js
@@ -15,6 +15,9 @@ module.exports = {
     const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
 
     for (const resource of Object.values(resources)) {
+      if (resource.Properties !== undefined && resource.Properties === null) {
+        delete resource.Properties;
+      }
       if (resource.Properties) {
         stripNullPropsFromObj(resource.Properties);
       }

--- a/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
@@ -46,16 +46,9 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
                 Runtime: 'nodejs12.x',
               },
             },
-            resourceWithEmptyProperties: {
-              Type: 'AWS::S3::Bucket',
-              Properties: {},
-            },
             resourceWithNullProperties: {
               Type: 'AWS::S3::Bucket',
               Properties: null,
-            },
-            resourceWithNoProperties: {
-              Type: 'AWS::S3::Bucket',
             },
           },
         },
@@ -78,31 +71,10 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
     expect(Object.keys(finalTemplate.Resources.anotherBucket.Properties).length).to.equal(1);
   });
 
-  it('Should leave Properties as is if it is an empty object', async () => {
-    expect(
-      Object.prototype.hasOwnProperty.call(
-        finalTemplate.Resources.resourceWithEmptyProperties,
-        'Properties'
-      )
-    ).to.equal(true);
-    expect(
-      Object.keys(finalTemplate.Resources.resourceWithEmptyProperties.Properties).length
-    ).to.equal(0);
-  });
-
   it('Should strip out Properties if it is defined with null value', async () => {
     expect(
       Object.prototype.hasOwnProperty.call(
         finalTemplate.Resources.resourceWithNullProperties,
-        'Properties'
-      )
-    ).to.equal(false);
-  });
-
-  it('Should skip if Properties is not defined', async () => {
-    expect(
-      Object.prototype.hasOwnProperty.call(
-        finalTemplate.Resources.resourceWithNoProperties,
         'Properties'
       )
     ).to.equal(false);

--- a/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
@@ -54,6 +54,9 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
               Type: 'AWS::S3::Bucket',
               Properties: null,
             },
+            resourceWithNoProperties: {
+              Type: 'AWS::S3::Bucket',
+            },
           },
         },
       },
@@ -91,6 +94,15 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
     expect(
       Object.prototype.hasOwnProperty.call(
         finalTemplate.Resources.resourceWithNullProperties,
+        'Properties'
+      )
+    ).to.equal(false);
+  });
+
+  it('Should skip if Properties is not defined', async () => {
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        finalTemplate.Resources.resourceWithNoProperties,
         'Properties'
       )
     ).to.equal(false);

--- a/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
@@ -46,6 +46,14 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
                 Runtime: 'nodejs12.x',
               },
             },
+            resourceWithEmptyProperties: {
+              Type: 'AWS::S3::Bucket',
+              Properties: {},
+            },
+            resourceWithNullProperties: {
+              Type: 'AWS::S3::Bucket',
+              Properties: null,
+            },
           },
         },
       },
@@ -65,5 +73,26 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
 
   it('Should not affect resources without null props', async () => {
     expect(Object.keys(finalTemplate.Resources.anotherBucket.Properties).length).to.equal(1);
+  });
+
+  it('Should leave Properties as is if it is an empty object', async () => {
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        finalTemplate.Resources.resourceWithEmptyProperties,
+        'Properties'
+      )
+    ).to.equal(true);
+    expect(
+      Object.keys(finalTemplate.Resources.resourceWithEmptyProperties.Properties).length
+    ).to.equal(0);
+  });
+
+  it('Should strip out Properties if it is defined with null value', async () => {
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        finalTemplate.Resources.resourceWithNullProperties,
+        'Properties'
+      )
+    ).to.equal(false);
   });
 });


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #11530 

Some considerations:
* This implementation only removes Properties if it is explicitly defined as null
* It leaves Properties = {} as is, since removing might damage some downstream logic that depends on this attribute to exist

Another implementation might be stripping Properties when it is either null or empty (code reference below):
```
if ('Properties' in resource) {
  // sanitize resource.Properties from all null attributes if itself is not null/empty
  if (resource.Properties) {
    stripNullPropsFromObj(resource.Properties);
  }
  
  // totally scrape out resource.Properties if it is null or empty (after sanitizing)
  // 1. either resource.Properties is null/empty by default
  // 2. or resource.Properties becomes empty after stripping all its null values
  if (!resource.Properties || Object.keys(resource.Properties).length === 0) {
    delete resource.Properties;
  }
}
```