### PR TITLE
fix: use relative paths for artifacts

### DIFF
--- a/lib/plugins/package/lib/package-service.js
+++ b/lib/plugins/package/lib/package-service.js
@@ -208,7 +208,10 @@ export default {
 
     const filePaths = await this.resolveFilePathsFunction(functionName)
     const artifactPath = await this.zipFiles(filePaths, zipFileName)
-    funcPackageConfig.artifact = artifactPath
+    funcPackageConfig.artifact = path.relative(
+      this.serverless.serviceDir,
+      artifactPath,
+    )
     return artifactPath
   },
 


### PR DESCRIPTION
Addresses https://github.com/serverless/serverless/issues/12775 by updating artifact paths to be relative. These paths are now saved in the `serverless-state.json` file. Previously, artifact paths were absolute, which worked with the `serverless deploy` command but caused issues when using `serverless deploy --package deployment-artifact` from a different directory than where `serverless package --package deployment-artifact` was executed. This resulted in the error: `No {package}.zip file found in the package path you provided`. Using relative paths resolves this issue, ensuring deployment artifacts can be found regardless of the execution directory, as long as the correct deployment package is provided in the `--package` option.