### PR TITLE
fix(AWS Deploy): Handle error for abnormal CloudFormation stack state during AWS deployment

### DIFF
--- a/lib/plugins/aws/deploy/lib/create-stack.js
+++ b/lib/plugins/aws/deploy/lib/create-stack.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const BbPromise = require('bluebird');
-const ServerlessError = require('../../../../serverless-error');
 const { progress, log } = require('@serverless/utils/log');
+const ServerlessError = require('../../../../serverless-error');
 const isChangeSetWithoutChanges = require('../../utils/is-change-set-without-changes');
+
+const inactiveStateNames = new Set(['REVIEW_IN_PROGRESS']);
 
 module.exports = {
   async create() {
@@ -89,14 +91,11 @@ module.exports = {
               }
             }
 
-            const inactiveStateNames = new Set(['REVIEW_IN_PROGRESS']);
-            const isSingleStack = data.Stacks.length <= 1;
             const stackStatus = data.Stacks[0].StackStatus;
-
-            if (isSingleStack && inactiveStateNames.has(stackStatus)) {
+            if (inactiveStateNames.has(stackStatus)) {
               const errorMessage = [
                 'Service cannot be deployed as the CloudFormation stack ',
-                "is in the 'REVIEW_IN_PROGRESS' state. ",
+                `is in the '${stackStatus}' state. `,
                 'This may signal either that stack is currently deployed by a different entity, ',
                 'or that the previous deployment failed and was left in an abnormal state, ',
                 "in which case you can mitigate the issue by running 'sls remove' command",

--- a/lib/plugins/aws/deploy/lib/create-stack.js
+++ b/lib/plugins/aws/deploy/lib/create-stack.js
@@ -89,11 +89,12 @@ module.exports = {
               }
             }
 
+            const inactiveStateNames = new Set(['REVIEW_IN_PROGRESS']);
             const stacksExist = Array.isArray(data.Stacks);
-            const singleStack = stacksExist && data.Stacks.length <= 1;
-            const shouldProcessStacks =
-              singleStack && data.Stacks[0].StackStatus === 'REVIEW_IN_PROGRESS';
-            if (shouldProcessStacks) {
+            const isSingleStack = stacksExist && data.Stacks.length <= 1;
+            const shouldCheckStackStatus =
+              isSingleStack && inactiveStateNames.has(data.Stacks[0].StackStatus);
+            if (shouldCheckStackStatus) {
               const errorMessage = [
                 'Service cannot be deployed as the CloudFormation stack ',
                 "is in the 'REVIEW_IN_PROGRESS' state. ",
@@ -101,7 +102,7 @@ module.exports = {
                 'or that the previous deployment failed and was left in an abnormal state, ',
                 "in which case you can mitigate the issue by running 'sls remove' command",
               ].join('');
-              throw new ServerlessError(errorMessage, 'INVALID_REVIEW_IN_PROGRESS_ERROR');
+              throw new ServerlessError(errorMessage, 'AWS_CLOUDFORMATION_INACTIVE_STACK');
             }
             return BbPromise.resolve('alreadyCreated');
           })

--- a/lib/plugins/aws/deploy/lib/create-stack.js
+++ b/lib/plugins/aws/deploy/lib/create-stack.js
@@ -88,11 +88,12 @@ module.exports = {
                 this.provider.disableTransferAccelerationForCurrentDeploy();
               }
             }
-            if (
-              Array.isArray(data.Stacks) &&
-              data.Stacks.length <= 1 &&
-              data.Stacks[0].StackStatus === 'REVIEW_IN_PROGRESS'
-            ) {
+
+            const stacksExist = Array.isArray(data.Stacks);
+            const singleStack = stacksExist && data.Stacks.length <= 1;
+            const shouldProcessStacks =
+              singleStack && data.Stacks[0].StackStatus === 'REVIEW_IN_PROGRESS';
+            if (shouldProcessStacks) {
               const errorMessage = [
                 'Service cannot be deployed as the CloudFormation stack ',
                 "is in the 'REVIEW_IN_PROGRESS' state. ",
@@ -100,7 +101,7 @@ module.exports = {
                 'or that the previous deployment failed and was left in an abnormal state, ',
                 "in which case you can mitigate the issue by running 'sls remove' command",
               ].join('');
-              throw new ServerlessError(errorMessage, 'REVIEW_IN_PROGRESS_ERROR');
+              throw new ServerlessError(errorMessage, 'INVALID_REVIEW_IN_PROGRESS_ERROR');
             }
             return BbPromise.resolve('alreadyCreated');
           })

--- a/lib/plugins/aws/deploy/lib/create-stack.js
+++ b/lib/plugins/aws/deploy/lib/create-stack.js
@@ -90,11 +90,10 @@ module.exports = {
             }
 
             const inactiveStateNames = new Set(['REVIEW_IN_PROGRESS']);
-            const stacksExist = Array.isArray(data.Stacks);
-            const isSingleStack = stacksExist && data.Stacks.length <= 1;
-            const shouldCheckStackStatus =
-              isSingleStack && inactiveStateNames.has(data.Stacks[0].StackStatus);
-            if (shouldCheckStackStatus) {
+            const isSingleStack = data.Stacks.length <= 1;
+            const stackStatus = data.Stacks[0].StackStatus;
+
+            if (isSingleStack && inactiveStateNames.has(stackStatus)) {
               const errorMessage = [
                 'Service cannot be deployed as the CloudFormation stack ',
                 "is in the 'REVIEW_IN_PROGRESS' state. ",

--- a/lib/plugins/aws/deploy/lib/create-stack.js
+++ b/lib/plugins/aws/deploy/lib/create-stack.js
@@ -88,6 +88,20 @@ module.exports = {
                 this.provider.disableTransferAccelerationForCurrentDeploy();
               }
             }
+            if (
+              Array.isArray(data.Stacks) &&
+              data.Stacks.length <= 1 &&
+              data.Stacks[0].StackStatus === 'REVIEW_IN_PROGRESS'
+            ) {
+              const errorMessage = [
+                'Service cannot be deployed as the CloudFormation stack ',
+                "is in the 'REVIEW_IN_PROGRESS' state. ",
+                'This may signal either that stack is currently deployed by a different entity, ',
+                'or that the previous deployment failed and was left in an abnormal state, ',
+                "in which case you can mitigate the issue by running 'sls remove' command",
+              ].join('');
+              throw new ServerlessError(errorMessage, 'REVIEW_IN_PROGRESS_ERROR');
+            }
             return BbPromise.resolve('alreadyCreated');
           })
       )

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -705,7 +705,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
           command: 'deploy',
           awsRequestStubMap,
         })
-      ).to.have.been.eventually.rejected.with.property('code', 'INVALID_REVIEW_IN_PROGRESS_ERROR');
+      ).to.have.been.eventually.rejected.with.property('code', 'AWS_CLOUDFORMATION_INACTIVE_STACK');
     });
 
     it('with existing stack - subsequent deploy', async () => {

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -651,6 +651,63 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
       expect(deleteObjectsStub).not.to.be.called;
     });
 
+    it('with nonexistent stack - should output an appropriate error message for an abnormal stack state', async () => {
+      const describeStacksStub = sinon
+        .stub()
+        .onFirstCall()
+        .resolves({
+          Stacks: [
+            {
+              StackStatus: 'REVIEW_IN_PROGRESS',
+            },
+          ],
+        });
+      const createChangeSetStub = sinon.stub().resolves({});
+      const executeChangeSetStub = sinon.stub().resolves({});
+      const s3UploadStub = sinon.stub().resolves();
+      const deleteObjectsStub = sinon.stub().resolves({});
+      const awsRequestStubMap = {
+        ...baseAwsRequestStubMap,
+        ECR: {
+          describeRepositories: sinon.stub().throws({
+            providerError: { code: 'RepositoryNotFoundException' },
+          }),
+        },
+        S3: {
+          deleteObjects: deleteObjectsStub,
+          listObjectsV2: { Contents: [] },
+          upload: s3UploadStub,
+          headBucket: {},
+        },
+        CloudFormation: {
+          describeStacks: describeStacksStub,
+          createChangeSet: createChangeSetStub,
+          executeChangeSet: executeChangeSetStub,
+          deleteChangeSet: {},
+          describeChangeSet: {
+            ChangeSetName: 'new-service-dev-change-set',
+            ChangeSetId: 'some-change-set-id',
+            StackName: 'new-service-dev',
+            Status: 'CREATE_COMPLETE',
+          },
+          describeStackEvents: {},
+          describeStackResource: {
+            StackResourceDetail: { PhysicalResourceId: 's3-bucket-resource' },
+          },
+          validateTemplate: {},
+          listStackResources: {},
+        },
+      };
+
+      await expect(
+        runServerless({
+          fixture: 'function',
+          command: 'deploy',
+          awsRequestStubMap,
+        })
+      ).to.have.been.eventually.rejected.with.property('code', 'REVIEW_IN_PROGRESS_ERROR');
+    });
+
     it('with existing stack - subsequent deploy', async () => {
       const s3BucketPrefix = 'serverless/test-aws-deploy-with-existing-stack/dev';
       const s3UploadStub = sinon.stub().resolves();

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -705,7 +705,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
           command: 'deploy',
           awsRequestStubMap,
         })
-      ).to.have.been.eventually.rejected.with.property('code', 'REVIEW_IN_PROGRESS_ERROR');
+      ).to.have.been.eventually.rejected.with.property('code', 'INVALID_REVIEW_IN_PROGRESS_ERROR');
     });
 
     it('with existing stack - subsequent deploy', async () => {

--- a/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/check-for-changes.test.js
@@ -571,7 +571,7 @@ describe('checkForChanges #2', () => {
       lastLifecycleHookName: 'aws:deploy:deploy:checkForChanges',
       awsRequestStubMap: {
         CloudFormation: {
-          describeStacks: {},
+          describeStacks: { Stacks: [{}] },
           describeStackResource: {
             StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
           },
@@ -617,7 +617,7 @@ describe('checkForChanges #2', () => {
 
 const commonAwsSdkMock = {
   CloudFormation: {
-    describeStacks: {},
+    describeStacks: { Stacks: [{}] },
     describeStackResource: {
       StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
     },

--- a/test/unit/lib/plugins/aws/deploy/lib/upload-artifacts.test.js
+++ b/test/unit/lib/plugins/aws/deploy/lib/upload-artifacts.test.js
@@ -307,7 +307,10 @@ describe('uploadArtifacts', () => {
       // There were observed race conditions (mostly in Node.js v6) where this temporary home
       // folder was cleaned before stream initialized fully, hence throwing uncaught
       // ENOENT exception into the air.
-      sinon.stub(fs, 'createReadStream').returns({ path: customResourcesFilePath, on: () => {} });
+      sinon.stub(fs, 'createReadStream').returns({
+        path: customResourcesFilePath,
+        on: () => {},
+      });
       serverless.serviceDir = serviceDirPath;
     });
 
@@ -351,7 +354,7 @@ describe('test/unit/lib/plugins/aws/deploy/lib/upload-artifacts.test.js', () => 
       lastLifecycleHookName: 'aws:deploy:deploy:uploadArtifacts',
       awsRequestStubMap: {
         CloudFormation: {
-          describeStacks: {},
+          describeStacks: { Stacks: [{}] },
           describeStackResource: {
             StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
           },

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.test.js
@@ -771,7 +771,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/hack/u
       lastLifecycleHookName: 'aws:deploy:deploy:checkForChanges',
       awsRequestStubMap: {
         CloudFormation: {
-          describeStacks: {},
+          describeStacks: { Stacks: [{}] },
           describeStackResource: {
             StackResourceDetail: { PhysicalResourceId: 'deployment-bucket' },
           },

--- a/test/unit/lib/plugins/package/lib/package-service.test.js
+++ b/test/unit/lib/plugins/package/lib/package-service.test.js
@@ -289,7 +289,7 @@ describe('test/unit/lib/plugins/package/lib/packageService.test.js', () => {
           headBucket: {},
         },
         CloudFormation: {
-          describeStacks: {},
+          describeStacks: { Stacks: [{}] },
           describeStackResource: { StackResourceDetail: { PhysicalResourceId: 'resource-id' } },
         },
         STS: {


### PR DESCRIPTION
![스크린샷 2023-03-27 오후 8 39 18](https://user-images.githubusercontent.com/49636918/227931093-aa819353-0d7a-4ac5-9e0c-46cc64dadc38.png)


An error that occurs when Serverless Deploy is forcibly terminated has been corrected.
When the status of the **CloudFormation Stack** is, `REVIREW_IN_PROGRESS` the code is configured to output an error message as discussed in the issue.

Closes: #11852