### PR TITLE
chore(deps): ignore @axiomhq/js v1.4.0+ due to Node.js 18 deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,6 +78,9 @@ updates:
       - dependency-name: 'glob'
         # glob v11 drops support for Node.js 18
         versions: ['>= 11.0.0']
+      - dependency-name: '@axiomhq/js'
+        # @axiomhq/js v1.4.0 drops support for Node.js 18
+        versions: ['>= 1.4.0']
 
   # Maintain Go dependencies
   - package-ecosystem: 'gomod'


### PR DESCRIPTION
## Summary

- Ignore `@axiomhq/js` version 1.4.0 and higher in Dependabot
- Prevent updates that drop support for Node.js 18 (required: Node.js 20+)

## Related

- Closes #13320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to maintain Node.js 18 compatibility by preventing automatic updates to incompatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->