### PR TITLE
chore: bump Jackson to 2.21 in Java runtime wrapper and add Maven Dependabot entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,6 +90,17 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
 
+  # Maintain Maven dependencies for Java runtime wrapper
+  - package-ecosystem: 'maven'
+    directory: '/packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java'
+    schedule:
+      interval: 'weekly'
+    cooldown:
+      default-days: 5
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+
   # Maintain GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml
+++ b/packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml
@@ -27,22 +27,22 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.20.1</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.20.1</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.20</version>
+      <version>2.21</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.20.1</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
### Motivation
- Consolidate four separate Jackson dependency bumps into a single change for the Java runtime wrapper to keep the bundled runtime up-to-date and consistent.
- Ensure Dependabot will monitor the Java runtime wrapper `pom.xml` so future Maven dependency updates are automated.

### Description
- Updated `packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml` to bump `jackson-core` to `2.21.0`.
- Updated `packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml` to bump `jackson-databind` to `2.21.0`.
- Updated `packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml` to bump `jackson-annotations` to `2.21` and `jackson-datatype-joda` to `2.21.0`.
- Added a Maven `dependabot` entry to `.github/dependabot.yml` that targets `packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java` with a weekly schedule and cooldown settings.

### Testing
- Ran `git diff --check` to verify there are no whitespace or conflict markers and it succeeded.
- Ran `git status --short --branch` to confirm the working tree contains only the expected changes and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ca04b529c8328b276372342c363d0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Jackson serialization libraries to version 2.21.x
  * Configured automated dependency updates with weekly scheduling and version-based cooldown policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->