### PR TITLE
feat(dev-mode): match shim runtime to local Node.js version

### DIFF
--- a/packages/serverless/lib/plugins/aws/dev/local-lambda/index.js
+++ b/packages/serverless/lib/plugins/aws/dev/local-lambda/index.js
@@ -288,19 +288,21 @@ const fileExists = async (filePath) => {
  *   - List of runtime versions that the wrapper supports
  *   - List of file extensions that the wrapper supports
  */
+const SUPPORTED_NODE_RUNTIMES = [
+  'nodejs14.x',
+  'nodejs16.x',
+  'nodejs18.x',
+  'nodejs20.x',
+  'nodejs22.x',
+  'nodejs24.x',
+]
+
 const runtimeWrappers = [
   {
     command: 'node',
     arguments: [],
     path: path.join(__dirname, 'runtime-wrappers/node.js'),
-    versions: [
-      'nodejs14.x',
-      'nodejs16.x',
-      'nodejs18.x',
-      'nodejs20.x',
-      'nodejs22.x',
-      'nodejs24.x',
-    ],
+    versions: SUPPORTED_NODE_RUNTIMES,
     extensions: ['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts'],
   },
 ]

--- a/packages/serverless/test/unit/lib/plugins/aws/dev.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/dev.test.js
@@ -1,18 +1,27 @@
-import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+import {
+  jest,
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
+
+const mockLogger = {
+  logoDevMode: jest.fn(),
+  blankLine: jest.fn(),
+  aside: jest.fn(),
+  notice: jest.fn(),
+  debug: jest.fn(),
+  warning: jest.fn(),
+  confirm: jest.fn(),
+  success: jest.fn(),
+  error: jest.fn(),
+}
 
 jest.unstable_mockModule('@serverless/util', () => ({
   log: {
-    get: jest.fn(() => ({
-      logoDevMode: jest.fn(),
-      blankLine: jest.fn(),
-      aside: jest.fn(),
-      notice: jest.fn(),
-      debug: jest.fn(),
-      warning: jest.fn(),
-      confirm: jest.fn(),
-      success: jest.fn(),
-      error: jest.fn(),
-    })),
+    get: jest.fn(() => mockLogger),
     error: jest.fn(),
     blankLine: jest.fn(),
     warning: jest.fn(),
@@ -43,6 +52,14 @@ jest.unstable_mockModule('@serverless/util', () => ({
 const { default: AwsDev } =
   await import('../../../../../lib/plugins/aws/dev/index.js')
 
+const originalProcessVersion = process.version
+
+const setProcessVersion = (version) => {
+  Object.defineProperty(process, 'version', {
+    configurable: true,
+    value: version,
+  })
+}
 const createServerless = () => {
   const provider = {
     getStage: jest.fn(),
@@ -53,8 +70,15 @@ const createServerless = () => {
   return {
     getProvider: jest.fn(() => provider),
     processedInput: { commands: [] },
+    configurationInput: {},
     service: {
       provider: {},
+      getServiceName: jest.fn(() => 'test-service'),
+      getAllFunctions: jest.fn(() => ['hello']),
+      getFunction: jest.fn(() => ({
+        handler: 'handler.main',
+        runtime: 'nodejs20.x',
+      })),
     },
   }
 }
@@ -63,7 +87,13 @@ describe('AwsDev', () => {
   let awsDev
 
   beforeEach(() => {
+    jest.clearAllMocks()
+    setProcessVersion(originalProcessVersion)
     awsDev = new AwsDev(createServerless(), {})
+  })
+
+  afterEach(() => {
+    setProcessVersion(originalProcessVersion)
   })
 
   describe('#validateOnExitOption()', () => {
@@ -89,6 +119,51 @@ describe('AwsDev', () => {
       } catch (error) {
         expect(error.code).toBe('INVALID_DEV_ON_EXIT_OPTION')
       }
+    })
+  })
+
+  describe('#update()', () => {
+    it('should set runtime to local node runtime when it is supported by AWS Lambda', async () => {
+      setProcessVersion('v22.1.0')
+      awsDev.getIotEndpoint = jest.fn().mockResolvedValue('iot-endpoint')
+
+      const functionConfig = {
+        handler: 'handler.main',
+        runtime: 'nodejs20.x',
+      }
+
+      awsDev.serverless.service.getFunction = jest.fn(() => functionConfig)
+      awsDev.serverless.service.provider.iam = {}
+      awsDev.serverless.getProvider().getStage.mockReturnValue('dev')
+
+      await awsDev.update()
+
+      expect(functionConfig.runtime).toBe('nodejs22.x')
+      expect(mockLogger.warning).toHaveBeenCalledWith(
+        'Your local machine is using Node.js v22, while at least one of your functions is not. Ensure matching runtime versions for accurate testing.',
+      )
+    })
+
+    it('should fall back to nodejs20.x when local node runtime is not supported by AWS Lambda', async () => {
+      setProcessVersion('v26.0.0')
+      awsDev.getIotEndpoint = jest.fn().mockResolvedValue('iot-endpoint')
+
+      const functionConfig = {
+        handler: 'handler.main',
+        runtime: 'nodejs20.x',
+      }
+
+      awsDev.serverless.service.getFunction = jest.fn(() => functionConfig)
+      awsDev.serverless.service.provider.iam = {}
+      awsDev.serverless.getProvider().getStage.mockReturnValue('dev')
+
+      await awsDev.update()
+
+      expect(functionConfig.runtime).toBe('nodejs20.x')
+      expect(mockLogger.warning).toHaveBeenCalledTimes(1)
+      expect(mockLogger.warning).toHaveBeenCalledWith(
+        'Your local machine is using Node.js v26, which is not yet supported by AWS Lambda. Falling back to nodejs20.x for dev mode deployment.',
+      )
     })
   })
 })


### PR DESCRIPTION
## Summary

- Match the dev mode shim's AWS Lambda runtime to the developer's local Node.js version instead of always hardcoding `nodejs20.x`
- Fall back to `nodejs20.x` with a warning when the local Node.js version is not yet supported by AWS Lambda
- Define a separate `AWS_LAMBDA_SUPPORTED_NODE_RUNTIMES` list (`18.x`, `20.x`, `22.x`, `24.x`) in `packages/serverless/lib/plugins/aws/dev/index.js`, decoupled from the local-lambda wrapper's broader runtime support list (which also includes deprecated `14.x`/`16.x`)
- Suppress the runtime mismatch warning when the unsupported-runtime fallback warning already fires, avoiding confusing duplicate warnings
- Extract inline runtime versions array into a named `SUPPORTED_NODE_RUNTIMES` const in `packages/serverless/lib/plugins/aws/dev/local-lambda/index.js` for readability

## Test plan

- [x] Added test: shim runtime matches local Node.js version when it is supported by AWS Lambda (e.g., local v22 → `nodejs22.x`)
- [x] Added test: shim falls back to `nodejs20.x` with a single warning when local version is unsupported (e.g., local v26)
- [x] All 33 dev-related unit tests pass (`dev.test.js` + `local-lambda.test.js`)

Closes https://github.com/serverless/serverless/issues/13355

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Node.js runtime compatibility. Functions now deploy using your local Node.js version when supported by AWS Lambda, with intelligent fallback to nodejs20.x for unsupported versions and appropriate warning messages.

* **Tests**
  * Added comprehensive test coverage for runtime selection and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is limited to Dev Mode shim configuration and logging, with added unit coverage; main risk is unexpected runtime selection for edge Node versions.
> 
> **Overview**
> Dev Mode no longer hardcodes the shim runtime to `nodejs20.x`; it now selects the local Node.js major version as the Lambda runtime when it’s in an allowlist, otherwise *falls back to `nodejs20.x`* and emits a single warning explaining the fallback.
> 
> Runtime mismatch warnings are refined to avoid duplicate/confusing messaging when the fallback path is taken, `local-lambda` runtime wrapper versions are refactored into a named `SUPPORTED_NODE_RUNTIMES` constant, and unit tests add coverage for the supported-runtime and unsupported-runtime fallback scenarios (including logger warning assertions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc60838ab826cb5c702a4171e66fa49b691eee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->