### PR TITLE
refactor: Fix typo in description of test of MSK event startingPosition config

### DIFF
--- a/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
@@ -150,7 +150,7 @@ describe('AwsCompileMSKEvents', () => {
     });
 
     describe('when startingPosition is AT_TIMESTAMP', () => {
-      it('if startingPosition is not provided, it should fail to compile EventSourceMapping resource properties', async () => {
+      it('if startingPositionTimestamp is not provided, it should fail to compile EventSourceMapping resource properties', async () => {
         await expect(
           runServerless({
             fixture: 'function',


### PR DESCRIPTION
- follow up to #12033

- fix a typo I made in the description of the test of the unhappy path whereby
an `msk` event is defined with `startingPosition` of `'AT_TIMESTAMP'` but
without a `startingPositionTimestamp`

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->
