### PR TITLE
Add support for dotnet10 AWS Lambda runtime

### DIFF
--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -573,6 +573,7 @@ class AwsProvider {
             enum: [
               'dotnet6',
               'dotnet8',
+              'dotnet10',
               'go1.x',
               'java25',
               'java21',


### PR DESCRIPTION
Q1: Provide a link to the corresponding issue

Closes: #13330


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for AWS Lambda .NET 10 runtime. You can now configure functions to run on .NET 10 using the framework’s runtime setting. Validation recognizes the new runtime, enabling deployment and updates without workarounds. This expands available runtime choices for new and existing services, facilitating upgrades and parity with recent AWS offerings. No changes are required unless you opt in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->