### PR TITLE
fix(appsync): use convertPathToPattern for Windows path compatibility

### DIFF
--- a/packages/serverless/lib/plugins/aws/appsync/resources/Schema.js
+++ b/packages/serverless/lib/plugins/aws/appsync/resources/Schema.js
@@ -1,4 +1,4 @@
-import { globbySync } from 'globby'
+import { convertPathToPattern, globbySync } from 'globby'
 import fs from 'fs'
 import path from 'path'
 import _ from 'lodash'
@@ -63,10 +63,13 @@ export class Schema {
   }
 
   generateSchema() {
+    const servicePath = this.api.plugin.serverless.config.servicePath
+    // Use convertPathToPattern to handle Windows backslashes and escape special chars,
+    // then path.posix.join to maintain forward slashes for globby compatibility
     const schemaFiles = flatten(
       globbySync(
         this.schemas.map((schema) =>
-          path.join(this.api.plugin.serverless.config.servicePath, schema),
+          path.posix.join(convertPathToPattern(servicePath), schema),
         ),
       ),
     )

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/given.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/given.js
@@ -11,7 +11,7 @@ import ServerlessAppsyncPlugin from '../../../../../../lib/plugins/aws/appsync/i
 export const createServerless = () => {
   const serverless = {
     config: {
-      servicePath: '',
+      servicePath: process.cwd(),
     },
     configurationInput: {
       appSync: appSyncConfig(),

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/resolvers.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/resolvers.test.js
@@ -10,11 +10,13 @@ describe('Resolvers', () => {
   let mockExists
 
   beforeEach(() => {
-    mock = jest
-      .spyOn(fs, 'readFileSync')
-      .mockImplementation(
-        (path) => `Content of ${`${path}`.replace(/\\/g, '/')}`,
-      )
+    mock = jest.spyOn(fs, 'readFileSync').mockImplementation((filePath) => {
+      // Strip cwd prefix for portable snapshot testing
+      const relativePath = `${filePath}`
+        .replace(/\\/g, '/')
+        .replace(process.cwd().replace(/\\/g, '/') + '/', '')
+      return `Content of ${relativePath}`
+    })
     mockExists = jest.spyOn(fs, 'existsSync').mockReturnValue(true)
   })
 

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/schema.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/schema.test.js
@@ -56,4 +56,18 @@ describe('schema', () => {
     ])
     expect(schema.generateSchema()).toMatchSnapshot()
   })
+
+  it('should handle absolute paths with servicePath', () => {
+    const api = new Api(given.appSyncConfig(), plugin)
+    const schema = new Schema(api, [
+      'test/unit/lib/plugins/aws/appsync/fixtures/schemas/multiple/*.graphql',
+    ])
+
+    // The schema should be generated correctly with absolute servicePath
+    // convertPathToPattern handles special characters and path separators correctly
+    const result = schema.generateSchema()
+    expect(result).toContain('type Query')
+    expect(result).toContain('type User')
+    expect(result).toContain('type Post')
+  })
 })


### PR DESCRIPTION
Fixes https://github.com/serverless/serverless/issues/13240

---

## Fix: Handle Windows path separators in AppSync schema glob patterns

### Problem

On Windows, the AppSync schema resolver failed to find `.graphql` files when using glob patterns (e.g., `Schema/*.graphql`). This resulted in empty `Definition` in the CloudFormation template.

### Root Cause

`globby` v10+ does not support backslash path separators. On Windows, `path.join()` produces paths with backslashes which caused globby to silently match zero files.

### Solution

Use `convertPathToPattern()` from globby to convert Windows backslashes to forward slashes, and `path.posix.join()` to maintain forward slashes when joining paths.

### Changes

- **`Schema.js`**: Use `convertPathToPattern` + `path.posix.join` for cross-platform path handling
- **`given.js`**: Updated test mock to use `process.cwd()` as `servicePath`
- **`resolvers.test.js`**: Fixed mock to strip `cwd` prefix for portable snapshots
- **`schema.test.js`**: Added test for absolute path handling