### PR TITLE
fix(binary-installer): correct grep -q usage to avoid duplicate PATH / duplicate PATH entries

### DIFF
--- a/binary-installer/install.sh
+++ b/binary-installer/install.sh
@@ -69,7 +69,7 @@ else
     add_to_path "$SHELL_CONFIG"
   fi
   SHELL_CONFIG=$HOME/.bash_profile
-  if [[ -r "$SHELL_CONFIG" ]]; then  if [[ -r "$SHELL_CONFIG" ]]; then
+  if [[ -r "$SHELL_CONFIG" ]]; then
 
     if ! grep -q '.serverless/bin' "$SHELL_CONFIG"; then
       add_to_path "$SHELL_CONFIG"
@@ -87,7 +87,6 @@ else
       fi
     fi
   fi
-fi
 fi
 
 


### PR DESCRIPTION
## Problem

The installer script incorrectly checks for `.serverless/bin`
in shell configuration files using command substitution with `grep -q`.

`grep -q` returns an exit status but produces no output, so using
command substitution (`$()` or backticks) always results in an empty
string. This causes the condition to always evaluate true and results
in duplicate PATH entries being appended on repeated installs.

## Solution

Check the exit status of `grep -q` directly instead of using command
substitution. Also added proper quoting for `$SHELL_CONFIG`.

## Result

The installer now correctly avoids adding duplicate `.serverless/bin`
entries to shell configuration files.

Fixes #13394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved shell installer script: tightened quoting and conditional checks to prevent word-splitting/globbing and ensure consistent behavior across zsh and bash variants.
  * Normalized PATH-append logic and removed a redundant nested check, simplifying installer flow while preserving existing behavior; trimmed an extraneous blank line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->