### PR TITLE
fix: Add Node 22 to `runtimeWrappers` versions

### DIFF
--- a/lib/plugins/aws/dev/local-lambda/index.js
+++ b/lib/plugins/aws/dev/local-lambda/index.js
@@ -289,7 +289,7 @@ const runtimeWrappers = [
     command: 'node',
     arguments: [],
     path: path.join(__dirname, 'runtime-wrappers/node.js'),
-    versions: ['nodejs14.x', 'nodejs16.x', 'nodejs18.x', 'nodejs20.x'],
+    versions: ['nodejs14.x', 'nodejs16.x', 'nodejs18.x', 'nodejs20.x', 'nodejs22.x'],
     extensions: ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'],
   },
 ]


### PR DESCRIPTION
Release https://github.com/serverless/serverless/releases/tag/v4.4.12 added support for `nodejs22.x`, however when trying it, there are issues with the runtime check `Unsupported runtime`. 

This PR adds in `nodejs22.x` into the list of supported runtimes.