### PR TITLE
chore(deps): consolidate npm dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,14 @@
 
 version: 2
 updates:
-  # Maintain NPM dependencies
+  # Maintain NPM dependencies across the workspace and the standalone packages
+  # (framework-dist, sf-core-installer) that are excluded from the workspace.
+  # Using `directories` keeps version bumps in sync across all manifests.
   - package-ecosystem: 'npm'
-    directory: '/'
-    exclude-paths:
-      - 'packages/framework-dist/**'
-      - 'packages/sf-core-installer/**'
+    directories:
+      - '/'
+      - '/packages/framework-dist'
+      - '/packages/sf-core-installer'
     schedule:
       interval: 'weekly'
     versioning-strategy: increase
@@ -87,36 +89,6 @@ updates:
       - dependency-name: 'uuid'
         # uuid v14 drops support for Node.js 18
         versions: ['>= 14.0.0']
-
-  # Maintain framework-dist dependencies (excluded from workspace, has its own shrinkwrap)
-  - package-ecosystem: 'npm'
-    directory: '/packages/framework-dist'
-    schedule:
-      interval: 'weekly'
-    cooldown:
-      default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
-    groups:
-      aws-sdk:
-        patterns:
-          - '@aws-sdk/*'
-
-  # Maintain sf-core-installer dependencies (excluded from workspace, has its own shrinkwrap)
-  - package-ecosystem: 'npm'
-    directory: '/packages/sf-core-installer'
-    schedule:
-      interval: 'weekly'
-    cooldown:
-      default-days: 5
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
-    ignore:
-      - dependency-name: 'undici'
-        # undici v7 drops support for Node.js 18
-        versions: ['>= 7.0.0']
       - dependency-name: 'rimraf'
         # rimraf v6 drops support for Node.js 18
         versions: ['>= 6.0.0']


### PR DESCRIPTION
## Summary

Replaces the three separate `package-ecosystem: npm` entries (root, `packages/framework-dist`, `packages/sf-core-installer`) with a single entry that uses [`directories`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot-yml-file#directories) (plural). Combined with the existing `aws-sdk` group, this means dependabot now opens a single grouped PR per bump that updates the workspace and the standalone packages together — keeping versions in sync across all npm manifests.

Today, an `@aws-sdk/*` bump produces two separate PRs (one for the workspace, one for `framework-dist`); they can drift out of sync until both are merged.

## Changes

- Merge the three `package-ecosystem: npm` entries into one with `directories: ['/', '/packages/framework-dist', '/packages/sf-core-installer']`.
- Drop the now-redundant `exclude-paths` from the root entry.
- Apply the full set of groups (`aws-sdk`, `dev-dependencies`, `patch-updates`) and `versioning-strategy: increase` to all three directories. Previously `framework-dist` only had a narrower `aws-sdk` group (no `@smithy/*`, `aws-sdk-v3-proxy`, `aws-iot-device-sdk`); `sf-core-installer` had no groups.
- Merge the `ignore` lists. Adds the `rimraf >= 6.0.0` rule from the old `sf-core-installer` entry to the unified list. `undici >= 7.0.0` was already in the root entry — no duplication.

Net change: 1 file, +7/-35 lines.

## Test plan

- [x] `dependabot.yml` parses as valid YAML.
- [x] Resulting npm entry covers all three directories with consistent groups, versioning strategy, cooldown, and ignore rules.
- [ ] After merge, the next dependabot run should open a single grouped PR for `@aws-sdk/*` covering both workspace and standalone manifests, instead of two separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated dependency update configuration across packages for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->