### PR TITLE
docs: Fix typo in docs/providers/aws/guide/variables.md

### DIFF
--- a/docs/providers/aws/guide/variables.md
+++ b/docs/providers/aws/guide/variables.md
@@ -318,7 +318,7 @@ The following variables are available:
 
 **accountId**
 
-Account ID of you AWS Account, based on the AWS Credentials that you have configured.
+Account ID of your AWS Account, based on the AWS Credentials that you have configured.
 
 ```yml
 service: new-service


### PR DESCRIPTION
Fixes minor typo ("of your AWS Account " rather than "of you AWS Account").