### PR TITLE
fix(esbuild): fix typo in exclude property

### DIFF
--- a/lib/plugins/esbuild/index.js
+++ b/lib/plugins/esbuild/index.js
@@ -392,8 +392,8 @@ class Esbuild {
     const buildProperties = await this._buildProperties()
     let external = new Set(buildProperties.external || [])
     let exclude = new Set(buildProperties.exclude || [])
-    if (buildProperties.excludes) {
-      external = [...external, ...buildProperties.excludes]
+    if (buildProperties.exclude) {
+      external = [...external, ...buildProperties.exclude]
     } else {
       const nodeRuntimeMatch = runtime.match(nodeRuntimeRe)
       if (nodeRuntimeMatch) {


### PR DESCRIPTION
As a side effect of this typo, it prevents users from including the latest aws packages to overwrite the lambda built-in ones. It also prevents marking the excluded list as externals.