### PR TITLE
fix: revert to original signature of getServerlessDeploymentBucketName

### DIFF
--- a/lib/plugins/aws/lib/set-bucket-name.js
+++ b/lib/plugins/aws/lib/set-bucket-name.js
@@ -6,10 +6,11 @@ export default {
 
     return this.provider
       .getServerlessDeploymentBucketName()
-      .then(({ bucketToUse, existingStackBucket, globalBucketUsed }) => {
-        this.bucketName = bucketToUse
-        this.existingStackBucket = existingStackBucket
-        this.globalDeploymentBucketUsed = globalBucketUsed
+      .then((deploymentBucket) => {
+        this.bucketName = deploymentBucket
+        this.deploymentBucketInStack = this.provider.deploymentBucketInStack
+        this.globalDeploymentBucketUsed =
+          this.provider.globalDeploymentBucketUsed
       })
   },
 }

--- a/lib/plugins/aws/package/lib/generate-core-template.js
+++ b/lib/plugins/aws/package/lib/generate-core-template.js
@@ -105,7 +105,7 @@ export default {
         userProvidedBucketName
 
       // do not remove the bucket if it already exists in the stack
-      if (!this.existingStackBucket) {
+      if (!this.deploymentBucketInStack) {
         delete this.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ServerlessDeploymentBucket
         delete this.serverless.service.provider.compiledCloudFormationTemplate
@@ -120,7 +120,7 @@ export default {
         this.bucketName
 
       // do not remove the bucket if it already exists in the stack
-      if (!this.existingStackBucket) {
+      if (!this.deploymentBucketInStack) {
         delete this.serverless.service.provider.compiledCloudFormationTemplate
           .Resources.ServerlessDeploymentBucket
         delete this.serverless.service.provider.compiledCloudFormationTemplate

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -1994,7 +1994,7 @@ class AwsProvider {
   }
 
   async getServerlessDeploymentBucketName() {
-    const existingStackBucket = await this.request(
+    const deploymentBucketInStack = await this.request(
       'CloudFormation',
       'describeStackResource',
       {
@@ -2009,36 +2009,25 @@ class AwsProvider {
         }
         throw err
       })
-
-    // If a deployment bucket is provided, use it.
+    this.deploymentBucketInStack = deploymentBucketInStack
+    this.globalDeploymentBucketUsed = false
     if (this.serverless.service.provider.deploymentBucket) {
-      return {
-        existingStackBucket,
-        bucketToUse: this.serverless.service.provider.deploymentBucket,
-        globalBucketUsed: false,
-      }
+      return this.serverless.service.provider.deploymentBucket
     }
 
     // If we are within Compose or there's no stack bucket, create or use the global deployment bucket.
-    if (this.serverless?.compose?.isWithinCompose || !existingStackBucket) {
+    if (this.serverless?.compose?.isWithinCompose || !deploymentBucketInStack) {
       const { bucketName: globalBucketName } =
         await getOrCreateGlobalDeploymentBucket({
           credentials: this.serverless.getProvider('aws').getCredentials(),
           region: this.serverless.getProvider('aws').getRegion(),
         })
-      return {
-        bucketToUse: globalBucketName,
-        globalBucketUsed: true,
-        existingStackBucket,
-      }
+      this.globalDeploymentBucketUsed = true
+      return globalBucketName
     }
 
     // If we are not within Compose and there's a stack bucket, use the stack bucket.
-    return {
-      bucketToUse: existingStackBucket,
-      globalBucketUsed: false,
-      existingStackBucket,
-    }
+    return deploymentBucketInStack
   }
 
   getDeploymentPrefix() {

--- a/lib/plugins/aws/remove/lib/bucket.js
+++ b/lib/plugins/aws/remove/lib/bucket.js
@@ -6,14 +6,9 @@ const { log } = utils
 export default {
   async setServerlessDeploymentBucketName() {
     try {
-      const {
-        bucketToUse: bucketName,
-        existingStackBucket,
-        globalBucketUsed,
-      } = await this.provider.getServerlessDeploymentBucketName()
-      this.bucketName = bucketName
-      this.existingStackBucket = existingStackBucket
-      this.globalDeploymentBucketUsed = globalBucketUsed
+      this.bucketName = await this.provider.getServerlessDeploymentBucketName()
+      this.deploymentBucketInStack = this.provider.deploymentBucketInStack
+      this.globalDeploymentBucketUsed = this.provider.globalDeploymentBucketUsed
     } catch (err) {
       // If there is a validation error with expected message, it means that logical resource for
       // S3 bucket does not exist and we want to proceed with empty `bucketName`
@@ -136,11 +131,13 @@ export default {
     await this.setServerlessDeploymentBucketName()
     // Clear the stack bucket if it exists
     if (
-      this.existingStackBucket &&
-      (await this.checkIfBucketExists(this.existingStackBucket))
+      this.deploymentBucketInStack &&
+      (await this.checkIfBucketExists(this.deploymentBucketInStack))
     ) {
-      const objectsInBucket = await this.listObjectsV2(this.existingStackBucket)
-      await this.deleteObjects(this.existingStackBucket, objectsInBucket)
+      const objectsInBucket = await this.listObjectsV2(
+        this.deploymentBucketInStack,
+      )
+      await this.deleteObjects(this.deploymentBucketInStack, objectsInBucket)
     } else {
       log.info(
         'ServerlessDeploymentBucket S3 bucket not found. Skipping S3 bucket objects removal',
@@ -162,7 +159,7 @@ export default {
     if (
       this.bucketName &&
       !this.globalDeploymentBucketUsed &&
-      this.bucketName !== this.existingStackBucket &&
+      this.bucketName !== this.deploymentBucketInStack &&
       (await this.checkIfBucketExists(this.bucketName))
     ) {
       const deploymentBucketObject =


### PR DESCRIPTION
This addresses https://github.com/serverless/serverless/issues/12799.
The recent change in the `getServerlessDeploymentBucketName` function signature caused errors in plugins that use it internally.