### PR TITLE
Make API UsagePlanKey resources create in sequence 

### DIFF
--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/usage-plan-keys.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/usage-plan-keys.js
@@ -3,11 +3,12 @@
 const _ = require('lodash');
 const ServerlessError = require('../../../../../../../serverless-error');
 
-function createUsagePlanKeyResource(that, usagePlanLogicalId, keyNumber, keyName) {
+function createUsagePlanKeyResource(that, usagePlanLogicalId, dependency, keyNumber, keyName) {
   const apiKeyLogicalId = that.provider.naming.getApiKeyLogicalId(keyNumber, keyName);
 
   const resourceTemplate = {
     Type: 'AWS::ApiGateway::UsagePlanKey',
+    DependsOn: dependency,
     Properties: {
       KeyId: {
         Ref: apiKeyLogicalId,
@@ -28,6 +29,7 @@ module.exports = {
     if (apiKeys) {
       const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
       let keyNumber = 0;
+      let dependsOn = undefined;
 
       apiKeys.forEach((apiKeyDefinition) => {
         // if multiple API key types are used
@@ -54,24 +56,31 @@ module.exports = {
               name
             );
             const usagePlanLogicalId = this.provider.naming.getUsagePlanLogicalId(name);
+            dependsOn ??= usagePlanLogicalId;
             const resourceTemplate = createUsagePlanKeyResource(
               this,
               usagePlanLogicalId,
+              dependsOn,
               keyNumber,
               name
             );
             _.merge(resources, {
               [usagePlanKeyLogicalId]: resourceTemplate,
             });
+            // make the UsagePlanKey depends on one by one, so it's running in sequence not in parallel
+            dependsOn = usagePlanKeyLogicalId;
           });
         } else {
           keyNumber += 1;
           const usagePlanKeyLogicalId = this.provider.naming.getUsagePlanKeyLogicalId(keyNumber);
           const usagePlanLogicalId = this.provider.naming.getUsagePlanLogicalId();
-          const resourceTemplate = createUsagePlanKeyResource(this, usagePlanLogicalId, keyNumber);
+          dependsOn ??= usagePlanLogicalId;
+          const resourceTemplate = createUsagePlanKeyResource(this, usagePlanLogicalId, dependsOn, keyNumber);
           _.merge(resources, {
             [usagePlanKeyLogicalId]: resourceTemplate,
           });
+          // make the UsagePlanKey depends on one by one, so it's running in sequence not in parallel
+          dependsOn = usagePlanKeyLogicalId;
         }
       });
     }


### PR DESCRIPTION
to avoid concurrent conflict error from AWS. 

Recently our stack with 18 API keys consistently failed in cloudformation deployment, with following error message : 

>2023-07-11 15:26:04	AWS::ApiGateway::UsagePlanKey	HandlerErrorCode: AlreadyExists)
"Resource handler returned message: "Unable to complete operation due to concurrent modification. Please try again later. (Service: ApiGateway, Status Code: 409, Request ID: XXXXXXXX HandlerErrorCode: AlreadyExists"

After consulting AWS support, they suggest : 

> Please note that CreateUsagePlanKey API call can run only one at a time in an AWS region. This error occurs when multiple concurrent CreateUsagePlanKey requests are made from an AWS account in a specific region. As mentioned above, the internal team and I observed multiple CreateUsagePlanKey API calls that were made at the same time or in a time difference of lesser than a second. Hence, this error is occurring due to the calls being too close to each other or one call not fully completing its tasks before another call is made.

> To prevent the issue please ensure that the CreateUsagePlanKey API calls are made one after the other spaced out in time rather than in parallel. In CloudFormation, use the DependsOn attribute[1] to declare an explicit dependency between the AWS::ApiGateway::UsagePlanKey resources.

I have made the fix as AWS suggested, create the dependency chain to ensure they are created in sequence. It might slow down the deployment, but with our testing, it's not significant. 


<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}
