### PR TITLE
fix: preserve case in normalizePathPart to prevent API Gateway path collisions

### DIFF
--- a/packages/serverless/lib/plugins/aws/lib/naming.js
+++ b/packages/serverless/lib/plugins/aws/lib/naming.js
@@ -34,7 +34,7 @@ export default {
   },
   normalizePathPart(rawPath) {
     return _.upperFirst(
-      _.capitalize(rawPath)
+      rawPath
         .replace(/-/g, 'Dash')
         .replace(/\{(.*)\}/g, '$1Var')
         .replace(/[^0-9A-Za-z]/g, ''),


### PR DESCRIPTION
Closes #11956

_.capitalize() lowercases all chars after the first, causing paths like /DevicePaymentService and /devicepaymentservice to generate identical CloudFormation IDs and fail on deploy.

Fix: use rawPath directly instead of _.capitalize(rawPath). _.upperFirst() still ensures a valid uppercase start for CloudFormation resource names.

Before: /DevicePaymentService and /devicepaymentservice both → 'Devicepaymentservice' (collision)
After: → 'DevicePaymentService' and 'Devicepaymentservice' (distinct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Optimized internal path normalization logic to improve processing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->