### PR TITLE
fix(esbuild): handle sourcemap object without type property

### DIFF
--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -413,6 +413,12 @@ class Esbuild {
           mergedOptions.sourcemap =
             this.serverless.service.build.esbuild.sourcemap.type
         }
+      } else if (
+        typeof this.serverless.service.build.esbuild.sourcemap === 'object'
+      ) {
+        // When sourcemap is an object without type (e.g., { setNodeOptions: false }),
+        // default to true for esbuild compatibility
+        mergedOptions.sourcemap = true
       }
 
       return mergedOptions


### PR DESCRIPTION
### Problem

Setting `build.esbuild.sourcemap.setNodeOptions: false` in `serverless.yml` caused an esbuild error:

```
"sourcemap" must be a string or a boolean
```

This happened because the full `sourcemap` object (`{ setNodeOptions: false }`) was passed directly to esbuild, which only accepts string or boolean values.

### Solution

When `sourcemap` is an object without a `type` property, default to `sourcemap: true` for esbuild while still respecting the `setNodeOptions` setting.
