### PR TITLE
Allow OriginAccessControlId field for CloudFront origins

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloud-front.js
+++ b/lib/plugins/aws/package/compile/events/cloud-front.js
@@ -48,6 +48,9 @@ class AwsCompileCloudFrontEvents {
         DomainName: {
           anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfFunction' }],
         },
+        OriginAccessControlId: {
+          anyOf: [{ type: 'string' }, { $ref: '#/definitions/awsCfFunction' }],
+        },
         OriginCustomHeaders: {
           type: 'array',
           items: {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

This PR addresses a small and obvious bug fix.

Amazon has [introduced Origin Access Control (OAC)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html) as a replacement for Origin Access Identities (OAI) to connect CloudFront distributions to S3 origins. Configuring this requires setting the `OriginAccessControlId` field in the `origin` configuration object ([docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-origin.html#cfn-cloudfront-distribution-origin-originaccesscontrolid)).

Serverless already allows setting this field just fine and will pass it along properly in the generated CloudFormation template. But it was not covered in the schema, so it fails validation and warns on the console.

This PR simply adds the field to the schema.