### PR TITLE
fix: remove inline-comment from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
-root = true  ; top-most EditorConfig file
+; top-most EditorConfig file
+root = true
 
 ; Unix-style newlines with a newline ending every file
 [*]


### PR DESCRIPTION
The EditorConfig spec does not allow inline comments since v0.15.0.

See: https://spec.editorconfig.org/#no-inline-comments