### PR TITLE
fix(dev): ensure a hyphen for each logged line

### DIFF
--- a/lib/plugins/aws/dev/local-lambda/index.js
+++ b/lib/plugins/aws/dev/local-lambda/index.js
@@ -187,9 +187,11 @@ class LocalLambda {
 
       // Write standard output
       child.stdout.on('data', (data) => {
-        logger.notice(
-          `${this.invocationColorFn('─')} ${data.toString().trim()}`,
-        )
+        const dataString = data.toString().trim()
+
+        dataString.split('\n').forEach((line) => {
+          logger.notice(`${this.invocationColorFn('─')} ${line}`)
+        })
       })
 
       // Write error output


### PR DESCRIPTION
Closes #12581

## Before
<img width="1188" alt="Screen Shot 2024-06-20 at 5 17 42 PM" src="https://github.com/serverless/serverless/assets/2312463/32aae492-a9b9-4631-bdd4-049262c7ff51">

## After
<img width="1186" alt="Screen Shot 2024-06-20 at 5 20 54 PM" src="https://github.com/serverless/serverless/assets/2312463/6075fa68-c331-43df-9673-56f1d3132740">
