### PR TITLE
feat: Add AWS lambda support for IPV6 outbound connections in VPC

### DIFF
--- a/lib/plugins/aws/deploy-function.js
+++ b/lib/plugins/aws/deploy-function.js
@@ -378,6 +378,10 @@ class AwsDeployFunction {
       const vpc = functionObj.vpc || providerObj.vpc;
       params.VpcConfig = {};
 
+      if (vpc.ipv6AllowedForDualStack) {
+        params.VpcConfig.Ipv6AllowedForDualStack = vpc.ipv6AllowedForDualStack;
+      }
+
       if (Array.isArray(vpc.securityGroupIds) && !vpc.securityGroupIds.some(_.isObject)) {
         params.VpcConfig.SecurityGroupIds = vpc.securityGroupIds;
       }
@@ -387,8 +391,11 @@ class AwsDeployFunction {
       }
 
       const didVpcChange = () => {
-        const remoteConfigToCompare = { SecurityGroupIds: [], SubnetIds: [] };
+        const remoteConfigToCompare = { Ipv6AllowedForDualStack: false, SecurityGroupIds: [], SubnetIds: [] };
         if (remoteFunctionConfiguration.VpcConfig) {
+          remoteConfigToCompare.Ipv6AllowedForDualStack = new Set(
+            remoteFunctionConfiguration.VpcConfig.Ipv6AllowedForDualStack || false
+          );
           remoteConfigToCompare.SecurityGroupIds = new Set(
             remoteFunctionConfiguration.VpcConfig.SecurityGroupIds || []
           );
@@ -397,6 +404,7 @@ class AwsDeployFunction {
           );
         }
         const localConfigToCompare = {
+          Ipv6AllowedForDualStack: new Set(params.VpcConfig.Ipv6AllowedForDualStack || false),
           SecurityGroupIds: new Set(params.VpcConfig.SecurityGroupIds || []),
           SubnetIds: new Set(params.VpcConfig.SubnetIds || []),
         };

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -389,6 +389,9 @@ class AwsCompileFunctions {
       if (!this.serverless.service.provider.vpc) this.serverless.service.provider.vpc = {};
 
       functionResource.Properties.VpcConfig = {
+        Ipv6AllowedForDualStack:
+          functionObject.vpc.ipv6AllowedForDualStack ||
+          this.serverless.service.provider.vpc.ipv6AllowedForDualStack,
         SecurityGroupIds:
           functionObject.vpc.securityGroupIds ||
           this.serverless.service.provider.vpc.securityGroupIds,

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -653,6 +653,7 @@ class AwsProvider {
           awsLambdaVpcConfig: {
             type: 'object',
             properties: {
+              ipv6AllowedForDualStack: { type: 'boolean' },
               securityGroupIds: {
                 anyOf: [
                   {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Add AWS lambda support for IPV6 outbound connections in VPC.

Reference: https://aws.amazon.com/about-aws/whats-new/2023/10/aws-lambda-ipv6-outbound-connections-vpc


<!-- Closes: #{ISSUE_NUMBER} -->
