### PR TITLE
feat: Add support for error action on IoT topic rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15875,7 +15875,7 @@
         "@aws-sdk/client-cloudformation": "3.1009.0",
         "@aws-sdk/client-s3": "3.1009.0",
         "@aws-sdk/client-ssm": "3.1009.0",
-        "@aws-sdk/client-sso-oidc": "^3.1009.0",
+        "@aws-sdk/client-sso-oidc": "3.1009.0",
         "@aws-sdk/client-sts": "3.1009.0",
         "@aws-sdk/credential-providers": "3.1009.0",
         "@axiomhq/js": "^1.3.1",

--- a/packages/serverless/lib/plugins/aws/package/compile/events/iot.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/iot.js
@@ -58,6 +58,7 @@ iot:
               additionalProperties: false,
             },
           },
+          required: ['lambda'],
           additionalProperties: false,
         },
       },
@@ -133,13 +134,53 @@ iot:
                 awsIotSqlVersion
             }
 
-            if (event.iot.errorAction) {
-              topicRuleResource.Properties.TopicRulePayload.ErrorAction = {}
-              if (event.iot.errorAction.lambda) {
-                topicRuleResource.Properties.TopicRulePayload.ErrorAction.Lambda = {
+            if (event.iot.errorAction?.lambda) {
+              topicRuleResource.Properties.TopicRulePayload.ErrorAction = {
+                Lambda: {
                   FunctionArn: event.iot.errorAction.lambda.functionArn,
-                }
+                },
               }
+
+              const errorLambdaPermissionLogicalId =
+                this.provider.naming.getLambdaIotPermissionLogicalId(
+                  functionName,
+                  iotNumberInFunction,
+                ) + 'ErrorAction'
+
+              const errorPermissionResource = {
+                Type: 'AWS::Lambda::Permission',
+                DependsOn: _.get(functionObj.targetAlias, 'logicalId'),
+                Properties: {
+                  FunctionName: event.iot.errorAction.lambda.functionArn,
+                  Action: 'lambda:InvokeFunction',
+                  Principal: 'iot.amazonaws.com',
+                  SourceArn: {
+                    'Fn::Join': [
+                      '',
+                      [
+                        'arn:',
+                        { Ref: 'AWS::Partition' },
+                        ':iot:',
+                        { Ref: 'AWS::Region' },
+                        ':',
+                        { Ref: 'AWS::AccountId' },
+                        ':rule/',
+                        { Ref: iotLogicalId },
+                      ],
+                    ],
+                  },
+                },
+              }
+
+              const newErrorPermissionObject = {
+                [errorLambdaPermissionLogicalId]: errorPermissionResource,
+              }
+
+              _.merge(
+                this.serverless.service.provider.compiledCloudFormationTemplate
+                  .Resources,
+                newErrorPermissionObject,
+              )
             }
 
             const permissionResource = {

--- a/packages/serverless/lib/plugins/aws/package/compile/events/iot.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/iot.js
@@ -40,6 +40,26 @@ iot:
           description: `Rule description.`,
           type: 'string',
         },
+        errorAction: {
+          description: `Error action configuration for the rule.
+@see https://docs.aws.amazon.com/iot/latest/developerguide/rule-error-handling.html`,
+          type: 'object',
+          properties: {
+            lambda: {
+              description: `Lambda function ARN for error handling.`,
+              type: 'object',
+              properties: {
+                functionArn: {
+                  description: `ARN of the Lambda function.`,
+                  type: 'string',
+                },
+              },
+              required: ['functionArn'],
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        },
       },
       required: ['sql'],
       additionalProperties: false,
@@ -111,6 +131,15 @@ iot:
             if (awsIotSqlVersion) {
               topicRuleResource.Properties.TopicRulePayload.AwsIotSqlVersion =
                 awsIotSqlVersion
+            }
+
+            if (event.iot.errorAction) {
+              topicRuleResource.Properties.TopicRulePayload.ErrorAction = {}
+              if (event.iot.errorAction.lambda) {
+                topicRuleResource.Properties.TopicRulePayload.ErrorAction.Lambda = {
+                  FunctionArn: event.iot.errorAction.lambda.functionArn,
+                }
+              }
             }
 
             const permissionResource = {

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
@@ -244,6 +244,39 @@ describe('AwsCompileIoTEvents', () => {
       ).toBe('2016-03-23')
     })
 
+    it('should support errorAction with lambda functionArn', () => {
+      awsCompileIoTEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              iot: {
+                sql: "SELECT * FROM 'topic_1'",
+                errorAction: {
+                  lambda: {
+                    functionArn: 'arn:aws:lambda:us-east-1:123456789012:function:errorHandler',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }
+
+      awsCompileIoTEvents.compileIoTEvents()
+
+      const resources =
+        awsCompileIoTEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+
+      expect(
+        resources.FirstIotTopicRule1.Properties.TopicRulePayload.ErrorAction,
+      ).toEqual({
+        Lambda: {
+          FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:errorHandler',
+        },
+      })
+    })
+
     it('should create resources for multiple functions', () => {
       awsCompileIoTEvents.serverless.service.functions = {
         first: {

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/iot.test.js
@@ -275,6 +275,20 @@ describe('AwsCompileIoTEvents', () => {
           FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:errorHandler',
         },
       })
+
+      // Should create Lambda permission for error action
+      expect(resources.FirstLambdaPermissionIotTopicRule1ErrorAction.Type).toBe(
+        'AWS::Lambda::Permission',
+      )
+      expect(
+        resources.FirstLambdaPermissionIotTopicRule1ErrorAction.Properties.Action,
+      ).toBe('lambda:InvokeFunction')
+      expect(
+        resources.FirstLambdaPermissionIotTopicRule1ErrorAction.Properties.Principal,
+      ).toBe('iot.amazonaws.com')
+      expect(
+        resources.FirstLambdaPermissionIotTopicRule1ErrorAction.Properties.FunctionName,
+      ).toBe('arn:aws:lambda:us-east-1:123456789012:function:errorHandler')
     })
 
     it('should create resources for multiple functions', () => {


### PR DESCRIPTION
## Description

This PR adds support for error action configuration on AWS IoT topic rules. This allows users to specify a Lambda function that will be invoked when the IoT rule fails to execute.

Closes #11642

## Changes

- Added `errorAction` property to the IoT event schema
- Added support for `errorAction.lambda.functionArn` to specify the error handling Lambda function
- Added unit test for the new functionality

## Usage Example

```yaml
functions:
  myFunction:
    handler: handler.main
    events:
      - iot:
          sql: "SELECT * FROM 'my/topic'"
          errorAction:
            lambda:
              functionArn: arn:aws:lambda:us-east-1:123456789012:function:errorHandler
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring IoT rule error actions: specify a Lambda function ARN to handle rule failures; compiled deployment includes the necessary permission for IoT to invoke that Lambda.

* **Tests**
  * Added unit tests to validate error-action configuration and correct CloudFormation compilation (including the error-action invocation permission).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->