### PR TITLE
Only set default runtime in deploy-function if PackageType is not Image

### DIFF
--- a/lib/plugins/aws/deploy-function.js
+++ b/lib/plugins/aws/deploy-function.js
@@ -308,10 +308,16 @@ class AwsDeployFunction {
       delete params.Timeout
     }
 
-    const runtime = this.provider.getRuntime(functionObj.runtime)
+    // do not apply default runtime if the function is being deployed
+    // using a custom docker image (note that earlier validation has
+    // already checked that the serverless.yml config did not attempt
+    // to specify multiple package types)
+    if (remoteFunctionConfiguration.PackageType !== "Image") {
+      const runtime = this.provider.getRuntime(functionObj.runtime)
 
-    if (runtime !== remoteFunctionConfiguration.Runtime) {
-      params.Runtime = runtime
+      if (runtime !== remoteFunctionConfiguration.Runtime) {
+        params.Runtime = runtime
+      }
     }
 
     // Check if we have remotely managed layers and add them to the update call

--- a/test/unit/lib/plugins/aws/deploy-function.test.js
+++ b/test/unit/lib/plugins/aws/deploy-function.test.js
@@ -441,9 +441,11 @@ describe('test/unit/lib/plugins/aws/deployFunction.test.js', () => {
     expect(updateFunctionCodeStub).to.be.calledOnce
     expect(updateFunctionCodeStub.args[0][0].ImageUri).to.equal(imageWithSha)
     expect(updateFunctionConfigurationStub).to.be.calledOnce
-    expect(
-      updateFunctionConfigurationStub.args[0][0].ImageConfig,
-    ).to.deep.equal({
+
+    const configParams = updateFunctionConfigurationStub.args[0][0]
+    expect(configParams.Handler).to.be.undefined
+    expect(configParams.Runtime).to.be.undefined
+    expect(configParams.ImageConfig).to.deep.equal({
       Command: ['anotherexecutable'],
       EntryPoint: ['executable', 'param1'],
       WorkingDirectory: './workdir',


### PR DESCRIPTION
See detailed bug description in #12778.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

> ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue
> ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it

IMO this qualifies as an "obvious bug fix", but please note that for reasons that will become clear as you read my answers to the questions below, I cannot verify that this fix works; I cannot even build the serverless CLI and try it with my real project, let alone run unit and integration tests. I'd welcome any help as to how to overcome this.

> ⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style

I did my best, but I cannot run Prettier locally (see #12761).

> ⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md

I modified a relevant unit test to add coverage for this bug and its fix, but I cannot run unit tests locally (see #12761).

> ⚠️⚠️ Ensure that support for Node.js v12 is maintained.

I would be very surprised if there were any issues specific to v12 in this diff, but I have not tested it, as I have not been able to install v12 on my mac (apple silicon).

> ⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
> • npm run prettier-check

Cannot run, as the `@serverlessinc/standards` module is not available.

> • npm run lint

```
➜ npm run lint
npm ERR! Missing script: "lint"
```

> • npm test

Cannot run; see #12761.

> ⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests

I cannot run any tests at all; see #12761.

> ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure

It appears that most public CI was removed here: https://github.com/serverless/serverless/commit/15ca61421ac846d24ec7dec6d5e0613f114b9dbb

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

> Q1: Provide a link to the corresponding issue

Closes: #12778
