### PR TITLE
fix(esbuild): do not pass invalid properties to esbuild (SC-2463, SC-2464, SC-2500)

### DIFF
--- a/docs/providers/aws/guide/building.md
+++ b/docs/providers/aws/guide/building.md
@@ -25,12 +25,12 @@ build:
     minify: false
     # NPM packages to not be bundled
     external:
-      - @aws-sdk/client-s3
+      - '@aws-sdk/client-s3'
     # NPM packages to not be bundled, as well as not included in node_modules
     # in the zip file uploaded to Lambda. By default this will be set to aws-sdk
     # if the runtime is set to nodejs16.x or lower or set to @aws-sdk/* if set to nodejs18.x or higher.
     exclude:
-      - @aws-sdk/*
+      - '@aws-sdk/*'
     # The packages config, this can be set to override the behavior of external
     # If this is set then all dependencies will be treated as external and not bundled.
     packages: external

--- a/lib/plugins/esbuild/index.js
+++ b/lib/plugins/esbuild/index.js
@@ -407,7 +407,7 @@ class Esbuild {
                 `.${functionName}`,
                 '',
               )
-              await esbuild.build({
+              const esbuildProps = {
                 ...buildProperties,
                 platform: 'node',
                 ...(buildProperties.bundle === true
@@ -421,7 +421,12 @@ class Esbuild {
                   handlerPath + '.js',
                 ),
                 logLevel: 'error',
-              })
+              }
+
+              // Remove the exclude property from the esbuildProps as it is not a valid esbuild property
+              delete esbuildProps.exclude
+
+              await esbuild.build(esbuildProps)
               if (!this.serverless.builtFunctions) {
                 this.serverless.builtFunctions = new Set()
               }

--- a/lib/plugins/esbuild/index.js
+++ b/lib/plugins/esbuild/index.js
@@ -423,8 +423,9 @@ class Esbuild {
                 logLevel: 'error',
               }
 
-              // Remove the exclude property from the esbuildProps as it is not a valid esbuild property
+              // Remove the following properties from the esbuildProps as they are not valid esbuild properties
               delete esbuildProps.exclude
+              delete esbuildProps.buildConcurrency
 
               await esbuild.build(esbuildProps)
               if (!this.serverless.builtFunctions) {


### PR DESCRIPTION
Fixes:
- https://github.com/serverless/serverless/issues/12645
- https://github.com/serverless/serverless/issues/12617
- https://github.com/serverless/serverless/issues/12616
