### PR TITLE
refactor to remove BbPromise.each()

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -72,7 +72,7 @@ class AwsCompileFunctions {
         }
       },
       'package:compileFunctions': async () =>
-        this.downloadPackageArtifacts().then(this.compileFunctions),
+        this.downloadPackageArtifacts().then(this.compileFunctions.bind(this)),
     };
   }
 

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const AWS = require('../../../../aws/sdk-v2');
-const BbPromise = require('bluebird');
 const crypto = require('crypto');
 const fs = require('fs');
 const _ = require('lodash');
@@ -73,7 +72,7 @@ class AwsCompileFunctions {
         }
       },
       'package:compileFunctions': async () =>
-        BbPromise.bind(this).then(this.downloadPackageArtifacts).then(this.compileFunctions),
+        this.downloadPackageArtifacts().then(this.compileFunctions),
     };
   }
 
@@ -840,9 +839,10 @@ class AwsCompileFunctions {
 
   async downloadPackageArtifacts() {
     const allFunctions = this.serverless.service.getAllFunctions();
-    return BbPromise.each(allFunctions, (functionName) =>
-      this.downloadPackageArtifact(functionName)
-    );
+    // download package artifact sequentially one after another
+    for (const functionName of allFunctions) {
+      await this.downloadPackageArtifact(functionName);
+    }
   }
 
   async compileFunctions() {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #8369

Include my comment along with the new code. We download package artifacts from S3 sequentially instead of running in async (maybe there was a reason behind that)

Another implementation can be:
```
return Promise.all(allFunctions.map((functionName) => this.downloadPackageArtifact(functionName)));
```