### PR TITLE
fix(appsync): allow @canonical, @hidden, @renamed on FIELD_DEFINITION

### DIFF
--- a/packages/serverless/lib/plugins/aws/appsync/resources/Schema.js
+++ b/packages/serverless/lib/plugins/aws/appsync/resources/Schema.js
@@ -18,9 +18,9 @@ directive @aws_cognito_user_pools(
   cognito_groups: [String]
 ) on FIELD_DEFINITION | OBJECT
 directive @aws_subscribe(mutations: [String]) on FIELD_DEFINITION
-directive @canonical on OBJECT
-directive @hidden on OBJECT
-directive @renamed on OBJECT
+directive @canonical on OBJECT | FIELD_DEFINITION
+directive @hidden on OBJECT | FIELD_DEFINITION
+directive @renamed on OBJECT | FIELD_DEFINITION
 scalar AWSDate
 scalar AWSTime
 scalar AWSDateTime

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/fixtures/schemas/merged-api/schema.graphql
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/fixtures/schemas/merged-api/schema.graphql
@@ -1,0 +1,20 @@
+type Query {
+  user(id: ID!): User! @canonical
+  internalAuthority(id: ID!): Authority! @hidden
+  legacyMessage(id: ID!): Message @renamed
+}
+
+type User @canonical {
+  id: ID!
+  name: String!
+}
+
+type Authority @hidden {
+  id: ID!
+  secret: String!
+}
+
+type Message @renamed {
+  id: ID!
+  body: String!
+}

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/graphql-tools-merge-compat.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/graphql-tools-merge-compat.test.js
@@ -200,9 +200,9 @@ describe('@graphql-tools/merge compatibility tests', () => {
       directive @aws_auth(cognito_groups: [String]) on FIELD_DEFINITION | OBJECT
       directive @aws_cognito_user_pools(cognito_groups: [String]) on FIELD_DEFINITION | OBJECT
       directive @aws_subscribe(mutations: [String]) on FIELD_DEFINITION
-      directive @canonical on OBJECT
-      directive @hidden on OBJECT
-      directive @renamed on OBJECT
+      directive @canonical on OBJECT | FIELD_DEFINITION
+      directive @hidden on OBJECT | FIELD_DEFINITION
+      directive @renamed on OBJECT | FIELD_DEFINITION
       scalar AWSDate
       scalar AWSTime
       scalar AWSDateTime

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/schema.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/schema.test.js
@@ -57,6 +57,14 @@ describe('schema', () => {
     expect(schema.generateSchema()).toMatchSnapshot()
   })
 
+  it('should accept Merged API directives on OBJECT and FIELD_DEFINITION', () => {
+    const api = new Api(given.appSyncConfig(), plugin)
+    const schema = new Schema(api, [
+      'test/unit/lib/plugins/aws/appsync/fixtures/schemas/merged-api/schema.graphql',
+    ])
+    expect(() => schema.generateSchema()).not.toThrow()
+  })
+
   it('should handle absolute paths with servicePath', () => {
     const api = new Api(given.appSyncConfig(), plugin)
     const schema = new Schema(api, [


### PR DESCRIPTION
## Summary

The bundled AppSync schema validator declares the Merged API directives `@canonical`, `@hidden`, and `@renamed` only on the `OBJECT` location, causing valid schemas that apply them to fields to be rejected at packaging time:

```
✖ ServerlessError: Invalid GraphQL schema:
     Directive "@canonical" may not be used on FIELD_DEFINITION.
     Directive "@hidden" may not be used on FIELD_DEFINITION.
```

[AWS's Merged API devguide](https://docs.aws.amazon.com/appsync/latest/devguide/merged-api.html) explicitly documents these directives as applying to "types/fields" and shows field-level usage in official examples, e.g.:

```graphql
getMessage(id: ID!): Message @renamed(to: "getChatMessage")
```

This change extends each of the three directive declarations to `OBJECT | FIELD_DEFINITION`, matching AWS's documented surface.

## Changes

- `packages/serverless/lib/plugins/aws/appsync/resources/Schema.js` — broaden `@canonical` / `@hidden` / `@renamed` directive locations to `OBJECT | FIELD_DEFINITION`.
- `packages/serverless/test/unit/lib/plugins/aws/appsync/graphql-tools-merge-compat.test.js` — keep inline `AWS_TYPES` copy in sync.
- `packages/serverless/test/unit/lib/plugins/aws/appsync/schema.test.js` + new `fixtures/schemas/merged-api/schema.graphql` — regression test that runs the directives through `Schema.generateSchema()` (which calls `validateSDL`) on both `OBJECT` and `FIELD_DEFINITION`.

## Out of scope

AWS's actual `@renamed` directive takes a required `to: String!` argument (`@renamed(to: "newName")`). Adding that argument to the local declaration would be a breaking change for any user currently relying on the lenient bare `@renamed` permitted by today's stub, so it is intentionally not part of this fix and should be addressed separately.

## Test plan

- [x] Unit tests pass (`schema.test.js`, `graphql-tools-merge-compat.test.js`)
- [x] End-to-end: minimal AppSync service using `@canonical` and `@hidden` on `FIELD_DEFINITION` packages successfully against the source build
- [x] Existing tests and snapshots remain green

Closes #13533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AppSync schema directives now support application to both object types and individual field definitions, enabling more granular control over API schema configuration and metadata.

* **Tests**
  * Added test fixtures and coverage to validate expanded directive compatibility across different schema elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: expands local AppSync directive stubs used for SDL validation and adds regression tests/fixtures; no runtime behavior or data handling changes beyond schema validation acceptance.
> 
> **Overview**
> AppSync schema validation now accepts Merged API directives `@canonical`, `@hidden`, and `@renamed` on **both** `OBJECT` and `FIELD_DEFINITION`, preventing packaging failures for schemas that annotate fields.
> 
> Adds a new merged-API schema fixture and a unit test to ensure `Schema.generateSchema()` validates successfully with these directives applied at field level, and updates the merge compatibility test’s `AWS_TYPES` stub to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab8b24decec608a562843889f2155b0fee3a57b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->