### PR TITLE
Fix minor typos in comments and docs

### DIFF
--- a/docs/scf/upgrading.md
+++ b/docs/scf/upgrading.md
@@ -109,7 +109,7 @@ cp serverless.containers.yml serverless.containers.yml.backup
 
 ### Update Your Configuration
 
-In your `serverless.containers.yml`, change the `name` property to create an entirely seperate stack of new infrastructure that does not have names that collide with existing infrastructure (in the case of testing on the same AWS account).
+In your `serverless.containers.yml`, change the `name` property to create an entirely separate stack of new infrastructure that does not have names that collide with existing infrastructure (in the case of testing on the same AWS account).
 
 Next, change the deployment type:
 

--- a/packages/serverless/lib/plugins/aws/appsync/resources/DataSource.js
+++ b/packages/serverless/lib/plugins/aws/appsync/resources/DataSource.js
@@ -108,7 +108,7 @@ export class DataSource {
           ],
         ],
       })
-    // FIXME: can we validate this and make TS infer mutually eclusive types?
+    // FIXME: can we validate this and make TS infer mutually exclusive types?
     if (!endpoint) {
       throw new Error('Specify either endpoint or domain')
     }

--- a/packages/serverless/lib/plugins/aws/dev/index.js
+++ b/packages/serverless/lib/plugins/aws/dev/index.js
@@ -900,7 +900,7 @@ class AwsDev {
       mainProgress.remove()
     })
 
-    // Each function has a seperate topic we need to subscribe to
+    // Each function has a separate topic we need to subscribe to
     const functionNames = this.serverless.service.getAllFunctions()
 
     for (const functionName of functionNames) {


### PR DESCRIPTION

**Repo:** serverless/serverless (⭐ 46000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Corrects three minor spelling errors: two instances of "seperate" → "separate"
(one in `docs/scf/upgrading.md` user-facing documentation, one in a code comment
in `packages/serverless/lib/plugins/aws/dev/index.js`) and "eclusive" → "exclusive"
in a FIXME comment in `packages/serverless/lib/plugins/aws/appsync/resources/DataSource.js`.

## Why
The docs typo is user-visible in the SCF upgrade guide. The code-comment typos
are small quality fixes that improve readability and keep grep-based searches
(e.g. searching for "separate" or "exclusive") reliable. Purely textual — no
behavior change.

## Testing
No runtime impact. Verified with `git diff` that only comments and one Markdown
sentence are touched. No test suite run needed for documentation-only typo fixes.

## Risk
Low — comment/markdown changes only, no code paths altered.
