### PR TITLE
fix: help command

### DIFF
--- a/lib/cli/commands-schema.js
+++ b/lib/cli/commands-schema.js
@@ -65,6 +65,12 @@ commands.set('print', {
   serviceDependencyMode: 'required',
 })
 
+commands.set('help', {
+  usage: 'Display Help',
+  options: {},
+  serviceDependencyMode: 'optional',
+})
+
 commands.set('package', {
   usage: 'Packages a Serverless Service',
   hasAwsExtension: true,


### PR DESCRIPTION
The help command seems to be completely broken. This fixes it.

<img width="708" alt="Screen Shot 2024-06-14 at 4 15 17 PM" src="https://github.com/serverless/serverless/assets/2312463/86248b73-1200-4e58-aa23-44f6ce1e473b">
