### PR TITLE
Fix documentation for azure blob trigger

### DIFF
--- a/docs/providers/azure/events/blobstorage.md
+++ b/docs/providers/azure/events/blobstorage.md
@@ -36,7 +36,7 @@ functions:
     handler: handler.hello
     events:
       - blob:
-        name: item #<string>, default - "myBlob", specifies which name is available on `context.bindings`
+          name: item #<string>, default - "myBlob", specifies which name is available on `context.bindings`
         path: hello/{name}
         connection: AzureWebJobsStorage #<string>, default - "AzureWebJobsStorage", App Setting/environment variable which contains Storage Account Connection String
 ```


### PR DESCRIPTION
Trying to deploy serverless app by following the existing documentation throws  "Error: Binding  nameTrigger not supported". Indentation mistake in the documentation is for the name parameter.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}
