### PR TITLE
fix: Remove references to deprecated AWS Lambda runtimes

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -37,7 +37,7 @@ functions:
     handler: handler.hello # required, handler set in AWS Lambda
     name: ${sls:stage}-lambdaName # optional, Deployed Lambda name
     description: Description of what the lambda function does # optional, Description to publish to AWS
-    runtime: python2.7 # optional overwrite, default is provider runtime
+    runtime: python3.9 # optional overwrite, default is provider runtime
     runtimeManagement:
       mode: manual # syntax required for manual, mode property also supports 'auto' or 'onFunctionUpdate' (see provider.runtimeManagement)
       arn: <aws runtime arn> # required when mode is manual

--- a/docs/providers/kubeless/cli-reference/create.md
+++ b/docs/providers/kubeless/cli-reference/create.md
@@ -65,7 +65,7 @@ These are the current available templates for Kubeless:
 serverless create --template kubeless-python --name my-special-service
 ```
 
-This example will generate scaffolding for a service with `kubeless` as a provider and `python2.7` as runtime. The scaffolding will be generated in the current working directory.
+This example will generate scaffolding for a service with `kubeless` as a provider and `python3.9` as runtime. The scaffolding will be generated in the current working directory.
 
 The provider which is used for deployment later on is Kubeless.
 
@@ -75,7 +75,7 @@ The provider which is used for deployment later on is Kubeless.
 serverless create --template kubeless-python --path my-new-service
 ```
 
-This example will generate scaffolding for a service with `kubeless` as a provider and `python2.7` as runtime. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
+This example will generate scaffolding for a service with `kubeless` as a provider and `python3.9` as runtime. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
 
 Additionally Serverless will rename the service according to the path you provide. In this example the service will be renamed to `my-new-service`.
 

--- a/docs/providers/kubeless/cli-reference/info.md
+++ b/docs/providers/kubeless/cli-reference/info.md
@@ -52,7 +52,7 @@ Metadata
   Timestamp:  2017-08-25T09:19:24Z
 Function Info
 Handler:  handler.hello
-Runtime:  python2.7
+Runtime:  python3.9
 Trigger:  HTTP
 Dependencies:
 Metadata:

--- a/docs/providers/kubeless/events/http.md
+++ b/docs/providers/kubeless/events/http.md
@@ -27,7 +27,7 @@ service: testing-pkg
 
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 
 plugins:
   - serverless-kubeless

--- a/docs/providers/kubeless/events/pubsub.md
+++ b/docs/providers/kubeless/events/pubsub.md
@@ -25,7 +25,7 @@ service: hello
 
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 
 plugins:
   - serverless-kubeless

--- a/docs/providers/kubeless/guide/debugging.md
+++ b/docs/providers/kubeless/guide/debugging.md
@@ -44,7 +44,7 @@ And its corresponding Serverless YAML file:
 service: bikesearch
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 
 plugins:
   - serverless-kubeless
@@ -120,9 +120,9 @@ Hit Ctrl-C to quit.
 172.17.0.1 - - [25/Aug/2017:08:46:04 +0000] "GET /healthz HTTP/1.1" 200 2 "" "Go-http-client/1.1" 0/82
 172.17.0.1 - - [25/Aug/2017:08:46:07 +0000] "POST / HTTP/1.1" 200 459 "" "" 1/957186
 Traceback (most recent call last):
-  File "/usr/local/lib/python2.7/site-packages/bottle.py", line 862, in _handle
+  File "/usr/local/lib/python3.9/site-packages/bottle.py", line 862, in _handle
     return route.call(**args)
-  File "/usr/local/lib/python2.7/site-packages/bottle.py", line 1740, in wrapper
+  File "/usr/local/lib/python3.9/site-packages/bottle.py", line 1740, in wrapper
     rv = callback(*a, **ka)
   File "/kubeless.py", line 35, in handler
     return func(bottle.request)
@@ -139,9 +139,9 @@ KeyError: 'term'
 172.17.0.1 - - [25/Aug/2017:08:49:04 +0000] "GET /healthz HTTP/1.1" 200 2 "" "Go-http-client/1.1" 0/98
 172.17.0.1 - - [25/Aug/2017:08:49:23 +0000] "POST / HTTP/1.1" 500 746 "" "" 0/655
 Traceback (most recent call last):
-  File "/usr/local/lib/python2.7/site-packages/bottle.py", line 862, in _handle
+  File "/usr/local/lib/python3.9/site-packages/bottle.py", line 862, in _handle
     return route.call(**args)
-  File "/usr/local/lib/python2.7/site-packages/bottle.py", line 1740, in wrapper
+  File "/usr/local/lib/python3.9/site-packages/bottle.py", line 1740, in wrapper
     rv = callback(*a, **ka)
   File "/kubeless.py", line 35, in handler
     return func(bottle.request)

--- a/docs/providers/kubeless/guide/deploying.md
+++ b/docs/providers/kubeless/guide/deploying.md
@@ -40,7 +40,7 @@ For example, let's take the following example `serverless.yml` file:
 service: new-project
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 
 plugins:
   - serverless-kubeless
@@ -86,7 +86,7 @@ In order to overcome this limitation, function code can be fetched from [externa
 ```yaml
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
   deploy:
     strategy: S3ZipContent
     options:

--- a/docs/providers/kubeless/guide/functions.md
+++ b/docs/providers/kubeless/guide/functions.md
@@ -26,7 +26,7 @@ service: my-service
 
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
   memorySize: 512M # optional, maximum memory
   timeout: 10 # optional, in seconds, default is 180
   namespace: funcions # optional, deployment namespace if not specified it uses "default"
@@ -80,7 +80,7 @@ service: my-service
 
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 
 plugins:
   - serverless-kubeless
@@ -340,7 +340,7 @@ service: hello
 
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 
 plugins:
   - serverless-kubeless

--- a/docs/providers/kubeless/guide/services.md
+++ b/docs/providers/kubeless/guide/services.md
@@ -85,7 +85,7 @@ You can see the name of the service, the provider configuration and the first fu
 service: new-project
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 
 plugins:
   - serverless-kubeless
@@ -151,7 +151,7 @@ service: users
 
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 …
 ```
 
@@ -166,7 +166,7 @@ service: users
 
 provider:
   name: kubeless
-  runtime: python2.7
+  runtime: python3.9
 
 …
 ```

--- a/docs/providers/spotinst/examples/python/README.md
+++ b/docs/providers/spotinst/examples/python/README.md
@@ -34,7 +34,7 @@ serverless invoke --function hello
 In your terminal window you should see the response
 
 ```bash
-'{"hello":"from Python2.7 function"}'
+'{"hello":"from Python3.9 function"}'
 ```
 
 Congrats you have deployed and ran your Hello World function!

--- a/docs/providers/tencent/cli-reference/create.md
+++ b/docs/providers/tencent/cli-reference/create.md
@@ -53,7 +53,7 @@ Most commonly used templates:
 - tencent-php
 - tencent-go
 
-**Note:** The templates will deploy the latest version of runtime by default. When you want to configure specific version of runtime, like `Node.js18`, `Python3.10` or `PHP5`, you have to configure the `runtime` property in `serverless.yml`.
+**Note:** The templates will deploy the latest version of runtime by default. When you want to configure specific version of runtime, like `Node.js18`, `Python3.9` or `PHP5`, you have to configure the `runtime` property in `serverless.yml`.
 
 ## Examples
 

--- a/docs/providers/tencent/cli-reference/create.md
+++ b/docs/providers/tencent/cli-reference/create.md
@@ -53,7 +53,7 @@ Most commonly used templates:
 - tencent-php
 - tencent-go
 
-**Note:** The templates will deploy the latest version of runtime by default. When you want to configure specific version of runtime, like `Node.js6`, `Python2.7` or `PHP5`, you have to configure the `runtime` property in `serverless.yml`.
+**Note:** The templates will deploy the latest version of runtime by default. When you want to configure specific version of runtime, like `Node.js18`, `Python3.10` or `PHP5`, you have to configure the `runtime` property in `serverless.yml`.
 
 ## Examples
 

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -254,7 +254,7 @@ class AwsInvokeLocal {
     }
 
     if (
-      ['python2.7', 'python3.6', 'python3.7', 'python3.8', 'python3.9', 'python3.10'].includes(
+      ['python3.7', 'python3.8', 'python3.9', 'python3.10'].includes(
         runtime
       )
     ) {
@@ -287,7 +287,7 @@ class AwsInvokeLocal {
       );
     }
 
-    if (['ruby2.5', 'ruby2.7'].includes(runtime)) {
+    if (['ruby2.7'].includes(runtime)) {
       const handlerComponents = handler.split(/\./);
       const handlerPath = handlerComponents[0];
       const handlerName = handlerComponents.slice(1).join('.');
@@ -465,7 +465,7 @@ class AwsInvokeLocal {
       'artifact'
     );
     // Workaround for https://github.com/serverless/serverless/issues/6028
-    // Java zip/jar implementaion doesn't preserve file permissions in a zip file.
+    // Java zip/jar implementation doesn't preserve file permissions in a zip file.
     // https://bugs.openjdk.java.net/browse/JDK-6194856
     // So we follow Java's way in java.util.zip.ZipEntry#isDirectory() to detect directory.
     const artifactFiles = await decompress(artifact, destination, {

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -253,11 +253,7 @@ class AwsInvokeLocal {
       );
     }
 
-    if (
-      ['python3.7', 'python3.8', 'python3.9', 'python3.10'].includes(
-        runtime
-      )
-    ) {
+    if (['python3.7', 'python3.8', 'python3.9', 'python3.10'].includes(runtime)) {
       const handlerComponents = handler.split(/\./);
       const handlerPath = handlerComponents.slice(0, -1).join('.');
       const handlerName = handlerComponents.pop();

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -629,7 +629,6 @@ class AwsProvider {
               'nodejs18.x',
               'provided',
               'provided.al2',
-              'python3.6',
               'python3.7',
               'python3.8',
               'python3.9',

--- a/test/unit/lib/cli/interactive-setup/dashboard-login.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-login.test.js
@@ -20,7 +20,16 @@ const ServerlessSDKMock = class ServerlessSDK {
       get: async () => {
         return {
           awsAccountId: '377024778620',
-          supportedRuntimes: ['nodejs10.x', 'nodejs12.x', 'python2.7', 'python3.6', 'python3.7'],
+          supportedRuntimes: [
+            'nodejs12.x',
+            'nodejs14.x',
+            'nodejs16.x',
+            'nodejs18.x',
+            'python3.7',
+            'python3.8',
+            'python3.9',
+            'python3.10',
+          ],
           supportedRegions: [
             'us-east-1',
             'us-east-2',

--- a/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -36,11 +36,14 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
             return {
               awsAccountId: '377024778620',
               supportedRuntimes: [
-                'nodejs10.x',
                 'nodejs12.x',
-                'python2.7',
-                'python3.6',
+                'nodejs14.x',
+                'nodejs16.x',
+                'nodejs18.x',
                 'python3.7',
+                'python3.8',
+                'python3.9',
+                'python3.10',
               ],
               supportedRegions: [
                 'us-east-1',
@@ -190,7 +193,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
               get: async () => {
                 return {
                   awsAccountId: '377024778620',
-                  supportedRuntimes: ['nodejs10.x', 'nodejs12.x'],
+                  supportedRuntimes: ['nodejs12.x', 'nodejs14.x', 'nodejs16.x', 'nodejs18.x'],
                   supportedRegions: ['us-east-1'],
                 };
               },

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -440,11 +440,11 @@ describe('AwsInvokeLocal', () => {
       ).to.be.equal(true);
     });
 
-    it('should call invokeLocalPython when python2.7 runtime is set', async () => {
-      awsInvokeLocal.options.functionObj.runtime = 'python2.7';
+    it('should call invokeLocalPython when python3.9 runtime is set', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'python3.9';
       await awsInvokeLocal.invokeLocal();
       // NOTE: this is important so that tests on Windows won't fail
-      const runtime = process.platform === 'win32' ? 'python.exe' : 'python2.7';
+      const runtime = process.platform === 'win32' ? 'python.exe' : 'python3.9';
       expect(invokeLocalPythonStub.calledOnce).to.be.equal(true);
       expect(
         invokeLocalPythonStub.calledWithExactly(runtime, 'handler', 'hello', {}, undefined)
@@ -467,8 +467,8 @@ describe('AwsInvokeLocal', () => {
       ).to.be.equal(true);
     });
 
-    it('should call invokeLocalRuby when ruby2.5 runtime is set', async () => {
-      awsInvokeLocal.options.functionObj.runtime = 'ruby2.5';
+    it('should call invokeLocalRuby when ruby2.7 runtime is set', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'ruby2.7';
       await awsInvokeLocal.invokeLocal();
       // NOTE: this is important so that tests on Windows won't fail
       const runtime = process.platform === 'win32' ? 'ruby.exe' : 'ruby';


### PR DESCRIPTION
what.

- Remove references to deprecated AWS Lambda runtimes (Python 2.7, 3.6 and Node 10.x).
- Update tests, documentation, etc.

why.

Since AWS is no longer supporting these runtimes it would be better if the documentation was up to date and pointed users towards new/supported configuration that actually works.

references.

Based on [AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy).

Test results (local run, excluding Ruby):
```text
  2823 passing (2m)
  179 pending

 Notice: Some tests were skipped due to following environment issues:

 - test/unit/lib/plugins/aws/invokeLocal/index.test.js: Ruby: "before all" hook in "Ruby" (in: t/unit/lib/plugins/aws/invoke-local/index.test.js)

   Ruby runtime is not installed
```