### PR TITLE
fix(compose): fix `package` command with cross-service dependency outputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13547,7 +13547,7 @@
         "@aws-sdk/client-cloudformation": "3.1092.0",
         "@aws-sdk/client-s3": "3.1092.0",
         "@aws-sdk/client-ssm": "3.1092.0",
-        "@aws-sdk/client-sso-oidc": "^3.1092.0",
+        "@aws-sdk/client-sso-oidc": "3.1092.0",
         "@aws-sdk/client-sts": "3.1092.0",
         "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/credential-providers": "3.1092.0",

--- a/packages/sf-core/src/lib/runners/compose/index.js
+++ b/packages/sf-core/src/lib/runners/compose/index.js
@@ -329,6 +329,15 @@ class Compose {
                   if (stateValue === undefined) {
                     if (command[0] === 'print') {
                       serviceParams[key] = 'NOT_AVAILABLE_IN_PRINT_COMMAND'
+                    } else if (command[0] === 'package') {
+                      serviceParams[key] = 'NOT_AVAILABLE_AT_PACKAGE_TIME'
+                      // logger.warning() is invisible during multi-service runs:
+                      // the renderer then runs at the 'compose' log level (0) and
+                      // drops every level above it, so the warning must go
+                      // through writeCompose like the rest of the run output.
+                      this.logger.writeCompose(
+                        `${style.warning('[!]')} ${style.bold(alias)}: could not resolve the parameter '${key}': output '${outputKey}' of service '${depService}' is not available at package time. The packaged artifact will contain the placeholder 'NOT_AVAILABLE_AT_PACKAGE_TIME' and should not be deployed as-is. Deploy '${depService}' first (or check the output name), then package again.`,
+                      )
                     } else if (
                       command[0] === 'remove' ||
                       command[0] === 'get-state'
@@ -528,25 +537,29 @@ class Compose {
     } = runnerOutput || {}
 
     const serviceUniqueIdProvided = serviceUniqueId && runnerType
-
-    if (
-      serviceUniqueIdProvided &&
+    const hasOutputs =
       returnedState &&
-      command[0] !== 'get-state'
-    ) {
+      returnedState.outputs &&
+      Object.keys(returnedState.outputs).length > 0
+    const shouldUseStoredState =
+      !hasOutputs &&
+      (!returnedState || ['package', 'print'].includes(command[0]))
+    const currentState = shouldUseStoredState ? null : returnedState
+
+    if (serviceUniqueIdProvided && currentState && command[0] !== 'get-state') {
       await state?.putServiceState({
         serviceUniqueId,
         runnerType,
-        value: JSON.stringify(returnedState),
+        value: JSON.stringify(currentState),
       })
     }
 
     if (
       state?.localState &&
-      (returnedState || graph.predecessors(alias)?.length)
+      (currentState || graph.predecessors(alias)?.length)
     ) {
       state.localState[alias] =
-        returnedState ||
+        currentState ||
         (serviceUniqueIdProvided
           ? await state?.getServiceState({
               serviceUniqueId,

--- a/packages/sf-core/tests/unit/runners/compose/index.test.js
+++ b/packages/sf-core/tests/unit/runners/compose/index.test.js
@@ -1,0 +1,459 @@
+import { jest } from '@jest/globals'
+
+const writeComposeMock = jest.fn()
+
+jest.unstable_mockModule('@serverless/util', () => {
+  const noopFn = () => ({
+    notice: () => {},
+    remove: () => {},
+    get: () => noopFn(),
+  })
+  return {
+    log: {
+      get: () => ({
+        info: () => {},
+        debug: () => {},
+        writeCompose: writeComposeMock,
+        logoCompose: () => {},
+      }),
+    },
+    progress: { get: noopFn },
+    style: {
+      aside: (value) => value,
+      bold: (value) => value,
+      strong: (value) => value,
+      error: (value) => value,
+      warning: (value) => value,
+    },
+    ServerlessError: class ServerlessError extends Error {
+      constructor(message, code, options) {
+        super(message)
+        this.code = code
+        if (options?.stack === false) this.stack = undefined
+      }
+    },
+    ServerlessErrorCodes: {
+      compose: {
+        COMPOSE_COULD_NOT_RESOLVE_PARAM: 'COMPOSE_COULD_NOT_RESOLVE_PARAM',
+        COMPOSE_CONFIGURATION_INVALID: 'COMPOSE_CONFIGURATION_INVALID',
+        COMPOSE_GRAPH_SERVICE_DEPENDENCY_DOES_NOT_EXIST:
+          'COMPOSE_GRAPH_SERVICE_DEPENDENCY_DOES_NOT_EXIST',
+        COMPOSE_GRAPH_CIRCULAR_DEPENDENCY: 'COMPOSE_GRAPH_CIRCULAR_DEPENDENCY',
+      },
+    },
+  }
+})
+
+jest.unstable_mockModule('../../../../src/lib/router.js', () => ({
+  getRunner: jest.fn(),
+  route: jest.fn(),
+}))
+
+jest.unstable_mockModule('../../../../src/utils/index.js', () => ({
+  getHumanFriendlyTime: jest.fn(),
+}))
+
+const { parseComposeGraph } =
+  await import('../../../../src/lib/runners/compose/index.js')
+
+/**
+ * Helper to build a two-service compose configuration where
+ * service-b depends on service-a's output via a param reference.
+ */
+const buildTwoServiceConfig = () => ({
+  services: {
+    'service-a': {
+      path: './service-a',
+    },
+    'service-b': {
+      path: './service-b',
+      params: {
+        apiUrl: '${service-a.apiEndpoint}',
+      },
+    },
+  },
+})
+
+/**
+ * Helper to create a mock state object.
+ */
+const createMockState = (localState = {}) => ({
+  localState,
+  putServiceState: jest.fn(),
+  getServiceState: jest.fn(),
+})
+
+describe('Compose', () => {
+  beforeEach(() => {
+    writeComposeMock.mockClear()
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    process.exitCode = undefined
+    jest.restoreAllMocks()
+  })
+
+  describe('executeComponentsGraph - param resolution', () => {
+    test('package command uses placeholder for unresolved cross-service params', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const receivedParams = {}
+      // service-a returns no outputs (as package does in practice)
+      const mockRunner = async ({ compose: composeCtx }) => {
+        receivedParams[composeCtx.serviceName] = { ...composeCtx.params }
+        return {
+          state: {},
+          serviceUniqueId: `stack-${composeCtx.serviceName}`,
+          runnerType: 'traditional',
+        }
+      }
+
+      const state = createMockState()
+
+      await compose.executeComponentsGraph({
+        command: ['package'],
+        options: {},
+        resolverProviders: {},
+        params: {},
+        runnerFunction: mockRunner,
+        state,
+      })
+
+      // service-b should receive the placeholder, not throw
+      expect(receivedParams['service-b'].apiUrl).toBe(
+        'NOT_AVAILABLE_AT_PACKAGE_TIME',
+      )
+      // ...and the user should be warned the artifact contains the placeholder
+      expect(writeComposeMock).toHaveBeenCalledWith(
+        expect.stringContaining('NOT_AVAILABLE_AT_PACKAGE_TIME'),
+      )
+    })
+
+    test('package command resolves cross-service param from stored outputs', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const receivedParams = {}
+      // package returns no outputs; the previously deployed outputs live in
+      // the remote state store
+      const mockRunner = async ({ compose: composeCtx }) => {
+        receivedParams[composeCtx.serviceName] = { ...composeCtx.params }
+        return {
+          state: {},
+          serviceUniqueId: `stack-${composeCtx.serviceName}`,
+          runnerType: 'traditional',
+        }
+      }
+
+      const state = createMockState()
+      state.getServiceState.mockResolvedValue({
+        outputs: { apiEndpoint: 'https://api.example.com' },
+      })
+
+      await compose.executeComponentsGraph({
+        command: ['package'],
+        options: {},
+        resolverProviders: {},
+        params: {},
+        runnerFunction: mockRunner,
+        state,
+      })
+
+      // service-b should receive the deployed value, not the placeholder
+      expect(receivedParams['service-b'].apiUrl).toBe('https://api.example.com')
+      expect(writeComposeMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('NOT_AVAILABLE_AT_PACKAGE_TIME'),
+      )
+      // ...and the stored state must not be clobbered with the empty package state
+      expect(state.putServiceState).not.toHaveBeenCalled()
+    })
+
+    test('print command uses placeholder for unresolved cross-service params', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const receivedParams = {}
+      const mockRunner = async ({ compose: composeCtx }) => {
+        receivedParams[composeCtx.serviceName] = { ...composeCtx.params }
+        return {
+          state: {},
+          serviceUniqueId: `stack-${composeCtx.serviceName}`,
+          runnerType: 'traditional',
+        }
+      }
+
+      const state = createMockState()
+
+      await compose.executeComponentsGraph({
+        command: ['print'],
+        options: {},
+        resolverProviders: {},
+        params: {},
+        runnerFunction: mockRunner,
+        state,
+      })
+
+      expect(receivedParams['service-b'].apiUrl).toBe(
+        'NOT_AVAILABLE_IN_PRINT_COMMAND',
+      )
+    })
+
+    test('deploy command fails when cross-service param cannot be resolved', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      // service-a returns no outputs, so service-b cannot resolve its param
+      const mockRunner = async ({ compose: composeCtx }) => ({
+        state: {},
+        serviceUniqueId: `stack-${composeCtx.serviceName}`,
+        runnerType: 'traditional',
+      })
+
+      const state = createMockState()
+
+      // With isMultipleComponents=true (default), errors are caught and
+      // recorded in failedRuns rather than thrown
+      await compose.executeComponentsGraph({
+        command: ['deploy'],
+        options: {},
+        resolverProviders: {},
+        params: {},
+        runnerFunction: mockRunner,
+        state,
+      })
+
+      expect(Object.keys(compose.failedRuns)).toContain('service-b')
+      expect(compose.failedRuns['service-b'][0].message).toMatch(
+        /Could not resolve the parameter 'apiUrl'/,
+      )
+    })
+
+    test('deploy command resolves cross-service param from state', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const receivedParams = {}
+      const mockRunner = async ({ compose: composeCtx }) => {
+        receivedParams[composeCtx.serviceName] = { ...composeCtx.params }
+        return {
+          state: { outputs: { apiEndpoint: 'https://api.example.com' } },
+          serviceUniqueId: `stack-${composeCtx.serviceName}`,
+          runnerType: 'traditional',
+        }
+      }
+
+      const state = createMockState()
+
+      await compose.executeComponentsGraph({
+        command: ['deploy'],
+        options: {},
+        resolverProviders: {},
+        params: {},
+        runnerFunction: mockRunner,
+        state,
+      })
+
+      expect(receivedParams['service-b'].apiUrl).toBe('https://api.example.com')
+    })
+
+    test('remove command uses empty string for unresolved cross-service params', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const receivedParams = {}
+      const mockRunner = async ({ compose: composeCtx }) => {
+        receivedParams[composeCtx.serviceName] = { ...composeCtx.params }
+        return {
+          state: {},
+          serviceUniqueId: `stack-${composeCtx.serviceName}`,
+          runnerType: 'traditional',
+        }
+      }
+
+      const state = createMockState()
+
+      await compose.executeComponentsGraph({
+        command: ['remove'],
+        options: {},
+        resolverProviders: {},
+        params: {},
+        runnerFunction: mockRunner,
+        state,
+      })
+
+      expect(receivedParams['service-b'].apiUrl).toBe('')
+    })
+  })
+
+  describe('updateLocalState', () => {
+    test('does not persist empty state to remote store', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const state = createMockState()
+
+      await compose.updateLocalState({
+        alias: 'service-a',
+        runnerOutput: {
+          state: {},
+          serviceUniqueId: 'stack-123',
+          runnerType: 'traditional',
+        },
+        command: ['package'],
+        state,
+        graph: compose.graph,
+      })
+
+      expect(state.putServiceState).not.toHaveBeenCalled()
+    })
+
+    test('persists state with outputs to remote store', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const state = createMockState()
+      const returnedState = {
+        outputs: { apiEndpoint: 'https://api.example.com' },
+      }
+
+      await compose.updateLocalState({
+        alias: 'service-a',
+        runnerOutput: {
+          state: returnedState,
+          serviceUniqueId: 'stack-123',
+          runnerType: 'traditional',
+        },
+        command: ['deploy'],
+        state,
+        graph: compose.graph,
+      })
+
+      expect(state.putServiceState).toHaveBeenCalledWith({
+        serviceUniqueId: 'stack-123',
+        runnerType: 'traditional',
+        value: JSON.stringify(returnedState),
+      })
+      expect(state.localState['service-a']).toEqual(returnedState)
+    })
+
+    test('falls back to remote state when runner returns no outputs', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const remoteState = {
+        outputs: { apiEndpoint: 'https://api.example.com' },
+      }
+      const state = createMockState()
+      state.getServiceState.mockResolvedValue(remoteState)
+
+      await compose.updateLocalState({
+        alias: 'service-a',
+        runnerOutput: {
+          state: {},
+          serviceUniqueId: 'stack-123',
+          runnerType: 'traditional',
+        },
+        command: ['package'],
+        state,
+        graph: compose.graph,
+      })
+
+      // Should not overwrite remote state
+      expect(state.putServiceState).not.toHaveBeenCalled()
+      // Should fetch remote state as fallback (service-a has a predecessor: service-b depends on it)
+      expect(state.getServiceState).toHaveBeenCalledWith({
+        serviceUniqueId: 'stack-123',
+        runnerType: 'traditional',
+      })
+      expect(state.localState['service-a']).toEqual(remoteState)
+    })
+
+    test('persists empty outputs from deploy to clear stale state', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const returnedState = { outputs: {} }
+      const state = createMockState()
+      state.getServiceState.mockResolvedValue({
+        outputs: { apiEndpoint: 'https://stale.example.com' },
+      })
+
+      await compose.updateLocalState({
+        alias: 'service-a',
+        runnerOutput: {
+          state: returnedState,
+          serviceUniqueId: 'stack-123',
+          runnerType: 'traditional',
+        },
+        command: ['deploy'],
+        state,
+        graph: compose.graph,
+      })
+
+      expect(state.putServiceState).toHaveBeenCalledWith({
+        serviceUniqueId: 'stack-123',
+        runnerType: 'traditional',
+        value: JSON.stringify(returnedState),
+      })
+      expect(state.getServiceState).not.toHaveBeenCalled()
+      expect(state.localState['service-a']).toEqual(returnedState)
+    })
+
+    test('does not persist state for get-state command', async () => {
+      const compose = await parseComposeGraph({
+        servicePath: '/tmp/project',
+        configuration: buildTwoServiceConfig(),
+        versions: { serverless_framework: '4.0.0' },
+      })
+
+      const state = createMockState()
+
+      await compose.updateLocalState({
+        alias: 'service-a',
+        runnerOutput: {
+          state: { outputs: { apiEndpoint: 'https://api.example.com' } },
+          serviceUniqueId: 'stack-123',
+          runnerType: 'traditional',
+        },
+        command: ['get-state'],
+        state,
+        graph: compose.graph,
+      })
+
+      expect(state.putServiceState).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
`serverless package` failed in compose projects with cross-service references
when dependency outputs were unavailable because package was not handled by the
parameter fallback.

Treat empty state from package and print as non-authoritative and fall back to
stored outputs. Continue persisting empty output maps from state-producing
commands so removed outputs do not remain stale.

When a referenced output is still unavailable at package time, substitute the
NOT_AVAILABLE_AT_PACKAGE_TIME placeholder and warn that the packaged artifact
should not be deployed as-is. The warning is emitted via writeCompose because
messages above the 'compose' renderer log level are dropped during
multi-service runs.

Closes: #13437