### PR TITLE
chore: release 4.33.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15879,7 +15879,7 @@
     },
     "packages/sf-core": {
       "name": "@serverlessinc/sf-core",
-      "version": "4.33.1",
+      "version": "4.33.2",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "3.1015.0",
         "@aws-sdk/client-s3": "3.1015.0",
@@ -15939,7 +15939,7 @@
     },
     "packages/sf-core-installer": {
       "name": "serverless",
-      "version": "4.33.1",
+      "version": "4.33.2",
       "hasInstallScript": true,
       "dependencies": {
         "rimraf": "5.0.10",

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "4.33.1",
+  "version": "4.33.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/sf-core/package.json
+++ b/packages/sf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/sf-core",
-  "version": "4.33.1",
+  "version": "4.33.2",
   "main": "src/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION

Release 4.33.2.

This release bumps the published framework CLI and installer packages to 4.33.2 so the release artifacts include the merged runtime tarball hotfix from #13454.

- Update `@serverlessinc/sf-core` to `4.33.2`
- Update the `serverless` npm installer package to `4.33.2`
- Update `package-lock.json` workspace package metadata accordingly



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Released version 4.33.2 for serverless and sf-core packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->