### PR TITLE
Add API Gateway ResponseTransferMode

### DIFF
--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/method/integration.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/method/integration.js
@@ -58,6 +58,10 @@ export default {
         undefined,
     }
 
+    if (http.responseTransferMode) {
+      integration.ResponseTransferMode = http.responseTransferMode
+    }
+
     // Valid integrations are:
     // * `HTTP` for integrating with an HTTP back end,
     // * `AWS` for any AWS service endpoints,

--- a/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.js
+++ b/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.js
@@ -89,6 +89,10 @@ export default {
             http.path = this.getHttpPath(http)
             http.method = this.getHttpMethod(http)
 
+            if (http.responseTransferMode) {
+              http.responseTransferMode = this.getResponseTransferMode(http, functionName)
+            }
+
             if (http.authorizer) {
               http.authorizer = this.getAuthorizer(http)
             }
@@ -255,6 +259,23 @@ export default {
 
   getHttpMethod(http) {
     return http.method.toLowerCase()
+  },
+
+  getResponseTransferMode(http, functionName) {
+    const validModes = ['BUFFERED', 'STREAM']
+    const mode =
+      typeof http.responseTransferMode === 'string'
+        ? http.responseTransferMode.toUpperCase()
+        : http.responseTransferMode
+
+    if (!validModes.includes(mode)) {
+      throw new ServerlessError(
+        `Invalid responseTransferMode "${http.responseTransferMode}" in function "${functionName}". Valid values are: ${validModes.join(', ')}`,
+        'API_GATEWAY_INVALID_RESPONSE_TRANSFER_MODE',
+      )
+    }
+
+    return mode
   },
 
   getAuthorizer(http) {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/method/index.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/method/index.test.js
@@ -1921,6 +1921,65 @@ describe('#compileMethods()', () => {
         .ApiGatewayMethodUsersCreatePost.Properties,
     ).to.not.have.key('OperationName')
   })
+
+  it('should set ResponseTransferMode when specified', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+          responseTransferMode: 'STREAM',
+        },
+      },
+    ]
+    awsCompileApigEvents.compileMethods()
+    expect(
+      awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .ApiGatewayMethodUsersCreatePost.Properties.Integration
+        .ResponseTransferMode,
+    ).to.equal('STREAM')
+  })
+
+  it('should set ResponseTransferMode to BUFFERED when specified', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+          responseTransferMode: 'BUFFERED',
+        },
+      },
+    ]
+    awsCompileApigEvents.compileMethods()
+    expect(
+      awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .ApiGatewayMethodUsersCreatePost.Properties.Integration
+        .ResponseTransferMode,
+    ).to.equal('BUFFERED')
+  })
+
+  it('should not set ResponseTransferMode when not specified', () => {
+    awsCompileApigEvents.validated.events = [
+      {
+        functionName: 'First',
+        http: {
+          path: 'users/create',
+          method: 'post',
+        },
+      },
+    ]
+    awsCompileApigEvents.compileMethods()
+    expect(
+      awsCompileApigEvents.serverless.service.provider
+        .compiledCloudFormationTemplate.Resources
+        .ApiGatewayMethodUsersCreatePost.Properties.Integration
+        .ResponseTransferMode,
+    ).to.be.undefined
+  })
 })
 
 describe('#compileMethods v2()', () => {

--- a/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.test.js
@@ -1670,4 +1670,76 @@ describe('test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/valida
       'API_GATEWAY_EXTERNAL_API_LOGS',
     )
   })
+
+  it('should accept valid responseTransferMode values', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'foo/bar',
+              responseTransferMode: 'BUFFERED',
+            },
+          },
+        ],
+      },
+      second: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'foo/baz',
+              responseTransferMode: 'STREAM',
+            },
+          },
+        ],
+      },
+    }
+
+    const validated = awsCompileApigEvents.validate()
+    expect(validated.events).to.be.an('Array').with.length(2)
+    expect(validated.events[0].http.responseTransferMode).to.equal('BUFFERED')
+    expect(validated.events[1].http.responseTransferMode).to.equal('STREAM')
+  })
+
+  it('should normalize responseTransferMode to uppercase', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'foo/bar',
+              responseTransferMode: 'buffered',
+            },
+          },
+        ],
+      },
+    }
+
+    const validated = awsCompileApigEvents.validate()
+    expect(validated.events[0].http.responseTransferMode).to.equal('BUFFERED')
+  })
+
+  it('should reject invalid responseTransferMode values', () => {
+    awsCompileApigEvents.serverless.service.functions = {
+      first: {
+        events: [
+          {
+            http: {
+              method: 'GET',
+              path: 'foo/bar',
+              responseTransferMode: 'INVALID',
+            },
+          },
+        ],
+      },
+    }
+
+    expect(() => awsCompileApigEvents.validate()).to.throw(
+      ServerlessError,
+      /Invalid responseTransferMode/,
+    )
+  })
 })


### PR DESCRIPTION
## Summary

This pull request adds support for AWS API Gateway's `responseTransferMode` parameter, enabling response streaming capabilities for serverless functions.

* [Building responsive APIs with Amazon API Gateway response streaming](https://aws.amazon.com/jp/blogs/compute/building-responsive-apis-with-amazon-api-gateway-response-streaming/)

## Changes

- **lib/plugins/aws/package/compile/events/api-gateway/lib/method/integration.js**: Added `ResponseTransferMode` parameter to the integration configuration, only setting it when explicitly provided
- **lib/plugins/aws/package/compile/events/api-gateway/lib/validate.js**: Added `getResponseTransferMode()` validation method that normalizes input to uppercase and validates allowed values (`BUFFERED`, `STREAM`)
- **test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/validate.test.js**: Added 3 test cases for validation logic
- **test/unit/lib/plugins/aws/package/compile/events/api-gateway/lib/method/index.test.js**: Added 3 test cases for CloudFormation template generation

## Usage Example

```yaml
functions:
  streamingFunction:
    handler: handler.stream
    events:
      - http:
          path: /stream
          method: GET
          responseTransferMode: STREAM
```

## Related Issue

None

## Testing

* [x] All tests pass (6 new test cases covering validation and integration)
* [x] Validates allowed values and provides clear error messages
* [x] Case-insensitive input (automatically normalized to uppercase)
* [x] No breaking changes - parameter is optional and only set when specified
* [x] Stream enabled in deployment confirmed

<img width="786" height="284" alt="Screenshot_2025-11-25_at_20_58_54" src="https://github.com/user-attachments/assets/42687ffd-6189-4f2f-a85b-bbac4bf19f87" />
