### PR TITLE
chore(deps): upgrade Go to 1.26 in binary installer

### DIFF
--- a/.github/workflows/ci-binary-installer.yml
+++ b/.github/workflows/ci-binary-installer.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '>=1.25'
+          go-version: '>=1.26.1'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Test: Unit'
         run: make test

--- a/.github/workflows/release-binary-installer.yml
+++ b/.github/workflows/release-binary-installer.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: '>=1.25'
+          go-version: '>=1.26.1'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/binary-installer/go.mod
+++ b/binary-installer/go.mod
@@ -1,6 +1,6 @@
 module sf-core
 
-go 1.25
+go 1.26.1
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/TESTING.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v18 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/TESTING.md#integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}

This PR upgrades the Go version used by the binary installer to `1.26`.

**Why this change:**
- **Addresses CVE-2026-27139:** The `std/os` package in older Go versions (e.g., 1.25.7) had a Directory Traversal vulnerability. Go 1.26.1 (and later patches) includes the fix.
- **Future-proofing:** By setting the Go version to `1.26` in `go.mod` and `>=1.26` in CI/release workflows, the build system will automatically pick up the latest patch version of Go 1.26, ensuring continuous security updates without manual intervention.
- **Compatibility:** A thorough analysis confirmed no breaking changes or incompatibilities with Go 1.26 in the existing codebase.

<div><a href="https://cursor.com/agents/bc-f1583ac0-e9f4-4e83-91b2-bb5166625990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1583ac0-e9f4-4e83-91b2-bb5166625990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI and release workflows now require Go >= 1.26.1.
  * Project module configuration updated to Go 1.26.1 to match the CI toolchain.
  * No functional or public API changes; impacts build/tooling and developer environment only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->