### PR TITLE
docs: fix typos in README, SCF upgrade guide, and AWS dev plugin comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 **The Serverless Framework** – Makes it easy to use AWS Lambda and other managed cloud services to build applications that auto-scale, cost nothing when idle, and result in radically low maintenance.
 
-The Serverless Framework is a command-line tool with approachable YAML syntax to deploy both your code and cloud infrastructure needed to make tons of serverless application use-cases, like APIs, front-ends, data pipelines and scheduled tasks. It's a multi-language framework that supports Node.js, Typescript, Python, Go, Java, and more. It's also completely extensible via over 1,000 plugins which add more serverless use-cases and workflows to the Framework.
+The Serverless Framework is a command-line tool with approachable YAML syntax to deploy both your code and cloud infrastructure needed to make tons of serverless application use-cases, like APIs, front-ends, data pipelines and scheduled tasks. It's a multi-language framework that supports Node.js, TypeScript, Python, Go, Java, and more. It's also completely extensible via over 1,000 plugins which add more serverless use-cases and workflows to the Framework.
 
 Actively maintained by [Serverless Inc](https://www.serverless.com).
 
@@ -49,7 +49,7 @@ Here's a list of everything that's new in V.4, so far:
 - **Introducing [Serverless MCP](https://www.serverless.com/framework/docs/guides/mcp):** Built for Cursor, Windsurf, and other AI-powered IDEs, it auto-detects cloud resources from your code, fetching logs, state, and config from AWS, enabling you to debug serverless apps directly in your IDE — no AWS console visit needed! Supports Serverless Framework, Cloudformation, and more.
 - **Introducing the [Serverless Container Framework](https://github.com/serverless/containers):** One solution to deploy serverless workloads everywhere - This is a new YAML file that works with the Serverless Framework CLI that gives you one experience to easily deploy containers to AWS Lambda and AWS ECS Fargate and migrate between them w/ zero-downtime — all without re-architecting. We launched this as a way to reduce large Lambda bills and give folks flexibility, but it is rapidly become the greatest developer experience for containers on AWS. Support for Google Cloud Run, Azure and more are coming soon.
 - **Support for AWS SAM, AWS Cloudformation, & Traditional Serverless Framework Projects:** Now, you can use one tool to deploy all three of these IaC project files. [More info here](https://www.serverless.com/framework/docs/guides/sam)
-- **Native Typescript Support:** You can now use `.ts` handlers in your AWS Lambda functions in `serverless.yml` and have them build automatically upon deploy. [ESBuild](https://esbuild.github.io/) is now included in the Framework which makes this possible. [More info here](https://www.serverless.com/framework/docs/providers/aws/guide/building).
+- **Native TypeScript Support:** You can now use `.ts` handlers in your AWS Lambda functions in `serverless.yml` and have them build automatically upon deploy. [ESBuild](https://esbuild.github.io/) is now included in the Framework which makes this possible. [More info here](https://www.serverless.com/framework/docs/providers/aws/guide/building).
 - **The AWS AI Stack:** V.4 is optimized for [the AWS AI Stack](https://github.com/serverless/aws-ai-stack). Deploy a full-stack, serverless, boilerplate for AI applications on AWS, featuring Bedrock LLMs like Claude 3.5 Sonnet and Llama3.1 and much more.
 - **New Dev Mode:** Run `serverless dev` to have events from your live architecture routed to your local code, enabling you to make fast changes without deployment. [More info here](https://www.serverless.com/framework/docs/providers/aws/cli-reference/dev).
 - **Latest Runtime Support:** Support for Node.js 22 (`nodejs24.x`, Python 3.14 (`python3.14`) and Java 25 (`java25`), on AWS Lambda.
@@ -161,7 +161,7 @@ serverless
 
 ## Create A Service
 
-The primary concept for a project in the Serverless Framework is known as a "Service", and its declared by a `serverless.yml` file, which contains simplified syntax for deploying cloud infrastructure, such as AWS Lambda functions, infrastructure that triggers those functions with events, and additional infrastructure your AWS Lambda functions may need for various use-cases (e.g. AWS DynamoDB database tables, AWS S3 storage buckets, AWS API Gateways for recieving HTTP requests and forwarding them to AWS Lambda).
+The primary concept for a project in the Serverless Framework is known as a "Service", and it's declared by a `serverless.yml` file, which contains simplified syntax for deploying cloud infrastructure, such as AWS Lambda functions, infrastructure that triggers those functions with events, and additional infrastructure your AWS Lambda functions may need for various use-cases (e.g. AWS DynamoDB database tables, AWS S3 storage buckets, AWS API Gateways for receiving HTTP requests and forwarding them to AWS Lambda).
 
 A Service can either be an entire application, logic for a specific domain (e.g. "blog", "users", "products"), or a microservice handling one task. You decide how to organize your project. Generally, we recommend starting with a monolithic approach to everything to reduce complexity, until breaking up logic is absolutely necessary.
 
@@ -391,7 +391,7 @@ More details on the **serverless-offline** plugins command can be found [here](h
 
 A big benefit of Serverless Framework is within its [Plugin ecosystem](https://serverless.com/plugins).
 
-Plugins extend or overwrite the Serverless Framework, giving it new use-cases or capabilites, and there are hundreds of them.
+Plugins extend or overwrite the Serverless Framework, giving it new use-cases or capabilities, and there are hundreds of them.
 
 Some of the most common Plugins are:
 

--- a/docs/scf/upgrading.md
+++ b/docs/scf/upgrading.md
@@ -109,7 +109,7 @@ cp serverless.containers.yml serverless.containers.yml.backup
 
 ### Update Your Configuration
 
-In your `serverless.containers.yml`, change the `name` property to create an entirely seperate stack of new infrastructure that does not have names that collide with existing infrastructure (in the case of testing on the same AWS account).
+In your `serverless.containers.yml`, change the `name` property to create an entirely separate stack of new infrastructure that does not have names that collide with existing infrastructure (in the case of testing on the same AWS account).
 
 Next, change the deployment type:
 

--- a/packages/serverless/lib/plugins/aws/dev/index.js
+++ b/packages/serverless/lib/plugins/aws/dev/index.js
@@ -608,7 +608,7 @@ class AwsDev {
       mainProgress.remove()
     })
 
-    // Each function has a seperate topic we need to subscribe to
+    // Each function has a separate topic we need to subscribe to
     const functionNames = this.serverless.service.getAllFunctions()
 
     for (const functionName of functionNames) {


### PR DESCRIPTION
### Summary
This pull request corrects a handful of spelling/grammar issues across docs and one inline code comment to improve clarity and address inline review notes.

___

### Changes
#### `README.md`
- Fixed grammar: `its` → `it’s`
- Fixed spelling: `recieving` → `receiving`

#### `docs/scf/upgrading.md`
- Fixed spelling: `seperate` → `separate`

#### `packages/serverless/lib/plugins/aws/dev/index.js`
- Fixed spelling in comment: `seperate` → `separate`
- Pre-commit formatting hooks (e.g., Prettier) ran and applied any formatting updates.

___

### Testing
- No tests added/updated (docs + comment-only changes).
- Pre-commit hooks completed successfully.

___

### Notes
- No functional behavior changes intended.