### PR TITLE
fix: use LoggingConfig.LogGroup for custom log group

### DIFF
--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -725,7 +725,7 @@ class AwsCompileFunctions {
 
     if (functionObject.logs || this.serverless.service.provider.logs?.lambda) {
       const functionLogConfig = functionObject.logs
-      const providerLogConfig = this.serverless.service.provider.logs.lambda
+      const providerLogConfig = this.serverless.service?.provider?.logs?.lambda
       const applicationLogLevel =
         functionLogConfig?.applicationLogLevel ||
         providerLogConfig?.applicationLogLevel
@@ -744,7 +744,7 @@ class AwsCompileFunctions {
         finalizedLogConfiguration.LogFormat = logFormat
       }
       if (logGroup) {
-        finalizedLogConfiguration.LogFormat = logGroup
+        finalizedLogConfiguration.LogGroup = logGroup
       }
       if (systemLogLevel && logFormat && logFormat === 'JSON') {
         finalizedLogConfiguration.SystemLogLevel = systemLogLevel


### PR DESCRIPTION
The custom logGroup is incorrectly set to the LogFormat key.