### PR TITLE
Avoid lambda permission for log subscriptions from depending on itself

### DIFF
--- a/lib/plugins/aws/package/compile/events/cloud-watch-log.js
+++ b/lib/plugins/aws/package/compile/events/cloud-watch-log.js
@@ -108,11 +108,12 @@ class AwsCompileCloudWatchLogEvents {
             `;
 
             const commonSuffixOfLogGroupName = this.longestCommonSuffix(logGroupNamesThisFunction);
+            const permissionDependsOn = dependsOn.filter((s) => s !== lambdaPermissionLogicalId);
 
             const permissionTemplate = `
             {
               "Type": "AWS::Lambda::Permission",
-              ${dependsOn.length ? `"DependsOn": ${JSON.stringify(dependsOn)},` : ''}
+              ${permissionDependsOn.length ? `"DependsOn": ${JSON.stringify(permissionDependsOn)},` : ''}
               "Properties": {
                 "FunctionName": ${JSON.stringify(resolveLambdaTarget(functionName, functionObj))},
                 "Action": "lambda:InvokeFunction",

--- a/test/unit/lib/plugins/aws/package/compile/events/cloud-watch-log.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/cloud-watch-log.test.js
@@ -48,8 +48,16 @@ describe('AwsCompileCloudWatchLogEvents', () => {
       ).to.equal('AWS::Logs::SubscriptionFilter');
       expect(
         awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstLogsSubscriptionFilterCloudWatchLog1.DependsOn
+      ).to.eql(['FirstLambdaPermissionLogsSubscriptionFilterCloudWatchLog']);
+      expect(
+        awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstLogsSubscriptionFilterCloudWatchLog2.Type
       ).to.equal('AWS::Logs::SubscriptionFilter');
+      expect(
+        awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstLogsSubscriptionFilterCloudWatchLog2.DependsOn
+      ).to.eql(['FirstLambdaPermissionLogsSubscriptionFilterCloudWatchLog']);
       expect(
         awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstLogsSubscriptionFilterCloudWatchLog1.Properties.LogGroupName
@@ -70,6 +78,10 @@ describe('AwsCompileCloudWatchLogEvents', () => {
         awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstLambdaPermissionLogsSubscriptionFilterCloudWatchLog.Type
       ).to.equal('AWS::Lambda::Permission');
+      expect(
+        awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstLambdaPermissionLogsSubscriptionFilterCloudWatchLog.DependsOn
+      ).to.be.undefined;
     });
 
     it('should respect 2 cloudwatchLog events for log group', () => {
@@ -101,6 +113,10 @@ describe('AwsCompileCloudWatchLogEvents', () => {
       ).to.equal('AWS::Logs::SubscriptionFilter');
       expect(
         awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstLogsSubscriptionFilterCloudWatchLog1.DependsOn
+      ).to.eql(['FirstLambdaPermissionLogsSubscriptionFilterCloudWatchLog']);
+      expect(
+        awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.FirstLogsSubscriptionFilterCloudWatchLog1.Properties.LogGroupName
       ).to.equal('/aws/lambda/hello1');
       expect(
@@ -113,8 +129,16 @@ describe('AwsCompileCloudWatchLogEvents', () => {
       ).to.equal('AWS::Lambda::Permission');
       expect(
         awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.FirstLambdaPermissionLogsSubscriptionFilterCloudWatchLog.DependsOn
+      ).to.be.undefined;
+      expect(
+        awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.SecondLogsSubscriptionFilterCloudWatchLog1.Type
       ).to.equal('AWS::Logs::SubscriptionFilter');
+      expect(
+        awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.SecondLogsSubscriptionFilterCloudWatchLog1.DependsOn
+      ).to.eql(['SecondLambdaPermissionLogsSubscriptionFilterCloudWatchLog']);
       expect(
         awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.SecondLogsSubscriptionFilterCloudWatchLog1.Properties.LogGroupName
@@ -127,6 +151,10 @@ describe('AwsCompileCloudWatchLogEvents', () => {
         awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.SecondLambdaPermissionLogsSubscriptionFilterCloudWatchLog.Type
       ).to.equal('AWS::Lambda::Permission');
+      expect(
+        awsCompileCloudWatchLogEvents.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources.SecondLambdaPermissionLogsSubscriptionFilterCloudWatchLog.DependsOn
+      ).to.be.undefined;
     });
 
     it('should respect "filter" variable', () => {


### PR DESCRIPTION
Closes #11869 

I just filtered the resources's own logical ID from the list of dependencies in the lambda permission template.