### PR TITLE
fix: use correct jackson-annotations version (2.21)

### DIFF
--- a/packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml
+++ b/packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.21.0</version>
+      <version>2.21</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
Starting from Jackson 2.20, the annotations module is published without a patch number (e.g. 2.21 instead of 2.21.0). The previous bump in #13340 set all jackson deps to 2.21.0, but jackson-annotations:2.21.0 does not exist on Maven Central.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the jackson-annotations dependency version used by the serverless plugin's Java runtime wrapper from 2.21.0 to 2.21, standardizing the declared version. This is a packaging/dependency metadata refinement with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->