### PR TITLE
fix: allow AND and OR inside alb query conditions

### DIFF
--- a/lib/plugins/aws/package/compile/events/alb/index.js
+++ b/lib/plugins/aws/package/compile/events/alb/index.js
@@ -66,9 +66,24 @@ class AwsCompileAlbEvents {
               maxLength: 128,
             }),
             query: {
-              type: 'object',
-              additionalProperties: { type: 'string', maxLength: 128 },
-              propertyNames: { type: 'string', maxLength: 128 },
+              anyOf: [
+                {
+                  type: 'object',
+                  additionalProperties: { type: 'string', maxLength: 128 },
+                  propertyNames: { type: 'string', maxLength: 128 },
+                },
+                defineArray(
+                  defineArray({
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['Key', 'Value'],
+                    properties: {
+                      Key: { type: 'string', maxLength: 128 },
+                      Value: { type: 'string', maxLength: 128 },
+                    },
+                  })
+                ),
+              ],
             },
           },
           additionalProperties: false,

--- a/lib/plugins/aws/package/compile/events/alb/lib/listener-rules.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/listener-rules.js
@@ -108,15 +108,26 @@ module.exports = {
         });
       }
       if (event.conditions.query) {
-        Conditions.push({
-          Field: 'query-string',
-          QueryStringConfig: {
-            Values: Object.keys(event.conditions.query).map((key) => ({
-              Key: key,
-              Value: event.conditions.query[key],
-            })),
-          },
-        });
+        if (Array.isArray(event.conditions.query)) {
+          event.conditions.query.forEach((query) => {
+            Conditions.push({
+              Field: 'query-string',
+              QueryStringConfig: {
+                Values: query,
+              },
+            });
+          });
+        } else {
+          Conditions.push({
+            Field: 'query-string',
+            QueryStringConfig: {
+              Values: Object.keys(event.conditions.query).map((key) => ({
+                Key: key,
+                Value: event.conditions.query[key],
+              })),
+            },
+          });
+        }
       }
       if (event.conditions.ip) {
         Conditions.push({


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

More details [here](https://github.com/serverless/serverless/pull/11881#issuecomment-1493437495)

Should we add a depreciation warning for the [previous schema](https://www.serverless.com/framework/docs/providers/aws/events/alb#using-different-conditions) as it is ambiguous and not well documented ?

```yaml
query:
  bar: true
```
This lets us think that query value is a boolean like in REST API (http) schema, which isn't!

And we can't guess without deploying and testing what is the behaviour of this declaration:
```yaml
query:
  foo: true
  bar: true
  baz: false
```
Actually if one of these keys (foo, bar, baz) is present in query string then the request will be accepted.


PS: as documented by [AWS](https://docs.aws.amazon.com/fr_fr/AWSCloudFormation/latest/UserGuide/aws-properties-elasticloadbalancingv2-listenerrule-querystringkeyvalue.html), query key isn't required and can be omitted
Closes: #11880
