### PR TITLE
fix: Kinesis Streams AT_TIMESTAMP functionality

### DIFF
--- a/lib/plugins/aws/package/compile/events/stream.js
+++ b/lib/plugins/aws/package/compile/events/stream.js
@@ -305,6 +305,21 @@ class AwsCompileStreamEvents {
               };
             }
 
+            if (
+              event.stream.startingPosition === 'AT_TIMESTAMP' &&
+              !event.stream.startingPositionTimestamp
+            ) {
+              throw new ServerlessError(
+                `You must specify startingPositionTimestamp for function: ${functionName} when startingPosition is AT_TIMESTAMP`,
+                'FUNCTION_STREAM_STARTING_POSITION_TIMESTAMP_INVALID'
+              );
+            }
+
+            if (event.stream.startingPositionTimestamp) {
+              streamResource.Properties.StartingPositionTimestamp =
+                event.stream.startingPositionTimestamp;
+            }
+
             const newStreamObject = {
               [streamLogicalId]: streamResource,
             };
@@ -339,21 +354,6 @@ class AwsCompileStreamEvents {
                 const consumerArn = event.stream.consumer;
                 streamResource.Properties.EventSourceArn = consumerArn;
                 kinesisConsumerStatement.Resource.push(consumerArn);
-              }
-
-              if (
-                event.stream.startingPosition === 'AT_TIMESTAMP' &&
-                !event.stream.startingPositionTimestamp
-              ) {
-                throw new ServerlessError(
-                  `You must specify startingPositionTimestamp for function: ${functionName} when startingPosition is AT_TIMESTAMP`,
-                  'FUNCTION_STREAM_STARTING_POSITION_TIMESTAMP_INVALID'
-                );
-              }
-
-              if (event.stream.startingPositionTimestamp) {
-                streamResource.Properties.StartingPositionTimestamp =
-                  event.stream.startingPositionTimestamp;
               }
             }
 

--- a/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/stream.test.js
@@ -1044,6 +1044,8 @@ describe('AwsCompileStreamEvents', () => {
                 stream: {
                   arn: 'arn:aws:kinesis:region:account:stream/def',
                   consumer: false,
+                  startingPosition: 'AT_TIMESTAMP',
+                  startingPositionTimestamp: 123,
                 },
               },
             ],
@@ -1310,7 +1312,11 @@ describe('AwsCompileStreamEvents', () => {
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.Properties.StartingPosition
-        ).to.equal('TRIM_HORIZON');
+        ).to.equal('AT_TIMESTAMP');
+        expect(
+          awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources.FirstEventSourceMappingKinesisDef.Properties.StartingPositionTimestamp
+        ).to.equal(123);
         expect(
           awsCompileStreamEvents.serverless.service.provider.compiledCloudFormationTemplate
             .Resources.FirstEventSourceMappingKinesisDef.Properties.Enabled
@@ -1436,7 +1442,6 @@ describe('AwsCompileStreamEvents', () => {
                 {
                   stream: {
                     arn: 'arn:aws:kinesis:region:account:stream/abc',
-                    consumer: true,
                     startingPosition: 'AT_TIMESTAMP',
                   },
                 },


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #12111 
