### PR TITLE
fix: use system temp dir for AJV cache to fix Windows EPERM error

### DIFF
--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -48,9 +48,8 @@ jobs:
         group:
           - ubuntu-latest
           - latest-arm-linux
-#          - gh-windows-latest
-    runs-on:
-      ${{ matrix.group }}
+          - gh-windows-latest
+    runs-on: ${{ matrix.group }}
     steps:
       - name: "Checkout Code"
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/packages/serverless/lib/classes/config-schema-handler/resolve-ajv-validate.js
+++ b/packages/serverless/lib/classes/config-schema-handler/resolve-ajv-validate.js
@@ -75,7 +75,7 @@ const getValidate = async (schema) => {
     }
     const moduleCode = standaloneCode(ajv, validate)
 
-    const tmpDir = await fsp.mkdtemp('sls-ajv')
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sls-ajv'))
 
     const tmpCachePath = path.resolve(tmpDir, filename)
     await fsp.writeFile(tmpCachePath, moduleCode)


### PR DESCRIPTION
## Fix Windows CI EPERM error in AJV schema validation cache

### Problem

The Windows CI runner was failing intermittently with:
```
EPERM: operation not permitted, rename 'C:\a\serverless\serverless\packages\sf-core\sls-ajvqlvHza...' -> 'C:\Users\runneradmin.serverless\artifacts\ajv-validate-...'
```
### Root Cause

The `fsp.mkdtemp('sls-ajv')` call in [resolve-ajv-validate.js](cci:7://file:///Users/czubocha/GolandProjects/v3-serverless/lib/classes/config-schema-handler/resolve-ajv-validate.js:0:0-0:0) was creating temporary directories in the **current working directory** instead of the system temp directory.

On Windows CI:
- **Source**: `C:\a\serverless\...\sls-ajvXXX\` (project workspace)
- **Dest**: `C:\Users\runneradmin\.serverless\...` (user home)

These are in different permission zones, causing `EPERM` errors during the atomic rename operation due to permission restrictions or file handle timing issues.

### Solution

Changed `mkdtemp` to use the proper system temp directory:
```javascript
// Before
const tmpDir = await fsp.mkdtemp('sls-ajv')

// After
const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sls-ajv'))