### PR TITLE
Include function name when reporting "no file matches patterns"

### DIFF
--- a/lib/plugins/package/lib/package-service.js
+++ b/lib/plugins/package/lib/package-service.js
@@ -314,7 +314,12 @@ module.exports = {
         .filter((r) => r[1] === true)
         .map((r) => r[0]);
       if (filePaths.length !== 0) return filePaths;
-      throw new ServerlessError('No file matches include / exclude patterns', 'NO_MATCHED_FILES');
+
+      const extra = params.contextName ? ` for ${params.contextName}` : '';
+      throw new ServerlessError(
+        `No file matches include / exclude patterns${extra}`,
+        'NO_MATCHED_FILES'
+      );
     });
   },
 };


### PR DESCRIPTION
Previously it was difficult to know which function was broken when the error `No file matches include / exclude patterns` occurred.

This adds the context (if known), so you now get the function name in the error:

```
No file matches include / exclude patterns for function "example"
```

This change is a bit longer than the 1-liner I expected, but lint & prettier conspired to make it so.