### PR TITLE
feat(logs): set custom log group name for API Gateway logs

### DIFF
--- a/docs/sf/providers/aws/events/apigateway.md
+++ b/docs/sf/providers/aws/events/apigateway.md
@@ -1808,6 +1808,17 @@ provider:
 
 The log streams will be generated in a dedicated log group which follows the naming schema `/aws/api-gateway/{service}-{stage}`.
 
+You can customize the log group name by specifying the `logGroup` property:
+
+```yml
+# serverless.yml
+provider:
+  name: aws
+  logs:
+    restApi:
+      logGroup: /my-custom-log-group/rest-api
+```
+
 **Note:** If external API Gateway resource is used and imported via `provider.apiGateway.restApiId` setting, `provider.logs.restApi` setting will be ignored.
 
 To be able to write logs, API Gateway [needs a CloudWatch role configured](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html). This setting is per region, shared by all the APIs. There are three approaches for handling it:

--- a/docs/sf/providers/aws/events/http-api.md
+++ b/docs/sf/providers/aws/events/http-api.md
@@ -303,6 +303,15 @@ provider:
       format: '{ "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime" }'
 ```
 
+By default, the log group name follows the naming schema `/aws/http-api/{stack-name}`. You can customize it by specifying the `logGroup` property:
+
+```yaml
+provider:
+  logs:
+    httpApi:
+      logGroup: /my-custom-log-group/http-api
+```
+
 See [AWS HTTP API Logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-logging-variables.html) documentation for more info on variables that can be used
 
 ### Reusing HTTP API in different services

--- a/docs/sf/providers/aws/events/websocket.md
+++ b/docs/sf/providers/aws/events/websocket.md
@@ -262,6 +262,17 @@ provider:
 
 The log streams will be generated in a dedicated log group which follows the naming schema `/aws/websocket/{service}-{stage}`.
 
+You can customize the log group name by specifying the `logGroup` property:
+
+```yml
+# serverless.yml
+provider:
+  name: aws
+  logs:
+    websocket:
+      logGroup: /my-custom-log-group/websocket
+```
+
 The default log level will be INFO. You can change this to error with the following:
 
 ```yml

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -667,6 +667,8 @@ provider:
     # Can only be configured if the API is created by Serverless Framework
     httpApi:
       format: '{ "requestId":"$context.requestId", "ip": "$context.identity.sourceIp", "requestTime":"$context.requestTime", "httpMethod":"$context.httpMethod","routeKey":"$context.routeKey", "status":"$context.status","protocol":"$context.protocol", "responseLength":"$context.responseLength" }'
+      # Custom log group name (default: /aws/http-api/{stack-name})
+      logGroup: /my-custom-log-group/http-api
 
     # Enable REST API logs
     # This can either be set to `restApi: true` to use defaults, or configured via subproperties
@@ -682,6 +684,8 @@ provider:
       level: INFO
       # Log full requests/responses for execution logging (default: true)
       fullExecutionData: true
+      # Custom log group name (default: /aws/api-gateway/{service}-{stage})
+      logGroup: /my-custom-log-group/rest-api
       # Existing IAM role to use for API Gateway when writing CloudWatch Logs (default: automatically created)
       role: arn:aws:iam::123456:role
       # Whether the API Gateway CloudWatch Logs role setting is not managed by Serverless (default: false)
@@ -700,6 +704,8 @@ provider:
       level: INFO
       # Log full requests/responses for execution logging (default: true)
       fullExecutionData: true
+      # Custom log group name (default: /aws/websocket/{service}-{stage})
+      logGroup: /my-custom-log-group/websocket
 
     # Optional, whether to write CloudWatch logs for custom resource lambdas as added by the framework. Default is true.
     frameworkLambda: false

--- a/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js
@@ -270,7 +270,8 @@ function handleLogs() {
     const stage = this.provider.getApiGatewayStage()
     const region = this.options.region
     const partition = this.partition
-    const logGroupName = `/aws/api-gateway/${service}-${stage}`
+    const logGroupName =
+      logs.logGroup || `/aws/api-gateway/${service}-${stage}`
 
     operations = []
 
@@ -402,9 +403,11 @@ async function removeAccessLoggingLogGroup() {
   const service = this.state.service.service
   const provider = this.state.service.provider
   const stage = this.provider.getApiGatewayStage()
-  const logGroupName = `/aws/api-gateway/${service}-${stage}`
+  const logs = provider.logs && provider.logs.restApi
+  const logGroupName =
+    (logs && logs.logGroup) || `/aws/api-gateway/${service}-${stage}`
 
-  let accessLogging = provider.logs && provider.logs.restApi
+  let accessLogging = logs
 
   if (accessLogging) {
     accessLogging =

--- a/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js
@@ -270,8 +270,7 @@ function handleLogs() {
     const stage = this.provider.getApiGatewayStage()
     const region = this.options.region
     const partition = this.partition
-    const logGroupName =
-      logs.logGroup || `/aws/api-gateway/${service}-${stage}`
+    const logGroupName = logs.logGroup || `/aws/api-gateway/${service}-${stage}`
 
     operations = []
 

--- a/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/stage.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/stage.js
@@ -104,8 +104,7 @@ export default {
 }
 
 function getLogGroupResource(service, stage, provider, logs) {
-  const logGroupName =
-    logs.logGroup || `/aws/api-gateway/${service}-${stage}`
+  const logGroupName = logs.logGroup || `/aws/api-gateway/${service}-${stage}`
 
   const resource = {
     Type: 'AWS::Logs::LogGroup',

--- a/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/stage.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/stage.js
@@ -85,6 +85,7 @@ export default {
             service,
             stage,
             this.provider,
+            logs,
           ),
         })
 
@@ -102,11 +103,14 @@ export default {
   },
 }
 
-function getLogGroupResource(service, stage, provider) {
+function getLogGroupResource(service, stage, provider, logs) {
+  const logGroupName =
+    logs.logGroup || `/aws/api-gateway/${service}-${stage}`
+
   const resource = {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
-      LogGroupName: `/aws/api-gateway/${service}-${stage}`,
+      LogGroupName: logGroupName,
     },
   }
 

--- a/packages/serverless/lib/plugins/aws/package/compile/events/http-api.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/http-api.js
@@ -158,10 +158,13 @@ class HttpApiEvents {
   compileLogGroup() {
     if (!this.config.accessLogFormat) return
 
+    const logGroupName =
+      this.config.logGroup || this.provider.naming.getHttpApiLogGroupName()
+
     const resource = {
       Type: 'AWS::Logs::LogGroup',
       Properties: {
-        LogGroupName: this.provider.naming.getHttpApiLogGroupName(),
+        LogGroupName: logGroupName,
       },
     }
 
@@ -544,6 +547,9 @@ Object.defineProperties(
             protocol: '$context.protocol',
             responseLength: '$context.responseLength',
           })}`
+        if (userLogsConfig.logGroup) {
+          this.config.logGroup = userLogsConfig.logGroup
+        }
       }
 
       for (const [functionName, functionData] of Object.entries(

--- a/packages/serverless/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -92,7 +92,12 @@ export default {
       Object.assign(stageResource.Properties, logProperties)
 
       Object.assign(cfTemplate.Resources, {
-        [logGroupLogicalId]: getLogGroupResource(service, stage, this.provider, logs),
+        [logGroupLogicalId]: getLogGroupResource(
+          service,
+          stage,
+          this.provider,
+          logs,
+        ),
       })
 
       return ensureApiGatewayCloudWatchRole(this.provider)
@@ -101,8 +106,7 @@ export default {
 }
 
 function getLogGroupResource(service, stage, provider, logs) {
-  const logGroupName =
-    logs.logGroup || `/aws/websocket/${service}-${stage}`
+  const logGroupName = logs.logGroup || `/aws/websocket/${service}-${stage}`
 
   const resource = {
     Type: 'AWS::Logs::LogGroup',

--- a/packages/serverless/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/websockets/lib/stage.js
@@ -92,7 +92,7 @@ export default {
       Object.assign(stageResource.Properties, logProperties)
 
       Object.assign(cfTemplate.Resources, {
-        [logGroupLogicalId]: getLogGroupResource(service, stage, this.provider),
+        [logGroupLogicalId]: getLogGroupResource(service, stage, this.provider, logs),
       })
 
       return ensureApiGatewayCloudWatchRole(this.provider)
@@ -100,11 +100,14 @@ export default {
   },
 }
 
-function getLogGroupResource(service, stage, provider) {
+function getLogGroupResource(service, stage, provider, logs) {
+  const logGroupName =
+    logs.logGroup || `/aws/websocket/${service}-${stage}`
+
   const resource = {
     Type: 'AWS::Logs::LogGroup',
     Properties: {
-      LogGroupName: `/aws/websocket/${service}-${stage}`,
+      LogGroupName: logGroupName,
     },
   }
   const logRetentionInDays = provider.getLogRetentionInDays()

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -1484,6 +1484,7 @@ class AwsProvider {
                       type: 'object',
                       properties: {
                         format: { type: 'string' },
+                        logGroup: { type: 'string' },
                       },
                       additionalProperties: false,
                     },
@@ -1500,6 +1501,7 @@ class AwsProvider {
                         format: { type: 'string' },
                         fullExecutionData: { type: 'boolean' },
                         level: { enum: ['INFO', 'ERROR'] },
+                        logGroup: { type: 'string' },
                         role: { $ref: '#/definitions/awsArn' },
                         roleManagedExternally: { type: 'boolean' },
                       },
@@ -1518,6 +1520,7 @@ class AwsProvider {
                         format: { type: 'string' },
                         fullExecutionData: { type: 'boolean' },
                         level: { enum: ['INFO', 'ERROR'] },
+                        logGroup: { type: 'string' },
                       },
                       additionalProperties: false,
                     },


### PR DESCRIPTION
Adds support for custom CloudWatch log group names for API Gateway access logs via `provider.logs.{restApi|httpApi|websocket}.logGroup`, matching the existing pattern for Lambda logs (`provider.logs.lambda.logGroup`).

### Usage

```yaml
provider:
  logs:
    restApi:
      logGroup: /custom/rest-api
    httpApi:
      logGroup: /custom/http-api
    websocket:
      logGroup: /custom/websocket
```

### Changes
- Added `logGroup` property to schema for restApi, httpApi, and websocket logs
- Updated stage compilation to use custom log group names (with existing defaults as fallback)
- Updated documentation (apigateway.md, http-api.md, websocket.md, serverless.yml.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a provider-level logGroup option to customize CloudWatch log group names for REST API, HTTP API, and WebSocket API logging.

* **Documentation**
  * Updated docs with examples showing how to set provider.logs.{restApi,httpApi,websocket}.logGroup and a note that provider log settings are ignored when an external REST API resource is used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->