### PR TITLE
Use nodejs18 in custom-resources

### DIFF
--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -172,7 +172,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
       FunctionName: absoluteFunctionName,
       Handler,
       MemorySize: 1024,
-      Runtime: 'nodejs16.x',
+      Runtime: 'nodejs18.x',
       Timeout: 180,
     },
     DependsOn: [],

--- a/lib/plugins/aws/custom-resources/resources/api-gateway-cloud-watch-role/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/api-gateway-cloud-watch-role/handler.js
@@ -2,6 +2,17 @@
 
 const { awsRequest, wait } = require('../utils');
 const { getEnvironment, handlerWrapper } = require('../utils');
+const {
+  APIGatewayClient,
+  GetAccountCommand,
+  UpdateAccountCommand,
+} = require('@aws-sdk/client-api-gateway');
+const {
+  IAMClient,
+  ListAttachedRolePoliciesCommand,
+  CreateRoleCommand,
+  AttachRolePolicyCommand,
+} = require('@aws-sdk/client-iam');
 
 async function handler(event, context) {
   if (event.RequestType === 'Create') {
@@ -17,10 +28,8 @@ async function handler(event, context) {
 async function create(event, context) {
   const { RoleArn } = event.ResourceProperties;
   const { Partition: partition, AccountId: accountId, Region: region } = getEnvironment(context);
-
-  const assignedRoleArn = (
-    await awsRequest({ name: 'APIGateway', params: { region } }, 'getAccount')
-  ).cloudwatchRoleArn;
+  const apiGatewayClient = new APIGatewayClient({ region });
+  const assignedRoleArn = (() => apiGatewayClient.send(new GetAccountCommand())).cloudwatchRoleArn;
 
   let roleArn = `arn:${partition}:iam::${accountId}:role/serverlessApiGatewayCloudWatchRole`;
   if (RoleArn) {
@@ -32,14 +41,18 @@ async function create(event, context) {
 
     const roleName = roleArn.slice(roleArn.lastIndexOf('/') + 1);
 
+    const iamClient = new IAMClient({ region });
     const attachedPolicies = await (async () => {
       try {
-        return (await awsRequest('IAM', 'listAttachedRolePolicies', { RoleName: roleName }))
-          .AttachedPolicies;
+        return (
+          await awsRequest(() =>
+            iamClient.send(new ListAttachedRolePoliciesCommand({ RoleName: roleName }))
+          )
+        ).AttachedPolicies;
       } catch (error) {
         if (error.code === 'NoSuchEntity') {
           // Role doesn't exist yet, create;
-          await awsRequest('IAM', 'createRole', {
+          const createRoleCommand = new CreateRoleCommand({
             AssumeRolePolicyDocument: JSON.stringify({
               Version: '2012-10-17',
               Statement: [
@@ -55,6 +68,7 @@ async function create(event, context) {
             Path: '/',
             RoleName: roleName,
           });
+          await awsRequest(() => iamClient.send(createRoleCommand));
           return [];
         }
         throw error;
@@ -66,10 +80,11 @@ async function create(event, context) {
         (policy) => policy.PolicyArn === apiGatewayPushToCloudWatchLogsPolicyArn
       )
     ) {
-      await awsRequest('IAM', 'attachRolePolicy', {
+      const attachRoleCommand = new AttachRolePolicyCommand({
         PolicyArn: apiGatewayPushToCloudWatchLogsPolicyArn,
         RoleName: roleName,
       });
+      await awsRequest(() => iamClient.send(attachRoleCommand));
     }
   }
 
@@ -78,7 +93,7 @@ async function create(event, context) {
 
   const updateAccount = async (counter = 1) => {
     try {
-      await awsRequest({ name: 'APIGateway', params: { region } }, 'updateAccount', {
+      const command = new UpdateAccountCommand({
         patchOperations: [
           {
             op: 'replace',
@@ -87,6 +102,8 @@ async function create(event, context) {
           },
         ],
       });
+
+      await awsRequest(() => apiGatewayClient.send(command));
     } catch (error) {
       if (counter < 10) {
         // Observed fails with errors marked as non-retryable. Still they're outcome of

--- a/lib/plugins/aws/custom-resources/resources/api-gateway-cloud-watch-role/handler.js
+++ b/lib/plugins/aws/custom-resources/resources/api-gateway-cloud-watch-role/handler.js
@@ -29,7 +29,8 @@ async function create(event, context) {
   const { RoleArn } = event.ResourceProperties;
   const { Partition: partition, AccountId: accountId, Region: region } = getEnvironment(context);
   const apiGatewayClient = new APIGatewayClient({ region });
-  const assignedRoleArn = (() => apiGatewayClient.send(new GetAccountCommand())).cloudwatchRoleArn;
+  const assignedRoleArn = (await awsRequest(() => apiGatewayClient.send(new GetAccountCommand())))
+    .cloudwatchRoleArn;
 
   let roleArn = `arn:${partition}:iam::${accountId}:role/serverlessApiGatewayCloudWatchRole`;
   if (RoleArn) {

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/permissions.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/permissions.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const { awsRequest } = require('../../utils');
+const {
+  LambdaClient,
+  AddPermissionCommand,
+  RemovePermissionCommand,
+} = require('@aws-sdk/client-lambda');
 
 function getStatementId(functionName, userPoolName) {
   const normalizedUserPoolName = userPoolName.toLowerCase().replace(/[.:*\s]/g, '');
@@ -13,23 +18,25 @@ function getStatementId(functionName, userPoolName) {
 
 async function addPermission(config) {
   const { functionName, userPoolName, partition, region, accountId, userPoolId } = config;
-  const payload = {
+  const addPermissionCommand = new AddPermissionCommand({
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,
     Principal: 'cognito-idp.amazonaws.com',
     StatementId: getStatementId(functionName, userPoolName),
     SourceArn: `arn:${partition}:cognito-idp:${region}:${accountId}:userpool/${userPoolId}`,
-  };
-  return awsRequest({ name: 'Lambda', params: { region } }, 'addPermission', payload);
+  });
+  const lambdaClient = new LambdaClient({ region });
+  return await awsRequest(() => lambdaClient.send(addPermissionCommand));
 }
 
 async function removePermission(config) {
   const { functionName, userPoolName, region } = config;
-  const payload = {
+  const removePermissionCommand = new RemovePermissionCommand({
     FunctionName: functionName,
     StatementId: getStatementId(functionName, userPoolName),
-  };
-  return awsRequest({ name: 'Lambda', params: { region } }, 'removePermission', payload);
+  });
+  const lambdaClient = new LambdaClient({ region });
+  return awsRequest(() => lambdaClient.send(removePermissionCommand));
 }
 
 module.exports = {

--- a/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
+++ b/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
@@ -1,6 +1,12 @@
 'use strict';
 
 const { awsRequest } = require('../../utils');
+const {
+  CognitoIdentityProviderClient,
+  ListUserPoolsCommand,
+  DescribeUserPoolCommand,
+  UpdateUserPoolCommand,
+} = require('@aws-sdk/client-cognito-identity-provider');
 
 const customSenderSources = ['CustomSMSSender', 'CustomEmailSender'];
 
@@ -32,18 +38,11 @@ function getUpdateConfigFromCurrentSetup(currentSetup) {
 
 async function findUserPoolByName(config) {
   const { userPoolName, region } = config;
-
-  const payload = {
-    MaxResults: 60,
-  };
+  const cognitoClient = new CognitoIdentityProviderClient({ region });
 
   async function recursiveFind(nextToken) {
-    if (nextToken) payload.NextToken = nextToken;
-    return awsRequest(
-      { name: 'CognitoIdentityServiceProvider', params: { region } },
-      'listUserPools',
-      payload
-    ).then((result) => {
+    const listUserPoolsCommand = new ListUserPoolsCommand({ MaxResults: 60, NextToken: nextToken });
+    return awsRequest(() => cognitoClient.send(listUserPoolsCommand)).then((result) => {
       const matches = result.UserPools.filter((pool) => pool.Name === userPoolName);
       if (matches.length) {
         return matches.shift();
@@ -58,12 +57,13 @@ async function findUserPoolByName(config) {
 
 async function getConfiguration(config) {
   const { region } = config;
+  const cognitoClient = new CognitoIdentityProviderClient({ region });
 
-  return findUserPoolByName(config).then((userPool) =>
-    awsRequest({ name: 'CognitoIdentityServiceProvider', params: { region } }, 'describeUserPool', {
-      UserPoolId: userPool.Id,
-    })
+  const userPool = await findUserPoolByName(config);
+  const response = await cognitoClient.send(
+    new DescribeUserPoolCommand({ UserPoolId: userPool.Id })
   );
+  return response.UserPool;
 }
 
 async function updateConfiguration(config) {
@@ -93,12 +93,10 @@ async function updateConfiguration(config) {
       UserPoolId,
       LambdaConfig,
     });
+    const cognitoIdentityProvider = new CognitoIdentityProviderClient({ region });
+    const updateUserPoolCommand = new UpdateUserPoolCommand(updatedConfig);
 
-    return awsRequest(
-      { name: 'CognitoIdentityServiceProvider', params: { region } },
-      'updateUserPool',
-      updatedConfig
-    );
+    return awsRequest(() => cognitoIdentityProvider.send(updateUserPoolCommand));
   });
 }
 
@@ -117,12 +115,10 @@ async function removeConfiguration(config) {
       UserPoolId,
       LambdaConfig,
     });
+    const client = new CognitoIdentityProviderClient({ region });
+    const updateUserPoolCommand = new UpdateUserPoolCommand(updatedConfig);
 
-    return awsRequest(
-      { name: 'CognitoIdentityServiceProvider', params: { region } },
-      'updateUserPool',
-      updatedConfig
-    );
+    return awsRequest(() => client.send(updateUserPoolCommand));
   });
 }
 

--- a/lib/plugins/aws/custom-resources/resources/event-bridge/lib/event-bridge.js
+++ b/lib/plugins/aws/custom-resources/resources/event-bridge/lib/event-bridge.js
@@ -2,6 +2,15 @@
 
 const { awsRequest } = require('../../utils');
 const { getEventBusName, getEventBusTargetId } = require('./utils');
+const {
+  EventBridgeClient,
+  CreateEventBusCommand,
+  DeleteEventBusCommand,
+  PutRuleCommand,
+  DeleteRuleCommand,
+  PutTargetsCommand,
+  RemoveTargetsCommand,
+} = require('@aws-sdk/client-eventbridge');
 
 async function createEventBus(config) {
   const { eventBus, region } = config;
@@ -10,9 +19,8 @@ async function createEventBus(config) {
     if (eventBus.startsWith('arn')) {
       return Promise.resolve();
     }
-    return awsRequest({ name: 'EventBridge', params: { region } }, 'createEventBus', {
-      Name: eventBus,
-    });
+    const client = new EventBridgeClient({ region });
+    return awsRequest(() => client.send(new CreateEventBusCommand({ Name: eventBus })));
   }
   return Promise.resolve();
 }
@@ -24,10 +32,8 @@ async function deleteEventBus(config) {
     if (eventBus.startsWith('arn')) {
       return Promise.resolve();
     }
-
-    return awsRequest({ name: 'EventBridge', params: { region } }, 'deleteEventBus', {
-      Name: eventBus,
-    });
+    const client = new EventBridgeClient({ region });
+    return awsRequest(() => client.send(new DeleteEventBusCommand({ Name: eventBus })));
   }
   return Promise.resolve();
 }
@@ -37,13 +43,18 @@ async function updateRuleConfiguration(config) {
 
   const EventBusName = getEventBusName(eventBus);
 
-  return awsRequest({ name: 'EventBridge', params: { region } }, 'putRule', {
-    Name: ruleName,
-    EventBusName,
-    EventPattern: JSON.stringify(pattern),
-    ScheduleExpression: schedule,
-    State: state,
-  });
+  const client = new EventBridgeClient({ region });
+  return awsRequest(() =>
+    client.send(
+      new PutRuleCommand({
+        Name: ruleName,
+        EventBusName,
+        EventPattern: JSON.stringify(pattern),
+        ScheduleExpression: schedule,
+        State: state,
+      })
+    )
+  );
 }
 
 async function removeRuleConfiguration(config) {
@@ -51,10 +62,15 @@ async function removeRuleConfiguration(config) {
 
   const EventBusName = getEventBusName(eventBus);
 
-  return awsRequest({ name: 'EventBridge', params: { region } }, 'deleteRule', {
-    Name: ruleName,
-    EventBusName,
-  });
+  const client = new EventBridgeClient({ region });
+  return awsRequest(() =>
+    client.send(
+      new DeleteRuleCommand({
+        Name: ruleName,
+        EventBusName,
+      })
+    )
+  );
 }
 
 async function updateTargetConfiguration(config) {
@@ -75,12 +91,18 @@ async function updateTargetConfiguration(config) {
     target = Object.assign(target, { InputTransformer: inputTransformer });
   }
 
+  const client = new EventBridgeClient({ region });
+
   return removeTargetConfiguration(config).then(() =>
-    awsRequest({ name: 'EventBridge', params: { region } }, 'putTargets', {
-      Rule: ruleName,
-      EventBusName,
-      Targets: [target],
-    })
+    awsRequest(() =>
+      client.send(
+        new PutTargetsCommand({
+          Rule: ruleName,
+          EventBusName,
+          Targets: [target],
+        })
+      )
+    )
   );
 }
 
@@ -89,11 +111,16 @@ async function removeTargetConfiguration(config) {
 
   const EventBusName = getEventBusName(eventBus);
 
-  return awsRequest({ name: 'EventBridge', params: { region } }, 'removeTargets', {
-    Ids: [getEventBusTargetId(ruleName)],
-    Rule: ruleName,
-    EventBusName,
-  });
+  const client = new EventBridgeClient({ region });
+  return awsRequest(() =>
+    client.send(
+      new RemoveTargetsCommand({
+        Ids: [getEventBusTargetId(ruleName)],
+        Rule: ruleName,
+        EventBusName,
+      })
+    )
+  );
 }
 
 module.exports = {

--- a/lib/plugins/aws/custom-resources/resources/event-bridge/lib/permissions.js
+++ b/lib/plugins/aws/custom-resources/resources/event-bridge/lib/permissions.js
@@ -2,6 +2,11 @@
 
 const { awsRequest } = require('../../utils');
 const { getEventBusName } = require('./utils');
+const {
+  LambdaClient,
+  AddPermissionCommand,
+  RemovePermissionCommand,
+} = require('@aws-sdk/client-lambda');
 
 function getStatementId(functionName, ruleName) {
   const normalizedRuleName = ruleName.toLowerCase().replace(/[.:*]/g, '');
@@ -19,23 +24,26 @@ async function addPermission(config) {
     const eventBusName = getEventBusName(eventBus);
     SourceArn = `arn:${partition}:events:${region}:${accountId}:rule/${eventBusName}/${ruleName}`;
   }
-  const payload = {
+  const addPermissionCommand = new AddPermissionCommand({
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,
     Principal: 'events.amazonaws.com',
     StatementId: getStatementId(functionName, ruleName),
     SourceArn,
-  };
-  return awsRequest({ name: 'Lambda', params: { region } }, 'addPermission', payload);
+  });
+  const lambdaClient = new LambdaClient({ region });
+  return await awsRequest(() => lambdaClient.send(addPermissionCommand));
 }
 
 async function removePermission(config) {
   const { functionName, region, ruleName } = config;
-  const payload = {
+
+  const removePermissionCommand = new RemovePermissionCommand({
     FunctionName: functionName,
     StatementId: getStatementId(functionName, ruleName),
-  };
-  return awsRequest({ name: 'Lambda', params: { region } }, 'removePermission', payload);
+  });
+  const lambdaClient = new LambdaClient({ region });
+  return awsRequest(() => lambdaClient.send(removePermissionCommand));
 }
 
 module.exports = {

--- a/lib/plugins/aws/custom-resources/resources/s3/lib/bucket.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/lib/bucket.js
@@ -2,6 +2,11 @@
 
 const crypto = require('crypto');
 const { awsRequest } = require('../../utils');
+const {
+  S3Client,
+  GetBucketNotificationConfigurationCommand,
+  PutBucketNotificationConfigurationCommand,
+} = require('@aws-sdk/client-s3');
 
 function generateId(functionName, bucketConfig) {
   const md5 = crypto.createHash('md5').update(JSON.stringify(bucketConfig)).digest('hex');
@@ -32,20 +37,17 @@ function createFilter(config) {
 async function getConfiguration(config) {
   const { bucketName, region } = config;
   const Bucket = bucketName;
-  const payload = {
+  const command = new GetBucketNotificationConfigurationCommand({
     Bucket,
-  };
-  return awsRequest(
-    { name: 'S3', params: { region } },
-    'getBucketNotificationConfiguration',
-    payload
-  ).then((data) => data);
+  });
+  const s3Client = new S3Client({ region });
+  return awsRequest(() => s3Client.send(command)).then((data) => data);
 }
 
 async function updateConfiguration(config) {
   const { lambdaArn, functionName, bucketName, bucketConfigs, region } = config;
   const Bucket = bucketName;
-
+  const s3Client = new S3Client({ region });
   return getConfiguration(config).then((NotificationConfiguration) => {
     // remove configurations for this specific function
     NotificationConfiguration.LambdaFunctionConfigurations =
@@ -67,22 +69,18 @@ async function updateConfiguration(config) {
       });
     });
 
-    const payload = {
+    const command = new PutBucketNotificationConfigurationCommand({
       Bucket,
       NotificationConfiguration,
-    };
-    return awsRequest(
-      { name: 'S3', params: { region } },
-      'putBucketNotificationConfiguration',
-      payload
-    );
+    });
+    return awsRequest(() => s3Client.send(command));
   });
 }
 
 async function removeConfiguration(config) {
   const { functionName, bucketName, region } = config;
   const Bucket = bucketName;
-
+  const s3Client = new S3Client({ region });
   return getConfiguration(config).then((NotificationConfiguration) => {
     // remove configurations for this specific function
     NotificationConfiguration.LambdaFunctionConfigurations =
@@ -90,15 +88,11 @@ async function removeConfiguration(config) {
         (conf) => !conf.Id.startsWith(functionName)
       );
 
-    const payload = {
+    const command = new PutBucketNotificationConfigurationCommand({
       Bucket,
       NotificationConfiguration,
-    };
-    return awsRequest(
-      { name: 'S3', params: { region } },
-      'putBucketNotificationConfiguration',
-      payload
-    );
+    });
+    return awsRequest(() => s3Client.send(command));
   });
 }
 

--- a/lib/plugins/aws/custom-resources/resources/s3/lib/permissions.js
+++ b/lib/plugins/aws/custom-resources/resources/s3/lib/permissions.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const { awsRequest } = require('../../utils');
+const {
+  LambdaClient,
+  AddPermissionCommand,
+  RemovePermissionCommand,
+} = require('@aws-sdk/client-lambda');
 
 function getStatementId(functionName, bucketName) {
   const normalizedBucketName = bucketName.replace(/[.:*]/g, '');
@@ -13,24 +18,26 @@ function getStatementId(functionName, bucketName) {
 
 async function addPermission(config) {
   const { functionName, bucketName, partition, region, accountId } = config;
-  const payload = {
+  const addPermissionCommand = new AddPermissionCommand({
     Action: 'lambda:InvokeFunction',
     FunctionName: functionName,
     Principal: 's3.amazonaws.com',
     StatementId: getStatementId(functionName, bucketName),
     SourceArn: `arn:${partition}:s3:::${bucketName}`,
     SourceAccount: accountId,
-  };
-  return awsRequest({ name: 'Lambda', params: { region } }, 'addPermission', payload);
+  });
+  const lambdaClient = new LambdaClient({ region });
+  return await awsRequest(() => lambdaClient.send(addPermissionCommand));
 }
 
 async function removePermission(config) {
   const { functionName, bucketName, region } = config;
-  const payload = {
+  const removePermissionCommand = new RemovePermissionCommand({
     FunctionName: functionName,
     StatementId: getStatementId(functionName, bucketName),
-  };
-  return awsRequest({ name: 'Lambda', params: { region } }, 'removePermission', payload);
+  });
+  const lambdaClient = new LambdaClient({ region });
+  return awsRequest(() => lambdaClient.send(removePermissionCommand));
 }
 
 module.exports = {

--- a/lib/plugins/aws/custom-resources/resources/utils.js
+++ b/lib/plugins/aws/custom-resources/resources/utils.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const AWS = require('aws-sdk');
 const https = require('https');
 const url = require('url');
 
 const logger = console;
-AWS.config.logger = console;
 
 async function response(event, context, status, data = {}, err) {
   const reason = err ? err.message : '';
@@ -98,23 +96,10 @@ const MAX_AWS_REQUEST_TRY = (() => {
   return userValue >= 0 ? userValue : DEFAULT_MAX_AWS_REQUEST_TRY;
 })();
 
-const getServiceInstance = (nameInput) => {
-  let name;
-  let params = {};
-  if (typeof nameInput === 'string') {
-    name = nameInput;
-  } else {
-    name = nameInput.name;
-    params = nameInput.params;
-  }
-  return new AWS[name](params);
-};
-
-async function awsRequest(service, method, ...args) {
-  const serviceInstance = getServiceInstance(service);
+async function retryableAwsCall(awsApiFunc) {
   const callAws = async (requestTry) => {
     try {
-      return await serviceInstance[method](...args).promise();
+      return await awsApiFunc();
     } catch (error) {
       if (
         requestTry < MAX_AWS_REQUEST_TRY &&
@@ -137,5 +122,5 @@ module.exports = {
   getLambdaArn,
   handlerWrapper,
   wait,
-  awsRequest,
+  awsRequest: retryableAwsCall,
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
     "sls": "./bin/serverless.js"
   },
   "dependencies": {
+    "@aws-sdk/client-api-gateway": "^3.410.0",
+    "@aws-sdk/client-cognito-identity-provider": "^3.410.0",
+    "@aws-sdk/client-eventbridge": "^3.411.0",
+    "@aws-sdk/client-iam": "^3.410.0",
+    "@aws-sdk/client-lambda": "^3.410.0",
+    "@aws-sdk/client-s3": "^3.410.0",
     "@serverless/dashboard-plugin": "^6.2.3",
     "@serverless/platform-client": "^4.3.2",
     "@serverless/utils": "^6.13.1",

--- a/test/unit/lib/plugins/aws/custom-resources/index.test.js
+++ b/test/unit/lib/plugins/aws/custom-resources/index.test.js
@@ -109,7 +109,7 @@ describe('#addCustomResourceToService()', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs16.x',
+        Runtime: 'nodejs18.x',
         Timeout: 180,
       },
       DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
@@ -128,7 +128,7 @@ describe('#addCustomResourceToService()', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs16.x',
+        Runtime: 'nodejs18.x',
         Timeout: 180,
       },
       DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
@@ -147,7 +147,7 @@ describe('#addCustomResourceToService()', () => {
         Role: {
           'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
         },
-        Runtime: 'nodejs16.x',
+        Runtime: 'nodejs18.x',
         Timeout: 180,
       },
       DependsOn: ['IamRoleCustomResourcesLambdaExecution'],


### PR DESCRIPTION
Closes: #12133
similar to #11359
As NodeJS 16 security support recently ended all internal lambda functions have to be migrated to the latest LTS nodejs18 
I made changes in the same way they were done in https://github.com/serverless/serverless/pull/11367/files
