### PR TITLE
feat: add support for `ap-east-2` region

### DIFF
--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -600,7 +600,7 @@ class AwsProvider {
               'ruby2.7',
               'ruby3.2',
               'ruby3.3',
-              'ruby3.4'
+              'ruby3.4',
             ],
           },
           awsLambdaRuntimeManagement: {
@@ -1544,6 +1544,7 @@ class AwsProvider {
                 'us-west-2',
                 'af-south-1',
                 'ap-east-1',
+                'ap-east-2',
                 'ap-northeast-1',
                 'ap-northeast-2',
                 'ap-northeast-3',


### PR DESCRIPTION
# Add Support for AWS Region Taipei `ap-east-2`

Resolves #13257

## Summary

Adds support for the new AWS Asia Pacific (Taipei) region `ap-east-2` to the Serverless Framework.

## Changes

### Schema Validation
Added `ap-east-2` to the allowed regions enum in `provider.region` schema validation.

## Files Changed

| File | Change |
|------|--------|
| `packages/serverless/lib/plugins/aws/provider.js` | Added `ap-east-2` to region enum |

## Limitations

> [!NOTE]
> The `serverless dev` command is **not supported** in `ap-east-2` because AWS IoT Core is not currently available in that region. Once AWS launches IoT Core in Taipei, we can add support for dev mode.

## Verification

Users can now deploy to `ap-east-2` region:

```yaml
provider:
  name: aws
  region: ap-east-2
```
