### PR TITLE
chore(dependabot): add ignore rule for get-stdin v10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,7 +83,7 @@ updates:
         versions: ['>= 1.4.0']
       - dependency-name: 'get-stdin'
         # get-stdin v10 drops support for Node.js 18
-        versions: [ '>= 10.0.0' ]
+        versions: ['>= 10.0.0']
 
   # Maintain framework-dist dependencies (excluded from workspace, has its own shrinkwrap)
   - package-ecosystem: 'npm'


### PR DESCRIPTION
drops Node.js 18 support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency update rules to allow an upcoming major-version update for a dependency.

**Note:** This release contains only internal maintenance updates with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->