### PR TITLE
Update schedule.md

### DIFF
--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -116,3 +116,4 @@ functions:
             key1: value1
             key2: value2
 ```
+**Note**: When visiting the lambda in the AWS Console with the `scheduler` method deployed, the EventBridge input trigger will not appear as it does with `eventBus`. But don't worry, the Schudeler trigger is working and invoking the lambda as configured.


### PR DESCRIPTION
Note informing that with the schudeler method it does not appear in the lambda as an input trigger, as explained by AWS support.

This will avoid many discussions about deploys made, but in lambda the eventbridge does not appear as an input trigger.

![image](https://github.com/serverless/serverless/assets/57275833/7d72d0e9-ecb9-4853-8fbc-dd65f861234c)
