### PR TITLE
chore(deps): bump axios from 1.15.0 to 1.15.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6827,9 +6827,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/packages/framework-dist/npm-shrinkwrap.json
+++ b/packages/framework-dist/npm-shrinkwrap.json
@@ -1840,9 +1840,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",


### PR DESCRIPTION
## Summary

Bumps [axios](https://github.com/axios/axios) from `1.15.0` to `1.15.2` (transitive lockfile-only update in `package-lock.json` and `packages/framework-dist/npm-shrinkwrap.json`).

This is a patch-level bump that pulls in two consecutive security-hardening releases.

## Risk

- Patch version bump, no breaking changes called out by upstream.
- Pure security/bug-fix release line; backwards compatible.
- Lockfile-only change — no source code or `package.json` `dependencies` ranges touched.

## Test plan

- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated axios dependency to the latest patch version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->