### PR TITLE
fix: prevent duplicate PATH entry for fish shell in binary-installer/install.sh

### DIFF
--- a/binary-installer/install.sh
+++ b/binary-installer/install.sh
@@ -56,8 +56,11 @@ add_to_path () {
 
 SHELLTYPE="$(basename "/$SHELL")"
 if [[ $SHELLTYPE = "fish" ]]; then
-  command fish -c 'set -U fish_user_paths $fish_user_paths ~/.serverless/bin'
-  printf "\n${yellow}Added ~/.serverless/bin to fish_user_paths universal variable$reset."
+  if ! fish -c 'contains -- ~/.serverless/bin $fish_user_paths'
+  then
+    command fish -c 'set -U fish_user_paths $fish_user_paths ~/.serverless/bin'
+    printf "\n${yellow}Added ~/.serverless/bin to fish_user_paths universal variable$reset."
+  fi
 elif [[ $SHELLTYPE = "zsh" ]]; then
   SHELL_CONFIG=$HOME/.zshrc
   if [ ! -r "$SHELL_CONFIG" ] || ! grep -q '.serverless/bin' "$SHELL_CONFIG"; then


### PR DESCRIPTION
Fixes #13394

## Problem
The `install.sh` script already had duplicate PATH checks for `bash` and `zsh` using `grep -q`, but the `fish` shell block was missing this check entirely. Running the installer multiple times on a fish shell would keep appending `~/.serverless/bin` to `fish_user_paths`, causing duplicate entries.

## Fix
Added a `contains` check for fish shell before appending to `fish_user_paths`, making it consistent with the behavior already in place for bash and zsh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the installation process for Fish shell by checking if the binary path is already configured before updating it, reducing unnecessary messages during reinstallation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->