### PR TITLE
fix(esbuild): write zip artifacts to .serverless/ for --package compatibility

### DIFF
--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -760,7 +760,6 @@ class Esbuild {
           const zipPath = path.join(
             this.serverless.config.serviceDir,
             '.serverless',
-            'build',
             zipName,
           )
 
@@ -884,7 +883,6 @@ class Esbuild {
     const zipPath = path.join(
       this.serverless.config.serviceDir,
       '.serverless',
-      'build',
       zipName,
     )
 

--- a/packages/sf-core/tests/integration/esbuild/package-individually/package-individually.test.js
+++ b/packages/sf-core/tests/integration/esbuild/package-individually/package-individually.test.js
@@ -62,7 +62,6 @@ describe('Serverless Framework Service - ESBuild Package Individually', () => {
       const zipPath = path.join(
         configFileDirPath,
         '.serverless',
-        'build',
         `${functionName}.zip`,
       )
       const exists = existsSync(zipPath)


### PR DESCRIPTION
## Summary

- Write esbuild zip artifacts to `.serverless/` instead of `.serverless/build/` to align with the convention expected by the deploy validation, upload, and compile steps

## Root cause

The esbuild plugin wrote zip artifacts to `.serverless/build/name.zip`, but:
- `save-service-state.js` only stores the basename (`name.zip`), stripping the `build/` segment
- `extended-validate.js` reconstructs the path as `.serverless/name.zip` — which doesn't exist

In a single-process `sls deploy`, this was masked because `package.artifact` stayed correct in memory. In a two-process `sls package` + `sls deploy --package` flow, the in-memory state was lost and the deploy failed with `MISSING_ARTIFACT_FILE`.

The `.serverless/build/` directory remains the staging area for intermediate build artifacts (compiled JS, `package.json`, lockfiles, `node_modules`). Only the final zip output moves to `.serverless/`, matching the traditional packager's behavior.

## Test plan

- [x] `sls package` followed by `sls deploy --package .serverless` succeeds (previously threw `MISSING_ARTIFACT_FILE`)
- [x] Deployed endpoint returns expected response
- [x] Verified bug reproduces with reverted change

## Related

Closes #12964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted packaging output so deployment zips are placed directly under `.serverless/<zipName>` instead of `.serverless/build/<zipName>`.

* **Tests**
  * Updated integration tests to expect zips in `.serverless/<zipName>` to match the new packaging layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes output location of final zip artifacts and updates an integration test expectation; build staging layout remains unchanged.
> 
> **Overview**
> Fixes esbuild packaging so final function/service zip artifacts are written directly to `.serverless/<name>.zip` instead of `.serverless/build/<name>.zip`, aligning with the paths expected by `--package` deploy workflows.
> 
> Updates the esbuild integration test to assert zips exist in `.serverless/` for individual function packaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f452ca0452ae6ced16d3d4da381f4025965e3fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->