### PR TITLE
refactor _.entries() to Object.entries()

### DIFF
--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/request-validator.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/request-validator.js
@@ -34,7 +34,7 @@ module.exports = {
       }
 
       if (event.http.request && event.http.request.schemas) {
-        for (const [contentType, schemaConfig] of _.entries(event.http.request.schemas)) {
+        for (const [contentType, schemaConfig] of Object.entries(event.http.request.schemas)) {
           let modelLogicalId;
 
           const referencedDefinitionFromProvider =

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -3,7 +3,6 @@
 const AWS = require('aws-sdk');
 const fse = require('fs-extra');
 const fsp = require('fs').promises;
-const _ = require('lodash');
 const path = require('path');
 const chai = require('chai');
 const sinon = require('sinon');
@@ -826,7 +825,7 @@ describe('AwsCompileFunctions', () => {
 
       return expect(awsCompileFunctions.compileFunctions()).to.be.fulfilled.then(() => {
         let versionDescription;
-        for (const [key, value] of _.entries(
+        for (const [key, value] of Object.entries(
           awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources
         )) {
           if (key.startsWith('FuncLambdaVersion')) {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Addresses: #7747 

There are 2 places that are left with `_.entries()`

Tested with:
`npx mocha test/unit/lib/plugins/aws/package/compile/functions.test.js`
`npx mocha test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/request-validator.test.js`
