### PR TITLE
feat: add nodejs22.x runtime

### DIFF
--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -668,6 +668,7 @@ class AwsProvider {
               'nodejs16.x',
               'nodejs18.x',
               'nodejs20.x',
+              'nodejs22.x',
               'provided',
               'provided.al2',
               'provided.al2023',


### PR DESCRIPTION
[Node.js 22 runtime now available in AWS Lambda](https://aws.amazon.com/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/).
Addresses https://github.com/serverless/serverless/issues/12914 