### PR TITLE
fix: correct dev dependency exclusion and async processing logic

### DIFF
--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -9,12 +9,13 @@ import * as child from 'child_process'
 import globby from 'globby'
 import _ from 'lodash'
 import pMap from 'p-map'
+import pReduce from 'p-reduce'
 import pMapSeries from 'p-map-series'
 import ServerlessError from '../../../serverless-error.js'
 import utils from '@serverlessinc/sf-core/src/utils.js'
 
 const { createWriteStream, unlinkSync } = fs
-const childProcess = promisify(child.exec)
+const execAsync = promisify(child.exec)
 const { log } = utils
 
 const excludeNodeDevDependenciesMemoized = _.memoize(excludeNodeDevDependencies)
@@ -218,20 +219,23 @@ async function excludeNodeDevDependencies(serviceDir) {
           ['dev', 'prod'],
           (env) => {
             const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile
-            return childProcess
-              .execAsync(
-                `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
-                {
-                  cwd: dirWithPackageJson,
-                  // We are overriding `NODE_ENV` because when it is set to "production"
-                  // it causes invalid output of `npm ls` with `--dev=true`
-                  env: {
-                    ...process.env,
-                    NODE_ENV: null,
-                  },
+            return execAsync(
+              `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
+              {
+                cwd: dirWithPackageJson,
+                // We are overriding `NODE_ENV` because when it is set to "production"
+                // it causes invalid output of `npm ls` with `--dev=true`
+                env: {
+                  ...process.env,
+                  NODE_ENV: null,
                 },
+              },
+            ).catch((err) => {
+              log.debug(
+                `Failed to run npm ls to retrieve dependencies for exclusion. Error: ${err.message}`,
               )
-              .catch(() => Promise.resolve())
+              Promise.resolve()
+            })
           },
           { concurrency: os.cpus().length },
         )
@@ -247,10 +251,15 @@ async function excludeNodeDevDependencies(serviceDir) {
                   Boolean,
                 ),
               )
-              .catch(() => Promise.resolve())
+              .catch((err) => {
+                log.debug(
+                  `Failed to read the dependencies exclusion file at ${depFile}. Error: ${err.message}`,
+                )
+                Promise.resolve()
+              })
           }),
         )
-        .then((devAndProDependencies) => {
+        .then(async (devAndProDependencies) => {
           const devDependencies = devAndProDependencies[0]
           const prodDependencies = devAndProDependencies[1]
 
@@ -267,37 +276,58 @@ async function excludeNodeDevDependencies(serviceDir) {
               (item) => item.replace(path.join(serviceDir, path.sep), ''),
               { concurrency: os.cpus().length },
             )
-              .filter((item) => item.length > 0 && item.match(nodeModulesRegex))
-              .reduce((globs, item) => {
-                const packagePath = path.join(serviceDir, item, 'package.json')
-                return fsp.readFile(packagePath, 'utf-8').then(
-                  (packageJsonFile) => {
-                    const lastIndex = item.lastIndexOf(path.sep) + 1
-                    const moduleName = item.substr(lastIndex)
-                    const modulePath = item.substr(0, lastIndex)
-
-                    const packageJson = JSON.parse(packageJsonFile)
-                    const bin = packageJson.bin
-
-                    const baseGlobs = [path.join(item, '**')]
-
-                    // NOTE: pkg.bin can be object, string, or undefined
-                    if (typeof bin === 'object') {
-                      Object.keys(bin).forEach((executable) => {
-                        baseGlobs.push(
-                          path.join(modulePath, '.bin', executable),
-                        )
-                      })
-                      // only 1 executable with same name as lib
-                    } else if (typeof bin === 'string') {
-                      baseGlobs.push(path.join(modulePath, '.bin', moduleName))
-                    }
-
-                    return globs.concat(baseGlobs)
-                  },
-                  () => globs,
+              .then((processedDependencies) => {
+                return processedDependencies.filter(
+                  (item) => item.length > 0 && item.match(nodeModulesRegex),
                 )
-              }, [])
+              })
+              .then((filteredDependencies) =>
+                pReduce(
+                  filteredDependencies,
+                  (globs, item) => {
+                    const packagePath = path.join(
+                      serviceDir,
+                      item,
+                      'package.json',
+                    )
+                    return fsp
+                      .readFile(packagePath, 'utf-8')
+                      .then((packageJsonFile) => {
+                        const lastIndex = item.lastIndexOf(path.sep) + 1
+                        const moduleName = item.slice(lastIndex)
+                        const modulePath = item.slice(0, lastIndex)
+
+                        const packageJson = JSON.parse(packageJsonFile)
+                        const bin = packageJson.bin
+
+                        const baseGlobs = [path.join(item, '**')]
+
+                        // NOTE: pkg.bin can be object, string, or undefined
+                        if (typeof bin === 'object') {
+                          Object.keys(bin).forEach((executable) => {
+                            baseGlobs.push(
+                              path.join(modulePath, '.bin', executable),
+                            )
+                          })
+                          // only 1 executable with same name as lib
+                        } else if (typeof bin === 'string') {
+                          baseGlobs.push(
+                            path.join(modulePath, '.bin', moduleName),
+                          )
+                        }
+
+                        return globs.concat(baseGlobs) // Append to the accumulator
+                      })
+                      .catch((err) => {
+                        log.debug(
+                          `Unable to read the package.json file at "${packagePath}" while processing dependencies for exclusion. Skipping this dependency. Error: ${err.message}`,
+                        )
+                        return globs
+                      }) // Handle errors by returning the existing globs
+                  },
+                  [], // Initial accumulator value for `globs`
+                ),
+              )
               .then((globs) => {
                 exAndIn.exclude = exAndIn.exclude.concat(globs)
                 return exAndIn
@@ -312,7 +342,10 @@ async function excludeNodeDevDependencies(serviceDir) {
           unlinkSync(nodeProdDepFile)
           return exAndIn
         })
-        .catch(() => exAndIn)
+        .catch((err) => {
+          log.debug(`Failed to exclude dev dependencies. Error: ${err.message}`)
+          return exAndIn
+        })
     )
   } catch (e) {
     // fail silently

--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -234,7 +234,6 @@ async function excludeNodeDevDependencies(serviceDir) {
               log.debug(
                 `Failed to run npm ls to retrieve dependencies for exclusion. Error: ${err.message}`,
               )
-              Promise.resolve()
             })
           },
           { concurrency: os.cpus().length },
@@ -255,7 +254,6 @@ async function excludeNodeDevDependencies(serviceDir) {
                 log.debug(
                   `Failed to read the dependencies exclusion file at ${depFile}. Error: ${err.message}`,
                 )
-                Promise.resolve()
               })
           }),
         )

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "p-limit": "^5.0.0",
     "p-map": "^7.0.2",
     "p-map-series": "^3.0.0",
+    "p-reduce": "^3.0.0",
     "p-try": "^3.0.0",
     "path2": "^0.1.0",
     "process-utils": "^4.0.0",


### PR DESCRIPTION
This PR addresses issues (https://github.com/serverless/serverless/issues/12911) in the dev dependency exclusion logic:
1. Call `execAsync` instead of `childProcess.execAsync`:
    - Fixes the usage of the `exec` function by replacing `childProcess.execAsync` with `execAsync` using `promisify` for proper execution.
2. Adjust `pMap` usage with `.then` -> `.filter` and `.then -> .pReduce`:
    - Updates the code to handle `pMap` results correctly, as `pMap` does not have `filter` and `reduce` methods like `bluebird`. These operations are now handled explicitly with `.then`.
    - Uses `pReduce` to properly handle the async `readFile` operation.
3. Add debug logs for error handling:
    - Improves error visibility by adding debug logs for errors instead of swallowing them silently, making the debugging process easier.