### PR TITLE
fix: Add minimal AWS IAM permissions

### DIFF
--- a/docs/guides/dashboard/providers.md
+++ b/docs/guides/dashboard/providers.md
@@ -173,7 +173,14 @@ If you are create a custom IAM Role with this policy, you will need to add a Tru
                 "sts:GetCallerIdentity",
                 "lambda:RemovePermission",
                 "s3:GetBucketLocation",
-                "lambda:GetPolicy"
+                "lambda:GetPolicy",
+                "apigateway:TagResource",
+                "iam:TagRole",
+                "lambda:TagResource",
+                "cloudformation:CreateChangeSet",
+                "cloudformation:DescribeChangeSet",
+                "cloudformation:ExecuteChangeSet",
+                "cloudformation:DeleteChangeSet"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
docs only: Add tagging and changeset actions necessary for running the minimal sample

This update reflects new permissions required for the AWS provider to allow tagging resources, and managing changesets (the default deployment method in Serverless v3)