### PR TITLE
chore: release 4.35.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15812,7 +15812,7 @@
     },
     "packages/sf-core": {
       "name": "@serverlessinc/sf-core",
-      "version": "4.35.0",
+      "version": "4.35.1",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "3.1035.0",
         "@aws-sdk/client-s3": "3.1035.0",

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "4.35.0",
+  "version": "4.35.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/sf-core/package.json
+++ b/packages/sf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/sf-core",
-  "version": "4.35.0",
+  "version": "4.35.1",
   "main": "src/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This is a patch release that includes:

- Security fix: Upgrade axios from 1.15.0 to 1.15.2 (#13544)

The axios upgrade addresses a security vulnerability that was discovered in version 1.15.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Patch version bumps for core packages: sf-core and sf-core-installer updated from 4.35.0 to 4.35.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only bumps in `package.json`/`package-lock.json` with no functional code changes; risk is limited to publishing/packaging metadata.
> 
> **Overview**
> Bumps the released version from `4.35.0` to `4.35.1` for `@serverlessinc/sf-core` and the `sf-core-installer`, and updates `package-lock.json` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a22e4908adff7481500cc1cde7f57763ab57e3bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->