### PR TITLE
Resolves #12770 - Add `UPDATE_FAILED` to 

### DIFF
--- a/lib/plugins/aws/lib/monitor-stack.js
+++ b/lib/plugins/aws/lib/monitor-stack.js
@@ -111,7 +111,7 @@ module.exports = {
                 (!this.options.verbose ||
                   (stackStatus &&
                     (stackStatus.endsWith('ROLLBACK_COMPLETE') ||
-                      ['DELETE_FAILED', 'DELETE_COMPLETE'].includes(stackStatus))))
+                      ['UPDATE_FAILED', 'DELETE_FAILED', 'DELETE_COMPLETE'].includes(stackStatus))))
               ) {
                 const decoratedErrorMessage = `${stackLatestError.ResourceStatus}: ${
                   stackLatestError.LogicalResourceId


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Resolves: #12770

QA
- deployed the sls template in the issue saw without `verbose` and without flag we rollback
- deployed the sls template in the issue saw with `verbose` and without flag we rollback
- deployed the sls template in the issue saw with `verbose` and with flag we didn't rollback
- deployed the sls template in the issue saw without `verbose` and with flag we didn't rollback

