### PR TITLE
fix: use provider restApiId in createProviderModel

### DIFF
--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/request-validator.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/request-validator.js
@@ -128,7 +128,7 @@ module.exports = {
       [modelLogicalId]: {
         Type: 'AWS::ApiGateway::Model',
         Properties: {
-          RestApiId: { Ref: this.apiGatewayRestApiLogicalId },
+          RestApiId: this.provider.getApiGatewayRestApiId(),
           Schema: definition,
           ContentType: 'application/json',
         },


### PR DESCRIPTION
Closes: #12048
