### PR TITLE
Add support for externally managed websocket event authorizers 

### DIFF
--- a/docs/providers/aws/events/websocket.md
+++ b/docs/providers/aws/events/websocket.md
@@ -117,7 +117,7 @@ functions:
     handler: handler.auth
 ```
 
-Or, if your authorizer function is not managed by this service, you can provide an arn instead:
+You also can provide an arn:
 
 ```yml
 functions:
@@ -127,6 +127,19 @@ functions:
       - websocket:
           route: $connect
           authorizer: arn:aws:lambda:us-east-1:1234567890:function:auth
+```
+
+If your authorizer is externally managed (not run by this service), you can use `managedExternally` to skip permission creation:
+```yml
+functions:
+  connectHandler:
+    handler: handler.connectHandler
+    events:
+      - websocket:
+          route: $connect
+          authorizer: 
+            arn: arn:aws:lambda:us-east-1:1234567890:function:auth
+            managedExternally: true
 ```
 
 By default, the `identitySource` property is set to `route.request.header.Auth`, meaning that your request must include the auth token in the `Auth` header of the request. You can overwrite this by specifying your own `identitySource` configuration:

--- a/lib/plugins/aws/package/compile/events/websockets/index.js
+++ b/lib/plugins/aws/package/compile/events/websockets/index.js
@@ -71,6 +71,7 @@ class AwsCompileWebsockets {
                     name: { $ref: '#/definitions/functionName' },
                     arn: { $ref: '#/definitions/awsArn' },
                     identitySource: { type: 'array', items: { type: 'string' } },
+                    managedExternally: { type: 'boolean' },
                   },
                   anyOf: [{ required: ['name'] }, { required: ['arn'] }],
                   additionalProperties: false,

--- a/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/permissions.js
@@ -6,6 +6,8 @@ const resolveLambdaTarget = require('../../../../../utils/resolve-lambda-target'
 module.exports = {
   compilePermissions() {
     this.validated.events.forEach((event) => {
+      if (event.authorizer && event.authorizer.managedExternally) return;
+
       const websocketApiId = this.provider.getApiGatewayWebsocketApiId();
       const lambdaLogicalId = this.provider.naming.getLambdaLogicalId(event.functionName);
       const functionObj = this.serverless.service.getFunction(event.functionName);

--- a/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/websockets/lib/validate.js
@@ -139,6 +139,10 @@ module.exports = {
               } else {
                 websocketObj.authorizer.identitySource = event.websocket.authorizer.identitySource;
               }
+
+              if (event.websocket.authorizer.managedExternally){
+                websocketObj.authorizer.managedExternally = true;
+              }
             }
             events.push(websocketObj);
             // dealing with the simplified string representation


### PR DESCRIPTION
Externally managed authorizers (like cross account) for a Websocket $connect route seems to create an invalid permission, causing deployment to fail. I found out that this is because although the documentation seems to suggest that cross-account lambda authorizers are supported with websocket, they currently aren't. The code always creates permissions instead of skipping them as is done with http api.

This small PR adds code to not generate a warning anymore when you use "managedExternally" in "authorizers"  since it exists now as well as code to detect that property and skip creating permissions. It also adds a documentation update to reflect that this is supported now more clearly.

I tried my best to follow CONTRIBUTING.md. If I did something wrong please let me know. I thought that this bug fix was simple enough to not warrant an issue. I consider it a bug fix because the documentation seems to imply that this is normally possible, but it wasn't:
![image](https://github.com/serverless/serverless/assets/16566003/2a33523e-4cf2-4d12-bb5a-fdd7668bdb57)