### PR TITLE
Allow passing of a roleArn to Scheduler

### DIFF
--- a/lib/plugins/aws/package/compile/events/schedule.js
+++ b/lib/plugins/aws/package/compile/events/schedule.js
@@ -88,6 +88,7 @@ class AwsCompileScheduledEvents {
               type: 'string',
               enum: [METHOD_EVENT_BUS, METHOD_SCHEDULER],
             },
+            roleArn: { $ref: '#/definitions/awsArn' },
             timezone: {
               type: 'string',
               pattern: '[\\w\\-\\/]+',
@@ -143,12 +144,13 @@ class AwsCompileScheduledEvents {
               Name = event.schedule.name
               timezone = event.schedule.timezone
               Description = event.schedule.description
+              roleArn = event.schedule.roleArn;
 
               const functionLogicalId =
                 this.provider.naming.getLambdaLogicalId(functionName)
               const functionResource = resources[functionLogicalId]
 
-              roleArn = functionResource.Properties.Role
+              roleArn = roleArn || functionResource.Properties.Role;
 
               method = event.schedule.method || METHOD_EVENT_BUS
 


### PR DESCRIPTION
### Summary

This PR addresses the issues highlighted in [PR #11707](https://github.com/serverless/serverless/pull/11707#pullrequestreview-1278132408) concerning the incorrect implementation of `roleARN` support for schedulers.

### Problem

The current implementation defaults to using the Lambda function's role, which presents several logical and security concerns:

1. A scheduler should not have the same permission boundaries as the Lambda function itself.
2. Assigning `InvokeFunction` permissions to the function's role means that the function could potentially call itself—an unintended and potentially dangerous behavior.

### Solution

This PR introduces the ability to override the default behavior by allowing `roleARN` to be explicitly specified, similar to the approach taken by AWS SAM ([reference](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-schedulev2.html#sam-function-schedulev2-rolearn)).