### PR TITLE
Support the new Python 3.11 lambda runtime and update examples to use Python 3.11

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -198,10 +198,9 @@ jobs:
           key: npm-v16-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('package.json') }}
 
       # Potentially needed for test/integration/curated-plugins-python.test.js
-      # (current GA runtime comes with Python 3.8 preinstalled, but that might be subject to changes)
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.11'
 
       - name: Install Node.js and npm
         uses: actions/setup-node@v1

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -37,7 +37,7 @@ functions:
     handler: handler.hello # required, handler set in AWS Lambda
     name: ${sls:stage}-lambdaName # optional, Deployed Lambda name
     description: Description of what the lambda function does # optional, Description to publish to AWS
-    runtime: python3.9 # optional overwrite, default is provider runtime
+    runtime: python3.11 # optional overwrite, default is provider runtime
     runtimeManagement:
       mode: manual # syntax required for manual, mode property also supports 'auto' or 'onFunctionUpdate' (see provider.runtimeManagement)
       arn: <aws runtime arn> # required when mode is manual

--- a/docs/providers/aws/guide/layers.md
+++ b/docs/providers/aws/guide/layers.md
@@ -32,7 +32,7 @@ layers:
     name: ${sls:stage}-layerName # optional, Deployed Lambda layer name
     description: Description of what the lambda layer does # optional, Description to publish to AWS
     compatibleRuntimes: # optional, a list of runtimes this layer is compatible with
-      - python3.8
+      - python3.11
     compatibleArchitectures: # optional, a list of architectures this layer is compatible with
       - x86_64
       - arm64
@@ -186,7 +186,7 @@ service: myService
 
 provider:
   name: aws
-  runtime: python3.8
+  runtime: python3.11
   layers:
     - arn:aws:lambda:us-east-1:xxxxxxxxxxxxx:layer:xxxxx:mylayer1
     - arn:aws:lambda:us-east-1:xxxxxxxxxxxxx:layer:xxxxx:mylayer2

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -1334,7 +1334,7 @@ layers:
     description: Description of what the lambda layer does
     # optional, a list of runtimes this layer is compatible with
     compatibleRuntimes:
-      - python3.8
+      - python3.11
     # optional, a list of architectures this layer is compatible with
     compatibleArchitectures:
       - x86_64

--- a/docs/providers/kubeless/cli-reference/create.md
+++ b/docs/providers/kubeless/cli-reference/create.md
@@ -65,7 +65,7 @@ These are the current available templates for Kubeless:
 serverless create --template kubeless-python --name my-special-service
 ```
 
-This example will generate scaffolding for a service with `kubeless` as a provider and `python3.9` as runtime. The scaffolding will be generated in the current working directory.
+This example will generate scaffolding for a service with `kubeless` as a provider and `python3.11` as runtime. The scaffolding will be generated in the current working directory.
 
 The provider which is used for deployment later on is Kubeless.
 
@@ -75,7 +75,7 @@ The provider which is used for deployment later on is Kubeless.
 serverless create --template kubeless-python --path my-new-service
 ```
 
-This example will generate scaffolding for a service with `kubeless` as a provider and `python3.9` as runtime. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
+This example will generate scaffolding for a service with `kubeless` as a provider and `python3.11` as runtime. The scaffolding will be generated in the `my-new-service` directory. This directory will be created if not present. Otherwise Serverless will use the already present directory.
 
 Additionally Serverless will rename the service according to the path you provide. In this example the service will be renamed to `my-new-service`.
 

--- a/docs/providers/kubeless/cli-reference/info.md
+++ b/docs/providers/kubeless/cli-reference/info.md
@@ -52,7 +52,7 @@ Metadata
   Timestamp:  2017-08-25T09:19:24Z
 Function Info
 Handler:  handler.hello
-Runtime:  python3.9
+Runtime:  python3.11
 Trigger:  HTTP
 Dependencies:
 Metadata:

--- a/docs/providers/kubeless/events/http.md
+++ b/docs/providers/kubeless/events/http.md
@@ -27,7 +27,7 @@ service: testing-pkg
 
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 
 plugins:
   - serverless-kubeless

--- a/docs/providers/kubeless/events/pubsub.md
+++ b/docs/providers/kubeless/events/pubsub.md
@@ -25,7 +25,7 @@ service: hello
 
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 
 plugins:
   - serverless-kubeless

--- a/docs/providers/kubeless/guide/debugging.md
+++ b/docs/providers/kubeless/guide/debugging.md
@@ -44,7 +44,7 @@ And its corresponding Serverless YAML file:
 service: bikesearch
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 
 plugins:
   - serverless-kubeless
@@ -120,9 +120,9 @@ Hit Ctrl-C to quit.
 172.17.0.1 - - [25/Aug/2017:08:46:04 +0000] "GET /healthz HTTP/1.1" 200 2 "" "Go-http-client/1.1" 0/82
 172.17.0.1 - - [25/Aug/2017:08:46:07 +0000] "POST / HTTP/1.1" 200 459 "" "" 1/957186
 Traceback (most recent call last):
-  File "/usr/local/lib/python3.9/site-packages/bottle.py", line 862, in _handle
+  File "/usr/local/lib/python3.11/site-packages/bottle.py", line 862, in _handle
     return route.call(**args)
-  File "/usr/local/lib/python3.9/site-packages/bottle.py", line 1740, in wrapper
+  File "/usr/local/lib/python3.11/site-packages/bottle.py", line 1740, in wrapper
     rv = callback(*a, **ka)
   File "/kubeless.py", line 35, in handler
     return func(bottle.request)
@@ -139,9 +139,9 @@ KeyError: 'term'
 172.17.0.1 - - [25/Aug/2017:08:49:04 +0000] "GET /healthz HTTP/1.1" 200 2 "" "Go-http-client/1.1" 0/98
 172.17.0.1 - - [25/Aug/2017:08:49:23 +0000] "POST / HTTP/1.1" 500 746 "" "" 0/655
 Traceback (most recent call last):
-  File "/usr/local/lib/python3.9/site-packages/bottle.py", line 862, in _handle
+  File "/usr/local/lib/python3.11/site-packages/bottle.py", line 862, in _handle
     return route.call(**args)
-  File "/usr/local/lib/python3.9/site-packages/bottle.py", line 1740, in wrapper
+  File "/usr/local/lib/python3.11/site-packages/bottle.py", line 1740, in wrapper
     rv = callback(*a, **ka)
   File "/kubeless.py", line 35, in handler
     return func(bottle.request)

--- a/docs/providers/kubeless/guide/deploying.md
+++ b/docs/providers/kubeless/guide/deploying.md
@@ -40,7 +40,7 @@ For example, let's take the following example `serverless.yml` file:
 service: new-project
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 
 plugins:
   - serverless-kubeless
@@ -86,7 +86,7 @@ In order to overcome this limitation, function code can be fetched from [externa
 ```yaml
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
   deploy:
     strategy: S3ZipContent
     options:

--- a/docs/providers/kubeless/guide/functions.md
+++ b/docs/providers/kubeless/guide/functions.md
@@ -26,8 +26,8 @@ service: my-service
 
 provider:
   name: kubeless
-  runtime: python3.9
-  memorySize: 512M # optional, maximum memory
+  runtime: python3.11
+  memorySize: 512 # optional, maximum memory
   timeout: 10 # optional, in seconds, default is 180
   namespace: funcions # optional, deployment namespace if not specified it uses "default"
   ingress: # optional, ingress configuration if not using nginx
@@ -46,7 +46,7 @@ functions:
     # The function to call as a response to the HTTP event
     handler: handler.hello # required, handler set
     description: Description of what the function does # optional, to set the description as an annotation
-    memorySize: 512M # optional, maximum memory
+    memorySize: 512 # optional, maximum memory
     timeout: 10 # optional, in seconds, default is 180
     namespace: funcions # optional, deployment namespace, if not specified "default" will be used
     port: 8081 # optional, deploy http-based function with a custom port, default is 8080
@@ -80,7 +80,7 @@ service: my-service
 
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 
 plugins:
   - serverless-kubeless
@@ -340,7 +340,7 @@ service: hello
 
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 
 plugins:
   - serverless-kubeless

--- a/docs/providers/kubeless/guide/services.md
+++ b/docs/providers/kubeless/guide/services.md
@@ -85,7 +85,7 @@ You can see the name of the service, the provider configuration and the first fu
 service: new-project
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 
 plugins:
   - serverless-kubeless
@@ -151,7 +151,7 @@ service: users
 
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 …
 ```
 
@@ -166,7 +166,7 @@ service: users
 
 provider:
   name: kubeless
-  runtime: python3.9
+  runtime: python3.11
 
 …
 ```

--- a/docs/providers/spotinst/examples/python/README.md
+++ b/docs/providers/spotinst/examples/python/README.md
@@ -34,7 +34,7 @@ serverless invoke --function hello
 In your terminal window you should see the response
 
 ```bash
-'{"hello":"from Python3.9 function"}'
+'{"hello":"from Python3.11 function"}'
 ```
 
 Congrats you have deployed and ran your Hello World function!

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -253,7 +253,7 @@ class AwsInvokeLocal {
       );
     }
 
-    if (['python3.7', 'python3.8', 'python3.9', 'python3.10'].includes(runtime)) {
+    if (['python3.7', 'python3.8', 'python3.9', 'python3.10', 'python3.11'].includes(runtime)) {
       const handlerComponents = handler.split(/\./);
       const handlerPath = handlerComponents.slice(0, -1).join('.');
       const handlerName = handlerComponents.pop();

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -629,6 +629,7 @@ class AwsProvider {
               'python3.8',
               'python3.9',
               'python3.10',
+              'python3.11',
               'ruby2.7',
               'ruby3.2',
             ],

--- a/test/fixtures/programmatic/curated-plugins-python/serverless.yml
+++ b/test/fixtures/programmatic/curated-plugins-python/serverless.yml
@@ -5,7 +5,7 @@ frameworkVersion: '*'
 
 provider:
   name: aws
-  runtime: python3.8
+  runtime: python3.11
 
 functions:
   function:

--- a/test/fixtures/programmatic/invocation/serverless.yml
+++ b/test/fixtures/programmatic/invocation/serverless.yml
@@ -32,10 +32,10 @@ functions:
     handler: remaining-time.handler
     timeout: 3
   python:
-    runtime: python3.8
+    runtime: python3.11
     handler: handler.handler
   pythonRemainingTime:
-    runtime: python3.8
+    runtime: python3.11
     handler: remaining_time.handler
     timeout: 3
   ruby:

--- a/test/unit/lib/cli/interactive-setup/dashboard-login.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-login.test.js
@@ -28,6 +28,7 @@ const ServerlessSDKMock = class ServerlessSDK {
             'python3.8',
             'python3.9',
             'python3.10',
+            'python3.11',
           ],
           supportedRegions: [
             'us-east-1',

--- a/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
+++ b/test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js
@@ -43,6 +43,7 @@ describe('test/unit/lib/cli/interactive-setup/dashboard-set-org.test.js', functi
                 'python3.8',
                 'python3.9',
                 'python3.10',
+                'python3.11',
               ],
               supportedRegions: [
                 'us-east-1',

--- a/test/unit/lib/plugins/aws/invoke-local/index.test.js
+++ b/test/unit/lib/plugins/aws/invoke-local/index.test.js
@@ -440,11 +440,11 @@ describe('AwsInvokeLocal', () => {
       ).to.be.equal(true);
     });
 
-    it('should call invokeLocalPython when python3.9 runtime is set', async () => {
-      awsInvokeLocal.options.functionObj.runtime = 'python3.9';
+    it('should call invokeLocalPython when python3.11 runtime is set', async () => {
+      awsInvokeLocal.options.functionObj.runtime = 'python3.11';
       await awsInvokeLocal.invokeLocal();
       // NOTE: this is important so that tests on Windows won't fail
-      const runtime = process.platform === 'win32' ? 'python.exe' : 'python3.9';
+      const runtime = process.platform === 'win32' ? 'python.exe' : 'python3.11';
       expect(invokeLocalPythonStub.calledOnce).to.be.equal(true);
       expect(
         invokeLocalPythonStub.calledWithExactly(runtime, 'handler', 'hello', {}, undefined)


### PR DESCRIPTION
AWS have now made the Lambda Python 3.11 runtime available, at least through the Lambda API: https://github.com/aws/aws-sdk-js/commit/baa3b7d22f754b5bec88930fd054946e72037839#diff-0521ffc53e94f05cb64ddd5e240950f5c51fb408c695f4aa9999db81b2ea42a4. ~I expect CloudFormation support is coming in a matter of hours or days, across all regions.~ **EDIT**: officially launched: https://aws.amazon.com/blogs/compute/python-3-11-runtime-now-available-in-aws-lambda/.