### PR TITLE
Retain aws-sdk package exclusion in node versions 18+

### DIFF
--- a/lib/plugins/esbuild/index.js
+++ b/lib/plugins/esbuild/index.js
@@ -400,10 +400,9 @@ class Esbuild {
         if (version >= 18) {
           external.add('@aws-sdk/*')
           exclude.add('@aws-sdk/*')
-        } else {
-          external.add('aws-sdk')
-          exclude.add('aws-sdk')
         }
+        external.add('aws-sdk')
+        exclude.add('aws-sdk')
       }
     }
     return { external, exclude }


### PR DESCRIPTION
aws-sdk is available in all lambdas as standard, incl versions 18+

Closes: No issue. Should be an obvious fix
