### PR TITLE
fix(esbuild): use compose dependencies when handling externals

### DIFF
--- a/lib/plugins/esbuild/index.js
+++ b/lib/plugins/esbuild/index.js
@@ -877,7 +877,7 @@ class Esbuild {
   }
 
   /**
-   * Searches for the directory containing "serverless.compose.yml" up to 3 levels up.
+   * Searches for the directory containing the compose file up to 3 levels up.
    * @param {string} startDir - The directory to start the search from.
    * @param {string} maxLevelsUp - The maximum number of parent directories to search, default is 3.
    * @returns {string|null} - The directory path containing the file, or throw error if not found.

--- a/lib/plugins/esbuild/index.js
+++ b/lib/plugins/esbuild/index.js
@@ -11,7 +11,7 @@ import pLimit from 'p-limit'
 import globby from 'globby'
 import micromatch from 'micromatch'
 import ServerlessError from '../../serverless-error.js'
-const { log } = utils
+const { log, fileExists } = utils
 
 const nodeRuntimeRe = /nodejs(?<version>\d+).x/
 
@@ -298,11 +298,10 @@ class Esbuild {
    *
    * @returns {Object} - The package.json object
    */
-  async _readPackageJson() {
-    const packageJsonPath = path.join(
-      this.serverless.serviceDir,
-      'package.json',
-    )
+  async _readPackageJson(specifiedPackageJsonPath) {
+    const packageJsonPath =
+      specifiedPackageJsonPath ||
+      path.join(this.serverless.serviceDir, 'package.json')
 
     if (existsSync(packageJsonPath)) {
       const packageJsonStr = await readFile(packageJsonPath, 'utf-8')
@@ -878,6 +877,39 @@ class Esbuild {
   }
 
   /**
+   * Searches for the directory containing "serverless.compose.yml" up to 3 levels up.
+   * @param {string} startDir - The directory to start the search from.
+   * @param {string} maxLevelsUp - The maximum number of parent directories to search, default is 3.
+   * @returns {string|null} - The directory path containing the file, or throw error if not found.
+   */
+  async _getComposeDir(startDir = process.cwd(), maxLevelsUp = 3) {
+    let currentDir = path.resolve(startDir)
+
+    for (let i = 0; i < maxLevelsUp; i++) {
+      const composeYmlPath = path.join(currentDir, 'serverless-compose.yml')
+      const composeYamlPath = path.join(currentDir, 'serverless-compose.yaml')
+
+      if (
+        (await fileExists(composeYmlPath)) ||
+        (await fileExists(composeYamlPath))
+      ) {
+        return currentDir
+      }
+
+      const parentDir = path.dirname(currentDir)
+
+      if (parentDir === currentDir) {
+        // Reached root directory
+        break
+      }
+
+      currentDir = parentDir
+    }
+
+    throw new Error('Cannot find "serverless.compose.yml|yaml" file')
+  }
+
+  /**
    * Take the package.json and add an updated version with no dev dependencies and external and excluded node_modules taken care of, to the .serverless/build directory
    */
   async _preparePackageJson() {
@@ -887,20 +919,44 @@ class Esbuild {
 
     const packageJson = await this._readPackageJson()
 
+    let composePackageJson = {}
+
+    if (this.serverless.compose.isWithinCompose) {
+      const composeDir = await this._getComposeDir(
+        this.serverless.config.serviceDir,
+        3,
+      )
+
+      composePackageJson = await this._readPackageJson(
+        path.join(composeDir, 'package.json'),
+      )
+    }
+
     const packageJsonNoDevDeps = {
       ...packageJson,
     }
+
     delete packageJsonNoDevDeps.devDependencies
 
     const buildProperties = await this._buildProperties()
 
-    if (packageJson.dependencies) {
+    if (packageJson.dependencies || composePackageJson.dependencies) {
       if (buildProperties.packages !== 'external') {
         packageJsonNoDevDeps.dependencies = {}
+
         for (const key of external) {
-          if (packageJson.dependencies[key]) {
-            packageJsonNoDevDeps.dependencies[key] =
-              packageJson.dependencies[key]
+          if (packageJson.dependencies) {
+            if (packageJson.dependencies[key]) {
+              packageJsonNoDevDeps.dependencies[key] =
+                packageJson.dependencies[key]
+            }
+          }
+
+          if (composePackageJson.dependencies) {
+            if (composePackageJson.dependencies[key]) {
+              packageJsonNoDevDeps.dependencies[key] =
+                composePackageJson.dependencies[key]
+            }
           }
         }
       }


### PR DESCRIPTION
This changes makes sure our esbuild implementation checks and uses parent compose dependencies when searching for externals.

Fixes:
  - #12957
  - #12840
  