### PR TITLE
Adds support for overriding the concurrency used in the packaging

### DIFF
--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -1,6 +1,6 @@
 import archiver from 'archiver'
 import os from 'os'
-import path from 'path'
+import path, { parse } from 'path'
 import crypto from 'crypto'
 import fs from 'fs'
 import fsp from 'fs/promises'
@@ -102,9 +102,13 @@ export default {
         const normalizedFiles = _.uniq(
           files.map((file) => path.normalize(file)),
         )
+        const concurrency = process.env.SLS_PACKAGE_CONCURRENCY ? parseInt(
+          process.env.SLS_PACKAGE_CONCURRENCY,
+          10,
+        ) : os.cpus().length
 
         return pMap(normalizedFiles, this.getFileContentAndStat.bind(this), {
-          concurrency: os.cpus().length,
+          concurrency,
         })
           .then((contents) => {
             contents


### PR DESCRIPTION
process
via the SLS_PACKAGE_CONCURRENCY environment variable.

Defaults to os.cpus().length if not set.
Benefits:
- Solve problems running sls in termux and proot environments on android. os.cpus() returns an empty list when running in proot and makes running the framework very difficult for deployments
- Allows better control over system resource usage in constrained environments.

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}
