### PR TITLE
Add support for nodejs20.x for Lambda

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -623,6 +623,7 @@ class AwsProvider {
               'nodejs14.x',
               'nodejs16.x',
               'nodejs18.x',
+              'nodejs20.x',
               'provided',
               'provided.al2',
               'python3.7',


### PR DESCRIPTION
Added support for nodejs20.x now that [Lambda supports it](https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/).  

Let me know if I should also add this to the dashboard code that lists up to nodejs18.x
