### PR TITLE
chore: Updated placement of dev mode docs

### DIFF
--- a/docs/menu.json
+++ b/docs/menu.json
@@ -476,6 +476,7 @@
   "Serverless.yml Reference": "providers/aws/guide/serverless.yml",
   "CLI Reference": {
     "Overview": "providers/aws/cli-reference",
+    "dev": "providers/aws/cli-reference/dev",
     "config": "providers/aws/cli-reference/config",
     "config credentials": "providers/aws/cli-reference/config-credentials",
     "create": "providers/aws/cli-reference/create",

--- a/docs/providers/aws/cli-reference/dev.md
+++ b/docs/providers/aws/cli-reference/dev.md
@@ -1,18 +1,18 @@
 <!--
-title: Serverless Framework - Console Dev Mode
+title: Serverless Framework Commands - Dev
 menuText: Serverless Console Dev Mode
-menuOrder: 12
+menuOrder: 1
 description: Launch a Serverless Console dev mode session in the terminal
 layout: Doc
 -->
 
 <!-- DOCS-SITE-LINK:START automatically generated  -->
 
-### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/guides/dev/)
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/aws/cli-reference/dev/)
 
 <!-- DOCS-SITE-LINK:END -->
 
-# Serverless Console Dev Mode
+# Dev
 
 The `serverless dev` command will launch a [Serverless Console Dev Mode](https://www.serverless.com/console/docs/application-guide/dev-mode) session in your terminal.
 


### PR DESCRIPTION
## Description
We haven't seen anyone send any dev mode events through yet and we are wondering if this could be because of the placement of the dev mode document. I am reordering the doc to be nested under the `CLI Reference` section.