### PR TITLE
fix: improve error message for parallel stack deployments (#11649)

### DIFF
--- a/lib/plugins/aws/deploy/lib/create-stack.js
+++ b/lib/plugins/aws/deploy/lib/create-stack.js
@@ -40,11 +40,25 @@ export default {
 
       // Create new change set
       log.info('Creating new change set')
-      await this.provider.request(
-        'CloudFormation',
-        'createChangeSet',
-        createChangeSetParams,
-      )
+      try {
+        await this.provider.request(
+          'CloudFormation',
+          'createChangeSet',
+          createChangeSetParams,
+        )
+      } catch (error) {
+        if (
+          error.message &&
+          error.message.includes('ChangeSet') &&
+          error.message.includes(
+            'cannot be created due to a mismatch with existing attribute Template',
+          )
+        ) {
+          error.message +=
+            '\n\n💡 This error may occur when multiple deployments of the same stack are triggered in parallel (for example, from concurrent CI/CD runs or PR merges).\nEnsure that only one deployment runs at a time for the same service and stage, or use unique stack names per environment.'
+        }
+        throw error
+      }
 
       // Wait for changeset to be created
       log.info('Waiting for new change set to be created')
@@ -74,6 +88,7 @@ export default {
       )
       monitorCfData = changeSetDescription
     }
+
     await this.monitorStack('create', monitorCfData)
   },
 


### PR DESCRIPTION
### Summary
This pull request improves the error message shown when a CloudFormation ChangeSet
cannot be created due to a mismatch with an existing template. 

Previously, the error message was unclear. Now it provides a clear explanation that
the issue often occurs when **multiple deployments run in parallel** (for example,
in CI/CD pipelines or simultaneous PR merges).

---

### Changes
- Updated `lib/plugins/aws/deploy/lib/create-stack.js` to add a more descriptive error message.
- Added guidance on how to avoid the issue (e.g., by ensuring one deployment at a time or using unique stack names).

---

### Related Issue
Fixes #11649

---

### Testing
- Verified that the new message appears only when the specific CloudFormation error occurs.
- No breaking changes were introduced.

---
