### PR TITLE
fix(test): make appsync utils test timezone-independent

### DIFF
--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/utils.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/utils.test.js
@@ -33,15 +33,15 @@ describe('parseDuration', () => {
 describe('parseDateTimeOrDuration', () => {
   it('should parse valid date', () => {
     expect(
-      parseDateTimeOrDuration('2021-12-31T16:57:00+00:00'),
-    ).toMatchInlineSnapshot(`"2021-12-31T16:57:00.000+00:00"`)
+      parseDateTimeOrDuration('2021-12-31T16:57:00+00:00').toMillis(),
+    ).toBe(new Date('2021-12-31T16:57:00.000Z').getTime())
 
-    expect(parseDateTimeOrDuration('10m')).toMatchInlineSnapshot(
-      `"2020-01-01T16:50:00.000+00:00"`,
+    expect(parseDateTimeOrDuration('10m').toMillis()).toBe(
+      new Date('2020-01-01T16:50:00.000Z').getTime(),
     )
 
-    expect(parseDateTimeOrDuration('1h')).toMatchInlineSnapshot(
-      `"2020-01-01T16:00:00.000+00:00"`,
+    expect(parseDateTimeOrDuration('1h').toMillis()).toBe(
+      new Date('2020-01-01T16:00:00.000Z').getTime(),
     )
 
     expect(function () {


### PR DESCRIPTION
Replace inline snapshot string comparisons with `toMillis()` timestamp
comparisons so `parseDateTimeOrDuration` tests pass in any timezone.

## Problem

The `parseDateTimeOrDuration` tests in `utils.test.js` use inline snapshots
that hardcode `+00:00` offset strings. Luxon's `DateTime.fromISO()` and
`DateTime.now()` return DateTimes in the local timezone, so these snapshots
fail in non-UTC environments (e.g. `Asia/Tokyo`, `US/Pacific`).

## Solution

Replace timezone-dependent string snapshot assertions with `toMillis()`
comparisons. Millisecond timestamps are timezone-independent, so the tests
now pass regardless of the system timezone. No production code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved unit test assertions to use deterministic numeric comparisons instead of string snapshots, enhancing test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->