### PR TITLE
added managedExternally option for websockets authorizer

### DIFF
--- a/lib/plugins/aws/package/compile/events/websockets/index.js
+++ b/lib/plugins/aws/package/compile/events/websockets/index.js
@@ -70,6 +70,7 @@ class AwsCompileWebsockets {
                   properties: {
                     name: { $ref: '#/definitions/functionName' },
                     arn: { $ref: '#/definitions/awsArn' },
+                    managedExternally: { type: 'boolean' },
                     identitySource: { type: 'array', items: { type: 'string' } },
                   },
                   anyOf: [{ required: ['name'] }, { required: ['arn'] }],

--- a/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/authorizers.js
@@ -8,7 +8,11 @@ module.exports = {
       if (!event.authorizer) {
         return;
       }
-      const functionObj = this.serverless.service.getFunction(event.authorizer.name);
+      let dependsOn = [];
+      if (!event.authorizer.managedExternally) {
+        const functionObj = this.serverless.service.getFunction(event.authorizer.name);
+        dependsOn = _.get(functionObj.targetAlias, 'logicalId');
+      }
       const websocketsAuthorizerLogicalId = this.provider.naming.getWebsocketsAuthorizerLogicalId(
         event.authorizer.name
       );
@@ -16,7 +20,7 @@ module.exports = {
       _.merge(this.serverless.service.provider.compiledCloudFormationTemplate.Resources, {
         [websocketsAuthorizerLogicalId]: {
           Type: 'AWS::ApiGatewayV2::Authorizer',
-          DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
+          DependsOn: dependsOn,
           Properties: {
             ApiId: this.provider.getApiGatewayWebsocketApiId(),
             Name: event.authorizer.name,

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
@@ -35,6 +35,7 @@ module.exports = {
                 // arn
                 websocketObj.authorizer = {
                   name: getAuthorizerNameFromArn(event.websocket.authorizer),
+                  managedExternally: event.websocket.managedExternally,
                   uri: {
                     'Fn::Join': [
                       '',
@@ -60,6 +61,7 @@ module.exports = {
                 const functionObj = this.serverless.service.getFunction(event.websocket.authorizer);
                 websocketObj.authorizer = {
                   name: event.websocket.authorizer,
+                  managedExternally: event.websocket.managedExternally,
                   uri: {
                     'Fn::Join': [
                       '',
@@ -79,7 +81,9 @@ module.exports = {
                 };
               }
             } else if (_.isObject(event.websocket.authorizer)) {
-              websocketObj.authorizer = {};
+              websocketObj.authorizer = {
+                managedExternally: event.websocket.authorizer.managedExternally;
+              };
               if (event.websocket.authorizer.arn) {
                 if (_.isObject(event.websocket.authorizer.arn)) {
                   if (!event.websocket.authorizer.name) {

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
@@ -82,7 +82,7 @@ module.exports = {
               }
             } else if (_.isObject(event.websocket.authorizer)) {
               websocketObj.authorizer = {
-                managedExternally: event.websocket.authorizer.managedExternally;
+                managedExternally: event.websocket.authorizer.managedExternally,
               };
               if (event.websocket.authorizer.arn) {
                 if (_.isObject(event.websocket.authorizer.arn)) {


### PR DESCRIPTION
Sorry, haven't created an issue or agreed on a solution. 
Currently it's possible to provide external authorizer function arn only for APIGateway V1 and for HTTP-based APIGateway V2. Added same ability for websockets-based APIGateway V2.
