### PR TITLE
fix(Packaging): DependsOn.push is not a function when extending compiled CF template

### DIFF
--- a/lib/plugins/aws/package/lib/merge-custom-provider-resources.js
+++ b/lib/plugins/aws/package/lib/merge-custom-provider-resources.js
@@ -56,6 +56,10 @@ module.exports = {
             case 'DependsOn':
               if (!template.Resources[resourceName].DependsOn) {
                 template.Resources[resourceName].DependsOn = [];
+              } else if (typeof template.Resources[resourceName].DependsOn === 'string') {
+                template.Resources[resourceName].DependsOn = [
+                  template.Resources[resourceName].DependsOn,
+                ];
               }
 
               template.Resources[resourceName].DependsOn.push(...value);

--- a/test/unit/lib/plugins/aws/package/lib/merge-custom-provider-resources.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/merge-custom-provider-resources.test.js
@@ -265,7 +265,7 @@ describe('mergeCustomProviderResources', () => {
       });
     });
 
-    it('should append for resources.extensions.*.DependsOn', () => {
+    it('should merge for resources.extensions.*.DependsOn when destination is a list and source is a list', () => {
       awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources = {
         SampleResource: {
           DependsOn: ['a'],
@@ -276,6 +276,72 @@ describe('mergeCustomProviderResources', () => {
         extensions: {
           SampleResource: {
             DependsOn: ['b'],
+          },
+        },
+      };
+
+      awsPackage.mergeCustomProviderResources();
+      expect(
+        awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .SampleResource.DependsOn
+      ).to.deep.equal(['a', 'b']);
+    });
+
+    it('should merge for resources.extensions.*.DependsOn when destination is a string and source is a string', () => {
+      awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources = {
+        SampleResource: {
+          DependsOn: 'a',
+        },
+      };
+
+      awsPackage.serverless.service.resources = {
+        extensions: {
+          SampleResource: {
+            DependsOn: 'b',
+          },
+        },
+      };
+
+      awsPackage.mergeCustomProviderResources();
+      expect(
+        awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .SampleResource.DependsOn
+      ).to.deep.equal(['a', 'b']);
+    });
+
+    it('should merge for resources.extensions.*.DependsOn when destination is a string and source is a list', () => {
+      awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources = {
+        SampleResource: {
+          DependsOn: 'a',
+        },
+      };
+
+      awsPackage.serverless.service.resources = {
+        extensions: {
+          SampleResource: {
+            DependsOn: ['b'],
+          },
+        },
+      };
+
+      awsPackage.mergeCustomProviderResources();
+      expect(
+        awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources
+          .SampleResource.DependsOn
+      ).to.deep.equal(['a', 'b']);
+    });
+
+    it('should merge for resources.extensions.*.DependsOn when destination is a list and source is a string', () => {
+      awsPackage.serverless.service.provider.compiledCloudFormationTemplate.Resources = {
+        SampleResource: {
+          DependsOn: ['a'],
+        },
+      };
+
+      awsPackage.serverless.service.resources = {
+        extensions: {
+          SampleResource: {
+            DependsOn: 'b',
           },
         },
       };


### PR DESCRIPTION
Fix `DependsOn.push is not a function` error when trying to add a new dependency via the extensions.

Minimal steps to reproduce:

1. npm i -g serverelss
2. serverless
3. Choose `AWS - Node.js - HTTP API`
4. Go to the project directory
5. Update `serverless.yml` with
```
service: aws-node-http-api-project
frameworkVersion: '3'

provider:
  name: aws
  runtime: nodejs18.x

functions:
  api:
    handler: index.handler
    events:
      - httpApi:
          path: /
          method: get

resources:
  extensions:
    HttpApiRouteGet:
      DependsOn: HttpApi
```
6. serverless package

Example of the error:
```

> aws-node-http-api-project@1.0.0 package
> sls package


Packaging aws-node-http-api-project for stage dev (us-east-1)
Environment: linux, node 18.16.0, framework 3.32.2 (local), plugin 6.2.3, SDK 4.3.2
Docs:        docs.serverless.com
Support:     forum.serverless.com
Bugs:        github.com/serverless/serverless/issues

Error:
TypeError: template.Resources[resourceName].DependsOn.push is not a function
    at AwsPackage.mergeCustomProviderResources (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/plugins/aws/package/lib/merge-custom-provider-resources.js:61:58)
    at aws:package:finalize:mergeCustomProviderResources (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/plugins/aws/package/index.js:111:14)
    at PluginManager.runHooks (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/classes/plugin-manager.js:530:15)
    at PluginManager.invoke (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/classes/plugin-manager.js:564:20)
    at async PluginManager.spawn (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/classes/plugin-manager.js:585:5)
    at async PluginManager.runHooks (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/classes/plugin-manager.js:530:9)
    at async PluginManager.invoke (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/classes/plugin-manager.js:564:9)
    at async PluginManager.run (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/classes/plugin-manager.js:604:7)
    at async Serverless.run (/home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/lib/serverless.js:179:5)
    at async /home/hokid/projects/opensource/_issue_serverless_dependson_push_fn/aws-node-http-api-project/node_modules/serverless/scripts/serverless.js:834:9

```