### PR TITLE
docs: fix apiType value in custom domain examples

### DIFF
--- a/docs/sf/providers/aws/guide/domains.md
+++ b/docs/sf/providers/aws/guide/domains.md
@@ -132,7 +132,7 @@ provider:
   domain:
     name: api.example.com
     basePath: v1
-    apiType: httpApi
+    apiType: http
     endpointType: regional
 
 functions:
@@ -170,7 +170,7 @@ provider:
   domain:
     name: api.example.com # Required: Your custom domain name
     basePath: v1 # Optional: Base path for API mapping
-    apiType: httpApi # Optional: API type (httpApi, rest, websocket)
+    apiType: http # Optional: API type (http, rest, websocket)
     endpointType: regional # Optional: Endpoint type (regional, edge)
 ```
 
@@ -182,10 +182,10 @@ You can configure multiple domains for the same service:
 provider:
   domains:
     - name: api.example.com
-      apiType: httpApi
+      apiType: http
       basePath: v1
     - name: api-staging.example.com
-      apiType: httpApi
+      apiType: http
       basePath: v1
     - name: websocket.example.com
       apiType: websocket
@@ -199,7 +199,7 @@ Below are all available configuration options for custom domains:
 | ------------------------------ | -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                         | string         | Yes      | Your custom domain name (e.g., `api.example.com`)                                                                                                                                                                                     |
 | `basePath`                     | string         | No       | Base path for API mapping (e.g., `v1`, `api`)                                                                                                                                                                                         |
-| `apiType`                      | string         | No       | API type: `httpApi`, `rest`, or `websocket`. Defaults to `httpApi`. Please note that Serverless Framework Services can only have 1 of each API Type. Therefore, when you specify `apiType` it will be auto-mapped to the correct one. |
+| `apiType`                      | string         | No       | API type: `http`, `rest`, or `websocket`. Defaults to `http`. Please note that Serverless Framework Services can only have 1 of each API Type. Therefore, when you specify `apiType` it will be auto-mapped to the correct one. |
 | `endpointType`                 | string         | No       | Endpoint type: `regional` or `edge`. Defaults to `regional`                                                                                                                                                                           |
 | `certificateArn`               | string         | No       | ARN of existing ACM certificate. If not provided, a new certificate will be created                                                                                                                                                   |
 | `certificateName`              | string         | No       | Name of existing ACM certificate to use instead of creating a new one                                                                                                                                                                 |
@@ -227,7 +227,7 @@ provider:
   domain:
     name: api.example.com
     basePath: v1
-    apiType: httpApi
+    apiType: http
     endpointType: regional
     certificateArn: arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
     createRoute53Record: true
@@ -262,7 +262,7 @@ service: my-service
 provider:
   domain:
     name: api.example.com
-    apiType: httpApi
+    apiType: http
 
 functions:
   hello:
@@ -381,7 +381,7 @@ provider:
   runtime: nodejs20.x
   domains:
     - name: api.example.com
-      apiType: httpApi
+      apiType: http
       basePath: v1
     - name: websocket.example.com
       apiType: websocket
@@ -456,7 +456,7 @@ provider:
     name: api.example.com
     certificateArn: arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
     createRoute53Record: false
-    apiType: httpApi
+    apiType: http
     endpointType: regional
 
 functions:
@@ -486,7 +486,7 @@ After deploying your service, you'll need to create DNS records in your registra
 | `certificateArn`      | Yes      | ARN of the manually created ACM certificate                 |
 | `createRoute53Record` | Yes      | Set to `false` to prevent automatic Route53 record creation |
 | `name`                | Yes      | Your custom domain name                                     |
-| `apiType`             | No       | API type (httpApi, rest, websocket) - defaults to httpApi   |
+| `apiType`             | No       | API type (http, rest, websocket) - defaults to http         |
 | `endpointType`        | No       | Endpoint type (regional, edge) - defaults to regional       |
 | `basePath`            | No       | Base path for API mapping                                   |
 
@@ -500,7 +500,7 @@ provider:
     - name: api.example.com
       certificateArn: arn:aws:acm:us-east-1:123456789012:certificate/api-cert-12345
       createRoute53Record: false
-      apiType: httpApi
+      apiType: http
     - name: websocket.example.com
       certificateArn: arn:aws:acm:us-east-1:123456789012:certificate/ws-cert-12345
       createRoute53Record: false

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -158,8 +158,8 @@ provider:
     name: api.example.com
     # Base path for API mapping (optional, e.g., 'v1', 'api')
     basePath: v1
-    # API type: 'httpApi', 'rest', or 'websocket' (optional, auto-detected from CloudFormation template)
-    apiType: httpApi
+    # API type: 'http', 'rest', or 'websocket' (optional, auto-detected from CloudFormation template)
+    apiType: http
     # Endpoint type: 'regional' or 'edge' (optional, default: 'regional')
     endpointType: regional
     # ARN of existing ACM certificate (optional, will create new if not provided)
@@ -203,7 +203,7 @@ provider:
   # OR multiple domains (object format)
   domains:
     - name: api.example.com
-      apiType: httpApi
+      apiType: http
       basePath: v1
     - name: websocket.example.com
       apiType: websocket


### PR DESCRIPTION
## Summary

Fixes incorrect `apiType` configuration value in custom domain documentation.

The docs showed `apiType: httpApi` but the valid values are `http`, `rest`, and `websocket`. Users following the documentation would get the error:
> "httpApi is not supported api type, use REST, HTTP or WEBSOCKET"

## Changes

- Updated all `apiType: httpApi` examples to `apiType: http` in `domains.md`
- Updated all `apiType: httpApi` examples to `apiType: http` in `serverless.yml.md`
- Updated documentation text and tables to list correct values: `http`, `rest`, `websocket`

## Test Plan

- [x] Verified all instances of `apiType: httpApi` are replaced
- [x] Verified documentation text matches valid values from code (`globals.js`)
- [x] Confirmed remaining `httpApi` references are intentional (event type, config section name)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AWS provider domain configuration: the API type identifier changed from `httpApi` to `http` (with `rest` and `websocket` also available)
  * Removed `certificateArn` parameter from domain configuration; use `certificateName` for ACM certificate specification
  * Updated all configuration examples, default values, and reference tables to reflect the new API type naming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->