### PR TITLE
Pin axios in framework-dist runtime package

### DIFF
--- a/packages/framework-dist/package.json
+++ b/packages/framework-dist/package.json
@@ -12,6 +12,9 @@
     "serverless": "./dist/sf-core.js",
     "sls": "./dist/sf-core.js"
   },
+  "overrides": {
+    "axios": "1.13.6"
+  },
   "dependencies": {
     "@aws-sdk/client-cloudfront-keyvaluestore": "3.1015.0",
     "@aws-sdk/signature-v4-crt": "3.1015.0",


### PR DESCRIPTION

<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/TESTING.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v18 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/TESTING.md#integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

Hotfix for the runtime release tarball installed by the binary updater.

Root cause:
- `packages/framework-dist/package.json` ships without a lockfile.
- The binary installer extracts the release archive and runs `npm install --no-audit --no-fund --no-progress` in `package/`.
- `@aws-sdk/signature-v4-crt` pulls in `aws-crt`, which depends on `axios` via `^1.12.2`.
- Fresh installs therefore resolve whatever matching axios version is current, which allowed compromised `axios@1.14.1` to be selected during the incident window.

Fix:
- Add `overrides.axios = 1.13.6` to `packages/framework-dist/package.json` so the extracted runtime package installs a known safe axios version regardless of the transitive semver range.

Validation:
- Reproduced the runtime package resolution in a clean temp directory.
- Without the override, a fresh `npm install --package-lock-only` resolved axios from the transitive semver range.
- With the override, the same install resolved `axios@1.13.6`.
- Packed `packages/framework-dist` and confirmed the generated tarball contains the override in `package/package.json`.

Closes: #13453

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions to improve framework stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->