### PR TITLE
prepare for supporting Ruby 3.2 runtime coming end of Q2 2023

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -283,7 +283,7 @@ class AwsInvokeLocal {
       );
     }
 
-    if (['ruby2.7'].includes(runtime)) {
+    if (['ruby2.7', 'ruby3.2'].includes(runtime)) {
       const handlerComponents = handler.split(/\./);
       const handlerPath = handlerComponents[0];
       const handlerName = handlerComponents.slice(1).join('.');

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -630,6 +630,7 @@ class AwsProvider {
               'python3.9',
               'python3.10',
               'ruby2.7',
+              'ruby3.2',
             ],
           },
           awsLambdaRuntimeManagement: {

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -478,6 +478,17 @@ describe('AwsInvokeLocal', () => {
       ).to.be.equal(true);
     });
 
+    it('should call invokeLocalRuby when ruby3.2 runtime is set', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'ruby3.2';
+      await awsInvokeLocal.invokeLocal();
+      // NOTE: this is important so that tests on Windows won't fail
+      const runtime = process.platform === 'win32' ? 'ruby.exe' : 'ruby';
+      expect(invokeLocalRubyStub.calledOnce).to.be.equal(true);
+      expect(
+        invokeLocalRubyStub.calledWithExactly(runtime, 'handler', 'hello', {}, undefined)
+      ).to.be.equal(true);
+    });
+
     it('should call invokeLocalDocker if using runtime provided', async () => {
       awsInvokeLocal.options.functionObj.runtime = 'provided';
       awsInvokeLocal.options.functionObj.handler = 'handler.foobar';


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}

[Ruby 2.7 went EOL](https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/) in the ruby community on March 30, 2023. AWS has already announced deprecation for Ruby 2.7 on [November 15, 2023](https://docs.aws.amazon.com/lambda/latest/dg/ruby-image.html#ruby-image-base).

According to [this comment](https://github.com/aws/aws-lambda-base-images/issues/54#issuecomment-1486974882) from March 28th, 2023 on the AWS Lambda Base Images repo, Ruby 3.2 support is coming the end of this month:

> Update: We have today released a [container base image for Ruby 3.2 support in Lambda](https://gallery.ecr.aws/lambda/ruby). This container image is fully supported and suitable for production applications. We will release the corresponding managed runtime within 90 days.

> We will update the aws_lambda_ric gem either with or very shortly after the managed runtime release. Until then, we recommend using the newly published container image to build Ruby 3.2 functions for Lambda.

I have been deploying an image-based solution to test my lambdas. As soon at this runtime is supported, the Serverless framework will throw an error if I try to deploy this runtime.

Can we prep this MR to be ready for that day?
