### PR TITLE
fix: improve security policy handling for AWS domains

### DIFF
--- a/packages/serverless/lib/plugins/aws/domains/globals.js
+++ b/packages/serverless/lib/plugins/aws/domains/globals.js
@@ -48,10 +48,11 @@ export default class Globals {
   }
 
   /* eslint camelcase: ["error", {allow: ["^tls_"]}] */
+  // Valid legacy values per AWS API docs: TLS_1_0, TLS_1_2
+  // TLS 1.3 is only available through enhanced SecurityPolicy_* values
   static tlsVersions = {
     tls_1_0: 'TLS_1_0',
     tls_1_2: 'TLS_1_2',
-    tls_1_3: 'TLS_1_3',
   }
 
   static routingPolicies = {

--- a/packages/serverless/lib/plugins/aws/domains/models/domain-config.js
+++ b/packages/serverless/lib/plugins/aws/domains/models/domain-config.js
@@ -148,11 +148,20 @@ class DomainConfig {
 
   static _getSecurityPolicy(securityPolicy) {
     const securityPolicyDefault = securityPolicy || Globals.tlsVersions.tls_1_2
+
+    // Enhanced security policies (e.g., SecurityPolicy_TLS13_2025_EDGE) are passed through directly
+    // See: https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-security-policies.html
+    if (securityPolicyDefault.startsWith('SecurityPolicy_')) {
+      return securityPolicyDefault
+    }
+
+    // Legacy shorthand support (tls_1_0, tls_1_2)
     const tlsVersionToUse =
       Globals.tlsVersions[securityPolicyDefault.toLowerCase()]
     if (!tlsVersionToUse) {
       throw new ServerlessError(
-        `${securityPolicyDefault} is not a supported securityPolicy, use tls_1_0 or tls_1_2.`,
+        `${securityPolicyDefault} is not a supported securityPolicy. ` +
+          'Use tls_1_0, tls_1_2, or an enhanced policy (e.g., SecurityPolicy_TLS13_2025_EDGE).',
         ServerlessErrorCodes.domains.DOMAIN_CONFIG_INVALID_SECURITY_POLICY,
       )
     }

--- a/packages/serverless/test/unit/lib/plugins/aws/domains/models/domain-config.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/domains/models/domain-config.test.js
@@ -1,0 +1,76 @@
+import DomainConfig from '../../../../../../../lib/plugins/aws/domains/models/domain-config.js'
+
+describe('DomainConfig', () => {
+  describe('_getSecurityPolicy', () => {
+    describe('legacy security policies', () => {
+      it('should return TLS_1_2 as default when no policy is specified', () => {
+        const result = DomainConfig._getSecurityPolicy(undefined)
+        expect(result).toBe('TLS_1_2')
+      })
+
+      it('should return TLS_1_0 for tls_1_0', () => {
+        const result = DomainConfig._getSecurityPolicy('tls_1_0')
+        expect(result).toBe('TLS_1_0')
+      })
+
+      it('should return TLS_1_2 for tls_1_2', () => {
+        const result = DomainConfig._getSecurityPolicy('tls_1_2')
+        expect(result).toBe('TLS_1_2')
+      })
+
+      it('should be case-insensitive for legacy policies', () => {
+        expect(DomainConfig._getSecurityPolicy('TLS_1_0')).toBe('TLS_1_0')
+        expect(DomainConfig._getSecurityPolicy('TLS_1_2')).toBe('TLS_1_2')
+      })
+
+      it('should throw for invalid legacy policy', () => {
+        expect(() => DomainConfig._getSecurityPolicy('invalid_policy')).toThrow(
+          /is not a supported securityPolicy/,
+        )
+      })
+
+      it('should throw for tls_1_3 (not a valid standalone value)', () => {
+        // TLS 1.3 is only available through enhanced SecurityPolicy_* values
+        expect(() => DomainConfig._getSecurityPolicy('tls_1_3')).toThrow(
+          /is not a supported securityPolicy/,
+        )
+      })
+
+      it('should include enhanced policy hint in error message', () => {
+        expect(() => DomainConfig._getSecurityPolicy('invalid')).toThrow(
+          /SecurityPolicy_TLS13_2025_EDGE/,
+        )
+      })
+    })
+
+    describe('enhanced security policies', () => {
+      it('should pass through SecurityPolicy_TLS13_2025_EDGE', () => {
+        const result = DomainConfig._getSecurityPolicy(
+          'SecurityPolicy_TLS13_2025_EDGE',
+        )
+        expect(result).toBe('SecurityPolicy_TLS13_2025_EDGE')
+      })
+
+      it('should pass through SecurityPolicy_TLS13_1_3_2025_09_REGIONAL', () => {
+        const result = DomainConfig._getSecurityPolicy(
+          'SecurityPolicy_TLS13_1_3_2025_09_REGIONAL',
+        )
+        expect(result).toBe('SecurityPolicy_TLS13_1_3_2025_09_REGIONAL')
+      })
+
+      it('should pass through SecurityPolicy_TLS13_1_2_2025_01_REGIONAL', () => {
+        const result = DomainConfig._getSecurityPolicy(
+          'SecurityPolicy_TLS13_1_2_2025_01_REGIONAL',
+        )
+        expect(result).toBe('SecurityPolicy_TLS13_1_2_2025_01_REGIONAL')
+      })
+
+      it('should pass through any policy starting with SecurityPolicy_', () => {
+        const result = DomainConfig._getSecurityPolicy(
+          'SecurityPolicy_FUTURE_POLICY',
+        )
+        expect(result).toBe('SecurityPolicy_FUTURE_POLICY')
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Add support for TLS 1.3 enhanced security policies in custom domains

**Closes #13290**

#### Problem

Users couldn't configure API Gateway custom domains with AWS's enhanced security policies like `SecurityPolicy_TLS13_2025_EDGE`. The framework only accepted legacy `tls_1_0` and `tls_1_2` values, throwing an error for any other input:

```
✖ Error: SecurityPolicy_TLS13_2025_EDGE is not a supported securityPolicy, use tls_1_0 or tls_1_2.
```

#### Solution

Modified the security policy validation to:
1. **Pass through enhanced policies** - Any value starting with `SecurityPolicy_` is now passed directly to AWS API Gateway
2. **Maintain backwards compatibility** - Legacy shorthand values (`tls_1_0`, `tls_1_2`) continue to work
3. **Remove invalid `tls_1_3`** - This was never a valid AWS value; TLS 1.3 is only available through `SecurityPolicy_*` policies
4. **Improve error messaging** - Now hints at enhanced policy usage when validation fails

#### AWS API Reference

Per [AWS CreateDomainName API](https://docs.aws.amazon.com/apigateway/latest/api/API_CreateDomainName.html), valid `securityPolicy` values are:
- Legacy: `TLS_1_0`, `TLS_1_2`
- Enhanced: `SecurityPolicy_TLS13_2025_EDGE`, `SecurityPolicy_TLS13_1_3_2025_09`, `SecurityPolicy_TLS12_PFS_2025_EDGE`, etc.

#### Usage

```yaml
  domains:
    - name: api.example.com
      securityPolicy: SecurityPolicy_TLS13_2025_EDGE  # Now works!
```

#### Changes

- [lib/plugins/aws/domains/models/domain-config.js](file:///Users/czubocha/GolandProjects/serverless/packages/serverless/lib/plugins/aws/domains/models/domain-config.js) - Enhanced policy passthrough logic
- [lib/plugins/aws/domains/globals.js](file:///Users/czubocha/GolandProjects/serverless/packages/serverless/lib/plugins/aws/domains/globals.js) - Removed invalid `tls_1_3` entry
- [test/unit/lib/plugins/aws/domains/models/domain-config.test.js](file:///Users/czubocha/GolandProjects/serverless/packages/serverless/test/unit/lib/plugins/aws/domains/models/domain-config.test.js) - **NEW** - 11 unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Domains now support enhanced SecurityPolicy values to enable TLS 1.3 access.

* **Improvements**
  * Enhanced error messages for invalid security policies with clearer guidance on available options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->