### PR TITLE
MSK trigger IAM role fixes

### DIFF
--- a/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/lib/plugins/aws/package/compile/events/msk/index.js
@@ -80,7 +80,7 @@ class AwsCompileMSKEvents {
       };
       const mskStatement = {
         Effect: 'Allow',
-        Action: ['kafka:DescribeCluster', 'kafka:GetBootstrapBrokers'],
+        Action: ['kafka:DescribeClusterV2', 'kafka:GetBootstrapBrokers'],
         Resource: [],
       };
 
@@ -166,7 +166,9 @@ class AwsCompileMSKEvents {
             };
           }
 
-          mskStatement.Resource.push(eventSourceArn);
+          if (mskStatement.Resource.indexOf(eventSourceArn) === -1) {
+            mskStatement.Resource.push(eventSourceArn);
+          }
 
           cfTemplate.Resources[mskEventLogicalId] = mskResource;
         }

--- a/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/msk/index.test.js
@@ -91,7 +91,7 @@ describe('AwsCompileMSKEvents', () => {
     it('should update default IAM role with MSK statement', () => {
       expect(defaultIamRole.Properties.Policies[0].PolicyDocument.Statement).to.deep.include({
         Effect: 'Allow',
-        Action: ['kafka:DescribeCluster', 'kafka:GetBootstrapBrokers'],
+        Action: ['kafka:DescribeClusterV2', 'kafka:GetBootstrapBrokers'],
         Resource: [arn],
       });
     });
@@ -194,7 +194,7 @@ describe('AwsCompileMSKEvents', () => {
       const defaultIamRole = cfTemplate.Resources.IamRoleLambdaExecution;
       expect(defaultIamRole.Properties.Policies[0].PolicyDocument.Statement).not.to.deep.include({
         Effect: 'Allow',
-        Action: ['kafka:DescribeCluster', 'kafka:GetBootstrapBrokers'],
+        Action: ['kafka:DescribeClusterV2', 'kafka:GetBootstrapBrokers'],
         Resource: [],
       });
 


### PR DESCRIPTION
This pull request (PR) is for upgrading the MSK IAM support from DescribeCluster to DescribeClusterV2. It also fixes a bug where duplicated MSK resources were added to the IAM role when multiple MSK triggers connected to the same MSK instance.