### PR TITLE
fix: add custom lambda log group to resource array in iam policy doc

### DIFF
--- a/lib/plugins/aws/package/lib/merge-iam-templates.js
+++ b/lib/plugins/aws/package/lib/merge-iam-templates.js
@@ -148,12 +148,16 @@ export default {
 
     // Ensure policies for functions with custom name resolution
     this.serverless.service.getAllFunctions().forEach((functionName) => {
-      const { name: resolvedFunctionName, disableLogs: areLogsDisabled } =
-        this.serverless.service.getFunction(functionName)
-      if (
-        !resolvedFunctionName ||
-        resolvedFunctionName.startsWith(canonicalFunctionNamePrefix)
-      ) {
+      const {
+        name: resolvedFunctionName,
+        disableLogs: areLogsDisabled,
+        logs: { logGroup: customLogGroupName } = {},
+      } = this.serverless.service.getFunction(functionName)
+      const isDefaultLogGroupName =
+        (!resolvedFunctionName ||
+          resolvedFunctionName.startsWith(canonicalFunctionNamePrefix)) &&
+        !customLogGroupName
+      if (isDefaultLogGroupName) {
         if (areLogsDisabled) {
           disableLogsCanonicallyNamedFunctions.push(resolvedFunctionName)
         } else {
@@ -164,6 +168,7 @@ export default {
 
       if (!areLogsDisabled) {
         const customFunctionNamelogGroupsPrefix =
+          customLogGroupName ??
           this.provider.naming.getLogGroupName(resolvedFunctionName)
 
         policyDocumentStatements[0].Resource.push({


### PR DESCRIPTION
IAM Policy Document for Lambda functions in the service does not take into account the custom log group specified in the `logs.logGroup` key. This PR addresses the issue by adding the custom log group name to the Resource array in the IAM Policy Document, instead of the default log group name, when necessary.