### PR TITLE
chore(deps): add glob v11 compatibility exclusion for Node.js 18 in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,9 @@ updates:
       - dependency-name: "chokidar"
         # chokidar v5 drops support for Node.js 18
         versions: [">= 5.0.0"]
+      - dependency-name: "glob"
+        # glob v11 drops support for Node.js 18
+        versions: [">= 11.0.0"]
 
   # Maintain Go dependencies
   - package-ecosystem: "gomod"


### PR DESCRIPTION
## Add `glob` to dependabot ignore list

### Description

`glob` v11+ drops support for Node.js 18, which conflicts with Serverless Framework's Node >=18 requirement. This PR adds `glob` to the dependabot ignore list to prevent automatic upgrade PRs for versions >= 11.0.0.

### Changes

- Added `glob` to .github/dependabot.yml ignore list with versions `>= 11.0.0`

### Context

The `glob` package changelog shows:
- **v11.0**: Drops support for Node.js versions before v20
- **v12**: Removes CLI `--shell` option
- **v13**: Moves CLI to separate `glob-bin` package

Since Serverless Framework must support Node >=18, we're pinned to `glob` v10.x (currently `^10.5.0`).