### PR TITLE
chore: bump dotenv-expand

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dayjs": "^1.11.7",
     "decompress": "^4.2.1",
     "dotenv": "^16.0.3",
-    "dotenv-expand": "^9.0.0",
+    "dotenv-expand": "^10.0.0",
     "essentials": "^1.2.0",
     "ext": "^1.7.0",
     "fastest-levenshtein": "^1.0.16",


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->
I encountered an issue while trying to deploy a serverless app (v3.28.1).
When a environment variable contains special characters, variable interpolation fails.

This issue has been tracked upstream here: https://github.com/motdotla/dotenv-expand/pull/73
and fixed in https://github.com/motdotla/dotenv-expand/pull/74

Bumped `dotenv-expand` to v10, which addresses this specific issue.

Please find a stacktrace below:

```
Environment: linux, node 16.19.1, framework 3.28.1 (local), plugin 6.2.3, SDK 4.3.2
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
TypeError: Cannot read properties of undefined (reading 'split')
    at /home/runner/work/[redacted]/node_modules/serverless/node_modules/dotenv-expand/lib/main.js:20:33
    at Array.reduce (<anonymous>)
    at _interpolate (/home/runner/work/[redacted]/node_modules/serverless/node_modules/dotenv-expand/lib/main.js:6:18)
    at Object.expand (/home/runner/work/[redacted]/node_modules/serverless/node_modules/dotenv-expand/lib/main.js:50:32)
    at loadDotenvFrom (/home/runner/work/[redacted]/node_modules/serverless/lib/cli/load-dotenv.js:17:23)
    at module.exports (/home/runner/work/[redacted]/node_modules/serverless/lib/cli/load-dotenv.js:32:44)
    at module.exports (/home/runner/work/[redacted]/node_modules/serverless/lib/cli/conditionally-load-dotenv.js:8:27)
    at /home/runner/work/[redacted]/node_modules/serverless/scripts/serverless.js:417:68
    at async /home/runner/work/[redacted]/node_modules/serverless/scripts/serverless.js:254:9
make: *** [Makefile:122: deploy] Error 1
```

