### PR TITLE
feat: Add support for java21 runtime (#12273)

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -455,7 +455,7 @@ functions:
     snapStart: true
 ```
 
-**Note:** Lambda SnapStart only supports the Java 11 and Java 17 runtimes and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
+**Note:** Lambda SnapStart only supports the Java 11, Java 17 and Java 21 runtimes and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
 
 ## VPC Configuration
 

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -266,7 +266,7 @@ class AwsInvokeLocal {
       );
     }
 
-    if (['java8', 'java11', 'java17'].includes(runtime)) {
+    if (['java8', 'java11', 'java17', 'java21'].includes(runtime)) {
       const className = handler.split('::')[0];
       const handlerName = handler.split('::')[1] || 'handleRequest';
       const artifact =

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -616,6 +616,7 @@ class AwsProvider {
             enum: [
               'dotnet6',
               'go1.x',
+              'java21',
               'java17',
               'java11',
               'java8',


### PR DESCRIPTION
Adds java21 also as a supported runtime since this is now officialy supported : https://aws.amazon.com/about-aws/whats-new/2023/11/aws-lambda-support-java-21/

Closes issue #12273
