### PR TITLE
fix(python): use forward slashes in uv group test assertions

### DIFF
--- a/packages/sf-core/tests/python/test.js
+++ b/packages/sf-core/tests/python/test.js
@@ -641,10 +641,10 @@ test('uv py3.13 can package flask with optional dependencies', async (t) => {
     'uv export used',
   )
   const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip')
-  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged')
-  t.true(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is packaged')
+  t.true(zipfiles.includes(`flask/__init__.py`), 'flask is packaged')
+  t.true(zipfiles.includes(`boto3/__init__.py`), 'boto3 is packaged')
   t.false(
-    zipfiles.includes(`pytest_cov${sep}__init__.py`),
+    zipfiles.includes(`pytest_cov/__init__.py`),
     'pytest-cov is NOT packaged',
   )
   t.end()
@@ -658,12 +658,9 @@ test('uv py3.13 can package flask with optional groups', async (t) => {
     'uv export used',
   )
   const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip')
-  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged')
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged')
-  t.true(
-    zipfiles.includes(`pytest_cov${sep}__init__.py`),
-    'pytest-cov is packaged',
-  )
+  t.true(zipfiles.includes(`flask/__init__.py`), 'flask is packaged')
+  t.false(zipfiles.includes(`boto3/__init__.py`), 'boto3 is NOT packaged')
+  t.true(zipfiles.includes(`pytest_cov/__init__.py`), 'pytest-cov is packaged')
   t.end()
 })
 
@@ -675,12 +672,9 @@ test('uv py3.13 can package with only groups', async (t) => {
     'uv export used',
   )
   const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip')
-  t.false(zipfiles.includes(`flask${sep}__init__.py`), 'flask is NOT packaged')
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged')
-  t.true(
-    zipfiles.includes(`pytest_cov${sep}__init__.py`),
-    'pytest-cov is packaged',
-  )
+  t.false(zipfiles.includes(`flask/__init__.py`), 'flask is NOT packaged')
+  t.false(zipfiles.includes(`boto3/__init__.py`), 'boto3 is NOT packaged')
+  t.true(zipfiles.includes(`pytest_cov/__init__.py`), 'pytest-cov is packaged')
   t.end()
 })
 
@@ -692,10 +686,10 @@ test('uv py3.13 can package with groups and without groups combined', async (t) 
     'uv export used',
   )
   const zipfiles = await listZipFiles('.serverless/sls-py-req-test.zip')
-  t.true(zipfiles.includes(`flask${sep}__init__.py`), 'flask is packaged')
-  t.false(zipfiles.includes(`boto3${sep}__init__.py`), 'boto3 is NOT packaged')
+  t.true(zipfiles.includes(`flask/__init__.py`), 'flask is packaged')
+  t.false(zipfiles.includes(`boto3/__init__.py`), 'boto3 is NOT packaged')
   t.false(
-    zipfiles.includes(`pytest_cov${sep}__init__.py`),
+    zipfiles.includes(`pytest_cov/__init__.py`),
     'pytest-cov is NOT packaged',
   )
   t.end()


### PR DESCRIPTION
## Summary

Four uv-related Python packaging tests still compared zip entries against `${sep}`-joined paths. Since zip entries are stored with forward slashes per the ZIP spec, these assertions fail on Windows where `${sep}` resolves to a backslash.

This change replaces `${sep}` with a literal `/` in the affected zip-entry comparisons, matching the convention already used throughout the rest of the file.

## Affected tests

- `uv py3.13 can package flask with optional dependencies`
- `uv py3.13 can package flask with optional groups`
- `uv py3.13 can package with only groups`
- `uv py3.13 can package with groups and without groups combined`

Filesystem-path uses of `${sep}` elsewhere in the file are intentionally left as-is, since those operations require OS-native separators.

## Test plan

- [x] Windows CI (`gh-windows-latest`) passes for the affected tests
- [x] Ubuntu CI continues to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for ZIP entry path validation to use consistent path formatting across dependency and group configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->