### PR TITLE
feat: Add support for provided.al2023 runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -626,6 +626,7 @@ class AwsProvider {
               'nodejs20.x',
               'provided',
               'provided.al2',
+              'provided.al2023',
               'python3.7',
               'python3.8',
               'python3.9',


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

AWS Lambda now supports Amazon Linux 2023 (AL2023) as a managed runtime. Closes: [#12250](https://github.com/serverless/serverless/issues/12250)

Related AWS Blog posts : https://aws.amazon.com/jp/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/
Related AWS SAM Release : https://github.com/aws/aws-sam-cli/releases/tag/v1.101.0
Related aws-sdk-js-v3 release : https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.448.0

