### PR TITLE
docs: clarify default logging behavior for API Gateway, HTTP API, and…

### DIFF
--- a/docs/sf/providers/aws/events/apigateway.md
+++ b/docs/sf/providers/aws/events/apigateway.md
@@ -1864,7 +1864,9 @@ provider:
 
 Valid values are INFO, ERROR.
 
-The existence of the `logs` property enables both access and execution logging. If you want to disable one or both of them, you can do so with the following:
+**Note:** If `logs.restApi` is not set at all, API Gateway logging will be disabled.
+
+When `logs.restApi` is set (either to `true` or as an object), both access and execution logging are enabled by default. If you want to disable one or both of them, you can do so with the following:
 
 ```yml
 # serverless.yml

--- a/docs/sf/providers/aws/events/http-api.md
+++ b/docs/sf/providers/aws/events/http-api.md
@@ -271,6 +271,8 @@ functions:
 
 ### Access logs
 
+**Note:** If `logs.httpApi` is not set at all, HTTP API logging will be disabled.
+
 Deployed stage can have access logging enabled, for that just turn on logs for HTTP API in provider settings as follows:
 
 ```yaml

--- a/docs/sf/providers/aws/events/websocket.md
+++ b/docs/sf/providers/aws/events/websocket.md
@@ -286,7 +286,9 @@ provider:
       format: '{ "requestId":"$context.requestId",   "ip": "$context.identity.sourceIp" }'
 ```
 
-The existence of the `logs` property enables both access and execution logging. If you want to disable one or both of them, you can do so with the following:
+**Note:** If `logs.websocket` is not set at all, WebSocket API logging will be disabled.
+
+When `logs.websocket` is set (either to `true` or as an object), both access and execution logging are enabled by default. If you want to disable one or both of them, you can do so with the following:
 
 ```yml
 # serverless.yml

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -665,12 +665,14 @@ provider:
     # Enable HTTP API logs
     # This can either be set to `httpApi: true` to use defaults, or configured via subproperties
     # Can only be configured if the API is created by Serverless Framework
+    # Note: If this property is not set, HTTP API logging will be disabled
     httpApi:
       format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
 
     # Enable REST API logs
     # This can either be set to `restApi: true` to use defaults, or configured via subproperties
     # Can only be configured if the API is created by Serverless Framework
+    # Note: If this property is not set, API Gateway logging will be disabled
     restApi:
       # Enables HTTP access logs (default: true)
       accessLogging: true
@@ -689,6 +691,7 @@ provider:
 
     # Enable Websocket API logs
     # This can either be set to `websocket: true` to use defaults, or configured via subproperties.
+    # Note: If this property is not set, WebSocket API logging will be disabled
     websocket:
       # Enables HTTP access logs (default: true)
       accessLogging: true


### PR DESCRIPTION
Just a minor clarification based on my work on log settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified default logging behavior for AWS services (API Gateway, HTTP API, and WebSocket APIs) in configuration guides, explaining when logging is disabled and when it's enabled by default with options to selectively disable components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->