### PR TITLE
Add AWS UAE region to supported list for v2

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1105,6 +1105,7 @@ class AwsProvider {
                 'eu-west-1',
                 'eu-west-2',
                 'eu-west-3',
+                'me-central-1',
                 'me-south-1',
                 'sa-east-1',
               ],


### PR DESCRIPTION
<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

A minor maintenance improvement to add the AWS region me-central-1 aka Middle East (UAE) to the supported regions list for serverless v2.

Based on https://github.com/serverless/serverless/pull/10586