### PR TITLE
feat: Add support for starting position AT_TIMESTAMP to MSK events

### DIFF
--- a/docs/providers/aws/events/msk.md
+++ b/docs/providers/aws/events/msk.md
@@ -47,7 +47,8 @@ functions:
 
 For the MSK event integration, you can set the `batchSize`, which effects how many messages can be processed in a single Lambda invocation. The default `batchSize` is 100, and the max `batchSize` is 10000.
 Likewise `maximumBatchingWindow` can be set to determine the amount of time the Lambda spends gathering records before invoking the function. The default is 0, but **if you set `batchSize` to more than 10, you must set `maximumBatchingWindow` to at least 1**. The maximum is 300.
-In addition, you can also configure `startingPosition`, which controls the position at which Lambda should start consuming messages from MSK topic. It supports two possible values, `TRIM_HORIZON` and `LATEST`, with `TRIM_HORIZON` being the default.
+In addition, you can also configure `startingPosition`, which controls the position at which Lambda should start consuming messages from the topic. It supports three possible values, `TRIM_HORIZON`, `LATEST` and `AT_TIMESTAMP`, with `TRIM_HORIZON` being the default.
+When `startingPosition` is configured as `AT_TIMESTAMP`, `startingPositionTimestamp` is also mandatory and is specified in Unix time seconds.
 
 In the following example, we specify that the `compute` function should have an `msk` event configured with `batchSize` of 1000, `maximumBatchingWindow` to 30 seconds and `startingPosition` equal to `LATEST`.
 

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -977,8 +977,10 @@ functions:
           batchSize: 100
           # Optional, must be in 0-300 range (seconds)
           maximumBatchingWindow: 30
-          # Optional, can be set to LATEST or TRIM_HORIZON
+          # Optional, can be set to LATEST, AT_TIMESTAMP or TRIM_HORIZON
           startingPosition: LATEST
+          # Mandatory when startingPosition is AT_TIMESTAMP, must be in Unix time seconds
+          startingPositionTimestamp: 10000123
           # (default: true)
           enabled: false
           # Optional, arn of the secret key for authenticating with the brokers in your MSK cluster.

--- a/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/lib/plugins/aws/package/compile/events/msk/index.js
@@ -2,6 +2,7 @@
 
 const getMskClusterNameToken = require('./get-msk-cluster-name-token');
 const resolveLambdaTarget = require('../../../../utils/resolve-lambda-target');
+const ServerlessError = require('../../../../../../serverless-error');
 const _ = require('lodash');
 
 class AwsCompileMSKEvents {
@@ -38,7 +39,10 @@ class AwsCompileMSKEvents {
         },
         startingPosition: {
           type: 'string',
-          enum: ['LATEST', 'TRIM_HORIZON'],
+          enum: ['LATEST', 'TRIM_HORIZON', 'AT_TIMESTAMP'],
+        },
+        startingPositionTimestamp: {
+          type: 'number',
         },
         topic: {
           type: 'string',
@@ -88,6 +92,13 @@ class AwsCompileMSKEvents {
           const maximumBatchingWindow = event.msk.maximumBatchingWindow;
           const enabled = event.msk.enabled;
           const startingPosition = event.msk.startingPosition || 'TRIM_HORIZON';
+          const startingPositionTimestamp = event.msk.startingPositionTimestamp;
+          if (startingPosition === 'AT_TIMESTAMP' && startingPositionTimestamp == null) {
+            throw new ServerlessError(
+              `You must specify startingPositionTimestamp for function: ${functionName} when startingPosition is AT_TIMESTAMP.`,
+              'FUNCTION_MSK_STARTING_POSITION_TIMESTAMP_INVALID'
+            );
+          }
           const saslScram512 = event.msk.saslScram512;
           const consumerGroupId = event.msk.consumerGroupId;
           const filterPatterns = event.msk.filterPatterns;
@@ -114,6 +125,10 @@ class AwsCompileMSKEvents {
               Topics: [topic],
             },
           };
+
+          if (startingPositionTimestamp != null) {
+            mskResource.Properties.StartingPositionTimestamp = startingPositionTimestamp;
+          }
 
           if (batchSize) {
             mskResource.Properties.BatchSize = batchSize;


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #12033

- Add support for a StartingPosition of AT_TIMESTAMP to MSK event source mappings. When this configuration is used,
StartingPositionTimestamp must also be provided, in Unix Time seconds, which is consistent with the existing support in the `kafka` event

- Support for this starting position has recently been added to AWS Lambda event source mappings using MSK
(https://aws.amazon.com/about-aws/whats-new/2023/06/aws-lambda-starting-timestamp-kafka-sources/)

- Since `runServerless` tests are expensive, test the happy path in the existing test of a valid configuration rather than adding an explicit separate test for it, but add a new test to explicitly verify the unhappy path in which a timestamp at which to start is not provided
