### PR TITLE
feat: Add support for nodejs20.x runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -623,6 +623,7 @@ class AwsProvider {
               'nodejs14.x',
               'nodejs16.x',
               'nodejs18.x',
+              'nodejs20.x',
               'provided',
               'provided.al2',
               'python3.7',


### PR DESCRIPTION
Node 20 is now supported by AWS Lambda. Corresponding issue https://github.com/serverless/serverless/issues/12252

Related AWS Blog Post: https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/
Related AWS SAM CLI Release: https://github.com/aws/aws-sam-cli/releases/tag/v1.102.0
Related AWS SDK Release: https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.446.0

