### PR TITLE
fix: Adding support for '$or' property in EventBridge pattern schema

### DIFF
--- a/lib/plugins/aws/package/compile/events/event-bridge/index.js
+++ b/lib/plugins/aws/package/compile/events/event-bridge/index.js
@@ -95,6 +95,7 @@ class AwsCompileEventBridgeEvents {
             'region': {},
             'resources': {},
             'detail': {},
+            '$or': { type: 'array' },
           },
           additionalProperties: false,
         },

--- a/test/unit/lib/plugins/aws/package/compile/events/event-bridge/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/event-bridge/index.test.js
@@ -152,6 +152,26 @@ const serverlessConfigurationExtension = {
         },
       ],
     },
+    orPattern: {
+      handler: 'index.handler',
+      events: [
+        {
+          eventBridge: {
+            eventBus: 'arn:aws:events:us-east-1:12345:event-bus/default',
+            pattern: {
+              $or: [
+                {
+                  detail: {
+                    eventSource: ['saas.external'],
+                  },
+                },
+                { source: ['aws.cloudformation'] },
+              ],
+            },
+          },
+        },
+      ],
+    },
   },
 };
 
@@ -271,6 +291,16 @@ describe('EventBridgeEvents', () => {
       } = eventBridgeConfig.InputTransformer;
       expect(InputTemplate).be.eq('{"time": <eventTime>, "key1": "value1"}');
       expect(eventTime).be.eq('$.time');
+    });
+
+    it('should support $or pattern in event pattern', () => {
+      const eventBridgeConfig = getEventBridgeConfigById('orPattern');
+      expect(eventBridgeConfig.Pattern.$or[0]).to.deep.equal({
+        detail: {
+          eventSource: ['saas.external'],
+        },
+      });
+      expect(eventBridgeConfig.Pattern.$or[1]).to.deep.equal({ source: ['aws.cloudformation'] });
     });
 
     it('should register created and delete event bus permissions for non default event bus', () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #11951

This PR enables the use of `$or` in eventbridge pattern blocks.

```yaml
pattern:
  '$or':
    - source: ['aws.ec2']
    - detail-type: ['AWS API Call via CloudTrail']
```

I made the schema enforce using an array, but have otherwise left the items to be anything.

[AWS EventBridge Pattern Docs](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html#eb-create-pattern)

