### PR TITLE
feat: add S3 Files support for Lambda file system configuration

### DIFF
--- a/docs/sf/providers/aws/guide/functions.md
+++ b/docs/sf/providers/aws/guide/functions.md
@@ -850,9 +850,13 @@ functions:
     maximumRetryAttempts: 1
 ```
 
-## EFS Configuration
+## File System Configuration
 
-You can use [Amazon EFS with Lambda](https://docs.aws.amazon.com/lambda/latest/dg/services-efs.html) by adding a `fileSystemConfig` property in the function configuration in `serverless.yml`. `fileSystemConfig` should be an object that contains the `arn` and `localMountPath` properties. The `arn` property should reference an existing EFS Access Point, where the `localMountPath` should specify the absolute path under which the file system will be mounted. Here's an example configuration:
+You can mount file systems on Lambda functions by adding a `fileSystemConfig` property in the function configuration in `serverless.yml`. Both [Amazon EFS](https://docs.aws.amazon.com/lambda/latest/dg/configuration-filesystem.html) and [Amazon S3 Files](https://docs.aws.amazon.com/lambda/latest/dg/configuration-filesystem-s3files.html) are supported.
+
+`fileSystemConfig` should be an object that contains the `arn` and `localMountPath` properties. The `arn` property should reference an existing access point (EFS or S3 Files), where the `localMountPath` should specify the absolute path under which the file system will be mounted. A VPC configuration is required for both file system types.
+
+### EFS Example
 
 ```yml
 # serverless.yml
@@ -871,6 +875,43 @@ functions:
       subnetIds:
         - subnetId1
 ```
+
+### S3 Files Example
+
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    fileSystemConfig:
+      localMountPath: /mnt/s3data
+      arn: arn:aws:s3files:us-east-1:111111111111:file-system/fs-0abcdef1234567890/access-point/fsap-0abcdef1234567890
+    vpc:
+      securityGroupIds:
+        - securityGroupId1
+      subnetIds:
+        - subnetId1
+```
+
+The file system type is automatically detected from the ARN. When using CloudFormation references for the ARN, specify the `type` field explicitly:
+
+```yml
+functions:
+  hello:
+    handler: handler.hello
+    fileSystemConfig:
+      localMountPath: /mnt/s3data
+      arn: !GetAtt MyS3FilesAccessPoint.AccessPointArn
+      type: s3files
+    vpc:
+      securityGroupIds:
+        - securityGroupId1
+      subnetIds:
+        - subnetId1
+```
+
+The framework automatically adds the required IAM permissions: `elasticfilesystem:ClientMount` and `elasticfilesystem:ClientWrite` for EFS, or `s3files:ClientMount` and `s3files:ClientWrite` for S3 Files.
+
+> **Note:** Optionally, for the best S3 Files read performance on functions with 512 MB or more memory, add `s3:GetObject` and `s3:GetObjectVersion` permissions for your S3 bucket via `provider.iam.role.statements`.
 
 ## Ephemeral storage
 

--- a/docs/sf/providers/aws/guide/iam.md
+++ b/docs/sf/providers/aws/guide/iam.md
@@ -329,11 +329,11 @@ When a per-function role is generated, the Framework augments it with sensible d
     - `xray:PutTelemetryRecords`
       on `*`.
 
-- EFS access (when `fileSystemConfig` is used)
-  - If `functions.<name>.fileSystemConfig.arn` is set, adds:
-    - `elasticfilesystem:ClientMount`
-    - `elasticfilesystem:ClientWrite`
-      on that EFS access point ARN.
+- File system access (when `fileSystemConfig` is used)
+  - If `functions.<name>.fileSystemConfig.arn` is set:
+    - For EFS: adds `elasticfilesystem:ClientMount` and `elasticfilesystem:ClientWrite` on that access point ARN.
+    - For S3 Files: adds `s3files:ClientMount` and `s3files:ClientWrite` on that access point ARN.
+  - The file system type is auto-detected from the ARN. When using CloudFormation references, set `fileSystemConfig.type` to `s3files` explicitly.
 
 Example:
 
@@ -342,7 +342,7 @@ functions:
   func1:
     handler: handler.func1
     # SQS and Streams events automatically grant minimal read permissions
-    # WebSockets, MQ, Kafka/MSK, CloudFront, Scheduler, X-Ray and EFS will also
+    # WebSockets, MQ, Kafka/MSK, CloudFront, Scheduler, X-Ray, EFS and S3 Files will also
     # add the necessary IAM permissions when configured below.
     events:
       - sqs: arn:aws:sqs:${aws:region}:${aws:accountId}:myQueue

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -941,12 +941,14 @@ functions:
         type: sns
         arn:
           Ref: SomeTopicName
-    # Mount an EFS filesystem
+    # Mount a file system (EFS or S3 Files)
     fileSystemConfig:
-      # ARN of EFS Access Point
+      # ARN of EFS or S3 Files Access Point
       arn: arn:aws:elasticfilesystem:us-east-1:11111111:access-point/fsap-a1a1a1
-      # Path under which EFS will be mounted and accessible in Lambda
+      # Path under which the file system will be mounted and accessible in Lambda
       localMountPath: /mnt/example
+      # File system type - auto-detected from ARN, required for CF references with S3 Files
+      # type: efs | s3files
     # Maximum retry attempts when an asynchronous invocation fails (between 0 and 2; default: 2)
     maximumRetryAttempts: 1
     # Maximum event age in seconds when invoking asynchronously (between 60 and 21600)

--- a/package-lock.json
+++ b/package-lock.json
@@ -6897,14 +6897,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -13041,8 +13041,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.2",

--- a/packages/framework-dist/npm-shrinkwrap.json
+++ b/packages/framework-dist/npm-shrinkwrap.json
@@ -1824,9 +1824,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/packages/serverless/lib/plugins/aws/package/compile/functions.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/functions.js
@@ -6,6 +6,7 @@ import deepSortObjectByKey from '../../../../utils/deep-sort-object-by-key.js'
 import getHashForFilePath from '../lib/get-hash-for-file-path.js'
 import resolveLambdaTarget from '../../utils/resolve-lambda-target.js'
 import parseS3URI from '../../utils/parse-s3-uri.js'
+import resolveFileSystemType from '../../utils/resolve-file-system-type.js'
 import { log, ServerlessError } from '@serverless/util'
 
 const defaultCors = {
@@ -734,12 +735,15 @@ class AwsCompileFunctions {
 
       const iamRoleLambdaExecution = cfTemplate.Resources.IamRoleLambdaExecution
 
+      const fsType = resolveFileSystemType(fileSystemConfig)
+      const actions =
+        fsType === 's3files'
+          ? ['s3files:ClientMount', 's3files:ClientWrite']
+          : ['elasticfilesystem:ClientMount', 'elasticfilesystem:ClientWrite']
+
       const stmt = {
         Effect: 'Allow',
-        Action: [
-          'elasticfilesystem:ClientMount',
-          'elasticfilesystem:ClientWrite',
-        ],
+        Action: actions,
         Resource: [fileSystemConfig.arn],
       }
 

--- a/packages/serverless/lib/plugins/aws/package/lib/roles-per-function-permissions.js
+++ b/packages/serverless/lib/plugins/aws/package/lib/roles-per-function-permissions.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import resolveFileSystemType from '../../utils/resolve-file-system-type.js'
 
 function applyLogPermissions({
   functionObject,
@@ -452,13 +453,19 @@ function applyXrayPermissions({
   }
 }
 
-function applyEfsPermissions({ functionObject, policyStatements }) {
+function applyFileSystemPermissions({ functionObject, policyStatements }) {
   const fileSystemConfig = functionObject.fileSystemConfig
   if (!fileSystemConfig || !fileSystemConfig.arn) return
 
+  const fsType = resolveFileSystemType(fileSystemConfig)
+  const actions =
+    fsType === 's3files'
+      ? ['s3files:ClientMount', 's3files:ClientWrite']
+      : ['elasticfilesystem:ClientMount', 'elasticfilesystem:ClientWrite']
+
   const stmt = {
     Effect: 'Allow',
-    Action: ['elasticfilesystem:ClientMount', 'elasticfilesystem:ClientWrite'],
+    Action: actions,
     Resource: [fileSystemConfig.arn],
   }
 
@@ -598,7 +605,7 @@ export default function applyPerFunctionPermissions({
     policyStatements,
     serverless,
   })
-  applyEfsPermissions({ functionObject, policyStatements })
+  applyFileSystemPermissions({ functionObject, policyStatements })
   applyDestinationPermissions({
     functionObject,
     policyStatements,

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -2614,17 +2614,22 @@ destinations:
               maximum: 10240,
             },
             fileSystemConfig: {
-              description: `EFS access point mount configuration.
-@see https://www.serverless.com/framework/docs/providers/aws/guide/functions#efs-configuration`,
+              description: `File system mount configuration (EFS or S3 Files).
+@see https://www.serverless.com/framework/docs/providers/aws/guide/functions#file-system-configuration`,
               type: 'object',
               properties: {
                 arn: {
-                  description: `EFS access point ARN.`,
+                  description: `File system access point ARN (EFS or S3 Files).`,
                   anyOf: [
                     {
                       type: 'string',
                       pattern:
                         '^arn:aws[a-zA-Z-]*:elasticfilesystem:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-[1-9]{1}:[0-9]{12}:access-point/fsap-[a-f0-9]{17}$',
+                    },
+                    {
+                      type: 'string',
+                      pattern:
+                        '^arn:aws[a-zA-Z-]*:s3files:[a-z]{2}((-gov)|(-iso(b?)))?-[a-z]+-[1-9]{1}:[0-9]{12}:file-system/fs-[0-9a-f]{17,40}/access-point/fsap-[0-9a-f]{17,40}$',
                     },
                     { $ref: '#/definitions/awsCfGetAtt' },
                     { $ref: '#/definitions/awsCfJoin' },
@@ -2635,6 +2640,10 @@ destinations:
                   description: `Local mount path in the Lambda function (/mnt/...).`,
                   type: 'string',
                   pattern: '^/mnt/[a-zA-Z0-9-_.]+$',
+                },
+                type: {
+                  description: `File system type. Auto-detected from literal ARN strings. Required when using CloudFormation references with S3 Files.`,
+                  enum: ['efs', 's3files'],
                 },
               },
               additionalProperties: false,

--- a/packages/serverless/lib/plugins/aws/utils/resolve-file-system-type.js
+++ b/packages/serverless/lib/plugins/aws/utils/resolve-file-system-type.js
@@ -1,0 +1,7 @@
+export default function resolveFileSystemType(fileSystemConfig) {
+  if (fileSystemConfig.type) return fileSystemConfig.type
+  if (typeof fileSystemConfig.arn === 'string') {
+    if (fileSystemConfig.arn.includes(':s3files:')) return 's3files'
+  }
+  return 'efs'
+}

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -757,8 +757,8 @@ describe('AwsCompileFunctions', () => {
       }
     })
 
-    describe('FileSystemConfig (EFS)', () => {
-      it('should configure FileSystemConfigs and IAM permissions when VPC is set', async () => {
+    describe('FileSystemConfig', () => {
+      it('should configure FileSystemConfigs and EFS IAM permissions when VPC is set', async () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
             handler: 'handler',
@@ -800,6 +800,112 @@ describe('AwsCompileFunctions', () => {
         })
       })
 
+      it('should configure S3 Files IAM permissions when S3 Files ARN is used', async () => {
+        const s3FilesArn =
+          'arn:aws:s3files:us-east-1:123456789012:file-system/fs-0abcdef1234567890/access-point/fsap-0abcdef1234567890'
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'handler',
+            name: 'func',
+            vpc: { securityGroupIds: ['sg-1'], subnetIds: ['sub-1'] },
+            fileSystemConfig: {
+              localMountPath: '/mnt/s3data',
+              arn: s3FilesArn,
+            },
+          },
+        }
+
+        await awsCompileFunctions.compileFunctions()
+
+        const resources =
+          awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources
+        const props = resources.FuncLambdaFunction.Properties
+
+        expect(props.FileSystemConfigs).toEqual([
+          {
+            Arn: s3FilesArn,
+            LocalMountPath: '/mnt/s3data',
+          },
+        ])
+
+        const policy =
+          resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument
+            .Statement
+        expect(policy).toContainEqual({
+          Effect: 'Allow',
+          Action: ['s3files:ClientMount', 's3files:ClientWrite'],
+          Resource: [s3FilesArn],
+        })
+      })
+
+      it('should use S3 Files IAM permissions when type is explicitly set to s3files', async () => {
+        const cfRef = {
+          'Fn::GetAtt': ['MyS3FilesAccessPoint', 'AccessPointArn'],
+        }
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'handler',
+            name: 'func',
+            vpc: { securityGroupIds: ['sg-1'], subnetIds: ['sub-1'] },
+            fileSystemConfig: {
+              localMountPath: '/mnt/s3data',
+              arn: cfRef,
+              type: 's3files',
+            },
+          },
+        }
+
+        await awsCompileFunctions.compileFunctions()
+
+        const resources =
+          awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources
+
+        expect(
+          resources.FuncLambdaFunction.Properties.FileSystemConfigs,
+        ).toEqual([{ Arn: cfRef, LocalMountPath: '/mnt/s3data' }])
+
+        const policy =
+          resources.IamRoleLambdaExecution.Properties.Policies[0].PolicyDocument
+            .Statement
+        expect(policy).toContainEqual({
+          Effect: 'Allow',
+          Action: ['s3files:ClientMount', 's3files:ClientWrite'],
+          Resource: [cfRef],
+        })
+      })
+
+      it('should default to EFS IAM permissions when CF reference is used without type', async () => {
+        const cfRef = { 'Fn::GetAtt': ['MyAccessPoint', 'AccessPointArn'] }
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'handler',
+            name: 'func',
+            vpc: { securityGroupIds: ['sg-1'], subnetIds: ['sub-1'] },
+            fileSystemConfig: {
+              localMountPath: '/mnt/data',
+              arn: cfRef,
+            },
+          },
+        }
+
+        await awsCompileFunctions.compileFunctions()
+
+        const policy =
+          awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution
+            .Properties.Policies[0].PolicyDocument.Statement
+        expect(policy).toContainEqual({
+          Effect: 'Allow',
+          Action: [
+            'elasticfilesystem:ClientMount',
+            'elasticfilesystem:ClientWrite',
+          ],
+          Resource: [cfRef],
+        })
+      })
+
       it('should throw error if fileSystemConfig is set without VPC', async () => {
         awsCompileFunctions.serverless.service.functions = {
           func: {
@@ -808,6 +914,22 @@ describe('AwsCompileFunctions', () => {
             fileSystemConfig: {
               localMountPath: '/mnt/efs',
               arn: 'arn:aws:elasticfilesystem:...',
+            },
+          },
+        }
+        await expect(awsCompileFunctions.compileFunctions()).rejects.toThrow(
+          /ensure that function has vpc configured/,
+        )
+      })
+
+      it('should throw error if S3 Files fileSystemConfig is set without VPC', async () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'handler',
+            name: 'func',
+            fileSystemConfig: {
+              localMountPath: '/mnt/s3data',
+              arn: 'arn:aws:s3files:us-east-1:123456789012:file-system/fs-0abcdef1234567890/access-point/fsap-0abcdef1234567890',
             },
           },
         }

--- a/packages/serverless/test/unit/lib/plugins/aws/package/lib/roles-per-function-permissions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/lib/roles-per-function-permissions.test.js
@@ -401,3 +401,186 @@ describe('applyPerFunctionPermissions - Destination Permissions', () => {
     )
   })
 })
+
+describe('applyPerFunctionPermissions - File System Permissions', () => {
+  let serverless
+  let provider
+  let policyStatements
+  let functionIamRole
+
+  beforeEach(() => {
+    provider = {
+      naming: {
+        getLogGroupName: jest.fn((name) => `/aws/lambda/${name}`),
+      },
+    }
+    serverless = {
+      service: {
+        provider: {},
+        getFunction: jest.fn((name) => ({
+          name: `test-service-dev-${name}`,
+        })),
+      },
+      getProvider: jest.fn(() => provider),
+    }
+    policyStatements = []
+    functionIamRole = {
+      Properties: {
+        ManagedPolicyArns: [],
+        AssumeRolePolicyDocument: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Principal: { Service: 'lambda.amazonaws.com' },
+              Action: 'sts:AssumeRole',
+            },
+          ],
+        },
+      },
+    }
+  })
+
+  it('should add EFS permissions for EFS ARN', () => {
+    const efsArn =
+      'arn:aws:elasticfilesystem:us-east-1:123456789012:access-point/fsap-0abcdef1234567890'
+    const functionObject = {
+      name: 'test-function',
+      fileSystemConfig: {
+        arn: efsArn,
+        localMountPath: '/mnt/efs',
+      },
+    }
+
+    applyPerFunctionPermissions({
+      functionName: 'myFunc',
+      functionObject,
+      functionIamRole,
+      policyStatements,
+      serverless,
+      provider,
+      throwError: jest.fn(),
+    })
+
+    expect(policyStatements).toContainEqual({
+      Effect: 'Allow',
+      Action: [
+        'elasticfilesystem:ClientMount',
+        'elasticfilesystem:ClientWrite',
+      ],
+      Resource: [efsArn],
+    })
+  })
+
+  it('should add S3 Files permissions for S3 Files ARN', () => {
+    const s3FilesArn =
+      'arn:aws:s3files:us-east-1:123456789012:file-system/fs-0abcdef1234567890/access-point/fsap-0abcdef1234567890'
+    const functionObject = {
+      name: 'test-function',
+      fileSystemConfig: {
+        arn: s3FilesArn,
+        localMountPath: '/mnt/s3data',
+      },
+    }
+
+    applyPerFunctionPermissions({
+      functionName: 'myFunc',
+      functionObject,
+      functionIamRole,
+      policyStatements,
+      serverless,
+      provider,
+      throwError: jest.fn(),
+    })
+
+    expect(policyStatements).toContainEqual({
+      Effect: 'Allow',
+      Action: ['s3files:ClientMount', 's3files:ClientWrite'],
+      Resource: [s3FilesArn],
+    })
+  })
+
+  it('should add S3 Files permissions when type is explicitly set to s3files', () => {
+    const cfRef = {
+      'Fn::GetAtt': ['MyS3FilesAccessPoint', 'AccessPointArn'],
+    }
+    const functionObject = {
+      name: 'test-function',
+      fileSystemConfig: {
+        arn: cfRef,
+        localMountPath: '/mnt/s3data',
+        type: 's3files',
+      },
+    }
+
+    applyPerFunctionPermissions({
+      functionName: 'myFunc',
+      functionObject,
+      functionIamRole,
+      policyStatements,
+      serverless,
+      provider,
+      throwError: jest.fn(),
+    })
+
+    expect(policyStatements).toContainEqual({
+      Effect: 'Allow',
+      Action: ['s3files:ClientMount', 's3files:ClientWrite'],
+      Resource: [cfRef],
+    })
+  })
+
+  it('should default to EFS permissions when CF reference is used without type', () => {
+    const cfRef = { 'Fn::GetAtt': ['MyAccessPoint', 'AccessPointArn'] }
+    const functionObject = {
+      name: 'test-function',
+      fileSystemConfig: {
+        arn: cfRef,
+        localMountPath: '/mnt/data',
+      },
+    }
+
+    applyPerFunctionPermissions({
+      functionName: 'myFunc',
+      functionObject,
+      functionIamRole,
+      policyStatements,
+      serverless,
+      provider,
+      throwError: jest.fn(),
+    })
+
+    expect(policyStatements).toContainEqual({
+      Effect: 'Allow',
+      Action: [
+        'elasticfilesystem:ClientMount',
+        'elasticfilesystem:ClientWrite',
+      ],
+      Resource: [cfRef],
+    })
+  })
+
+  it('should not add permissions when fileSystemConfig is not set', () => {
+    const functionObject = {
+      name: 'test-function',
+    }
+
+    applyPerFunctionPermissions({
+      functionName: 'myFunc',
+      functionObject,
+      functionIamRole,
+      policyStatements,
+      serverless,
+      provider,
+      throwError: jest.fn(),
+    })
+
+    expect(
+      policyStatements.some(
+        (s) =>
+          s.Action &&
+          (s.Action.includes('elasticfilesystem:ClientMount') ||
+            s.Action.includes('s3files:ClientMount')),
+      ),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Add Amazon S3 Files as a supported file system type alongside EFS in `fileSystemConfig`
- Extend schema to accept S3 Files access point ARNs and an optional `type` field (`'efs'` | `'s3files'`)
- Auto-detect file system type from literal ARN strings; for CloudFormation references, default to EFS (backward compatible) and require `type: s3files` for S3 Files
- Auto-add correct IAM permissions: `s3files:ClientMount`/`s3files:ClientWrite` for S3 Files, `elasticfilesystem:ClientMount`/`elasticfilesystem:ClientWrite` for EFS
- Extract `resolveFileSystemType` to shared utility at `packages/serverless/lib/plugins/aws/utils/resolve-file-system-type.js`
- Support both shared IAM role and per-function IAM role modes

## Test plan

- [x] Unit tests for S3 Files compilation (auto-detect, explicit type, CF reference default, VPC error) — `packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js`
- [x] Unit tests for per-function IAM permissions (EFS, S3 Files, CF ref with type, CF ref default, no config) — `packages/serverless/test/unit/lib/plugins/aws/package/lib/roles-per-function-permissions.test.js`
- [x] All 77 tests pass (60 compilation + 17 per-function permissions)
- [x] Deploy test with real S3 Files resources: Lambda successfully wrote/read 10MB files via `/mnt/s3data`
- [x] Verified auto-generated IAM policy contains `s3files:ClientMount`/`s3files:ClientWrite` scoped to access point ARN
- [x] Snyk code scan: 0 issues

## How to test

### S3 Files with literal ARN (type auto-detected):

```yml
functions:
  hello:
    handler: handler.hello
    fileSystemConfig:
      localMountPath: /mnt/s3data
      arn: arn:aws:s3files:us-east-1:111111111111:file-system/fs-abc123/access-point/fsap-abc123
    vpc:
      securityGroupIds:
        - sg-xxx
      subnetIds:
        - subnet-xxx
```

### S3 Files with CloudFormation reference (type required):

```yml
functions:
  hello:
    handler: handler.hello
    fileSystemConfig:
      localMountPath: /mnt/s3data
      arn: !GetAtt MyS3FilesAccessPoint.AccessPointArn
      type: s3files
    vpc:
      securityGroupIds:
        - sg-xxx
      subnetIds:
        - subnet-xxx
```

### EFS (unchanged, fully backward compatible):

```yml
functions:
  hello:
    handler: handler.hello
    fileSystemConfig:
      localMountPath: /mnt/efs
      arn: arn:aws:elasticfilesystem:us-east-1:111111111111:access-point/fsap-abc123
    vpc:
      securityGroupIds:
        - sg-xxx
      subnetIds:
        - subnet-xxx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the Framework generates IAM policies for Lambda file system mounts and broadens config schema validation, which could affect deploy-time permissions if mis-detected. Logic is small and covered by unit tests, but touches packaging/compile and per-function IAM paths.
> 
> **Overview**
> Adds **Amazon S3 Files** support alongside EFS for Lambda `fileSystemConfig`, including updated docs and `serverless.yml` reference examples.
> 
> Updates the AWS config schema to accept S3 Files access point ARNs and an optional `fileSystemConfig.type` (`efs` | `s3files`), with a new `resolveFileSystemType` helper to auto-detect type from literal ARNs (and require explicit `type` for CF references).
> 
> Adjusts IAM auto-permissions generation in both shared-role compilation and per-function IAM roles to grant `s3files:ClientMount`/`s3files:ClientWrite` for S3 Files (otherwise EFS `elasticfilesystem:*`), and adds unit tests covering detection, explicit typing, defaults, and VPC-required errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ccbbe51f3102032711f8bd38316f204c4b19308. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lambda functions can mount Amazon EFS or Amazon S3 Files; filesystem type auto-detected from ARN or explicitly set for CloudFormation.
  * VPC is required for both filesystem types; framework adds appropriate mount/write IAM permissions per filesystem type.

* **Documentation**
  * Updated configuration and IAM guidance with examples for EFS and S3 Files and notes on optional S3 read grants for performance.

* **Tests**
  * Added unit tests covering EFS and S3 Files scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->