### PR TITLE
chore: Upgrade `child-process-ext` to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bluebird": "^3.7.2",
     "cachedir": "^2.3.0",
     "chalk": "^4.1.2",
-    "child-process-ext": "^2.1.1",
+    "child-process-ext": "^3.0.1",
     "ci-info": "^3.8.0",
     "cli-progress-footer": "^2.3.2",
     "d": "^1.0.1",


### PR DESCRIPTION
Simple dependency update to bump transitive `cross-spawn` dependency to v7