### PR TITLE
Chore: Update tutorial.md to reflect proper filenames

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -93,7 +93,7 @@ Of course, if you don’t want to set-up a provider on a dashboard account, you 
 
 ## What have we just done?
 
-After a successful deployment you should see, either in the dashboard or on the CLI, that you have an HTTP endpoint you can call. Also, if you open the service we just created in your favourite IDE or text editor and look at the contents of the `serverless.yml`, this is what controls pretty much everything in our service. You will notice a section where the functions you have are defined with events attached to them. Also take note that the code that executes when this HTTP endpoint is called is defined in the `handler.js` file in a function called `hello`. If you edit this file then run `serverless deploy` your changes will be pushed to your AWS account and when you next call that endpoint either in the browser or using curl, you should see your changes reflected:
+After a successful deployment you should see, either in the dashboard or on the CLI, that you have an HTTP endpoint you can call. Also, if you open the service we just created in your favourite IDE or text editor and look at the contents of the `serverless.yml`, this is what controls pretty much everything in our service. You will notice a section where the functions you have are defined with events attached to them. Also take note that the code that executes when this HTTP endpoint is called is defined in the `index.js` file. If you edit this file then run `serverless deploy` your changes will be pushed to your AWS account and when you next call that endpoint either in the browser or using curl, you should see your changes reflected:
 
 ```bash
 curl [your endpoint address]


### PR DESCRIPTION
When creating an “AWS - Node.js - HTTP API” resource from the template, the handler function is called `index.js`, instead of `handler.js` as the docs suggest. 

Also there is no `hello` function inside the `index.js` file.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}
