### PR TITLE
fix(aws-package): use path.basename for artifact filenames (Windows path bug)

### DIFF
--- a/lib/plugins/aws/lib/upload-zip-file.js
+++ b/lib/plugins/aws/lib/upload-zip-file.js
@@ -9,7 +9,7 @@ const { log } = utils
 export default {
   async uploadZipFile({ filename, s3KeyDirname, basename }) {
     const logger = log.get('deploy:upload')
-    if (!basename) basename = filename.split(path.sep).pop()
+    if (!basename) basename = path.basename(filename)
 
     // TODO refactor to be async (use util function to compute checksum async)
     const data = fs.readFileSync(filename)

--- a/lib/plugins/aws/package/compile/functions.js
+++ b/lib/plugins/aws/package/compile/functions.js
@@ -273,7 +273,7 @@ class AwsCompileFunctions {
 
       functionResource.Properties.Code.S3Key = `${
         this.serverless.service.package.artifactDirectoryName
-      }/${artifactFilePath.split(path.sep).pop()}`
+      }/${path.basename(artifactFilePath)}`
       functionResource.Properties.Runtime = functionObject.runtime
     } else {
       functionResource.Properties.Code.ImageUri = functionImageUri

--- a/lib/plugins/aws/package/compile/layers.js
+++ b/lib/plugins/aws/package/compile/layers.js
@@ -39,7 +39,7 @@ class AwsCompileLayers {
     }
 
     const s3Folder = this.serverless.service.package.artifactDirectoryName
-    const s3FileName = artifactFilePath.split(path.sep).pop()
+    const s3FileName = path.basename(artifactFilePath)
     newLayer.Properties.Content.S3Key = `${s3Folder}/${s3FileName}`
 
     newLayer.Properties.LayerName = layerObject.name || layerName

--- a/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -111,11 +111,11 @@ describe('AwsCompileFunctions', () => {
         awsCompileFunctions.downloadPackageArtifacts(),
       ).to.be.fulfilled.then(() => {
         const artifactFileName =
-          awsCompileFunctions.serverless.service.functions[
-            functionName
-          ].package.artifact
-            .split(path.sep)
-            .pop()
+          path.basename(
+            awsCompileFunctions.serverless.service.functions[
+              functionName
+            ].package.artifact
+          )
 
         expect(requestStub.callCount).to.equal(1)
         expect(artifactFileName).to.equal(s3ArtifactName)
@@ -132,10 +132,9 @@ describe('AwsCompileFunctions', () => {
       return expect(
         awsCompileFunctions.downloadPackageArtifacts(),
       ).to.be.fulfilled.then(() => {
-        const artifactFileName =
+        const artifactFileName = path.basename(
           awsCompileFunctions.serverless.service.package.artifact
-            .split(path.sep)
-            .pop()
+        )
 
         expect(requestStub.callCount).to.equal(1)
         expect(artifactFileName).to.equal(s3ArtifactName)
@@ -173,11 +172,9 @@ describe('AwsCompileFunctions', () => {
 
         const s3Folder =
           awsCompileFunctions.serverless.service.package.artifactDirectoryName
-        const s3FileName = awsCompileFunctions.serverless.service.functions[
-          functionName
-        ].package.artifact
-          .split(path.sep)
-          .pop()
+        const s3FileName = path.basename(
+          awsCompileFunctions.serverless.service.functions[functionName].package.artifact
+        )
 
         expect(functionResource.Properties.Code.S3Key).to.deep.equal(
           `${s3Folder}/${s3FileName}`,
@@ -371,9 +368,9 @@ describe('AwsCompileFunctions', () => {
     it('should create a simple function resource', async () => {
       const s3Folder =
         awsCompileFunctions.serverless.service.package.artifactDirectoryName
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep)
-        .pop()
+      const s3FileName = path.basename(
+        awsCompileFunctions.serverless.service.package.artifact
+      )
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -414,9 +411,9 @@ describe('AwsCompileFunctions', () => {
       beforeEach(() => {
         s3Folder =
           awsCompileFunctions.serverless.service.package.artifactDirectoryName
-        s3FileName = awsCompileFunctions.serverless.service.package.artifact
-          .split(path.sep)
-          .pop()
+        s3FileName = path.basename(
+          awsCompileFunctions.serverless.service.package.artifact
+        )
       })
 
       describe('when IamRoleLambdaExecution is used', () => {
@@ -681,9 +678,9 @@ describe('AwsCompileFunctions', () => {
       beforeEach(() => {
         s3Folder =
           awsCompileFunctions.serverless.service.package.artifactDirectoryName
-        s3FileName = awsCompileFunctions.serverless.service.package.artifact
-          .split(path.sep)
-          .pop()
+        s3FileName = path.basename(
+          awsCompileFunctions.serverless.service.package.artifact
+        )
       })
 
       describe('when IamRoleLambdaExecution is used', () => {
@@ -761,9 +758,9 @@ describe('AwsCompileFunctions', () => {
     it('should create a function resource with function level environment config', async () => {
       const s3Folder =
         awsCompileFunctions.serverless.service.package.artifactDirectoryName
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep)
-        .pop()
+      const s3FileName = path.basename(
+        awsCompileFunctions.serverless.service.package.artifact
+      )
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -836,9 +833,9 @@ describe('AwsCompileFunctions', () => {
     it('should consider function based config when creating a function resource', async () => {
       const s3Folder =
         awsCompileFunctions.serverless.service.package.artifactDirectoryName
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep)
-        .pop()
+      const s3FileName = path.basename(
+        awsCompileFunctions.serverless.service.package.artifact
+      )
       awsCompileFunctions.serverless.service.functions = {
         func: {
           name: 'customized-func-function',
@@ -948,9 +945,9 @@ describe('AwsCompileFunctions', () => {
     it('should set function declared reserved concurrency limit', async () => {
       const s3Folder =
         awsCompileFunctions.serverless.service.package.artifactDirectoryName
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep)
-        .pop()
+      const s3FileName = path.basename(
+        awsCompileFunctions.serverless.service.package.artifact
+      )
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -1010,9 +1007,9 @@ describe('AwsCompileFunctions', () => {
     it('should set function declared reserved concurrency limit even if it is zero', async () => {
       const s3Folder =
         awsCompileFunctions.serverless.service.package.artifactDirectoryName
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep)
-        .pop()
+      const s3FileName = path.basename(
+        awsCompileFunctions.serverless.service.package.artifact
+      )
       awsCompileFunctions.serverless.service.functions = {
         func: {
           handler: 'func.function.handler',
@@ -1091,9 +1088,9 @@ describe('AwsCompileFunctions', () => {
     it('should not set unset properties when not specified in yml (layers, vpc, etc)', async () => {
       const s3Folder =
         awsCompileFunctions.serverless.service.package.artifactDirectoryName
-      const s3FileName = awsCompileFunctions.serverless.service.package.artifact
-        .split(path.sep)
-        .pop()
+      const s3FileName = path.basename(
+        awsCompileFunctions.serverless.service.package.artifact
+      )
 
       awsCompileFunctions.serverless.service.functions = {
         func: {

--- a/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -78,9 +78,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const layerResource =
       cfResources[naming.getLambdaLayerLogicalId(resourceName)]
     const s3Folder = service.package.artifactDirectoryName
-    const s3FileName = service.layers[resourceName].package.artifact
-      .split(path.sep)
-      .pop()
+    const s3FileName = path.basename(service.layers[resourceName].package.artifact)
 
     expect(layerResource.Properties.Content.S3Key).to.equal(
       `${s3Folder}/${s3FileName}`,
@@ -92,9 +90,7 @@ describe('lib/plugins/aws/package/compile/layers/index.test.js', () => {
     const layerResource =
       cfResources[naming.getLambdaLayerLogicalId(resourceName)]
     const s3Folder = service.package.artifactDirectoryName
-    const s3FileName = service.layers[resourceName].package.artifact
-      .split(path.sep)
-      .pop()
+    const s3FileName = path.basename(service.layers[resourceName].package.artifact)
 
     expect(layerResource.Type).to.equals('AWS::Lambda::LayerVersion')
     expect(layerResource.Properties.Content.S3Key).to.equal(


### PR DESCRIPTION
<!-- ⚠️ Acknowledge ALL remarks above -->

This is an **obvious bug fix**: on Windows, generating S3 artifact filenames using `split(path.sep).pop()` breaks when path separators are mixed. Replace with `path.basename()` to make it cross-platform safe, and keep S3 keys POSIX (`/`) only.

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/test/README.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v12 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier-check
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/README.md#aws-integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

### What/Why
- `artifactFilePath.split(path.sep).pop()` fails for Windows-style or mixed separators.
- Use Node's `path.basename()` which correctly handles both `\` and `/`.
- Keeps S3 object keys consistent (POSIX `/`), independent from local FS.

### Scope (files)
- `lib/plugins/aws/lib/upload-zip-file.js`
- `lib/plugins/aws/package/compile/functions.js`
- `lib/plugins/aws/package/compile/layers.js`
- tests updated:
  - `test/unit/lib/plugins/aws/package/compile/functions.test.js`
  - `test/unit/lib/plugins/aws/package/compile/layers.test.js`

### How it’s implemented
- Replace all artifact filename extractions with:
  ```js
  const basename = path.basename(artifactFilePath)

Closes: #13120
