### PR TITLE
12381 Update kafka.js to support onfailure destination for kafka events

### DIFF
--- a/lib/plugins/aws/package/compile/events/kafka.js
+++ b/lib/plugins/aws/package/compile/events/kafka.js
@@ -100,6 +100,17 @@ class AwsCompileKafkaEvents {
           pattern: '[a-zA-Z0-9-/*:_+=.@-]*',
         },
         filterPatterns: { $ref: '#/definitions/filterPatterns' },
+        destinations: {
+          type: 'object',
+          properties: {
+            onFailure: {
+              type: 'string',
+              maxLength: 200,
+            },
+          },
+          additionalProperties: false,
+          required: ['onFailure'],
+        },
       },
       additionalProperties: false,
       required: ['accessConfigurations', 'bootstrapServers', 'topic'],
@@ -267,6 +278,17 @@ class AwsCompileKafkaEvents {
             Filters: filterPatterns.map((pattern) => ({
               Pattern: JSON.stringify(pattern),
             })),
+          };
+        }
+
+        const destinations = event.kafka.destinations;
+        if (destinations) {
+          let OnFailureDestinationArn = event.kafka.destinations.onFailure;
+
+          kafkaResource.Properties.DestinationConfig = {
+            OnFailure: {
+              Destination: OnFailureDestinationArn,
+            },
           };
         }
 


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #12381
