### PR TITLE
Adhere to Serverless.yml exclude list

### DIFF
--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -351,7 +351,8 @@ async function excludeNodeDevDependencies(serviceDir, cachedThis) {
         })
     )
   } catch (e) {
-    // fail silently
+    console.error(`Excluding/including files/directories in packaging has failed.
+Most likely reason is permission issues. Error encountered:`, e.message);
     return Promise.resolve(exAndIn)
   }
 }

--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -49,7 +49,7 @@ export default {
         log.info('Excluding development dependencies')
       }
 
-      const exAndInNode = await excludeNodeDevDependenciesMemoized(serviceDir)
+      const exAndInNode = await excludeNodeDevDependenciesMemoized(serviceDir, this)
       params.exclude = _.union(params.exclude, exAndInNode.exclude)
       params.include = _.union(params.include, exAndInNode.include)
       params.devDependencyExcludeSet = new Set(exAndInNode.exclude)
@@ -163,7 +163,7 @@ export default {
   },
 }
 
-async function excludeNodeDevDependencies(serviceDir) {
+async function excludeNodeDevDependencies(serviceDir, cachedThis) {
   const exAndIn = {
     include: [],
     exclude: [],
@@ -178,12 +178,17 @@ async function excludeNodeDevDependencies(serviceDir) {
     `node-dependencies-${randHash}-prod`,
   )
 
+  // Adhere to excluded patterns from serverless.yml
+  // If we have access issues, e.g. Docker as `root` we must exclude what the user has set to exclude
+  // as this is set to fail silently, we'll include all devDependencies otherwise!
+  // `patterns` has e.g. '!coverage/**', but globby needs '!**/coverage' so we'll transform the pattern
+  const globPatterns = cachedThis.serverless.service.package.patterns.flatMap((pattern) => pattern?.[0] === '!'
+    ? pattern.replace(/^!([\w\-\/\\.]+)\/\*\*/, '!**/$1') : [])
+  globPatterns.unshift('**/package.json') // includes must come before excludes
+
   try {
     const packageJsonFilePaths = globby.sync(
-      [
-        '**/package.json',
-        // TODO add glob for node_modules filtering
-      ],
+      globPatterns,
       {
         cwd: serviceDir,
         dot: true,

--- a/lib/plugins/package/lib/zip-service.js
+++ b/lib/plugins/package/lib/zip-service.js
@@ -178,12 +178,12 @@ async function excludeNodeDevDependencies(serviceDir, cachedThis) {
     `node-dependencies-${randHash}-prod`,
   )
 
-  // Adhere to excluded patterns from serverless.yml
+  // Adhere to excluded patterns from serverless.yml!
   // If we have access issues, e.g. Docker as `root` we must exclude what the user has set to exclude
   // as this is set to fail silently, we'll include all devDependencies otherwise!
   // `patterns` has e.g. '!coverage/**', but globby needs '!**/coverage' so we'll transform the pattern
-  const globPatterns = cachedThis.serverless.service.package.patterns.flatMap((pattern) => pattern?.[0] === '!'
-    ? pattern.replace(/^!([\w\-\/\\.]+)\/\*\*/, '!**/$1') : [])
+  const globPatterns = cachedThis.serverless.service?.package?.patterns?.flatMap((pattern) => pattern?.[0] === '!'
+    ? pattern.replace(/^!([\w\-\/\\.]+)\/\*\*/, '!**/$1') : []) || [];
   globPatterns.unshift('**/package.json') // includes must come before excludes
 
   try {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->
Solves https://github.com/serverless/serverless/issues/12379

Issue is that Docker runs as `root` and adds persistence directories as owner `root` and `globby` throws as it has no access. The code is set to fail silently why it just skips excludes and includes all `devDependencies` as well in final package.

My suggested code will take the `package.patterns` list and exclude any excluded patterns from the `globby` reading.

Hence, if I exclude the Docker persistence directories in `package.patterns` they will not be read by `globby` and I will get a proper `zip` with excluded  `devDependencies`.

Closes: #{ISSUE_NUMBER}
