### PR TITLE
feat(AWS Schedule): Support groupName for scheduler method

### DIFF
--- a/docs/providers/aws/events/schedule.md
+++ b/docs/providers/aws/events/schedule.md
@@ -116,3 +116,14 @@ functions:
             key1: value1
             key2: value2
 ```
+
+You can configure a scheduler group for the schedules with the property `groupName` which can be either the name of or a ref to an existing group. You can create the schedule group as a resource.
+
+```yaml
+resources:
+  Resources:
+    - SchedulerGroup:
+      Type: AWS::Scheduler::ScheduleGroup
+      Properties:
+        Name: ${self:service}-${sls:stage}
+```

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -42,7 +42,12 @@ class AwsCompileScheduledEvents {
             enabled: { type: 'boolean' },
             name: { type: 'string', minLength: 1, maxLength: 64, pattern: '[\\.\\-_A-Za-z0-9]+' },
             description: { type: 'string', maxLength: 512 },
-            groupName: { type: 'string', maxLength: 64, pattern: '[\\.\\-_A-Za-z0-9]+' },
+            groupName: {
+              anyOf: [
+                { $ref: '#/definitions/awsCfFunction' },
+                { type: 'string', maxLength: 64, pattern: '[\\.\\-_A-Za-z0-9]+' },
+              ],
+            },
             input: {
               anyOf: [
                 { type: 'string', maxLength: 8192 },

--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -42,6 +42,7 @@ class AwsCompileScheduledEvents {
             enabled: { type: 'boolean' },
             name: { type: 'string', minLength: 1, maxLength: 64, pattern: '[\\.\\-_A-Za-z0-9]+' },
             description: { type: 'string', maxLength: 512 },
+            groupName: { type: 'string', maxLength: 64, pattern: '[\\.\\-_A-Za-z0-9]+' },
             input: {
               anyOf: [
                 { type: 'string', maxLength: 8192 },
@@ -114,6 +115,7 @@ class AwsCompileScheduledEvents {
           if (event.schedule) {
             let ScheduleExpressions;
             let State;
+            let GroupName;
             let Input;
             let InputPath;
             let InputTransformer;
@@ -130,6 +132,7 @@ class AwsCompileScheduledEvents {
               if (event.schedule.enabled === false) {
                 State = 'DISABLED';
               }
+              GroupName = event.schedule.groupName;
               Input = event.schedule.input;
               InputPath = event.schedule.inputPath;
               InputTransformer = event.schedule.inputTransformer;
@@ -148,6 +151,13 @@ class AwsCompileScheduledEvents {
                 throw new ServerlessError(
                   'You cannot specify a name when defining more than one rate expression',
                   'SCHEDULE_NAME_NOT_ALLOWED_MULTIPLE_RATES'
+                );
+              }
+
+              if (GroupName && method !== METHOD_SCHEDULER) {
+                throw new ServerlessError(
+                  'Cannot setup "schedule" event: "groupName" is only supported with "scheduler" mode',
+                  'SCHEDULE_PARAMETER_NOT_SUPPORTED'
                 );
               }
 
@@ -226,6 +236,7 @@ class AwsCompileScheduledEvents {
                     Name,
                     Description,
                     ScheduleExpressionTimezone: timezone,
+                    GroupName,
                   },
                 };
               } else {

--- a/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/schedule.test.js
@@ -122,6 +122,7 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
             method: METHOD_SCHEDULER,
             name: 'scheduler-scheduled-event',
             description: 'Scheduler Scheduled Event',
+            groupName: 'Scheduler Group Name',
             input: '{"key":"array"}',
           },
         },
@@ -217,6 +218,19 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
       expect(scheduleCfResources[7].Properties.Description).to.be.undefined;
       expect(scheduleCfResources[8].Properties.Description).to.equal('Scheduler Scheduled Event');
       expect(scheduleCfResources[9].Properties.Description).to.be.undefined;
+    });
+
+    it('should respect the "groupName" variable', () => {
+      expect(scheduleCfResources[0].Properties.GroupName).to.be.undefined;
+      expect(scheduleCfResources[1].Properties.GroupName).to.be.undefined;
+      expect(scheduleCfResources[2].Properties.GroupName).to.be.undefined;
+      expect(scheduleCfResources[3].Properties.GroupName).to.be.undefined;
+      expect(scheduleCfResources[4].Properties.GroupName).to.be.undefined;
+      expect(scheduleCfResources[5].Properties.GroupName).to.be.undefined;
+      expect(scheduleCfResources[6].Properties.GroupName).to.be.undefined;
+      expect(scheduleCfResources[7].Properties.GroupName).to.be.undefined;
+      expect(scheduleCfResources[8].Properties.GroupName).to.be.equal('Scheduler Group Name');
+      expect(scheduleCfResources[9].Properties.GroupName).to.be.undefined;
     });
 
     it('should respect the "inputPath" variable', () => {
@@ -315,6 +329,22 @@ describe('test/unit/lib/plugins/aws/package/compile/events/schedule.test.js', ()
       ServerlessError,
       'You cannot specify a name when defining more than one rate expression'
     );
+  });
+
+  it('should throw when passing "groupName" to method:eventBus resources', async () => {
+    const events = [
+      {
+        schedule: {
+          rate: 'rate(15 minutes)',
+          method: METHOD_EVENT_BUS,
+          groupName: 'Group Name',
+        },
+      },
+    ];
+
+    await expect(run(events))
+      .to.be.eventually.rejectedWith(ServerlessError)
+      .and.have.property('code', 'SCHEDULE_PARAMETER_NOT_SUPPORTED');
   });
 
   it('should throw when passing "inputPath" to method:schedule resources', async () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #12319

Allows users to specify a schedule group for schedule events with method `scheduler` in AWS.

For convenience, we could create a schedule group, if none with the given name exists, rather than relying on the user to create one as a resource. Since I believe the common use case is to have more than one schedule in the same group, referring to the group as `!Ref SchedulerGroup` should be preferred and that is cleaner when users define the group themselves.