### PR TITLE
feat: Add support for cloudwatch log class (#12278)

### DIFF
--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -648,6 +648,8 @@ By default, the framework will create LogGroups for your Lambdas. This makes it 
 
 You can opt out of the default behavior by setting `disableLogs: true`
 
+You can specify the CloudWatch log class by setting `logGroupClass` to `STANDARD` or `INFREQUENT_ACCESS`.
+
 You can also specify the duration for CloudWatch log retention by setting `logRetentionInDays`.
 
 You can specify the DataProtectionPolicy for the LogGroup by setting `logDataProtectionPolicy`. On how to define the policy consult the [aws docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data-start.html).
@@ -659,6 +661,7 @@ functions:
     disableLogs: true
   goodBye:
     handler: handler.goodBye
+    logGroupClass: `INFREQUENT_ACCESS`
     logRetentionInDays: 14
     logDataProtectionPolicy:
       Name: data-protection-policy

--- a/docs/providers/aws/guide/functions.md
+++ b/docs/providers/aws/guide/functions.md
@@ -648,7 +648,7 @@ By default, the framework will create LogGroups for your Lambdas. This makes it 
 
 You can opt out of the default behavior by setting `disableLogs: true`
 
-You can specify the CloudWatch log class by setting `logGroupClass` to `STANDARD` or `INFREQUENT_ACCESS`.
+You can specify the CloudWatch log class by setting `logGroupClass` to `STANDARD` or `INFREQUENT_ACCESS`. Log groups with the `INFREQUENT_ACCESS` class have the `/aws/lambda/ia/` log group name prefix. AWS does not allow changing the class of the log group once it is created. To workaround this, if you want the possibility to interchange between the two classes in the future, then set `changeableLogGroupClass: true`. This will make the serverless stack create a log group for each class but the function will use the one currently specified by `logGroupClass`.
 
 You can also specify the duration for CloudWatch log retention by setting `logRetentionInDays`.
 

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -130,6 +130,8 @@ provider:
   # Can be overridden for each function separately inside the functions block, see below on page.
   # Valid values: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html
   logGroupClass: INFREQUENT_ACCESS
+  # Defines whether LogGroupClass can be changed for existing functions
+  changeableLogGroupClass: false
   # Duration for CloudWatch log retention (default: forever).
   # Can be overridden for each function separately inside the functions block, see below on page.
   # Valid values: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html

--- a/docs/providers/aws/guide/serverless.yml.md
+++ b/docs/providers/aws/guide/serverless.yml.md
@@ -126,6 +126,10 @@ provider:
   # Function environment variables
   environment:
     APP_ENV_VARIABLE: FOOBAR
+  # CloudWatch logs class (default: STANDARD).
+  # Can be overridden for each function separately inside the functions block, see below on page.
+  # Valid values: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html
+  logGroupClass: INFREQUENT_ACCESS
   # Duration for CloudWatch log retention (default: forever).
   # Can be overridden for each function separately inside the functions block, see below on page.
   # Valid values: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html

--- a/lib/plugins/aws/custom-resources/index.js
+++ b/lib/plugins/aws/custom-resources/index.js
@@ -196,6 +196,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
         Type: 'AWS::Logs::LogGroup',
         Properties: {
           LogGroupName: awsProvider.naming.getLogGroupName(absoluteFunctionName),
+          LogGroupClass: awsProvider.getLogGroupClass(),
           RetentionInDays: awsProvider.getLogRetentionInDays(),
           DataProtectionPolicy: awsProvider.getLogDataProtectionPolicy(),
         },

--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -126,11 +126,16 @@ module.exports = {
   },
 
   // Log Group
-  getLogGroupLogicalId(functionName) {
-    return `${this.getNormalizedFunctionName(functionName)}LogGroup`;
+  getLogGroupLogicalId(functionName, logGroupClass = 'STANDARD') {
+    return (
+      `${this.getNormalizedFunctionName(functionName)}` +
+      `${logGroupClass === 'STANDARD' ? '' : this.toStartCase(logGroupClass.toLowerCase())}LogGroup`
+    );
   },
-  getLogGroupName(functionName) {
-    return `/aws/lambda/${functionName}`;
+  getLogGroupName(functionName, logGroupClass = 'STANDARD') {
+    return logGroupClass === 'INFREQUENT_ACCESS'
+      ? `/aws/lambda/ia/${functionName}`
+      : `/aws/lambda/${functionName}`;
   },
 
   // Lambda

--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/stage.js
@@ -108,6 +108,11 @@ function getLogGroupResource(service, stage, provider) {
     },
   };
 
+  const logGroupClass = provider.getLogGroupClass();
+  if (logGroupClass) {
+    resource.Properties.LogGroupClass = logGroupClass;
+  }
+
   const logRetentionInDays = provider.getLogRetentionInDays();
   if (logRetentionInDays) {
     resource.Properties.RetentionInDays = logRetentionInDays;

--- a/lib/plugins/aws/package/compile/events/http-api.js
+++ b/lib/plugins/aws/package/compile/events/http-api.js
@@ -138,6 +138,11 @@ class HttpApiEvents {
       Properties: { LogGroupName: this.provider.naming.getHttpApiLogGroupName() },
     };
 
+    const logGroupClass = this.provider.getLogGroupClass();
+    if (logGroupClass) {
+      resource.Properties.LogGroupClass = logGroupClass;
+    }
+
     const logRetentionInDays = this.provider.getLogRetentionInDays();
     if (logRetentionInDays) {
       resource.Properties.RetentionInDays = logRetentionInDays;

--- a/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -104,6 +104,10 @@ function getLogGroupResource(service, stage, provider) {
       LogGroupName: `/aws/websocket/${service}-${stage}`,
     },
   };
+  const logGroupClass = provider.getLogGroupClass();
+  if (logGroupClass) {
+    resource.Properties.LogGroupClass = logGroupClass;
+  }
   const logRetentionInDays = provider.getLogRetentionInDays();
   if (logRetentionInDays) {
     resource.Properties.RetentionInDays = logRetentionInDays;

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -440,10 +440,19 @@ class AwsCompileFunctions {
       functionResource.Properties.ReservedConcurrentExecutions = functionObject.reservedConcurrency;
     }
 
-    if (!functionObject.disableLogs) {
-      functionResource.DependsOn = [this.provider.naming.getLogGroupLogicalId(functionName)].concat(
-        functionResource.DependsOn || []
-      );
+    const logGroupClass =
+      functionObject.logGroupClass || this.serverless.service.provider.logGroupClass;
+    if (!functionObject.disableLogs || (logGroupClass && logGroupClass !== 'STANDARD')) {
+      if (logGroupClass && logGroupClass !== 'STANDARD') {
+        functionResource.Properties.LoggingConfig = functionResource.Properties.LoggingConfig || {};
+        functionResource.Properties.LoggingConfig.LogGroup = this.provider.naming.getLogGroupName(
+          functionObject.name,
+          logGroupClass
+        );
+      }
+      functionResource.DependsOn = [
+        this.provider.naming.getLogGroupLogicalId(functionName, logGroupClass),
+      ].concat(functionResource.DependsOn || []);
     }
 
     if (functionObject.layers) {

--- a/lib/plugins/aws/package/lib/merge-iam-templates.js
+++ b/lib/plugins/aws/package/lib/merge-iam-templates.js
@@ -26,6 +26,12 @@ module.exports = {
           },
         };
 
+        const logGroupClass =
+          functionObject.logGroupClass || this.provider.getLogGroupClass();
+        if (logGroupClass) {
+          newLogGroup[logGroupLogicalId].Properties.LogGroupClass = logGroupClass;
+        }
+
         const logRetentionInDays =
           functionObject.logRetentionInDays || this.provider.getLogRetentionInDays();
         if (logRetentionInDays) {

--- a/lib/plugins/aws/package/lib/merge-iam-templates.js
+++ b/lib/plugins/aws/package/lib/merge-iam-templates.js
@@ -13,41 +13,62 @@ module.exports = {
     // create log group resources
     this.serverless.service
       .getAllFunctions()
-      .filter((functionName) => !this.serverless.service.getFunction(functionName).disableLogs)
+      .filter((functionName) => {
+        const functionObject = this.serverless.service.getFunction(functionName);
+        const functionLogGroupClass =
+          functionObject.logGroupClass || this.provider.getLogGroupClass();
+        return (
+          !functionObject.disableLogs ||
+          (functionLogGroupClass && functionLogGroupClass !== 'STANDARD')
+        );
+      })
       .forEach((functionName) => {
         const functionObject = this.serverless.service.getFunction(functionName);
-        const logGroupLogicalId = this.provider.naming.getLogGroupLogicalId(functionName);
-        const newLogGroup = {
-          [logGroupLogicalId]: {
-            Type: 'AWS::Logs::LogGroup',
-            Properties: {
-              LogGroupName: this.provider.naming.getLogGroupName(functionObject.name),
-            },
-          },
-        };
-
-        const logGroupClass =
+        const functionLogGroupClass =
           functionObject.logGroupClass || this.provider.getLogGroupClass();
-        if (logGroupClass) {
-          newLogGroup[logGroupLogicalId].Properties.LogGroupClass = logGroupClass;
-        }
+        const changeableLogGroupClass =
+          functionObject.changeableLogGroupClass || this.provider.getChangeableLogGroupClass();
+        for (const logGroupClass of changeableLogGroupClass
+          ? ['STANDARD', 'INFREQUENT_ACCESS']
+          : [functionLogGroupClass || 'STANDARD']) {
+          const logGroupLogicalId = this.provider.naming.getLogGroupLogicalId(
+            functionName,
+            logGroupClass
+          );
+          const newLogGroup = {
+            [logGroupLogicalId]: {
+              Type: 'AWS::Logs::LogGroup',
+              Properties: {
+                LogGroupName: this.provider.naming.getLogGroupName(
+                  functionObject.name,
+                  logGroupClass
+                ),
+              },
+            },
+          };
 
-        const logRetentionInDays =
-          functionObject.logRetentionInDays || this.provider.getLogRetentionInDays();
-        if (logRetentionInDays) {
-          newLogGroup[logGroupLogicalId].Properties.RetentionInDays = logRetentionInDays;
-        }
+          if (functionLogGroupClass || changeableLogGroupClass) {
+            newLogGroup[logGroupLogicalId].Properties.LogGroupClass = logGroupClass;
+          }
 
-        const logDataProtectionPolicy =
-          functionObject.logDataProtectionPolicy || this.provider.getLogDataProtectionPolicy();
-        if (logDataProtectionPolicy) {
-          newLogGroup[logGroupLogicalId].Properties.DataProtectionPolicy = logDataProtectionPolicy;
-        }
+          const logRetentionInDays =
+            functionObject.logRetentionInDays || this.provider.getLogRetentionInDays();
+          if (logRetentionInDays) {
+            newLogGroup[logGroupLogicalId].Properties.RetentionInDays = logRetentionInDays;
+          }
 
-        _.merge(
-          this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
-          newLogGroup
-        );
+          const logDataProtectionPolicy =
+            functionObject.logDataProtectionPolicy || this.provider.getLogDataProtectionPolicy();
+          if (logDataProtectionPolicy) {
+            newLogGroup[logGroupLogicalId].Properties.DataProtectionPolicy =
+              logDataProtectionPolicy;
+          }
+
+          _.merge(
+            this.serverless.service.provider.compiledCloudFormationTemplate.Resources,
+            newLogGroup
+          );
+        }
       });
 
     const iamRole = _.get(this.serverless.service.provider.iam, 'role', {});
@@ -113,7 +134,6 @@ module.exports = {
     const canonicalFunctionNamePrefix = `${
       this.provider.serverless.service.service
     }-${this.provider.getStage()}`;
-    const logGroupsPrefix = this.provider.naming.getLogGroupName(canonicalFunctionNamePrefix);
 
     const policyDocumentStatements =
       this.serverless.service.provider.compiledCloudFormationTemplate.Resources[
@@ -125,11 +145,14 @@ module.exports = {
 
     // Ensure policies for functions with custom name resolution
     this.serverless.service.getAllFunctions().forEach((functionName) => {
-      const { name: resolvedFunctionName, disableLogs: areLogsDisabled } =
-        this.serverless.service.getFunction(functionName);
+      const {
+        name: resolvedFunctionName,
+        disableLogs: areLogsDisabled,
+        logGroupClass: functionLogGroupClass,
+      } = this.serverless.service.getFunction(functionName);
       if (!resolvedFunctionName || resolvedFunctionName.startsWith(canonicalFunctionNamePrefix)) {
         if (areLogsDisabled) {
-          disableLogsCanonicallyNamedFunctions.push(resolvedFunctionName);
+          disableLogsCanonicallyNamedFunctions.push({ resolvedFunctionName, functionName });
         } else {
           hasOneOrMoreCanonicallyNamedFunctions = true;
         }
@@ -137,8 +160,11 @@ module.exports = {
       }
 
       if (!areLogsDisabled) {
-        const customFunctionNamelogGroupsPrefix =
-          this.provider.naming.getLogGroupName(resolvedFunctionName);
+        const logGroupClass = functionLogGroupClass || this.provider.getLogGroupClass();
+        const customFunctionNamelogGroupsPrefix = this.provider.naming.getLogGroupName(
+          resolvedFunctionName,
+          logGroupClass
+        );
 
         policyDocumentStatements[0].Resource.push({
           'Fn::Sub':
@@ -155,27 +181,38 @@ module.exports = {
     });
 
     if (hasOneOrMoreCanonicallyNamedFunctions) {
+      const logGroupsPrefixPattern = this.provider.naming.getLogGroupName(
+        `*${canonicalFunctionNamePrefix}`
+      );
       // Ensure general policies for functions with default name resolution
       policyDocumentStatements[0].Resource.push({
         'Fn::Sub':
           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-          `:log-group:${logGroupsPrefix}*:*`,
+          `:log-group:${logGroupsPrefixPattern}*:*`,
       });
 
       policyDocumentStatements[1].Resource.push({
         'Fn::Sub':
           'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-          `:log-group:${logGroupsPrefix}*:*:*`,
+          `:log-group:${logGroupsPrefixPattern}*:*:*`,
       });
       if (disableLogsCanonicallyNamedFunctions.length > 0) {
         // add deny rule for disabled logs function
-        const arnOfDisableLogGroups = disableLogsCanonicallyNamedFunctions.map((functionName) => {
-          return {
-            'Fn::Sub':
-              'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
-              `:log-group:${this.provider.naming.getLogGroupName(functionName)}:*`,
-          };
-        });
+        const arnOfDisableLogGroups = disableLogsCanonicallyNamedFunctions.map(
+          ({ resolvedFunctionName, functionName }) => {
+            const logGroupClass =
+              this.serverless.service.getFunction(functionName).logGroupClass ||
+              this.provider.getLogGroupClass();
+            return {
+              'Fn::Sub':
+                'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}' +
+                `:log-group:${this.provider.naming.getLogGroupName(
+                  resolvedFunctionName,
+                  logGroupClass
+                )}:*`,
+            };
+          }
+        );
         this.mergeStatements([
           {
             Effect: 'Deny',

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -698,7 +698,7 @@ class AwsProvider {
           },
           awsLogGroupClass: {
             type: 'string',
-            enum: ['STANDARD', 'INFREQUENT_ACCESS']
+            enum: ['STANDARD', 'INFREQUENT_ACCESS'],
           },
           awsLogGroupName: {
             type: 'string',
@@ -887,6 +887,7 @@ class AwsProvider {
             },
             apiName: { type: 'string' },
             architecture: { $ref: '#/definitions/awsLambdaArchitecture' },
+            changeableLogGroupClass: { type: 'boolean' },
             cfnRole: { $ref: '#/definitions/awsArn' },
             cloudFront: {
               type: 'object',
@@ -1338,6 +1339,7 @@ class AwsProvider {
           properties: {
             architecture: { $ref: '#/definitions/awsLambdaArchitecture' },
             awsKmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
+            changeableLogGroupClass: { type: 'boolean' },
             condition: { $ref: '#/definitions/awsResourceCondition' },
             dependsOn: { $ref: '#/definitions/awsResourceDependsOn' },
             description: { type: 'string', maxLength: 256 },
@@ -1962,6 +1964,10 @@ class AwsProvider {
     }
 
     return provider.alb.targetGroupPrefix;
+  }
+
+  getChangeableLogGroupClass() {
+    return this.serverless.service.provider.changeableLogGroupClass;
   }
 
   getLogGroupClass() {

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -696,6 +696,10 @@ class AwsProvider {
             type: 'string',
             pattern: '^[#A-Za-z0-9-_./]+[*]?$',
           },
+          awsLogGroupClass: {
+            type: 'string',
+            enum: ['STANDARD', 'INFREQUENT_ACCESS']
+          },
           awsLogGroupName: {
             type: 'string',
             pattern: '^[/#A-Za-z0-9-_.]+$',
@@ -1146,6 +1150,9 @@ class AwsProvider {
               enum: ['20200924', '20201221'],
             },
             layers: { $ref: '#/definitions/awsLambdaLayers' },
+            logGroupClass: {
+              $ref: '#/definitions/awsLogGroupClass',
+            },
             logRetentionInDays: {
               $ref: '#/definitions/awsLogRetentionInDays',
             },
@@ -1430,6 +1437,9 @@ class AwsProvider {
             kmsKeyArn: { $ref: '#/definitions/awsKmsArn' },
             snapStart: { type: 'boolean' },
             layers: { $ref: '#/definitions/awsLambdaLayers' },
+            logGroupClass: {
+              $ref: '#/definitions/awsLogGroupClass',
+            },
             logRetentionInDays: {
               $ref: '#/definitions/awsLogRetentionInDays',
             },
@@ -1952,6 +1962,10 @@ class AwsProvider {
     }
 
     return provider.alb.targetGroupPrefix;
+  }
+
+  getLogGroupClass() {
+    return this.serverless.service.provider.logGroupClass;
   }
 
   getLogRetentionInDays() {

--- a/test/fixtures/programmatic/http-api/serverless.yml
+++ b/test/fixtures/programmatic/http-api/serverless.yml
@@ -6,6 +6,7 @@ frameworkVersion: '*'
 provider:
   name: aws
   runtime: nodejs16.x
+  logGroupClass: 'STANDARD'
   logRetentionInDays: 14
 
 functions:

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/stage/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/stage/index.test.js
@@ -264,6 +264,23 @@ describe('#compileStage()', () => {
       });
     });
 
+    it('should set log group class if provider.logGroupClass is set', async () => {
+      serverless.service.provider.logGroupClass = 'INFREQUENT_ACCESS';
+
+      return awsCompileApigEvents.compileStage().then(() => {
+        const resources =
+          awsCompileApigEvents.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+
+        expect(resources[logGroupLogicalId]).to.deep.equal({
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            LogGroupName: '/aws/api-gateway/my-service-dev',
+            LogGroupClass: serverless.service.provider.logGroupClass,
+          },
+        });
+      });
+    });
+
     it('should set log retention if provider.logRetentionInDays is set', async () => {
       serverless.service.provider.logRetentionInDays = 30;
 

--- a/test/unit/lib/plugins/aws/package/compile/events/http-api.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/http-api.test.js
@@ -262,6 +262,7 @@ describe('lib/plugins/aws/package/compile/events/httpApi.test.js', () => {
     it('should configure log group resource', () => {
       expect(cfLogGroup.Type).to.equal('AWS::Logs::LogGroup');
       expect(cfLogGroup.Properties).to.have.property('LogGroupName');
+      expect(cfLogGroup.Properties).to.have.property('LogGroupClass');
       expect(cfLogGroup.Properties).to.have.property('RetentionInDays');
     });
 

--- a/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/websockets/lib/stage.test.js
@@ -131,6 +131,24 @@ describe('#compileStage()', () => {
         });
       }));
 
+    it('should set a LogGroupClass in a Log Group if provider has logGroupClass', async () => {
+      awsCompileWebsocketsEvents.serverless.service.provider.logGroupClass = 'INFREQUENT_ACCESS';
+
+      return awsCompileWebsocketsEvents.compileStage().then(() => {
+        const resources =
+          awsCompileWebsocketsEvents.serverless.service.provider.compiledCloudFormationTemplate
+            .Resources;
+
+        expect(resources[logGroupLogicalId]).to.deep.equal({
+          Type: 'AWS::Logs::LogGroup',
+          Properties: {
+            LogGroupName: '/aws/websocket/my-service-dev',
+            LogGroupClass: awsCompileWebsocketsEvents.serverless.service.provider.logGroupClass,
+          },
+        });
+      });
+    });
+
     it('should set a RetentionInDays in a Log Group if provider has logRetentionInDays', async () => {
       awsCompileWebsocketsEvents.serverless.service.provider.logRetentionInDays = 42;
 

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1668,6 +1668,10 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
               },
             },
             fnDisabledLogs: { handler: 'trigger.handler', disableLogs: true },
+            fnChangeableLogGroupClass: {
+              handler: 'trigger.handler',
+              changeableLogGroupClass: true,
+            },
             fnMaximumEventAge: { handler: 'trigger.handler', maximumEventAge: 3600 },
             fnMaximumRetryAttempts: { handler: 'trigger.handler', maximumRetryAttempts: 0 },
             fnFileSystemConfig: {
@@ -2226,6 +2230,22 @@ describe('lib/plugins/aws/package/compile/functions/index.test.js', () => {
       expect(cfResources[naming.getLambdaLogicalId('fnDisabledLogs')]).to.not.have.property(
         'DependsOn'
       );
+    });
+
+    it('should support `functions[].changeableLogGroupClass`', () => {
+      const standardLogGroup =
+        cfResources[naming.getLogGroupLogicalId('fnChangeableLogGroupClass', 'STANDARD')].Properties
+          .LogGroupName;
+      const infrequentAccessLogGroup =
+        cfResources[naming.getLogGroupLogicalId('fnChangeableLogGroupClass', 'INFREQUENT_ACCESS')]
+          .Properties.LogGroupName;
+
+      expect(standardLogGroup)
+        .to.be.a('string')
+        .and.not.satisfy((name) => name.startsWith('/aws/lambda/ia/'));
+      expect(infrequentAccessLogGroup)
+        .to.be.a('string')
+        .and.satisfy((name) => name.startsWith('/aws/lambda/ia/'));
     });
 
     it('should support `functions[].maximumEventAge`', () => {

--- a/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
@@ -195,6 +195,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
                 securityGroupIds: ['xxx'],
                 subnetIds: ['xxx'],
               },
+              logGroupClass: 'STANDARD',
               logRetentionInDays: 5,
               iamManagedPolicies: [
                 'arn:aws:iam::123456789012:user/*',
@@ -307,6 +308,7 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
                 securityGroupIds: ['xxx'],
                 subnetIds: ['xxx'],
               },
+              logGroupClass: 'STANDARD',
               logRetentionInDays: 5,
               logDataProtectionPolicy: {
                 Name: 'data-protection-policy',
@@ -428,6 +430,14 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         });
       });
 
+      it('should support `provider.logGroupClass`', () => {
+        const normalizedName = naming.getLogGroupLogicalId('basic');
+        const iamResource = cfResources[normalizedName];
+        expect(iamResource.Type).to.be.equal('AWS::Logs::LogGroup');
+        expect(iamResource.Properties.LogGroupClass).to.be.equal('STANDARD');
+        expect(iamResource.Properties.LogGroupName).to.be.equal(`/aws/lambda/${service}-dev-basic`);
+      });
+
       it('should support `provider.logRetentionInDays`', () => {
         const normalizedName = naming.getLogGroupLogicalId('basic');
         const iamResource = cfResources[normalizedName];
@@ -486,6 +496,10 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
                 handler: 'index.handler',
                 disableLogs: true,
               },
+              fnLogGroupClass: {
+                handler: 'index.handler',
+                logGroupClass: 'STANDARD',
+              },
               fnLogRetentionInDays: {
                 handler: 'index.handler',
                 logRetentionInDays: 5,
@@ -538,6 +552,18 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
         const functionLogGroupName = naming.getLogGroupName(functionName);
 
         expect(cfResources).to.not.have.property(functionLogGroupName);
+      });
+
+      it('should support `functions[].logGroupClass`', async () => {
+        const functionName = serverless.service.getFunction('fnLogGroupClass').name;
+        const normalizedName = naming.getLogGroupLogicalId('fnLogGroupClass');
+        const logResource = cfResources[normalizedName];
+
+        expect(logResource.Type).to.be.equal('AWS::Logs::LogGroup');
+        expect(logResource.Properties.LogGroupClass).to.be.equal('STANDARD');
+        expect(logResource.Properties.LogGroupName).to.be.equal(
+          naming.getLogGroupName(functionName)
+        );
       });
 
       it('should support `functions[].logRetentionInDays`', async () => {

--- a/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
+++ b/test/unit/lib/plugins/aws/package/lib/merge-iam-templates.test.js
@@ -122,14 +122,14 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           'logs:TagResource',
         ]);
         expect(createLogStatement.Resource).to.deep.includes({
-          'Fn::Sub': `${arnLogPrefix}:log-group:/aws/lambda/${service}-dev*:*`,
+          'Fn::Sub': `${arnLogPrefix}:log-group:/aws/lambda/*${service}-dev*:*`,
         });
 
         const putLogStatement = Properties.Policies[0].PolicyDocument.Statement[1];
         expect(putLogStatement.Effect).to.be.equal('Allow');
         expect(putLogStatement.Action).to.be.deep.equal(['logs:PutLogEvents']);
         expect(putLogStatement.Resource).to.deep.includes({
-          'Fn::Sub': `${arnLogPrefix}:log-group:/aws/lambda/${service}-dev*:*:*`,
+          'Fn::Sub': `${arnLogPrefix}:log-group:/aws/lambda/*${service}-dev*:*:*`,
         });
       });
 
@@ -492,6 +492,10 @@ describe('lib/plugins/aws/package/lib/mergeIamTemplates.test.js', () => {
           command: 'package',
           configExt: {
             functions: {
+              fnChangeableLogGroupClass: {
+                handler: 'index.handler',
+                changeableLogGroupClass: true,
+              },
               fnDisableLogs: {
                 handler: 'index.handler',
                 disableLogs: true,


### PR DESCRIPTION
Adds support for setting cloudwatch log group log class since this can now this can be set to Standard or Infrequent Access:  
https://aws.amazon.com/blogs/aws/new-amazon-cloudwatch-log-class-for-infrequent-access-logs-at-a-reduced-price/

Closes issue https://github.com/serverless/serverless/issues/12278