### PR TITLE
chore(deps): patch uuid buffer-bounds vulnerability and bump dockerode to v5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -84,6 +84,9 @@ updates:
       - dependency-name: 'get-stdin'
         # get-stdin v10 drops support for Node.js 18
         versions: ['>= 10.0.0']
+      - dependency-name: 'uuid'
+        # uuid v14 drops support for Node.js 18
+        versions: ['>= 14.0.0']
 
   # Maintain framework-dist dependencies (excluded from workspace, has its own shrinkwrap)
   - package-ecosystem: 'npm'

--- a/package-lock.json
+++ b/package-lock.json
@@ -2542,7 +2542,9 @@
       }
     },
     "node_modules/@axiomhq/js/node_modules/uuid": {
-      "version": "11.1.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -6896,10 +6898,16 @@
       }
     },
     "node_modules/aws-sdk/node_modules/uuid": {
-      "version": "8.0.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/axios": {
@@ -8226,9 +8234,9 @@
       }
     },
     "node_modules/dockerode": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.10.tgz",
-      "integrity": "sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-5.0.0.tgz",
+      "integrity": "sha512-C52mvJ+7lcyhWNfrzVfFsbTrBfy/ezE9FGEYLpu17FUeBcCkxERk9nN7uDl/478ynDiQ4U+5DbQC2vENHkVEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
@@ -8236,24 +8244,10 @@
         "@grpc/proto-loader": "^0.7.13",
         "docker-modem": "^5.0.7",
         "protobufjs": "^7.3.2",
-        "tar-fs": "^2.1.4",
-        "uuid": "^10.0.0"
+        "tar-fs": "^2.1.4"
       },
       "engines": {
-        "node": ">= 8.0"
-      }
-    },
-    "node_modules/dockerode/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "node": ">= 14.17"
       }
     },
     "node_modules/dotenv": {
@@ -14961,9 +14955,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+      "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -15916,7 +15910,7 @@
         "@aws-sdk/client-s3": "3.1017.0",
         "aws-sdk-v3-proxy": "^2.2.0",
         "chalk": "^5.6.2",
-        "dockerode": "^4.0.10",
+        "dockerode": "^5.0.0",
         "enquirer": "^2.4.1",
         "lodash": "^4.18.1",
         "ora": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
   },
   "overrides": {
     "help-me": "^5.0.0",
-    "fast-xml-parser": "^5.3.6"
+    "fast-xml-parser": "^5.3.6",
+    "aws-sdk": {
+      "uuid": "^11.1.1"
+    }
   }
 }

--- a/packages/framework-dist/npm-shrinkwrap.json
+++ b/packages/framework-dist/npm-shrinkwrap.json
@@ -713,13 +713,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
-      "integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.8",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1519,10 +1519,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "license": "MIT"
+    },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2207,9 +2213,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
@@ -2222,9 +2228,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
-      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
       "funding": [
         {
           "type": "github",
@@ -2233,9 +2239,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.0"
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -2682,9 +2689,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -2846,9 +2853,9 @@
       "license": "MIT"
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -14,7 +14,7 @@
     "aws-sdk-v3-proxy": "^2.2.0",
     "@aws-sdk/client-s3": "3.1017.0",
     "chalk": "^5.6.2",
-    "dockerode": "^4.0.10",
+    "dockerode": "^5.0.0",
     "enquirer": "^2.4.1",
     "lodash": "^4.18.1",
     "ora": "^8.2.0",


### PR DESCRIPTION
## Summary

Patches [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (moderate) — `uuid` v3/v5/v6 missing buffer bounds check when `buf` is provided.

Also patches the remaining instance of [GHSA-gh4j-gqv2-49f6](https://github.com/advisories/GHSA-gh4j-gqv2-49f6) (`fast-xml-parser` XMLBuilder injection) in `packages/framework-dist`, which was missed by the previous fix because that package is excluded from the workspace and uses its own `npm-shrinkwrap.json`.

## Changes

### uuid

| Location | Before | After | Method |
|---|---|---|---|
| top-level `uuid` | 13.0.0 | 13.0.1 | security backport |
| `aws-sdk/node_modules/uuid` | 8.0.0 | 11.1.1 | targeted override (v8 has no backport; v11.1.1 is the smallest semver-compatible bump that retains CommonJS support and Node.js 18 compatibility) |
| `@axiomhq/js/node_modules/uuid` | 11.1.0 | 11.1.1 | security backport |

The targeted override is added to root `package.json`:

```json
"overrides": {
  ...,
  "aws-sdk": { "uuid": "^11.1.1" }
}
```

`aws-sdk` v2 only uses `require('uuid').v4()` for idempotency tokens — that named export has been continuously available and unchanged in semantics since uuid v3. uuid v12+ removed the CommonJS distribution, which is why v11.1.1 (still dual CJS/ESM) is the highest safe target while we support Node.js 18.

### dockerode

`packages/util/package.json`: `dockerode` `^4.0.10` → `^5.0.0`.

Dockerode 5.0.0 drops the `uuid` dependency entirely (replaced with the built-in `crypto.randomUUID()`). The 5.0.0 source diff against 4.0.10 is exactly one line in `lib/session.js` plus the `package.json` changes — no public API changes. The major version bump is purely from the `engines.node` requirement going from `>= 8.0` to `>= 14.17`, which is satisfied by our `>=18` floor.

### fast-xml-parser (framework-dist)

`packages/framework-dist/npm-shrinkwrap.json` patched the same way as the previous fix:
- `@aws-sdk/xml-builder` 3.972.16 → 3.972.19
- `@smithy/types` 4.13.1 → 4.14.1
- `fast-xml-parser` 5.5.8 → 5.7.1
- `fast-xml-builder` 1.1.4 → 1.1.5
- `path-expression-matcher` 1.2.0 → 1.5.0
- `strnum` 2.2.2 → 2.2.3
- New transitive: `@nodable/entities` 2.1.0

### Dependabot

Added `uuid >= 14.0.0` to the ignore list. uuid v14 drops Node.js 18 support (requires `globalThis.crypto`, Node 20+).

## Notes on `npm audit`

`npm audit` will continue to flag `uuid` versions 11.1.1, 12.0.1, and 13.0.1 even though all three are explicit security backports of the same fix per their release notes. The `Patched versions` field on the GitHub advisory still lists only `14.0.0` and has not yet been updated to recognise the backports. Tracking issue upstream: https://github.com/uuidjs/uuid/issues/951.

The installed code is patched.

## Test plan

- [x] `npm ci` succeeds at the repo root and in `packages/framework-dist`
- [x] Installed versions verified: `dockerode@5.0.0` (no nested `uuid`), top-level `uuid@13.0.1`, `aws-sdk/node_modules/uuid@11.1.1`, `@axiomhq/js/node_modules/uuid@11.1.1`
- [x] `npm audit signatures` passes (`packages/framework-dist`: 183 packages verified)
- [x] `dockerode` removed from `npm audit` findings; `fast-xml-parser` finding cleared in `framework-dist`
- [x] No Node.js engine bumps introduced; Node 18 floor preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple project dependencies to latest compatible versions
  * Configured dependency management and package overrides for improved stability and Node.js 18 compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->