### PR TITLE
fix: ignore invalid credentials errors when retrieving AWS env vars for local invoke

### DIFF
--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -170,17 +170,23 @@ class AwsInvokeLocal {
 
   async getCredentialEnvVars() {
     const credentialEnvVars = {}
-    const { credentials } = await this.provider.getCredentials()
-    if (credentials) {
-      if (credentials.accessKeyId) {
-        credentialEnvVars.AWS_ACCESS_KEY_ID = credentials.accessKeyId
+    try {
+      const { credentials } = await this.provider.getCredentials()
+      if (credentials) {
+        if (credentials.accessKeyId) {
+          credentialEnvVars.AWS_ACCESS_KEY_ID = credentials.accessKeyId
+        }
+        if (credentials.secretAccessKey) {
+          credentialEnvVars.AWS_SECRET_ACCESS_KEY = credentials.secretAccessKey
+        }
+        if (credentials.sessionToken) {
+          credentialEnvVars.AWS_SESSION_TOKEN = credentials.sessionToken
+        }
       }
-      if (credentials.secretAccessKey) {
-        credentialEnvVars.AWS_SECRET_ACCESS_KEY = credentials.secretAccessKey
-      }
-      if (credentials.sessionToken) {
-        credentialEnvVars.AWS_SESSION_TOKEN = credentials.sessionToken
-      }
+    } catch (error) {
+      this.logger.debug('Ignoring error while loading AWS credentials:', error)
+      // ignore errors if credentials are unavailable
+      // since they are not required for local invocation
     }
     return credentialEnvVars
   }

--- a/lib/plugins/aws/invoke-local/index.js
+++ b/lib/plugins/aws/invoke-local/index.js
@@ -171,7 +171,7 @@ class AwsInvokeLocal {
   async getCredentialEnvVars() {
     const credentialEnvVars = {}
     try {
-      const { credentials } = await this.provider.getCredentials()
+      const credentials = await this.provider.getCredentials()
       if (credentials) {
         if (credentials.accessKeyId) {
           credentialEnvVars.AWS_ACCESS_KEY_ID = credentials.accessKeyId


### PR DESCRIPTION
Addresses https://github.com/serverless/serverless/issues/12912