### PR TITLE
feat: Support for Java17 as runtime for AWS Lambda functions

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -443,7 +443,7 @@ functions:
     snapStart: true
 ```
 
-**Note:** Lambda SnapStart only supports the Java 11 and Java17 runtime and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
+**Note:** Lambda SnapStart only supports the Java 11 and Java 17 runtimes and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
 
 ## VPC Configuration
 

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -443,7 +443,7 @@ functions:
     snapStart: true
 ```
 
-**Note:** Lambda SnapStart only supports the Java 11 runtime and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
+**Note:** Lambda SnapStart only supports the Java 11 and Java17 runtime and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
 
 ## VPC Configuration
 

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -266,7 +266,7 @@ class AwsInvokeLocal {
       );
     }
 
-    if (['java8', 'java11'].includes(runtime)) {
+    if (['java8', 'java11', 'java17'].includes(runtime)) {
       const className = handler.split('::')[0];
       const handlerName = handler.split('::')[1] || 'handleRequest';
       const artifact =

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -617,6 +617,7 @@ class AwsProvider {
               'dotnet6',
               'dotnetcore3.1',
               'go1.x',
+              'java17',
               'java11',
               'java8',
               'java8.al2',


### PR DESCRIPTION
Adds java17 also as a supported runtime since this is now officialy supported : https://aws.amazon.com/blogs/compute/java-17-runtime-now-available-on-aws-lambda/

Closes issue #11937
