### PR TITLE
feat: Added warning about dev mode

### DIFF
--- a/lib/cli/interactive-setup/console-dev-mode-feed.js
+++ b/lib/cli/interactive-setup/console-dev-mode-feed.js
@@ -160,7 +160,8 @@ const connectToWebSocket = async ({ functionName, region, accountId, org, state 
       const uiLink = `${frontend}/${org.orgName}/dev-mode?devModeCloudAccountId=${accountId}&${functionNameQueryParams}`;
       writeText(
         style.aside(
-          '\n• Use the `--verbose` flag to see inputs and outputs of all requests (e.g. DynamoDB inputs/outputs).',
+          '\n• WARNING: Dev mode will not sample traces. This can lean to console usage being higher than expected.',
+          '• Use the `--verbose` flag to see inputs and outputs of all requests (e.g. DynamoDB inputs/outputs).',
           `• Use the Console Dev Mode UI for deeper inspection: ${uiLink}\n`,
           'Waiting for activity... Invoke your functions now.'
         )

--- a/lib/cli/interactive-setup/console-enable-dev-mode.js
+++ b/lib/cli/interactive-setup/console-enable-dev-mode.js
@@ -71,12 +71,18 @@ const checkInstrumentationStatus = async (context) => {
   };
 };
 
+const headerMessage = 'Instrumenting functions';
+const warningMessage =
+  'WARNING: Dev mode will not sample traces. This can lean to console usage being higher than expected.';
+
 const waitForInstrumentation = async (context) => {
   const instrumentationProgress = progress.get(progressKey);
   let isInstrumenting = true;
   while (isInstrumenting) {
     const { isInstrumented: done, total, instrumented } = await checkInstrumentationStatus(context);
-    instrumentationProgress.update(`Instrumenting ${instrumented}/${total} functions`);
+    instrumentationProgress.update(
+      `${headerMessage}\n${warningMessage}\nInstrumenting ${instrumented}/${total} functions`
+    );
     if (done) {
       isInstrumenting = false;
     } else {
@@ -162,7 +168,9 @@ module.exports = {
 
   async run(context) {
     const instrumentationProgress = progress.get(progressKey);
-    instrumentationProgress.notice('Instrumenting functions', 'This may take a few minutes...');
+    instrumentationProgress.notice(
+      `${headerMessage}\n${warningMessage}\nThis may take a few minutes...`
+    );
     // Chunk targetInstrumentations into 50 resources per request
     const distributeArrayBy50 = (array) => {
       const result = [];


### PR DESCRIPTION
## Description
Adding warning about dev mode increasing console usage due to traces not being sampled out.

## Screenshots
**During instrumentation**
<img width="1169" alt="Screenshot 2023-05-17 at 10 34 31 AM" src="https://github.com/serverless/serverless/assets/1753824/e6303a15-ca60-42ba-ae82-d6dfefa80726">
**When dev mode is waiting for activity**
<img width="1416" alt="Screenshot 2023-05-17 at 10 35 25 AM" src="https://github.com/serverless/serverless/assets/1753824/a79022e8-6788-40a3-8b59-a8e2798b2302">

