### PR TITLE
docs: add note about not setting type: module when using TS

### DIFF
--- a/docs/providers/aws/guide/building.md
+++ b/docs/providers/aws/guide/building.md
@@ -20,6 +20,8 @@ In Serverless Framework V.4, [esbuild](https://github.com/evanw/esbuild) is incl
 
 By default, if your AWS Lambda handler is using Typescript files directly, the Framework will build your code automagically upon deploy, without a plugin. No configuration is necessary by default.
 
+**Note:** Even though you are writing ESM code, you should not set "type": "module" in your package.json file, as your code will be transpiled to CommonJS.
+
 ### Configuration
 
 V.4 introduces a new `build` configuration block, which you can use to customize [esbuild](https://github.com/evanw/esbuild) settings.


### PR DESCRIPTION
Helps people avoid the following issue:

Closes https://github.com/serverless/serverless/issues/12706