### PR TITLE
refactor async functions `/test/.../aws/.../events/apiGateway`

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/index.test.js
@@ -86,7 +86,7 @@ describe('AwsCompileApigEvents', () => {
     it('should setup an empty array to gather the method logical ids', () =>
       expect(awsCompileApigEvents.apiGatewayMethodLogicalIds).to.deep.equal([]));
 
-    it('should run "package:compileEvents" promise chain in order', () => {
+    it('should run "package:compileEvents" promise chain in order', async () => {
       const validateStub = sinon.stub(awsCompileApigEvents, 'validate').returns({
         events: [
           {
@@ -125,7 +125,7 @@ describe('AwsCompileApigEvents', () => {
         getServiceState.getServiceState.restore();
       });
 
-      it('should run the promise chain in order', () => {
+      it('should run the promise chain in order', async () => {
         getServiceStateStub.returns({
           service: {
             functions: {
@@ -148,7 +148,7 @@ describe('AwsCompileApigEvents', () => {
         });
       });
 
-      it('should not skip the updateStage step when no http events are found', () => {
+      it('should not skip the updateStage step when no http events are found', async () => {
         getServiceStateStub.returns({
           service: {
             functions: {
@@ -165,7 +165,7 @@ describe('AwsCompileApigEvents', () => {
       });
     });
 
-    it('should run "before:remove:remove" promise chain in order', () => {
+    it('should run "before:remove:remove" promise chain in order', async () => {
       const validateStub = sinon.stub(validate, 'validate').returns();
 
       return awsCompileApigEvents.hooks['before:remove:remove']().then(() => {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/authorizers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/authorizers.test.js
@@ -221,7 +221,7 @@ describe('#compileAuthorizers()', () => {
 });
 
 describe('#compileAuthorizers() #2', () => {
-  it('Should reference provisioned alias when pointing local lambda authorizer', () =>
+  it('Should reference provisioned alias when pointing local lambda authorizer', async () =>
     runServerless({
       fixture: 'function',
       configExt: {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/disassociate-usage-plan.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/disassociate-usage-plan.test.js
@@ -62,7 +62,7 @@ describe('#disassociateUsagePlan()', () => {
     awsProvider.request.restore();
   });
 
-  it('should remove association from the usage plan', () => {
+  it('should remove association from the usage plan', async () => {
     disassociateUsagePlan.serverless.service.provider.apiGateway = { apiKeys: ['apiKey1'] };
 
     return disassociateUsagePlan.disassociateUsagePlan().then(() => {
@@ -94,7 +94,7 @@ describe('#disassociateUsagePlan()', () => {
     });
   });
 
-  it('should resolve if no api keys are given', () => {
+  it('should resolve if no api keys are given', async () => {
     disassociateUsagePlan.serverless.service.provider.apiGateway = { apiKeys: [] };
 
     return disassociateUsagePlan.disassociateUsagePlan().then(() => {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.test.js
@@ -135,7 +135,7 @@ describe('#updateStage()', () => {
     awsProvider.request.restore();
   });
 
-  it('should update the stage based on the serverless file configuration', () => {
+  it('should update the stage based on the serverless file configuration', async () => {
     context.state.service.provider.tags = {
       'Containing Space': 'bar',
       'bar': 'high-priority',
@@ -213,7 +213,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should support gov regions', () => {
+  it('should support gov regions', async () => {
     options.region = 'us-gov-east-1';
     awsProvider.getAccountInfo.restore();
     providerGetAccountInfoStub = sinon.stub(awsProvider, 'getAccountInfo').resolves({
@@ -298,7 +298,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should support all partitions', () => {
+  it('should support all partitions', async () => {
     options.region = 'cn-northwest-1';
     awsProvider.getAccountInfo.restore();
     providerGetAccountInfoStub = sinon.stub(awsProvider, 'getAccountInfo').resolves({
@@ -382,7 +382,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should not perform any actions if settings are not configure', () => {
+  it('should not perform any actions if settings are not configure', async () => {
     context.state.service.provider.tags = {
       old: 'tag',
     };
@@ -409,7 +409,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should create a new stage and proceed as usual if none can be found', () => {
+  it('should create a new stage and proceed as usual if none can be found', async () => {
     context.state.service.provider.tracing = { apiGateway: false };
     providerRequestStub
       .withArgs('APIGateway', 'getStage', {
@@ -480,7 +480,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should ignore external api gateway', () => {
+  it('should ignore external api gateway', async () => {
     context.state.service.provider.apiGateway = { restApiId: 'foobarfoo1' };
     context.state.service.provider.tracing = { apiGateway: false };
     return updateStage.call(context).then(() => {
@@ -489,7 +489,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should resolve custom APIGateway name', () => {
+  it('should resolve custom APIGateway name', async () => {
     context.state.service.provider.tracing = { apiGateway: false };
     providerRequestStub
       .withArgs('APIGateway', 'getRestApis', {
@@ -525,7 +525,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should resolve custom APIGateway resource', () => {
+  it('should resolve custom APIGateway resource', async () => {
     context.state.service.provider.tracing = { apiGateway: false };
     const resources = context.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     resources.CustomApiGatewayRestApi = resources.ApiGatewayRestApi;
@@ -545,7 +545,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should not resolve if the AWS::ApiGateway::Resource is not present', () => {
+  it('should not resolve if the AWS::ApiGateway::Resource is not present', async () => {
     context.state.service.provider.tracing = { apiGateway: false };
     const resources = context.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     delete resources.ApiGatewayRestApi;
@@ -555,7 +555,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should resolve expected restApiId when beyond 500 APIs are deployed', () => {
+  it('should resolve expected restApiId when beyond 500 APIs are deployed', async () => {
     context.state.service.provider.tracing = { apiGateway: false };
     providerRequestStub
       .withArgs('APIGateway', 'getRestApis', {
@@ -605,7 +605,7 @@ describe('#updateStage()', () => {
     }
   );
 
-  it('should update the stage with a custom APIGW log format if given', () => {
+  it('should update the stage with a custom APIGW log format if given', async () => {
     context.state.service.provider.logs = {
       restApi: {
         format: 'requestId: $context.requestId',
@@ -657,7 +657,7 @@ describe('#updateStage()', () => {
     expect(patchOperations).to.include.deep.members([patchOperation]);
   }
 
-  function checkLogLevel(setLevel, expectedLevel) {
+  async function checkLogLevel(setLevel, expectedLevel) {
     if (setLevel) {
       context.state.service.provider.logs = {
         restApi: {
@@ -686,7 +686,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should disable execution logging when executionLogging is set to false', () => {
+  it('should disable execution logging when executionLogging is set to false', async () => {
     context.state.service.provider.logs = {
       restApi: {
         executionLogging: false,
@@ -698,7 +698,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should disable existing access log settings when accessLogging is set to false', () => {
+  it('should disable existing access log settings when accessLogging is set to false', async () => {
     context.state.service.provider.logs = {
       restApi: {
         accessLogging: false,
@@ -711,7 +711,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  it('should delete any existing CloudWatch LogGroup when accessLogging is set to false', () => {
+  it('should delete any existing CloudWatch LogGroup when accessLogging is set to false', async () => {
     context.state.service.provider.logs = {
       restApi: {
         accessLogging: false,
@@ -727,7 +727,7 @@ describe('#updateStage()', () => {
     });
   });
 
-  function checkDataTrace(value) {
+  async function checkDataTrace(value) {
     context.state.service.provider.logs = {
       restApi: {
         fullExecutionData: value,

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/method/request-parameters.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/method/request-parameters.test.js
@@ -11,7 +11,7 @@ describe('ApiGatewayEvents', () => {
   describe('Request parameters', () => {
     let cfResources;
     let naming;
-    before(() =>
+    before(async () =>
       runServerless({
         fixture: 'api-gateway',
         configExt: {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/stage/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/stage/index.test.js
@@ -60,7 +60,7 @@ describe('#compileStage()', () => {
       };
     });
 
-    it.skip('should create a dedicated stage resource if tracing is configured', () =>
+    it.skip('should create a dedicated stage resource if tracing is configured', async () =>
       awsCompileApigEvents.compileStage().then(() => {
         const resources =
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
@@ -85,7 +85,7 @@ describe('#compileStage()', () => {
         });
       }));
 
-    it('should NOT create a dedicated stage resource if tracing is not enabled', () => {
+    it('should NOT create a dedicated stage resource if tracing is not enabled', async () => {
       awsCompileApigEvents.serverless.service.provider.tracing = {};
 
       return awsCompileApigEvents.compileStage().then(() => {
@@ -105,7 +105,7 @@ describe('#compileStage()', () => {
   });
 
   describe('tags', () => {
-    it.skip('should create a dedicated stage resource if provider.stackTags is configured', () => {
+    it.skip('should create a dedicated stage resource if provider.stackTags is configured', async () => {
       awsCompileApigEvents.serverless.service.provider.stackTags = {
         foo: '1',
       };
@@ -134,7 +134,7 @@ describe('#compileStage()', () => {
       });
     });
 
-    it.skip('should create a dedicated stage resource if provider.tags is configured', () => {
+    it.skip('should create a dedicated stage resource if provider.tags is configured', async () => {
       awsCompileApigEvents.serverless.service.provider.tags = {
         foo: '1',
       };
@@ -163,7 +163,7 @@ describe('#compileStage()', () => {
       });
     });
 
-    it.skip('should override provider.stackTags by provider.tags', () => {
+    it.skip('should override provider.stackTags by provider.tags', async () => {
       awsCompileApigEvents.serverless.service.provider.stackTags = {
         foo: 'from-stackTags',
         bar: 'from-stackTags',
@@ -209,7 +209,7 @@ describe('#compileStage()', () => {
       };
     });
 
-    it.skip('should create a dedicated stage resource if logs are configured', () =>
+    it.skip('should create a dedicated stage resource if logs are configured', async () =>
       awsCompileApigEvents.compileStage().then(() => {
         const resources =
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
@@ -250,7 +250,7 @@ describe('#compileStage()', () => {
         });
       }));
 
-    it('should create a Log Group resource', () => {
+    it('should create a Log Group resource', async () => {
       return awsCompileApigEvents.compileStage().then(() => {
         const resources =
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
@@ -264,7 +264,7 @@ describe('#compileStage()', () => {
       });
     });
 
-    it('should set log retention if provider.logRetentionInDays is set', () => {
+    it('should set log retention if provider.logRetentionInDays is set', async () => {
       serverless.service.provider.logRetentionInDays = 30;
 
       return awsCompileApigEvents.compileStage().then(() => {
@@ -281,7 +281,7 @@ describe('#compileStage()', () => {
       });
     });
 
-    it('should ensure CloudWatch role custom resource', () => {
+    it('should ensure CloudWatch role custom resource', async () => {
       return awsCompileApigEvents.compileStage().then(() => {
         const resources =
           awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
@@ -296,7 +296,7 @@ describe('#compileStage()', () => {
       });
     });
 
-    it('should skip CloudWatch role custom resource when restApi.roleManagedExternally is set', () => {
+    it('should skip CloudWatch role custom resource when restApi.roleManagedExternally is set', async () => {
       awsCompileApigEvents.serverless.service.provider.logs.restApi = {
         roleManagedExternally: true,
       };

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.test.js
@@ -1141,7 +1141,7 @@ describe('#validate()', () => {
     expect(validated.events[0].http.async);
   });
 
-  it('should not show a warning message when using request.parameter with LAMBDA-PROXY', () => {
+  it('should not show a warning message when using request.parameter with LAMBDA-PROXY', async () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {
         events: [
@@ -1181,7 +1181,7 @@ describe('#validate()', () => {
     });
   });
 
-  it('should remove non-parameter request/response config with LAMBDA-PROXY', () => {
+  it('should remove non-parameter request/response config with LAMBDA-PROXY', async () => {
     awsCompileApigEvents.serverless.service.functions = {
       first: {
         events: [


### PR DESCRIPTION
…it/lib/plugins/aws/package/compile/events/api-gateway/`

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Addresses: #8368
`/test/unit/lib/plugins/aws/package/compile/events/apiGateway`

Consideration: during refactoring I notice several test functions return promise -> reduce readability with nested blocks -> to should refactor with `await/async` wherever applicable

Perform test for this PR:
`npx mocha "test/unit/lib/plugins/aws/package/compile/events/api-gateway/**/*.test.js"`

![image](https://user-images.githubusercontent.com/3896985/224274680-f6b9eef6-fbca-4f85-8b83-5aa2df390f22.png)


