### PR TITLE
fix(engine): update z.record() to Zod v4 two-argument syntax

### DIFF
--- a/packages/engine/src/types/aws.js
+++ b/packages/engine/src/types/aws.js
@@ -99,7 +99,7 @@ export const ConfigContainerSchema = z
   .object({
     src: z.string().describe('Path to the container source code'),
     environment: z
-      .record(JSONValue)
+      .record(z.string(), JSONValue)
       .optional()
       .describe('Environment variables to pass to the container'),
     compute: ConfigContainerCompute.describe(


### PR DESCRIPTION
# Fix z.record() Zod v4 migration in aws.js

## Summary

- Fix `TypeError: Cannot read properties of undefined (reading '_zod')` when deploying Fargate container services with `aws@1.0` deployment type
- Update `z.record(JSONValue)` to `z.record(z.string(), JSONValue)` to comply with Zod v4 API
- Add unit tests for container schema environment variable validation

## Related

Closes #13297


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced environment variable validation in container configurations with explicit string key type enforcement, ensuring more consistent and reliable schema validation.

* **Tests**
  * Added comprehensive test coverage for environment variable handling in container configurations, including support for multiple data types, nested structures, and optional environment properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->