### PR TITLE
fix: check if config file is present

### DIFF
--- a/lib/plugins/esbuild/index.js
+++ b/lib/plugins/esbuild/index.js
@@ -138,7 +138,7 @@ class Esbuild {
     serviceDir,
     handlerPropertyName = 'handler',
   ) {
-    if (configFile.build?.esbuild === false) {
+    if (!configFile || configFile?.build?.esbuild === false) {
       return false
     }
 


### PR DESCRIPTION
It throws an exception when running a command that doesn’t require a config file to be present.