### PR TITLE
fix: enable polling in chokidar to prevent EMFILE errors on macOS

### DIFF
--- a/packages/engine/src/lib/devMode/index.js
+++ b/packages/engine/src/lib/devMode/index.js
@@ -903,6 +903,9 @@ export class ServerlessEngineDevMode {
       },
       ignoreInitial: true,
       followSymlinks: false,
+      // usePolling is enabled because chokidar v4 removed fsevents support,
+      // causing "EMFILE: too many open files" errors on macOS with large projects
+      usePolling: true,
       // Add debounce to prevent rapid-fire events
       awaitWriteFinish: {
         stabilityThreshold: 300,

--- a/packages/serverless/lib/plugins/aws/dev/index.js
+++ b/packages/serverless/lib/plugins/aws/dev/index.js
@@ -105,10 +105,13 @@ class AwsDev {
     mainProgress.notice('Connecting')
 
     // TODO: This should be applied more selectively
+    // usePolling is enabled because chokidar v4 removed fsevents support,
+    // causing "EMFILE: too many open files" errors on macOS with large projects
     chokidar
       .watch(this.serverless.config.serviceDir, {
         ignored: /\.serverless/,
         ignoreInitial: true,
+        usePolling: true,
       })
       .on('all', async (event, path) => {
         await this.serverless.pluginManager.spawn('dev-build')
@@ -751,12 +754,16 @@ class AwsDev {
       this.serverless.configurationFilename,
     )
 
-    chokidar.watch(configFilePath).on('change', (event, path) => {
-      logger.warning(
-        `If you've made infrastructure changes, restart the dev command w/ "serverless dev"`,
-      )
-      logger.blankLine()
-    })
+    chokidar
+      .watch(configFilePath, {
+        usePolling: true,
+      })
+      .on('change', (event, path) => {
+        logger.warning(
+          `If you've made infrastructure changes, restart the dev command w/ "serverless dev"`,
+        )
+        logger.blankLine()
+      })
   }
 
   /**


### PR DESCRIPTION
## Summary

- Enable polling mode (`usePolling: true`) in chokidar file watchers to prevent "EMFILE: too many open files" errors on macOS

## Context

In v4.31.0, we upgraded chokidar from v3.6.0 to v4.0.3. Chokidar v4 removed bundled fsevents support (native macOS file watching), causing the file watcher to fall back to `fs.watch` which creates one file descriptor per file/directory. On larger projects, this can exhaust the OS file descriptor limit, resulting in `EMFILE: too many open files` errors during `serverless dev`.

Enabling polling mode (`usePolling: true`) switches chokidar to use `fs.watchFile` which avoids this issue by using a different file watching mechanism that doesn't exhaust file descriptors.

Fixes #13268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file watching reliability for large projects on macOS by switching to polling-based file detection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->