### PR TITLE
Provide bucket name

### DIFF
--- a/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
+++ b/lib/plugins/aws/deploy/lib/ensure-valid-bucket-exists.js
@@ -54,7 +54,7 @@ module.exports = {
       if (!(await this.checkIfBucketExists(this.bucketName))) {
         // It means that bucket was removed manually but is still a part of the CloudFormation stack, we cannot manually fix it
         throw new ServerlessError(
-          'Deployment bucket has been removed manually. Please recreate it or remove your service and attempt to deploy it again',
+          `Deployment bucket (${this.bucketName}) has been removed manually. Please recreate it or remove your service and attempt to deploy it again`,
           'DEPLOYMENT_BUCKET_REMOVED_MANUALLY'
         );
       }


### PR DESCRIPTION
Bugfix to print the bucket name if it doesn't exist. Without this information it is not possible to create the bucket manually.

Found this bug after trying to remove a AWS Lambda function which failed. I needed the bucket name to create it manually in the AWS Console. 