### PR TITLE
Fixes getting image sha256 from 'docker images' instead of the output of 'docker push'

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -2285,10 +2285,33 @@ Object.defineProperties(
             );
           }
 
+          imageProgress.notice(`Getting image sha256 from image "${imageName}"`);
+          const imageDockerArgs = [
+            'images',
+            '--digests',
+            `--filter "reference=${localTag}"`,
+            '--format "{{.Digest}}"',
+          ];
+          try {
+            const { stdBuffer: imagesDockerStdBuffer } = await spawnExt('docker', imageDockerArgs);
+            if (imagesDockerStdBuffer) {
+              log.info(imagesDockerStdBuffer.toString().trimRight());
+              imageSha = imagesDockerStdBuffer
+                .toString()
+                .trim()
+                .match(/(sha256:[a-f0-9]{64})/)[0];
+            }
+          } catch (err) {
+            throw new ServerlessError(
+              `Encountered error during executing: docker ${imageDockerArgs.join(
+                ' '
+              )}\nOutput of the command:\n${err.stdBuffer}`,
+              'DOCKER_IMAGES_ERROR'
+            );
+          }
+
           imageProgress.notice(`Uploading image "${imageName}"`);
-          const dockerPushOutput = await this.dockerPushToEcr(remoteTag);
-          // Extract imageSha from `docker push` output
-          imageSha = dockerPushOutput.match(/(sha256:[a-f0-9]{64})/)[0];
+          await this.dockerPushToEcr(remoteTag);
         } finally {
           imageProgress.remove();
         }


### PR DESCRIPTION
Get image sha256 by docker images command, instead of using output of docker push

https://github.com/serverless/serverless/issues/12192

Closes: #12192
