### PR TITLE
feat(alb): support listener arn import

### DIFF
--- a/lib/plugins/aws/package/compile/events/alb/index.js
+++ b/lib/plugins/aws/package/compile/events/alb/index.js
@@ -123,6 +123,7 @@ class AwsCompileAlbEvents {
           anyOf: [
             { $ref: '#/definitions/awsAlbListenerArn' },
             { $ref: '#/definitions/awsCfRef' },
+            { $ref: '#/definitions/awsCfImport' },
           ],
         },
         multiValueHeaders: { type: 'boolean' },

--- a/lib/plugins/aws/package/compile/events/alb/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/alb/lib/validate.js
@@ -120,6 +120,9 @@ export default {
       if (listenerArn.Ref) {
         return { albId: listenerArn.Ref, listenerId: listenerArn.Ref }
       }
+      if (listenerArn['Fn::ImportValue']) {
+        return { albId: listenerArn['Fn::ImportValue'], listenerId: listenerArn['Fn::ImportValue'] }
+      }
     }
     const matches = listenerArn.match(this.ALB_LISTENER_REGEXP)
     if (!matches) {

--- a/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/alb/lib/validate.test.js
@@ -184,6 +184,16 @@ describe('#validate()', () => {
         listenerId: 'HTTPListener1',
       })
     })
+
+    it('returns the ImportValue when given an object for the listener ARN', () => {
+      const listenerArn = { 'Fn::ImportValue': 'sharedValueToImport' }
+      expect(
+        awsCompileAlbEvents.validateListenerArn(listenerArn, 'functionname'),
+      ).to.deep.equal({
+        albId: 'sharedValueToImport',
+        listenerId: 'sharedValueToImport',
+      })
+    })
   })
 
   describe('#validatePriorities()', () => {


### PR DESCRIPTION
With this change, serverless will support Fn::ImportValue the same way as the Ref works now: assuming the name based on the referred key.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #7646
