### PR TITLE
fix: consolidate Resources pattern properties to fix Typescript generation bug

### DIFF
--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -1992,25 +1992,36 @@ class AwsProvider {
                   additionalProperties: false,
                 },
               },
+              // Consolidated pattern to support both Resource names and Fn::ForEach macros
+              // This is necessary because json-schema-to-typescript (used in @serverless/typescript repo) has a limitation where it only supports a single patternProperty
+              // See: https://github.com/bcherny/json-schema-to-typescript/pull/144
               patternProperties: {
-                '^[a-zA-Z0-9]{1,255}$': {
-                  type: 'object',
-                  properties: {
-                    Type: { type: 'string' },
-                    Properties: { type: 'object' },
-                    CreationPolicy: { type: 'object' },
-                    DeletionPolicy: { type: 'string' },
-                    DependsOn: { $ref: '#/definitions/awsResourceDependsOn' },
-                    Metadata: { type: 'object' },
-                    UpdatePolicy: { type: 'object' },
-                    UpdateReplacePolicy: { type: 'string' },
-                    Condition: { $ref: '#/definitions/awsResourceCondition' },
-                  },
-                  required: ['Type'],
-                  additionalProperties: false,
-                },
-                '^Fn::ForEach::[a-zA-Z0-9]+$': {
-                  $ref: '#/definitions/awsCfForEach',
+                '^([a-zA-Z0-9]{1,255}|Fn::ForEach::[a-zA-Z0-9]+)$': {
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        Type: { type: 'string' },
+                        Properties: { type: 'object' },
+                        CreationPolicy: { type: 'object' },
+                        DeletionPolicy: { type: 'string' },
+                        DependsOn: {
+                          $ref: '#/definitions/awsResourceDependsOn',
+                        },
+                        Metadata: { type: 'object' },
+                        UpdatePolicy: { type: 'object' },
+                        UpdateReplacePolicy: { type: 'string' },
+                        Condition: {
+                          $ref: '#/definitions/awsResourceCondition',
+                        },
+                      },
+                      required: ['Type'],
+                      additionalProperties: false,
+                    },
+                    {
+                      $ref: '#/definitions/awsCfForEach',
+                    },
+                  ],
                 },
               },
               additionalProperties: false,


### PR DESCRIPTION
Closes https://github.com/serverless/serverless/issues/13183

---
# Summary
This Pull Request updates the AWS provider JSON schema in the Serverless framework to consolidate the handling of resource names and Fn::ForEach macros. This is done to work around a limitation in the json-schema-to-typescript library, ensuring better support for these patterns.
## Main Changes:
* Consolidated patternProperties: Combined two patterns (^[a-zA-Z0-9]{1,255}$ and ^Fn::ForEach::[a-zA-Z0-9]+$) into a single pattern ^([a-zA-Z0-9]{1,255}|Fn::ForEach::[a-zA-Z0-9]+)$.
* Enhanced validation schema: Added support for a oneOf validation to accommodate both standard resource patterns and Fn::ForEach macros.
* Improved compatibility: Resolved a known limitation in json-schema-to-typescript that restricted the use of multiple patternProperty definitions.

This change is specific to improving JSON schema compatibility and does not affect runtime behavior.