### PR TITLE
fix: use path.relative to handle symlinked serviceDirs in excludeNodeDevDependencies

### DIFF
--- a/packages/serverless/lib/plugins/package/lib/zip-service.js
+++ b/packages/serverless/lib/plugins/package/lib/zip-service.js
@@ -270,7 +270,7 @@ async function excludeNodeDevDependencies(serviceDir) {
           if (dependencies.length) {
             return pMap(
               dependencies,
-              (item) => item.replace(path.join(serviceDir, path.sep), ''),
+              (item) => path.relative(serviceDir, item),
               { concurrency: os.cpus().length },
             )
               .then((processedDependencies) => {

--- a/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -150,6 +150,51 @@ describe('zipService', () => {
       expect(updatedParams.include).toContain('user-defined-include-me')
       expect(updatedParams.zipFileName).toBe(params.zipFileName)
     })
+
+    it('should correctly exclude dev dependencies when serviceDir is a symlink', async () => {
+      // Create a real directory and a symlink pointing to it
+      const realDir = path.join(tmpDirPath, 'real-service')
+      const symlinkDir = path.join(tmpDirPath, 'symlink-service')
+      fs.mkdirSync(realDir, { recursive: true })
+      fs.symlinkSync(realDir, symlinkDir)
+
+      // Set up package.json with a dev dependency
+      fs.writeFileSync(
+        path.join(realDir, 'package.json'),
+        JSON.stringify({
+          name: 'test-service',
+          devDependencies: { 'dev-dep': '1.0.0' },
+          dependencies: {},
+        }),
+      )
+
+      // Create node_modules structure
+      fs.mkdirSync(path.join(realDir, 'node_modules', 'dev-dep'), {
+        recursive: true,
+      })
+      fs.writeFileSync(
+        path.join(realDir, 'node_modules', 'dev-dep', 'package.json'),
+        JSON.stringify({ name: 'dev-dep', version: '1.0.0' }),
+      )
+
+      // Point serviceDir to the symlink path
+      serverless.serviceDir = symlinkDir
+      serverless.config.serviceDir = symlinkDir
+      packagePlugin = new Package(serverless, {})
+
+      const updatedParams = await packagePlugin.excludeDevDependencies(params)
+
+      // The dev dependency should be excluded via glob patterns
+      const hasDevDepExclusion = updatedParams.exclude.some(
+        (pattern) =>
+          pattern.includes('node_modules/dev-dep') ||
+          pattern.includes('node_modules\\dev-dep'),
+      )
+      expect(hasDevDepExclusion).toBe(true)
+
+      // Clean up symlink
+      fs.unlinkSync(symlinkDir)
+    })
   })
 
   describe('#zip()', () => {


### PR DESCRIPTION
## Problem
When deploying from environments where the project directory is accessed via a symlink
(e.g., AWS CodeBuild), `excludeNodeDevDependencies` fails to strip the `serviceDir`
prefix from `npm ls --parseable` output because the paths differ (symlink vs resolved).
This causes all dev dependencies to be bundled into the Lambda zip.

## Root Cause
`String.replace()` at zip-service.js:273 does a literal string match of `serviceDir`
against paths from `npm ls`. When `serviceDir` is a symlink path but `npm ls` returns
the resolved path, the replacement fails silently.

## Fix
Replace `String.replace(path.join(serviceDir, path.sep), '')` with
`path.relative(serviceDir, item)` which correctly computes relative paths regardless
of symlink resolution differences.

## Test Plan
- Added unit test for symlink path mismatch scenario
- Verified existing tests still pass

Fixes #13447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved path normalization for more reliable cross-platform path handling during package processing.

* **Tests**
  * Extended test coverage for development dependency exclusion, including symlink support and path separator handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->