### PR TITLE
AWS Lambda: Remove `nodejs12.x` runtime

### DIFF
--- a/lib/cli/interactive-setup/dashboard-login.js
+++ b/lib/cli/interactive-setup/dashboard-login.js
@@ -65,7 +65,7 @@ module.exports = {
       return false;
     }
     const { supportedRegions, supportedRuntimes } = sdkMetadata;
-    if (!supportedRuntimes.includes(_.get(configuration.provider, 'runtime') || 'nodejs12.x')) {
+    if (!supportedRuntimes.includes(_.get(configuration.provider, 'runtime') || 'nodejs14.x')) {
       context.inapplicabilityReasonCode = 'UNSUPPORTED_RUNTIME';
       return false;
     }

--- a/lib/cli/interactive-setup/dashboard-set-org.js
+++ b/lib/cli/interactive-setup/dashboard-set-org.js
@@ -218,7 +218,7 @@ module.exports = {
     // We want to still allow onboarding from Dashboard (idenfitied by explicit `--org` passed)
     if (
       !options.org &&
-      !supportedRuntimes.includes(_.get(configuration.provider, 'runtime') || 'nodejs12.x')
+      !supportedRuntimes.includes(_.get(configuration.provider, 'runtime') || 'nodejs14.x')
     ) {
       context.inapplicabilityReasonCode = 'UNSUPPORTED_RUNTIME';
       return false;

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -623,7 +623,6 @@ class AwsProvider {
               'java11',
               'java8',
               'java8.al2',
-              'nodejs12.x',
               'nodejs14.x',
               'nodejs16.x',
               'nodejs18.x',

--- a/lib/plugins/package/lib/package-service.js
+++ b/lib/plugins/package/lib/package-service.js
@@ -29,7 +29,7 @@ module.exports = {
   },
 
   getRuntime(runtime) {
-    const defaultRuntime = 'nodejs12.x';
+    const defaultRuntime = 'nodejs14.x';
     return runtime || this.serverless.service.provider.runtime || defaultRuntime;
   },
 

--- a/lib/utils/telemetry/generate-payload.js
+++ b/lib/utils/telemetry/generate-payload.js
@@ -27,7 +27,7 @@ const getServiceConfig = ({ configuration, options, variableSources }) => {
   const isAwsProvider = providerName === 'aws';
 
   const defaultRuntime = isAwsProvider
-    ? configuration.provider.runtime || 'nodejs12.x'
+    ? configuration.provider.runtime || 'nodejs14.x'
     : _.get(configuration, 'provider.runtime');
 
   const functions = (() => {

--- a/test/fixtures/cli/variables/serverless.yml
+++ b/test/fixtures/cli/variables/serverless.yml
@@ -3,7 +3,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 custom:
   importedFile: ${file(config.json)}

--- a/test/fixtures/programmatic/api-gateway-extended/serverless.yml
+++ b/test/fixtures/programmatic/api-gateway-extended/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
   apiGateway:
     shouldStartNameWithService: true

--- a/test/fixtures/programmatic/api-gateway/serverless.yml
+++ b/test/fixtures/programmatic/api-gateway/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   apiGateway:
     shouldStartNameWithService: true
 

--- a/test/fixtures/programmatic/check-for-changes/serverless.yml
+++ b/test/fixtures/programmatic/check-for-changes/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   fn1:

--- a/test/fixtures/programmatic/cognito-user-pool/serverless.yml
+++ b/test/fixtures/programmatic/cognito-user-pool/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/config-schema-extensions-error/serverless.yml
+++ b/test/fixtures/programmatic/config-schema-extensions-error/serverless.yml
@@ -2,7 +2,7 @@ service: configSchemaExtensionsError
 
 provider:
   name: someProvider
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 configValidationMode: error
 frameworkVersion: '*'

--- a/test/fixtures/programmatic/ecr/serverless.yml
+++ b/test/fixtures/programmatic/ecr/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   ecr:
     images:
       baseimage:

--- a/test/fixtures/programmatic/event-bridge/serverless.yml
+++ b/test/fixtures/programmatic/event-bridge/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-cloud-front/serverless.yml
+++ b/test/fixtures/programmatic/function-cloud-front/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   foo:

--- a/test/fixtures/programmatic/function-efs/serverless.yml
+++ b/test/fixtures/programmatic/function-efs/serverless.yml
@@ -7,7 +7,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/function-layers/serverless.yml
+++ b/test/fixtures/programmatic/function-layers/serverless.yml
@@ -1,7 +1,7 @@
 service: service
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 layers:
   testLayer:

--- a/test/fixtures/programmatic/function-msk/serverless.yml
+++ b/test/fixtures/programmatic/function-msk/serverless.yml
@@ -8,7 +8,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/http-api-catch-all/serverless.yml
+++ b/test/fixtures/programmatic/http-api-catch-all/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   foo:

--- a/test/fixtures/programmatic/http-api-export/serverless.yml
+++ b/test/fixtures/programmatic/http-api-export/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 resources:
   Resources:

--- a/test/fixtures/programmatic/http-api/serverless.yml
+++ b/test/fixtures/programmatic/http-api/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   logRetentionInDays: 14
 
 functions:

--- a/test/fixtures/programmatic/invocation/serverless.yml
+++ b/test/fixtures/programmatic/invocation/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   callback:

--- a/test/fixtures/programmatic/iot-fleet-provisioning/serverless.yml
+++ b/test/fixtures/programmatic/iot-fleet-provisioning/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/iot/serverless.yml
+++ b/test/fixtures/programmatic/iot/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/layer/serverless.yml
+++ b/test/fixtures/programmatic/layer/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   function:

--- a/test/fixtures/programmatic/multi-service/service-a/serverless.yml
+++ b/test/fixtures/programmatic/multi-service/service-a/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 custom:
   env: ${env:ENV_SOURCE_TEST, null}

--- a/test/fixtures/programmatic/package-artifact-in-serverless-dir/serverless.yml
+++ b/test/fixtures/programmatic/package-artifact-in-serverless-dir/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 plugins:
   # Mutates `package.artifact` to point to copied `.serverless/NAME.zip`

--- a/test/fixtures/programmatic/package-artifact/serverless.yml
+++ b/test/fixtures/programmatic/package-artifact/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 package:
   artifact: artifact.zip

--- a/test/fixtures/programmatic/packaging/serverless.yml
+++ b/test/fixtures/programmatic/packaging/serverless.yml
@@ -6,7 +6,7 @@ disabledDeprecations: LOAD_VARIABLES_FROM_ENV_FILES
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   fnService:

--- a/test/fixtures/programmatic/plugin/serverless.yml
+++ b/test/fixtures/programmatic/plugin/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 plugins:
   - ./plugin

--- a/test/fixtures/programmatic/provisioned-concurrency/serverless.yml
+++ b/test/fixtures/programmatic/provisioned-concurrency/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/request-parameters/serverless.yml
+++ b/test/fixtures/programmatic/request-parameters/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   target:

--- a/test/fixtures/programmatic/request-schema/serverless.yml
+++ b/test/fixtures/programmatic/request-schema/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   apiGateway:
     request:
       schemas:

--- a/test/fixtures/programmatic/s3/serverless.yml
+++ b/test/fixtures/programmatic/s3/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
   s3:
     customBucket:

--- a/test/fixtures/programmatic/schedule/serverless.yml
+++ b/test/fixtures/programmatic/schedule/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/sns/serverless.yml
+++ b/test/fixtures/programmatic/sns/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/sqs/serverless.yml
+++ b/test/fixtures/programmatic/sqs/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/stream/serverless.yml
+++ b/test/fixtures/programmatic/stream/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
 
 functions:

--- a/test/fixtures/programmatic/variables-legacy/serverless.yml
+++ b/test/fixtures/programmatic/variables-legacy/serverless.yml
@@ -2,7 +2,7 @@ service: service
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 custom:
   importedFile: ${file(config.json)}

--- a/test/fixtures/programmatic/websocket/serverless.yml
+++ b/test/fixtures/programmatic/websocket/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
   versionFunctions: false
   logs:
     websocket: true

--- a/test/integration-package/cloudformation.tests.js
+++ b/test/integration-package/cloudformation.tests.js
@@ -44,7 +44,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs12.x',
+        Runtime: 'nodejs16.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],
@@ -75,7 +75,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs12.x',
+        Runtime: 'nodejs16.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],
@@ -109,7 +109,7 @@ describe('Integration test - Packaging - CloudFormation', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs12.x',
+        Runtime: 'nodejs16.x',
         Timeout: 6,
       },
       DependsOn: ['HelloLogGroup'],

--- a/test/integration-package/fixtures/artifact/serverless.yml
+++ b/test/integration-package/fixtures/artifact/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   hello:

--- a/test/integration-package/fixtures/individually-function/serverless.yml
+++ b/test/integration-package/fixtures/individually-function/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   hello:

--- a/test/integration-package/fixtures/individually/serverless.yml
+++ b/test/integration-package/fixtures/individually/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 package:
   individually: true

--- a/test/integration-package/fixtures/regular/serverless.yml
+++ b/test/integration-package/fixtures/regular/serverless.yml
@@ -4,7 +4,7 @@ configValidationMode: error
 
 provider:
   name: aws
-  runtime: nodejs12.x
+  runtime: nodejs16.x
 
 functions:
   hello:

--- a/test/unit/lib/cli/interactive-setup/console-login.test.js
+++ b/test/unit/lib/cli/interactive-setup/console-login.test.js
@@ -121,7 +121,7 @@ describe('test/unit/lib/cli/interactive-setup/console-login.test.js', function (
     });
     const context = {
       serviceDir: process.cwd(),
-      configuration: { provider: { name: 'aws', runtime: 'nodejs12.x' } },
+      configuration: { provider: { name: 'aws', runtime: 'nodejs16.x' } },
       configurationFilename: 'serverless.yml',
       options: { console: true },
       initial: {},

--- a/test/unit/lib/cli/interactive-setup/dashboard-login.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-login.test.js
@@ -21,7 +21,6 @@ const ServerlessSDKMock = class ServerlessSDK {
         return {
           awsAccountId: '377024778620',
           supportedRuntimes: [
-            'nodejs12.x',
             'nodejs14.x',
             'nodejs16.x',
             'nodejs18.x',
@@ -140,7 +139,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-login.test.js', function
     });
     const context = {
       serviceDir: process.cwd(),
-      configuration: { provider: { name: 'aws', runtime: 'nodejs12.x' } },
+      configuration: { provider: { name: 'aws', runtime: 'nodejs16.x' } },
       configurationFilename: 'serverless.yml',
       options: {},
       initial: {},
@@ -164,7 +163,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-login.test.js', function
     });
     const context = {
       serviceDir: process.cwd(),
-      configuration: { provider: { name: 'aws', runtime: 'nodejs12.x' } },
+      configuration: { provider: { name: 'aws', runtime: 'nodejs16.x' } },
       configurationFilename: 'serverless.yml',
       options: { org: 'someorg' },
       initial: {},
@@ -185,7 +184,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-login.test.js', function
     });
     const context = {
       serviceDir: process.cwd(),
-      configuration: { org: 'someorg', provider: { name: 'aws', runtime: 'nodejs12.x' } },
+      configuration: { org: 'someorg', provider: { name: 'aws', runtime: 'nodejs16.x' } },
       configurationFilename: 'serverless.yml',
       options: {},
       initial: {},
@@ -209,7 +208,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-login.test.js', function
     });
     const context = {
       serviceDir: process.cwd(),
-      configuration: { provider: { name: 'aws', runtime: 'nodejs12.x' } },
+      configuration: { provider: { name: 'aws', runtime: 'nodejs16.x' } },
       configurationFilename: 'serverless.yml',
       options: {},
       initial: {},

--- a/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -36,7 +36,6 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
             return {
               awsAccountId: '377024778620',
               supportedRuntimes: [
-                'nodejs12.x',
                 'nodejs14.x',
                 'nodejs16.x',
                 'nodejs18.x',
@@ -172,7 +171,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
       serviceDir: process.cwd(),
       configuration: {
         service: 'some-aws-service',
-        provider: { name: 'aws', runtime: 'nodejs12.x' },
+        provider: { name: 'aws', runtime: 'nodejs16.x' },
       },
       configurationFilename: 'serverless.yml',
       options: {},
@@ -193,7 +192,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
               get: async () => {
                 return {
                   awsAccountId: '377024778620',
-                  supportedRuntimes: ['nodejs12.x', 'nodejs14.x', 'nodejs16.x', 'nodejs18.x'],
+                  supportedRuntimes: ['nodejs14.x', 'nodejs16.x', 'nodejs18.x'],
                   supportedRegions: ['us-east-1'],
                 };
               },

--- a/test/unit/lib/plugins/aws/deploy/index.test.js
+++ b/test/unit/lib/plugins/aws/deploy/index.test.js
@@ -1225,7 +1225,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
         Key: 'serverless/test-package-artifact/dev/1589988704359-2020-05-20T15:31:44.359Z/compiled-cloudformation-template.json',
       })
       .returns({
-        Metadata: { filesha256: 'ehiUQMDbrQnzl3h86rfG0T6nICXzNTiQ0xXZSuIw98s=' },
+        Metadata: { filesha256: 'sazQTKx8BgZJIMV2cJhXcOT68Q8KaP9mHdI9C2dST40=' },
       });
     s3HeadObjectStub
       .withArgs({
@@ -1233,7 +1233,7 @@ describe('test/unit/lib/plugins/aws/deploy/index.test.js', () => {
         Key: 'serverless/test-package-artifact/dev/1589988704359-2020-05-20T15:31:44.359Z/serverless-state.json',
       })
       .returns({
-        Metadata: { filesha256: 'JZ0oWM9ZWnYOxa3CRNeBRE5HAg+Q9RSwdxcKbik33d8=' },
+        Metadata: { filesha256: 'fSU2tLfTe72BW+k8hJvm6VkzHtssCtrTG+uqGGg4YzI=' },
       });
 
     s3HeadObjectStub

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -421,7 +421,7 @@ describe('AwsInvokeLocal', () => {
         it(`should call invokeLocalNodeJs for any node.js runtime version for ${item.path}`, async () => {
           awsInvokeLocal.options.functionObj.handler = item.path;
 
-          awsInvokeLocal.options.functionObj.runtime = 'nodejs12.x';
+          awsInvokeLocal.options.functionObj.runtime = 'nodejs16.x';
           await awsInvokeLocal.invokeLocal();
           expect(invokeLocalNodeJsStub.calledOnce).to.be.equal(true);
           expect(
@@ -486,8 +486,8 @@ describe('AwsInvokeLocal', () => {
       expect(invokeLocalDockerStub.calledWithExactly()).to.be.equal(true);
     });
 
-    it('should call invokeLocalDocker if using --docker option with nodejs12.x', async () => {
-      awsInvokeLocal.options.functionObj.runtime = 'nodejs12.x';
+    it('should call invokeLocalDocker if using --docker option with nodejs16.x', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'nodejs16.x';
       awsInvokeLocal.options.functionObj.handler = 'handler.foobar';
       awsInvokeLocal.options.docker = true;
       await awsInvokeLocal.invokeLocal();
@@ -629,7 +629,7 @@ describe('AwsInvokeLocal', () => {
           handler: 'handler.hello',
           name: 'hello',
           timeout: 4,
-          runtime: 'nodejs12.x',
+          runtime: 'nodejs16.x',
           environment: {
             functionVar: 'functionValue',
           },
@@ -657,7 +657,7 @@ describe('AwsInvokeLocal', () => {
       expect(spawnExtStub.getCall(0).args).to.deep.equal(['docker', ['version']]);
       expect(spawnExtStub.getCall(1).args).to.deep.equal([
         'docker',
-        ['images', '-q', 'lambci/lambda:nodejs12.x'],
+        ['images', '-q', 'lambci/lambda:nodejs16.x'],
       ]);
       expect(spawnExtStub.getCall(3).args).to.deep.equal([
         'docker',
@@ -688,7 +688,7 @@ describe('AwsInvokeLocal', () => {
           'commandLineEnvVar=commandLineEnvVarValue',
           '-p',
           '9292:9292',
-          'sls-docker-nodejs12.x',
+          'sls-docker-nodejs16.x',
           'handler.hello',
           '{}',
         ],

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1139,7 +1139,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
                 sharedEnvVar: 'valueFromFunction',
               },
               memorySize: 2048,
-              runtime: 'nodejs12.x',
+              runtime: 'nodejs16.x',
               runtimeManagement: 'onFunctionUpdate',
               versionFunction: true,
             },
@@ -1743,7 +1743,7 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               ExternalLambdaLayer: {
                 Type: 'AWS::Lambda::LayerVersion',
                 Properties: {
-                  CompatibleRuntimes: ['nodejs12.x'],
+                  CompatibleRuntimes: ['nodejs16.x'],
                   Content: {
                     S3Bucket: 'bucket',
                     S3Key: 'key',

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -48,7 +48,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
           layerTwo: {
             description: 'Layer two example',
             path: 'layer',
-            compatibleRuntimes: ['nodejs12.x'],
+            compatibleRuntimes: ['nodejs16.x'],
             compatibleArchitectures: ['arm64'],
             licenseInfo: 'GPL',
             allowedAccounts: ['123456789012', '123456789013'],
@@ -186,7 +186,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const layerOne = cfResources[layerResourceName];
 
     expect(layerOne.Type).to.equals('AWS::Lambda::LayerVersion');
-    expect(layerOne.Properties.CompatibleRuntimes).to.deep.equals(['nodejs12.x']);
+    expect(layerOne.Properties.CompatibleRuntimes).to.deep.equals(['nodejs16.x']);
   });
 
   it('should support `layers[].compatibleArchitectures`', () => {

--- a/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/strip-null-props-from-template-resources.test.js
@@ -43,7 +43,7 @@ describe('test/unit/lib/plugins/aws/package/lib/stripNullPropsFromTemplateResour
                 Code: {
                   S3Bucket: 's3-containing-lambda',
                 },
-                Runtime: 'nodejs12.x',
+                Runtime: 'nodejs16.x',
               },
             },
             resourceWithNullProperties: {

--- a/test/unit/lib/utils/telemetry/generate-payload.test.js
+++ b/test/unit/lib/utils/telemetry/generate-payload.test.js
@@ -21,7 +21,7 @@ const getGeneratePayload = () =>
     '@serverless/utils/get-notifications-mode': () => 'on',
   });
 
-describe('test/unit/lib/utils/telemetry/generatePayload.test.js', () => {
+describe('test/unit/lib/utils/telemetry/generate-payload.test.js', () => {
   let isTTYCache;
   let originalModulesCache;
   before(() => {

--- a/test/unit/lib/utils/telemetry/generate-payload.test.js
+++ b/test/unit/lib/utils/telemetry/generate-payload.test.js
@@ -318,7 +318,7 @@ describe('test/unit/lib/utils/telemetry/generate-payload.test.js', () => {
         variableSources: [],
         provider: {
           name: 'aws',
-          runtime: 'nodejs12.x',
+          runtime: 'nodejs14.x',
           stage: 'dev',
           region: 'us-east-1',
         },


### PR DESCRIPTION
Support for the `node12.x` runtime was dropped on AWS side