### PR TITLE
fix: custom resource runtime upgrade

### DIFF
--- a/lib/plugins/aws/customResources/index.js
+++ b/lib/plugins/aws/customResources/index.js
@@ -173,7 +173,7 @@ async function addCustomResourceToService(awsProvider, resourceName, iamRoleStat
       FunctionName: absoluteFunctionName,
       Handler,
       MemorySize: 1024,
-      Runtime: 'nodejs16.x',
+      Runtime: 'nodejs18.x',
       Timeout: 180,
     },
     DependsOn: [],

--- a/test/unit/lib/plugins/aws/customResources/index.test.js
+++ b/test/unit/lib/plugins/aws/customResources/index.test.js
@@ -109,7 +109,7 @@ describe('#addCustomResourceToService()', () => {
           Role: {
             'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
           },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 180,
         },
         DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
@@ -128,7 +128,7 @@ describe('#addCustomResourceToService()', () => {
           Role: {
             'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
           },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 180,
         },
         DependsOn: ['IamRoleCustomResourcesLambdaExecution'],
@@ -147,7 +147,7 @@ describe('#addCustomResourceToService()', () => {
           Role: {
             'Fn::GetAtt': ['IamRoleCustomResourcesLambdaExecution', 'Arn'],
           },
-          Runtime: 'nodejs16.x',
+          Runtime: 'nodejs18.x',
           Timeout: 180,
         },
         DependsOn: ['IamRoleCustomResourcesLambdaExecution'],


### PR DESCRIPTION
AWS is deprecating the node js v16 lambda runtime. This PR upgrades to node 18.

Reading the contribution guide lines here: https://github.com/talis/serverless/blob/main/CONTRIBUTING.md#when-you-propose-a-new-feature-or-bug-fix

> There are just a few situations (listed below) in which it is fine to submit PR without a corresponding issue:
>
> - Documentation update
> - Obvious bug fix
> - Maintenance improvement

I'm classifying this as an "Obvious bug fix/Maintenance improvement" - so there is not an issue number linked to this PR.

This is very similar to https://github.com/serverless/serverless/pull/12055 which bumped the version from 12 to 16.
