### PR TITLE
Allow AWS Lambda function events[].stream.consumer to be explicitly set to false

### DIFF
--- a/lib/plugins/aws/package/compile/events/stream.js
+++ b/lib/plugins/aws/package/compile/events/stream.js
@@ -47,7 +47,7 @@ class AwsCompileStreamEvents {
             startingPosition: { enum: ['LATEST', 'TRIM_HORIZON', 'AT_TIMESTAMP'] },
             startingPositionTimestamp: { type: 'number' },
             enabled: { type: 'boolean' },
-            consumer: { anyOf: [{ const: true }, { $ref: '#/definitions/awsArn' }] },
+            consumer: { anyOf: [{ type: 'boolean' }, { $ref: '#/definitions/awsArn' }] },
             batchWindow: { type: 'integer', minimum: 0, maximum: 300 },
             maximumRetryAttempts: { type: 'integer', minimum: -1, maximum: 10000 },
             bisectBatchOnFunctionError: { type: 'boolean' },

--- a/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
@@ -1363,7 +1363,11 @@ describe('AwsCompileStreamEvents', () => {
                 stream: 'arn:aws:kinesis:region:account:stream/foo',
               },
               {
-                stream: 'arn:aws:kinesis:region:account:stream/bar',
+                stream: {
+                  type: 'kinesis',
+                  arn: 'arn:aws:kinesis:region:account:stream/bar',
+                  consumer: false,
+                },
               },
               {
                 stream: {


### PR DESCRIPTION
Closes: #11988 
