### PR TITLE
feat: integrate serverless-prune-plugin functionality

### DIFF
--- a/docs/sf/menu.json
+++ b/docs/sf/menu.json
@@ -43,6 +43,7 @@
     "Layers": "providers/aws/guide/layers",
     "Managed Instances": "providers/aws/guide/managed-instances",
     "Alerts": "providers/aws/guide/alerts",
+    "Version Pruning": "providers/aws/guide/prune",
     "Domains": "providers/aws/guide/domains",
     "IAM Function Permissions": "providers/aws/guide/iam",
     "Parameters": "guides/parameters",
@@ -126,6 +127,7 @@
     "plugin install": "providers/aws/cli-reference/plugin-install",
     "plugin uninstall": "providers/aws/cli-reference/plugin-uninstall",
     "print": "providers/aws/cli-reference/print",
+    "prune": "providers/aws/cli-reference/prune",
     "support": "providers/aws/cli-reference/support",
     "usage": "providers/aws/cli-reference/usage",
     "reconcile": "providers/aws/cli-reference/reconcile"

--- a/docs/sf/providers/aws/cli-reference/prune.md
+++ b/docs/sf/providers/aws/cli-reference/prune.md
@@ -1,0 +1,67 @@
+<!--
+title: Serverless Framework Commands - AWS Lambda - Prune
+description: Clean up old Lambda function and layer versions
+short_title: Commands - Prune
+keywords: ['Serverless', 'Framework', 'AWS Lambda', 'prune', 'cleanup', 'versions']
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/aws/cli-reference/prune)
+
+<!-- DOCS-SITE-LINK:END -->
+
+# AWS - Prune
+
+The `prune` command removes old versions of deployed Lambda functions and layers, keeping only the specified number of most recent versions.
+
+```bash
+serverless prune -n <number>
+```
+
+## Options
+
+- `--number` or `-n` **Required.** Number of previous versions to keep.
+- `--stage` or `-s` The stage to prune.
+- `--region` or `-r` The region to prune.
+- `--function` or `-f` Limit pruning to a specific function.
+- `--layer` or `-l` Limit pruning to a specific layer.
+- `--includeLayers` or `-i` Include layers in pruning.
+- `--dryRun` or `-d` Preview what would be deleted without deleting.
+- `--verbose` Enable detailed output.
+
+## Provided lifecycle events
+
+- `prune:prune`
+
+## Examples
+
+### Keep 3 most recent versions
+
+```bash
+serverless prune -n 3
+```
+
+### Dry-run to preview deletions
+
+```bash
+serverless prune -n 3 --dryRun --verbose
+```
+
+### Prune a specific function
+
+```bash
+serverless prune -n 5 -f myFunction
+```
+
+### Prune including layers
+
+```bash
+serverless prune -n 3 --includeLayers
+```
+
+### Prune only a specific layer
+
+```bash
+serverless prune -n 3 -l myLayer
+```

--- a/docs/sf/providers/aws/guide/prune.md
+++ b/docs/sf/providers/aws/guide/prune.md
@@ -1,0 +1,88 @@
+<!--
+title: Lambda Version Pruning
+description: Automatically clean up old Lambda function and layer versions
+short_title: Pruning
+keywords:
+  [
+    'Serverless Framework',
+    'AWS Lambda',
+    'Prune',
+    'Cleanup',
+    'Versions',
+  ]
+-->
+
+# Pruning Lambda Versions
+
+Lambda version pruning is built into the Serverless Framework. Thanks to Clay Gregory and contributors for the [original serverless-prune-plugin](https://github.com/claygregory/serverless-prune-plugin).
+
+## Why Prune?
+
+AWS Lambda retains all published versions of your functions. Over time, this can:
+
+- Consume storage quota
+- Clutter the Lambda console
+- Slow down deployment tooling that enumerates versions (due to pagination / extra API calls)
+
+The prune feature automatically removes old versions while keeping a configurable number of recent versions.
+
+## Configuration
+
+Add the `prune` section to your `custom` block:
+
+```yaml
+custom:
+  prune:
+    automatic: true # Prune after each deploy
+    number: 3 # Keep 3 most recent versions
+    includeLayers: true # Also prune layer versions
+```
+
+### Configuration Options
+
+| Option          | Type    | Default | Description                                |
+| --------------- | ------- | ------- | ------------------------------------------ |
+| `automatic`     | boolean | `false` | Enable automatic pruning after deploy      |
+| `number`        | integer | -       | Number of versions to keep (required for automatic) |
+| `includeLayers` | boolean | `false` | Include Lambda layers in pruning           |
+
+## Manual Pruning
+
+Use the `prune` command to manually clean up versions:
+
+```bash
+# Keep 5 most recent versions
+serverless prune -n 5
+
+# Preview what would be deleted
+serverless prune -n 3 --dryRun --verbose
+
+# Prune a specific function
+serverless prune -n 3 -f myFunction
+
+# Prune layers only
+serverless prune -n 3 -l myLayer
+
+# Prune functions and layers
+serverless prune -n 3 --includeLayers
+```
+
+## Alias Protection
+
+Versions that are referenced by Lambda aliases will **never** be deleted, regardless of the `number` setting. This ensures stable deployments and traffic shifting configurations remain intact.
+
+## Dry Run Mode
+
+Use `--dryRun` with `--verbose` to preview what would be deleted:
+
+```bash
+serverless prune -n 3 --dryRun --verbose
+```
+
+Output:
+
+```
+Prune: myFunction:4 selected for deletion.
+Prune: myFunction:3 selected for deletion.
+Prune: Dry-run enabled, no pruning actions will be performed.
+```

--- a/packages/serverless/lib/classes/plugin-manager.js
+++ b/packages/serverless/lib/classes/plugin-manager.js
@@ -67,6 +67,7 @@ import pluginAwsDomains from '../plugins/aws/domains/index.js'
 import pluginAxiom from '../plugins/observability/axiom/index.js'
 import pluginPythonRequirements from '../plugins/python/index.js'
 import pluginAwsAppsync from '../plugins/aws/appsync/index.js'
+import pluginPrune from '../plugins/prune/index.js'
 import { createRequire } from 'module'
 
 const internalPlugins = [
@@ -130,6 +131,7 @@ const internalPlugins = [
   pluginAwsDomains,
   pluginPythonRequirements,
   pluginAwsAppsync,
+  pluginPrune,
 ]
 
 // Describe core-bundled plugins so we can coordinate loading with any legacy entries in `plugins:`
@@ -174,6 +176,11 @@ const bundledPluginDefinitions = [
             ...context,
           })
         : true,
+  },
+  {
+    module: pluginPrune,
+    externalNames: ['serverless-prune-plugin'],
+    allowCommunityOverride: true,
   },
 ]
 

--- a/packages/serverless/lib/plugins/prune/index.js
+++ b/packages/serverless/lib/plugins/prune/index.js
@@ -1,0 +1,439 @@
+import { log } from '@serverless/util'
+
+class Prune {
+  constructor(serverless, options, { log: pluginLog, progress } = {}) {
+    this.serverless = serverless
+    this.options = options || {}
+    this.provider = this.serverless.getProvider('aws')
+    this.log = pluginLog || log
+    this.progress = progress
+
+    this.pluginCustom = this.loadCustom(this.serverless.service.custom)
+
+    // Define schema for custom.prune configuration
+    serverless.configSchemaHandler.defineCustomProperties({
+      properties: {
+        prune: {
+          type: 'object',
+          properties: {
+            automatic: {
+              type: 'boolean',
+            },
+            number: {
+              type: 'integer',
+              minimum: 0,
+            },
+            includeLayers: {
+              type: 'boolean',
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+    })
+
+    this.commands = {
+      prune: {
+        usage:
+          'Clean up deployed functions and/or layers by deleting older versions.',
+        lifecycleEvents: ['prune'],
+        options: {
+          number: {
+            usage: 'Number of previous versions to keep',
+            shortcut: 'n',
+            required: true,
+            type: 'string',
+          },
+          stage: {
+            usage: 'Stage of the service',
+            shortcut: 's',
+            type: 'string',
+          },
+          region: {
+            usage: 'Region of the service',
+            shortcut: 'r',
+            type: 'string',
+          },
+          function: {
+            usage: 'Function name. Limits cleanup to the specified function',
+            shortcut: 'f',
+            required: false,
+            type: 'string',
+          },
+          layer: {
+            usage: 'Layer name. Limits cleanup to the specified Lambda layer',
+            shortcut: 'l',
+            required: false,
+            type: 'string',
+          },
+          includeLayers: {
+            usage: 'Boolean flag. Includes the pruning of Lambda layers.',
+            shortcut: 'i',
+            required: false,
+            type: 'boolean',
+          },
+          dryRun: {
+            usage:
+              'Simulate pruning without executing delete actions. Deletion candidates are logged when used in conjunction with --verbose',
+            shortcut: 'd',
+            required: false,
+            type: 'boolean',
+          },
+          verbose: {
+            usage: 'Enable detailed output during plugin execution',
+            required: false,
+            type: 'boolean',
+          },
+        },
+      },
+    }
+
+    this.hooks = {
+      'prune:prune': this.cliPrune.bind(this),
+      'after:deploy:deploy': this.postDeploy.bind(this),
+    }
+  }
+
+  getNumber() {
+    return this.options.number || this.pluginCustom.number
+  }
+
+  loadCustom(custom) {
+    const pluginCustom = {}
+    if (custom && custom.prune) {
+      if (custom.prune.number != null) {
+        const number = parseInt(custom.prune.number)
+        if (!isNaN(number)) pluginCustom.number = number
+      }
+
+      if (typeof custom.prune.automatic === 'boolean') {
+        pluginCustom.automatic = custom.prune.automatic
+      }
+
+      if (typeof custom.prune.includeLayers === 'boolean') {
+        pluginCustom.includeLayers = custom.prune.includeLayers
+      }
+    }
+
+    return pluginCustom
+  }
+
+  async cliPrune() {
+    if (this.options.dryRun) {
+      this.logNotice('Dry-run enabled, no pruning actions will be performed.')
+    }
+
+    if (this.options.includeLayers) {
+      await Promise.all([this.pruneFunctions(), this.pruneLayers()])
+      return
+    }
+
+    if (this.options.layer && !this.options.function) {
+      await this.pruneLayers()
+    } else {
+      await this.pruneFunctions()
+    }
+  }
+
+  async postDeploy() {
+    this.pluginCustom = this.loadCustom(this.serverless.service.custom)
+
+    if (this.options.noDeploy === true) {
+      return
+    }
+
+    if (
+      this.pluginCustom.automatic &&
+      this.pluginCustom.number !== undefined &&
+      this.pluginCustom.number >= 0
+    ) {
+      if (this.pluginCustom.includeLayers) {
+        await Promise.all([this.pruneFunctions(), this.pruneLayers()])
+        return
+      }
+
+      await this.pruneFunctions()
+    }
+  }
+
+  async pruneLayers() {
+    const selectedLayers = this.options.layer
+      ? [this.options.layer]
+      : this.serverless.service.getAllLayers()
+    const layerNames = selectedLayers.map(
+      (key) => this.serverless.service.getLayer(key).name || key,
+    )
+
+    this.createProgress('prune-plugin-prune-layers', 'Pruning layer versions')
+
+    const layersData = []
+    for (const layerName of layerNames) {
+      const versions = await this.listVersionsForLayer(layerName)
+      layersData.push({ name: layerName, versions })
+    }
+
+    for (const { name, versions } of layersData) {
+      if (!versions.length) {
+        continue
+      }
+
+      const deletionCandidates = this.selectPruneVersionsForLayer(versions)
+      if (deletionCandidates.length > 0) {
+        this.updateProgress(
+          'prune-plugin-prune-layers',
+          `Pruning layer versions (${name})`,
+        )
+      }
+
+      if (this.options.dryRun) {
+        this.printPruningCandidates(name, deletionCandidates)
+      } else {
+        await this.deleteVersionsForLayer(name, deletionCandidates)
+      }
+    }
+
+    this.clearProgress('prune-plugin-prune-layers')
+    this.logSuccess('Pruning of layers complete')
+  }
+
+  async pruneFunctions() {
+    const selectedFunctions = this.options.function
+      ? [this.options.function]
+      : this.serverless.service.getAllFunctions()
+    const functionNames = selectedFunctions.map(
+      (key) => this.serverless.service.getFunction(key).name,
+    )
+
+    this.createProgress(
+      'prune-plugin-prune-functions',
+      'Pruning function versions',
+    )
+
+    const functionsData = []
+    for (const functionName of functionNames) {
+      const [versions, aliases] = await Promise.all([
+        this.listVersionForFunction(functionName),
+        this.listAliasesForFunction(functionName),
+      ])
+      functionsData.push({ name: functionName, versions, aliases })
+    }
+
+    for (const { name, versions, aliases } of functionsData) {
+      if (!versions.length) {
+        continue
+      }
+
+      const deletionCandidates = this.selectPruneVersionsForFunction(
+        versions,
+        aliases,
+      )
+      if (deletionCandidates.length > 0) {
+        this.updateProgress(
+          'prune-plugin-prune-functions',
+          `Pruning function versions (${name})`,
+        )
+      }
+
+      if (this.options.dryRun) {
+        this.printPruningCandidates(name, deletionCandidates)
+      } else {
+        await this.deleteVersionsForFunction(name, deletionCandidates)
+      }
+    }
+
+    this.clearProgress('prune-plugin-prune-functions')
+    this.logSuccess('Pruning of functions complete')
+  }
+
+  async deleteVersionsForLayer(layerName, versions) {
+    for (const version of versions) {
+      this.logInfo(`Deleting layer version ${layerName}:${version}.`)
+
+      const params = {
+        LayerName: layerName,
+        VersionNumber: version,
+      }
+
+      await this.provider.request('Lambda', 'deleteLayerVersion', params)
+    }
+  }
+
+  async deleteVersionsForFunction(functionName, versions) {
+    for (const version of versions) {
+      this.logInfo(`Deleting function version ${functionName}:${version}.`)
+
+      const params = {
+        FunctionName: functionName,
+        Qualifier: version,
+      }
+
+      try {
+        await this.provider.request('Lambda', 'deleteFunction', params)
+      } catch (e) {
+        // Ignore if trying to delete replicated lambda edge function
+        if (
+          e.providerError &&
+          e.providerError.statusCode === 400 &&
+          e.providerError.message.startsWith('Lambda was unable to delete') &&
+          e.providerError.message.indexOf(
+            'because it is a replicated function.',
+          ) > -1
+        ) {
+          this.logWarning(
+            `Unable to delete replicated Lambda@Edge function version ${functionName}:${version}.`,
+          )
+        } else {
+          throw e
+        }
+      }
+    }
+  }
+
+  async listAliasesForFunction(functionName) {
+    const params = {
+      FunctionName: functionName,
+    }
+
+    try {
+      return await this.makeLambdaRequest(
+        'listAliases',
+        params,
+        (r) => r.Aliases,
+      )
+    } catch (e) {
+      // Ignore if function not deployed
+      if (e.providerError && e.providerError.statusCode === 404) return []
+      throw e
+    }
+  }
+
+  async listVersionForFunction(functionName) {
+    const params = {
+      FunctionName: functionName,
+    }
+
+    try {
+      return await this.makeLambdaRequest(
+        'listVersionsByFunction',
+        params,
+        (r) => r.Versions,
+      )
+    } catch (e) {
+      // Ignore if function not deployed
+      if (e.providerError && e.providerError.statusCode === 404) return []
+      throw e
+    }
+  }
+
+  async listVersionsForLayer(layerName) {
+    const params = {
+      LayerName: layerName,
+    }
+
+    try {
+      return await this.makeLambdaRequest(
+        'listLayerVersions',
+        params,
+        (r) => r.LayerVersions,
+      )
+    } catch (e) {
+      // Ignore if layer not deployed
+      if (e.providerError && e.providerError.statusCode === 404) return []
+      throw e
+    }
+  }
+
+  async makeLambdaRequest(action, params, responseMapping) {
+    const results = []
+
+    let response = await this.provider.request('Lambda', action, params)
+    results.push(...responseMapping(response))
+
+    while (response.NextMarker) {
+      response = await this.provider.request('Lambda', action, {
+        ...params,
+        Marker: response.NextMarker,
+      })
+      results.push(...responseMapping(response))
+    }
+
+    return results
+  }
+
+  selectPruneVersionsForFunction(versions, aliases) {
+    const aliasedVersion = aliases.map((a) => a.FunctionVersion)
+
+    return versions
+      .map((f) => f.Version)
+      .filter((v) => v !== '$LATEST') // skip $LATEST
+      .filter((v) => aliasedVersion.indexOf(v) === -1) // skip aliased versions
+      .sort((a, b) =>
+        parseInt(a) === parseInt(b) ? 0 : parseInt(a) > parseInt(b) ? -1 : 1,
+      )
+      .slice(this.getNumber())
+  }
+
+  selectPruneVersionsForLayer(versions) {
+    return versions
+      .map((f) => f.Version)
+      .sort((a, b) =>
+        parseInt(a) === parseInt(b) ? 0 : parseInt(a) > parseInt(b) ? -1 : 1,
+      )
+      .slice(this.getNumber())
+  }
+
+  printPruningCandidates(name, deletionCandidates) {
+    deletionCandidates.forEach((version) =>
+      this.logInfo(`${name}:${version} selected for deletion.`),
+    )
+  }
+
+  // -- Logging utilities ---
+
+  logInfo(message) {
+    if (this.log.info) this.log.info(message)
+    else if (this.log) this.log(`Prune: ${message}`)
+  }
+
+  logNotice(message) {
+    if (this.log.notice) this.log.notice(message)
+    else if (this.log) this.log(`Prune: ${message}`)
+  }
+
+  logWarning(message) {
+    if (this.log.warning) this.log.warning(message)
+    else if (this.log) this.log(`Prune: ${message}`)
+  }
+
+  logSuccess(message) {
+    if (this.log.success) this.log.success(message)
+    else if (this.log) this.log(`Prune: ${message}`)
+  }
+
+  createProgress(name, message) {
+    if (!this.progress) {
+      this.logInfo(`${message}...`)
+    } else {
+      this.progress.create({
+        message,
+        name,
+      })
+    }
+  }
+
+  updateProgress(name, message) {
+    if (!this.progress) {
+      this.logInfo(message)
+    } else {
+      this.progress.get(name).update(message)
+    }
+  }
+
+  clearProgress(name) {
+    if (this.progress) {
+      this.progress.get(name).remove()
+    }
+  }
+}
+
+export default Prune

--- a/packages/serverless/test/unit/lib/plugins/prune/index.test.js
+++ b/packages/serverless/test/unit/lib/plugins/prune/index.test.js
@@ -1,0 +1,658 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+import Prune from '../../../../../lib/plugins/prune/index.js'
+
+describe('Prune', () => {
+  let serverless
+  let options
+  let plugin
+  let providerRequest
+
+  const createMockServerless = (functions = [], serviceCustom = {}) => {
+    providerRequest = jest.fn()
+    const serverlessMock = {
+      getProvider: jest.fn().mockReturnValue({
+        request: providerRequest,
+      }),
+      cli: { log: jest.fn() },
+      service: {
+        getAllFunctions: jest.fn().mockReturnValue(functions),
+        getFunction: jest.fn().mockImplementation((key) => ({
+          name: `service-${key}`,
+        })),
+        getAllLayers: jest.fn().mockReturnValue([]),
+        getLayer: jest.fn(),
+        custom: serviceCustom,
+      },
+      configSchemaHandler: {
+        defineCustomProperties: jest.fn(),
+      },
+    }
+    return serverlessMock
+  }
+
+  const createMockServerlessWithLayers = (layers = [], serviceCustom = {}) => {
+    const serverlessMock = createMockServerless([], serviceCustom)
+    serverlessMock.service.getAllLayers = jest.fn().mockReturnValue(layers)
+    serverlessMock.service.getLayer = jest.fn().mockImplementation((key) => ({
+      name: `layer-${key}`,
+    }))
+    return serverlessMock
+  }
+
+  const createAliasResponse = (versions) => ({
+    Aliases: [...versions, '$LATEST'].map((v) => ({
+      FunctionVersion: `${v}`,
+      Description: `Alias v${v}`,
+    })),
+  })
+
+  const createVersionsResponse = (versions) => ({
+    Versions: versions.map((v) => ({
+      Version: `${v}`,
+      Description: `Version v${v}`,
+    })),
+  })
+
+  const createLayerVersionsResponse = (versions) => ({
+    LayerVersions: versions.map((v) => ({
+      Version: `${v}`,
+    })),
+  })
+
+  describe('constructor', () => {
+    it('should assign correct properties and define schema', () => {
+      serverless = createMockServerless()
+      options = { stage: 'dev', region: 'us-east-1' }
+      plugin = new Prune(serverless, options)
+
+      expect(plugin.serverless).toBe(serverless)
+      expect(plugin.options).toBe(options)
+      expect(serverless.getProvider).toHaveBeenCalledWith('aws')
+      expect(
+        serverless.configSchemaHandler.defineCustomProperties,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            prune: expect.objectContaining({
+              type: 'object',
+            }),
+          }),
+        }),
+      )
+    })
+
+    it('should load custom options from serverless.yml', () => {
+      serverless = createMockServerless([], {
+        prune: { automatic: true, number: 5, includeLayers: true },
+      })
+      plugin = new Prune(serverless, {})
+
+      expect(plugin.pluginCustom.number).toBe(5)
+      expect(plugin.pluginCustom.automatic).toBe(true)
+      expect(plugin.pluginCustom.includeLayers).toBe(true)
+      expect(plugin.getNumber()).toBe(5)
+    })
+
+    it('should set up commands and hooks', () => {
+      serverless = createMockServerless()
+      plugin = new Prune(serverless, {})
+
+      expect(plugin.commands.prune).toBeDefined()
+      expect(plugin.commands.prune.lifecycleEvents).toContain('prune')
+      expect(plugin.hooks['prune:prune']).toBeDefined()
+      expect(plugin.hooks['after:deploy:deploy']).toBeDefined()
+    })
+
+    it('should prioritize CLI number over serverless.yml', () => {
+      serverless = createMockServerless([], { prune: { number: 5 } })
+      plugin = new Prune(serverless, { number: 7 })
+
+      expect(plugin.getNumber()).toBe(7)
+    })
+  })
+
+  describe('deleteVersionsForFunction', () => {
+    beforeEach(() => {
+      serverless = createMockServerless()
+      plugin = new Prune(serverless, {})
+    })
+
+    it('should delete specified function versions', async () => {
+      await plugin.deleteVersionsForFunction('MyFunc', ['1', '2'])
+
+      expect(providerRequest).toHaveBeenCalledTimes(2)
+      expect(providerRequest).toHaveBeenCalledWith('Lambda', 'deleteFunction', {
+        FunctionName: 'MyFunc',
+        Qualifier: '1',
+      })
+      expect(providerRequest).toHaveBeenCalledWith('Lambda', 'deleteFunction', {
+        FunctionName: 'MyFunc',
+        Qualifier: '2',
+      })
+    })
+
+    it('should ignore Lambda@Edge replication errors', async () => {
+      providerRequest.mockRejectedValue({
+        providerError: {
+          statusCode: 400,
+          message:
+            'Lambda was unable to delete ... because it is a replicated function.',
+        },
+      })
+
+      await expect(
+        plugin.deleteVersionsForFunction('MyEdgeFunc', ['1']),
+      ).resolves.not.toThrow()
+    })
+
+    it('should throw other errors', async () => {
+      providerRequest.mockRejectedValue(new Error('Unexpected error'))
+      await expect(
+        plugin.deleteVersionsForFunction('MyFunc', ['1']),
+      ).rejects.toThrow('Unexpected error')
+    })
+
+    it('should not request deletions if provided versions array is empty', async () => {
+      await plugin.deleteVersionsForFunction('MyFunction', [])
+      expect(providerRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pruneFunctions', () => {
+    it('should delete old versions of functions', async () => {
+      serverless = createMockServerless(['FuncA', 'FuncB'])
+      plugin = new Prune(serverless, { number: 2 })
+
+      providerRequest
+        .mockResolvedValueOnce(createVersionsResponse([1, 2, 3, 4, 5])) // FuncA
+        .mockResolvedValueOnce(createAliasResponse([])) // FuncA aliases
+        .mockResolvedValueOnce(createVersionsResponse([1, 2, 3])) // FuncB
+        .mockResolvedValueOnce(createAliasResponse([])) // FuncB aliases
+
+      await plugin.pruneFunctions()
+
+      // FuncA: keep 5, 4. delete 3, 2, 1
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({
+          FunctionName: 'service-FuncA',
+          Qualifier: '1',
+        }),
+      )
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({
+          FunctionName: 'service-FuncA',
+          Qualifier: '2',
+        }),
+      )
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({
+          FunctionName: 'service-FuncA',
+          Qualifier: '3',
+        }),
+      )
+      // FuncB: keep 3, 2. delete 1
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({
+          FunctionName: 'service-FuncB',
+          Qualifier: '1',
+        }),
+      )
+    })
+
+    it('should keep requested number of version', async () => {
+      serverless = createMockServerless(['FuncA'], { prune: { number: 5 } })
+      plugin = new Prune(serverless, { number: 3 })
+
+      providerRequest
+        .mockResolvedValueOnce(createVersionsResponse([1, 2, 3, 4]))
+        .mockResolvedValueOnce(createAliasResponse([]))
+
+      await plugin.pruneFunctions()
+
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ Qualifier: '1' }),
+      )
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ Qualifier: '2' }),
+      )
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ Qualifier: '3' }),
+      )
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ Qualifier: '4' }),
+      )
+    })
+
+    it('should not delete $LATEST version', async () => {
+      serverless = createMockServerless(['FuncA'])
+      plugin = new Prune(serverless, { number: 1 })
+
+      providerRequest
+        .mockResolvedValueOnce(createVersionsResponse([1, 2]))
+        .mockResolvedValueOnce(createAliasResponse([]))
+
+      await plugin.pruneFunctions()
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ Qualifier: '$LATEST' }),
+      )
+    })
+
+    it('should not delete aliased versions', async () => {
+      serverless = createMockServerless(['FuncA'])
+      plugin = new Prune(serverless, { number: 1 })
+
+      providerRequest
+        .mockResolvedValueOnce(createVersionsResponse([1, 2, 3]))
+        .mockResolvedValueOnce(createAliasResponse([1]))
+
+      await plugin.pruneFunctions()
+
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ Qualifier: '2' }),
+      )
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ Qualifier: '1' }),
+      )
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ Qualifier: '3' }),
+      )
+    })
+
+    it('should always match delete requests to correct function', async () => {
+      serverless = createMockServerless(['FuncA', 'FuncB'])
+      plugin = new Prune(serverless, { number: 2 })
+
+      providerRequest.mockImplementation((service, action, params) => {
+        if (action === 'listVersionsByFunction') {
+          if (params.FunctionName === 'service-FuncA')
+            return createVersionsResponse([1])
+          if (params.FunctionName === 'service-FuncB')
+            return createVersionsResponse([1, 2, 3])
+        }
+        if (action === 'listAliases') return createAliasResponse([])
+        return Promise.resolve({})
+      })
+
+      await plugin.pruneFunctions()
+
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ FunctionName: 'service-FuncA' }),
+      )
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({
+          FunctionName: 'service-FuncB',
+          Qualifier: '1',
+        }),
+      )
+    })
+
+    it('should ignore functions that are not deployed', async () => {
+      serverless = createMockServerless(['FuncA', 'FuncB'])
+      plugin = new Prune(serverless, { number: 1 })
+
+      providerRequest.mockImplementation((service, action, params) => {
+        if (params.FunctionName === 'service-FuncA') {
+          return Promise.reject({ providerError: { statusCode: 404 } })
+        }
+        if (action === 'listVersionsByFunction')
+          return createVersionsResponse([1, 2])
+        if (action === 'listAliases') return createAliasResponse([])
+        return Promise.resolve({})
+      })
+
+      await plugin.pruneFunctions()
+
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ FunctionName: 'service-FuncA' }),
+      )
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({
+          FunctionName: 'service-FuncB',
+          Qualifier: '1',
+        }),
+      )
+    })
+
+    it('should only operate on target function if specified from CLI', async () => {
+      serverless = createMockServerless(['FuncA', 'FuncB'])
+      plugin = new Prune(serverless, { function: 'FuncA', number: 1 })
+
+      providerRequest
+        .mockResolvedValueOnce(createVersionsResponse([1, 2]))
+        .mockResolvedValueOnce(createAliasResponse([]))
+
+      await plugin.pruneFunctions()
+
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ FunctionName: 'service-FuncA' }),
+      )
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteFunction',
+        expect.objectContaining({ FunctionName: 'service-FuncB' }),
+      )
+    })
+
+    it('should respect dryRun flag', async () => {
+      serverless = createMockServerless(['FuncA'])
+      plugin = new Prune(serverless, { number: 1, dryRun: true })
+      const deleteSpy = jest.spyOn(plugin, 'deleteVersionsForFunction')
+
+      providerRequest
+        .mockResolvedValueOnce(createVersionsResponse([1, 2]))
+        .mockResolvedValueOnce(createAliasResponse([]))
+
+      await plugin.pruneFunctions()
+      expect(deleteSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('pruneLayers', () => {
+    it('should delete old versions of layers', async () => {
+      serverless = createMockServerlessWithLayers(['LayerA', 'LayerB'])
+      plugin = new Prune(serverless, { number: 2, includeLayers: true })
+
+      providerRequest
+        .mockResolvedValueOnce(createLayerVersionsResponse([1, 2, 3, 4, 5]))
+        .mockResolvedValueOnce(createLayerVersionsResponse([1, 2, 3]))
+
+      await plugin.pruneLayers()
+
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteLayerVersion',
+        {
+          LayerName: 'layer-LayerA',
+          VersionNumber: '1',
+        },
+      )
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteLayerVersion',
+        {
+          LayerName: 'layer-LayerA',
+          VersionNumber: '2',
+        },
+      )
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteLayerVersion',
+        {
+          LayerName: 'layer-LayerA',
+          VersionNumber: '3',
+        },
+      )
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteLayerVersion',
+        {
+          LayerName: 'layer-LayerB',
+          VersionNumber: '1',
+        },
+      )
+    })
+
+    it('should keep requested number of version', async () => {
+      serverless = createMockServerlessWithLayers(['LayerA'])
+      plugin = new Prune(serverless, { number: 3, includeLayers: true })
+
+      providerRequest.mockResolvedValueOnce(
+        createLayerVersionsResponse([1, 2, 3, 4]),
+      )
+
+      await plugin.pruneLayers()
+
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteLayerVersion',
+        expect.objectContaining({ VersionNumber: '1' }),
+      )
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteLayerVersion',
+        expect.objectContaining({ VersionNumber: '2' }),
+      )
+    })
+
+    it('should handle non-deployed layers', async () => {
+      serverless = createMockServerlessWithLayers(['LayerA'])
+      plugin = new Prune(serverless, { number: 1, includeLayers: true })
+
+      providerRequest.mockRejectedValueOnce({
+        providerError: { statusCode: 404 },
+      })
+
+      await expect(plugin.pruneLayers()).resolves.not.toThrow()
+    })
+
+    it('should only operate on target layer if specified from CLI', async () => {
+      serverless = createMockServerlessWithLayers(['LayerA', 'LayerB'])
+      plugin = new Prune(serverless, {
+        layer: 'LayerA',
+        includeLayers: true,
+        number: 1,
+      })
+
+      providerRequest.mockResolvedValueOnce(createLayerVersionsResponse([1, 2]))
+
+      await plugin.pruneLayers()
+
+      expect(providerRequest).toHaveBeenCalledWith(
+        'Lambda',
+        'deleteLayerVersion',
+        expect.objectContaining({ LayerName: 'layer-LayerA' }),
+      )
+      expect(providerRequest).not.toHaveBeenCalledWith(
+        'Lambda',
+        'deleteLayerVersion',
+        expect.objectContaining({ LayerName: 'layer-LayerB' }),
+      )
+    })
+
+    it('should respect dryRun flag', async () => {
+      serverless = createMockServerlessWithLayers(['LayerA'])
+      plugin = new Prune(serverless, {
+        number: 1,
+        dryRun: true,
+        includeLayers: true,
+      })
+      const deleteSpy = jest.spyOn(plugin, 'deleteVersionsForLayer')
+
+      providerRequest.mockResolvedValueOnce(createLayerVersionsResponse([1, 2]))
+
+      await plugin.pruneLayers()
+      expect(deleteSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('postDeploy', () => {
+    it('should run auto-prune if enabled', async () => {
+      serverless = createMockServerless(['FuncA'], {
+        prune: { automatic: true, number: 3 },
+      })
+      plugin = new Prune(serverless, {})
+      const pruneSpy = jest.spyOn(plugin, 'pruneFunctions').mockResolvedValue()
+
+      await plugin.postDeploy()
+      expect(pruneSpy).toHaveBeenCalled()
+    })
+
+    it('should prune all functions if number is 0', async () => {
+      serverless = createMockServerless(['FuncA'], {
+        prune: { automatic: true, number: 0 },
+      })
+      plugin = new Prune(serverless, {})
+      const pruneSpy = jest.spyOn(plugin, 'pruneFunctions').mockResolvedValue()
+
+      await plugin.postDeploy()
+      expect(pruneSpy).toHaveBeenCalled()
+    })
+
+    it('should skip if automatic is true but no number', async () => {
+      serverless = createMockServerless(['FuncA'], {
+        prune: { automatic: true },
+      })
+      plugin = new Prune(serverless, {})
+      const pruneSpy = jest.spyOn(plugin, 'pruneFunctions')
+
+      await plugin.postDeploy()
+      expect(pruneSpy).not.toHaveBeenCalled()
+    })
+
+    it('should skip auto-prune if disabled', async () => {
+      serverless = createMockServerless(['FuncA'], {
+        prune: { automatic: false },
+      })
+      plugin = new Prune(serverless, {})
+      const pruneSpy = jest.spyOn(plugin, 'pruneFunctions')
+
+      await plugin.postDeploy()
+      expect(pruneSpy).not.toHaveBeenCalled()
+    })
+
+    it('should skip if noDeploy is true', async () => {
+      serverless = createMockServerless([], {
+        prune: { automatic: true, number: 3 },
+      })
+      plugin = new Prune(serverless, { noDeploy: true })
+      const pruneSpy = jest.spyOn(plugin, 'pruneFunctions')
+
+      await plugin.postDeploy()
+      expect(pruneSpy).not.toHaveBeenCalled()
+    })
+
+    it('should not prune layers if includeLayers is false', async () => {
+      serverless = createMockServerlessWithLayers(['LayerA'], {
+        prune: { automatic: true, number: 3, includeLayers: false },
+      })
+      plugin = new Prune(serverless, {})
+      const pruneSpy = jest.spyOn(plugin, 'pruneLayers')
+
+      await plugin.postDeploy()
+      expect(pruneSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cliPrune', () => {
+    it('should only prune functions by default', async () => {
+      serverless = createMockServerless(['FuncA'])
+      plugin = new Prune(serverless, { number: 3 })
+      const pruneFuncsSpy = jest
+        .spyOn(plugin, 'pruneFunctions')
+        .mockResolvedValue()
+      const pruneLayersSpy = jest
+        .spyOn(plugin, 'pruneLayers')
+        .mockResolvedValue()
+
+      await plugin.cliPrune()
+      expect(pruneFuncsSpy).toHaveBeenCalled()
+      expect(pruneLayersSpy).not.toHaveBeenCalled()
+    })
+
+    it('should prune functions and layers if includeLayers is set', async () => {
+      serverless = createMockServerlessWithLayers(['LayerA'])
+      plugin = new Prune(serverless, { number: 3, includeLayers: true })
+      const pruneFuncsSpy = jest
+        .spyOn(plugin, 'pruneFunctions')
+        .mockResolvedValue()
+      const pruneLayersSpy = jest
+        .spyOn(plugin, 'pruneLayers')
+        .mockResolvedValue()
+
+      await plugin.cliPrune()
+      expect(pruneFuncsSpy).toHaveBeenCalled()
+      expect(pruneLayersSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('logging helpers', () => {
+    let logMock
+    beforeEach(() => {
+      serverless = createMockServerless()
+      logMock = {
+        info: jest.fn(),
+        warning: jest.fn(),
+        success: jest.fn(),
+      }
+      plugin = new Prune(serverless, {}, { log: logMock })
+    })
+
+    it('should log info', () => {
+      plugin.logInfo('test info')
+      expect(logMock.info).toHaveBeenCalledWith('test info')
+    })
+
+    it('should log warning', () => {
+      plugin.logWarning('test warning')
+      expect(logMock.warning).toHaveBeenCalledWith('test warning')
+    })
+
+    it('should log success', () => {
+      plugin.logSuccess('test success')
+      expect(logMock.success).toHaveBeenCalledWith('test success')
+    })
+  })
+
+  describe('pagination', () => {
+    it('should handle paginated lambda requests', async () => {
+      serverless = createMockServerless()
+      plugin = new Prune(serverless, {})
+
+      providerRequest
+        .mockResolvedValueOnce({
+          Versions: [{ Version: '1' }],
+          NextMarker: 'marker1',
+        })
+        .mockResolvedValueOnce({
+          Versions: [{ Version: '2' }],
+        })
+
+      const versions = await plugin.listVersionForFunction('MyFunc')
+      expect(versions).toHaveLength(2)
+      expect(providerRequest).toHaveBeenCalledTimes(2)
+      expect(providerRequest).toHaveBeenNthCalledWith(
+        2,
+        'Lambda',
+        'listVersionsByFunction',
+        {
+          FunctionName: 'MyFunc',
+          Marker: 'marker1',
+        },
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This PR integrates the `serverless-prune-plugin` directly into the Serverless Framework core as a bundled plugin. This migration improves the developer experience by providing built-in Lambda version management without requiring external dependencies.

## Key Changes

### 🚀 Core Integration
- **New Core Plugin**: Implemented `Prune` core plugin in `packages/serverless/lib/plugins/prune/index.js`.
- **ESM Transition**: Converted the original CommonJS codebase to ES Modules.
- **Async/Await**: Replaced all `bluebird` promises with native `async/await` and `Promise` methods.
- **Plugin Manager Integration**: Registered the plugin in `plugin-manager.js` as a core-bundled plugin. The `prune` command is now **always available**.
- **Schema Validation**: Defined a full JSON schema for `custom.prune` configuration (`automatic`, `number`, `includeLayers`).

### 📚 Documentation
- **New Usage Guide**: Created a comprehensive Version Pruning Guide (`docs/sf/providers/aws/guide/prune.md`).
- **New CLI Reference**: Created CLI Reference for Prune (`docs/sf/providers/aws/cli-reference/prune.md`).
- **Navigation Update**: Added "Version Pruning" to the documentation menu.

### 🧪 Testing & Verification
- **Jest Test Suite**: Migrated the original Mocha suite to a native Jest suite with 33 comprehensive tests.
    - Passes with 100% success: `npm run test:unit -- test/unit/lib/plugins/prune/index.test.js`
- **Manual Verification**: Verified `serverless prune` command and automatic pruning after deployment using a real AWS test service.
- **Security**: Passed Snyk Code scan with 0 issues.

## Verification Results

### Unit Tests
```bash
PASS test/unit/lib/plugins/prune/index.test.js
Test Suites: 1 passed, 1 total
Tests:       33 passed, 33 total
```

### Manual CLI Test (Dry-run)
```bash
$ serverless prune -n 3 --dryRun --verbose
Dry-run enabled, no pruning actions will be performed.
✔ Pruning of functions complete
```