### PR TITLE
fix: pass explicit ContentLength for S3 uploads to handle symlinks

### DIFF
--- a/packages/serverless/lib/plugins/aws/lib/upload-zip-file.js
+++ b/packages/serverless/lib/plugins/aws/lib/upload-zip-file.js
@@ -20,10 +20,11 @@ export default {
     let streamError
     artifactStream.on('error', (error) => (streamError = error))
 
-    // Use statSync to get the actual file size (follows symlinks).
-    // This is necessary because AWS SDK v3's lib-storage uses lstatSync internally,
-    // which returns the symlink size instead of the target file size.
-    const fileSize = fs.statSync(filename).size
+    // Use data.length to get the actual file size.
+    // This works correctly with symlinks because readFileSync follows symlinks.
+    // AWS SDK v3's lib-storage uses lstatSync internally which doesn't follow symlinks,
+    // so we must pass ContentLength explicitly.
+    const fileSize = data.length
 
     const key = `${s3KeyDirname}/${basename}`
     logger.debug('upload to %s/%s', this.bucketName, key)


### PR DESCRIPTION
## Summary

- Fix S3 multipart upload failure when uploading symlinked files with AWS SDK v3
- Add explicit `ContentLength` parameter using `fs.statSync()` which follows symlinks
- Resolves "Expected N part(s) but uploaded M part(s)" error caused by `lstatSync` returning symlink size instead of target file size

## Root cause

AWS SDK v3's `@aws-sdk/lib-storage` uses `lstatSync` to determine file size for multipart uploads. When the serverless-python-requirements plugin creates a symlink to cached `pythonRequirements.zip`, `lstatSync` returns the symlink size (~126 bytes) instead of the actual file size (~40MB), causing a mismatch between expected and actual upload parts.

## Test plan

- [x] Verify `statSync` and `lstatSync` return same size for regular files (no regression)
- [x] Verify symlink upload works with explicit `ContentLength`
- [x] Run `simple-nodejs` integration test
- [x] Manual test with reproduction (pythonRequirements layer with static cache)

## Related

- Original symlink PR: https://github.com/serverless/serverless-python-requirements/pull/644


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure accurate file-size calculation for uploads and explicitly include Content-Length when sending files to S3.
  * Resolve mismatches caused by symlinked files so package uploads during serverless deployments are consistent and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes S3 upload request parameters in the deploy path; incorrect size calculation could cause upload failures or unexpected multipart behavior, especially for large artifacts and symlinks.
> 
> **Overview**
> Ensures deployment zip uploads to S3 explicitly include `ContentLength`, computed from the bytes read via `fs.readFileSync`, to avoid AWS SDK v3 multipart upload part-count mismatches when the artifact path is a symlink.
> 
> Adds inline documentation explaining the symlink/lstat behavior and why `ContentLength` must be provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80372113b148ebc5dc4c7717cbe50b46369d3094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->