### PR TITLE
feat: add ruby3.4 runtime

### DIFF
--- a/packages/serverless/lib/plugins/aws/invoke-local/index.js
+++ b/packages/serverless/lib/plugins/aws/invoke-local/index.js
@@ -415,7 +415,7 @@ class AwsInvokeLocal {
       )
     }
 
-    if (['ruby2.7', 'ruby3.2', 'ruby3.3'].includes(runtime)) {
+    if (['ruby2.7', 'ruby3.2', 'ruby3.3', 'ruby3.4'].includes(runtime)) {
       const handlerComponents = handler.split(/\./)
       const handlerPath = handlerComponents[0]
       const handlerName = handlerComponents.slice(1).join('.')

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -600,6 +600,7 @@ class AwsProvider {
               'ruby2.7',
               'ruby3.2',
               'ruby3.3',
+              'ruby3.4'
             ],
           },
           awsLambdaRuntimeManagement: {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/TESTING.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v18 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/TESTING.md#integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

AWS has recently added support for Ruby 3.4 runtimes
https://aws.amazon.com/about-aws/whats-new/2025/03/aws-lambda-support-ruby-3-4/

I have read the CLA Document and I hereby sign the CLA