### PR TITLE
docs: remove misleading "Installing Serverless in an existing service" section

### DIFF
--- a/docs/sf/providers/aws/guide/services.md
+++ b/docs/sf/providers/aws/guide/services.md
@@ -277,27 +277,3 @@ provider:
 …
 ```
 
-## Installing Serverless in an existing service
-
-If you already have a Serverless service, and would prefer to lock down the framework version using `package.json`, then you can install Serverless as follows:
-
-```bash
-# from within a service
-npm install serverless --save-dev
-```
-
-### Invoking Serverless locally
-
-To execute the locally installed Serverless executable you have to reference the binary out of the node modules directory.
-
-Example:
-
-```bash
-npx serverless deploy
-```
-
-or
-
-```bash
-node ./node_modules/serverless/bin/serverless deploy
-```


### PR DESCRIPTION
## Summary
- Removes the section that incorrectly suggested installing Serverless via `package.json` locks the framework version
- In v4 the npm package is a thin wrapper that downloads and runs the framework — it doesn't provide a local pinned copy
- Version pinning is done via `frameworkVersion` in `serverless.yml`, which is already documented in the "Version Pinning" section

Closes #13448

## Test plan
- [ ] Verify the "Version Pinning" section still exists and is accurate
- [ ] Confirm no other docs reference the removed section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed documentation section regarding Serverless installation and deployment procedures from the AWS services guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->