### PR TITLE
fix: use require.resolve to find plugins

### DIFF
--- a/lib/classes/plugin-manager.js
+++ b/lib/classes/plugin-manager.js
@@ -4,7 +4,7 @@ import utils from '@serverlessinc/sf-core/src/utils.js';
 import ServerlessError from '../serverless-error.js';
 import renderCommandHelp from '../cli/render-help/command.js';
 import tokenizeException from '../utils/tokenize-exception.js';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { fileURLToPath } from 'url';
 // Load Plugins
 import pluginPackage from '../plugins/package/package.js';
 import pluginDeploy from '../plugins/deploy.js';
@@ -59,6 +59,7 @@ import pluginAwsDeployFunction from '../plugins/aws/deploy-function.js';
 import pluginAwsDeployList from '../plugins/aws/deploy-list.js';
 import pluginAwsInvokeLocal from '../plugins/aws/invoke-local/index.js';
 import pluginEsbuild from '../plugins/esbuild/index.js';
+import { createRequire } from 'module';
 
 const { log, getPluginWriters, readFile } = utils;
 
@@ -173,11 +174,9 @@ class PluginManager {
 
     this.cliOptions = {};
     this.cliCommands = [];
-    this.pluginIndependentCommands = new Set(['help', 'plugin']);
 
     this.plugins = [];
     this.externalPlugins = new Set();
-    this.localPluginsPaths = [];
     this.commands = {};
     this.aliases = {};
     this.hooks = {};
@@ -254,7 +253,6 @@ class PluginManager {
     const reorderedServicePlugins = this.sortServicePlugins(resolvedServicePlugins);
     reorderedServicePlugins.filter(Boolean).forEach((Plugin) => this.addPlugin(Plugin));
 
-    isRegisteringExternalPlugins = false;
     isRegisteringExternalPlugins = true;
     return this.asyncPluginInit();
   }
@@ -268,64 +266,39 @@ class PluginManager {
    * @returns
    */
   async requireServicePlugin(serviceDir, pluginListedName, legacyLocalPluginsPath) {
+    const logger = log.get('sls:plugins:load');
+
+    const require = async (dir, module) => {
+      try {
+        const require = createRequire(path.resolve(dir, 'require-resolver'));
+        return require.resolve(module);
+      } catch (error) {
+        logger.debug(`Failed to resolve path for module ${module} from ${dir} due to '${error}'`);
+        return null
+      }
+    };
+
     /**
      * Check the Service directory for the plugin.
      * This will check in the node_modules of the service directory
      * and in the service directory itself.
      */
-    const serviceDirRequire = async (dir, module) => {
-      const logger = log.get('sls:plugins:load');
-      // Attempt to construct the full path for local modules or node_modules
-      const fullPath = path.resolve(dir, module);
-      try {
-        // Convert the path to a URL and dynamically import the module
-        const moduleUrl = pathToFileURL(fullPath).href;
-        await import(moduleUrl);
-        return moduleUrl; // Return URL if module can be imported successfully
-      } catch (error) {
-        logger.debug(`Failed to import module ${module} from ${fullPath} due to '${error}'\nTrying to import 'main' file from ${dir}/node_modules/${module}/package.json`);
-        // If direct path import fails, try resolving under node_modules
-        const packageJsonPath = path.resolve(dir, 'node_modules', module, 'package.json');
-        try {
-          const packageJson = await readFile(packageJsonPath);
-          let { main } = JSON.parse(packageJson);
-          if (!main) {
-            main = 'plugin.js';
-          }
-          const pluginPath = path.resolve(dir, 'node_modules', module, main);
-          const pluginUrl = pathToFileURL(pluginPath).href;
-          await import(pluginUrl);
-          return pluginUrl; // Return URL if module can be imported successfully
-        } catch (error) {
-          logger.debug(`Failed to import module ${module} due to '${error}'`);
-          throw Object.assign(new Error('Plugin not found'), { code: 'PLUGIN_NOT_FOUND' });
-        }
-      }
-    };
-
-    const localPluginPath = await serviceDirRequire(serviceDir, pluginListedName);
-
+    const localPluginPath = await require(serviceDir, pluginListedName);
     if (localPluginPath) {
-      if (pluginListedName.startsWith('./')) {
-        this.localPluginsPaths.push({
-          resolvedPath: fileURLToPath(localPluginPath),
-          inputPath: pluginListedName,
-        });
-      }
-      return import(localPluginPath);
+      return await import(localPluginPath);
     }
 
     /**
      * Search in the Framework's node_modules
      */
-    const externalPluginPath = await (async () => {
-      try {
-        return await import(pluginListedName);
-      } catch (error) {
-        throw Object.assign(new Error('Plugin not found'), { code: 'PLUGIN_NOT_FOUND' });
-      }
-    })();
-    return import(externalPluginPath);
+    const externalPluginPath = await require(fileURLToPath(import.meta.url), pluginListedName);
+    if (!externalPluginPath) {
+      throw new ServerlessError(
+        `Serverless plugin "${pluginListedName}" not found.`,
+        'PLUGIN_NOT_FOUND'
+      );
+    }
+    return await import(externalPluginPath);
   }
 
   async resolveServicePlugins(servicePlugs) {
@@ -384,29 +357,6 @@ class PluginManager {
 
     // Sort by prioritizing build plugins first, then the rest of the plugins
     return [...prioritized, ...rest];
-  }
-
-  getLocalPluginsPathPatterns() {
-    return this.localPluginsPaths
-      .map(({ resolvedPath, inputPath }) => {
-        const absoluteInputPath = path.resolve(this.serverless.serviceDir, inputPath);
-        if (
-          absoluteInputPath === resolvedPath ||
-          absoluteInputPath + path.extname(resolvedPath) === resolvedPath
-        ) {
-          return path.relative(this.serverless.serviceDir, resolvedPath);
-        }
-
-        if (resolvedPath.startsWith(absoluteInputPath + path.sep)) {
-          return path.relative(
-            this.serverless.serviceDir,
-            path.join(path.dirname(resolvedPath), '/**')
-          );
-        }
-
-        return null;
-      })
-      .filter((v) => v !== null);
   }
 
   parsePluginsObject(servicePlugs) {


### PR DESCRIPTION
* utilize [createRequire](https://nodejs.org/api/module.html#modulecreaterequirefilename) and [require.resolve](https://nodejs.org/api/modules.html#requireresolverequest-options)  to find plugins in the same manner as in v3
* remove unused fields `pluginIndependentCommands`, `localPluginsPaths` and the method `getLocalPluginsPathPatterns` from the `PluginManager` class to streamline the codebase