### PR TITLE
fix(installer): bump Go to 1.26.3

### DIFF
--- a/.github/workflows/ci-binary-installer.yml
+++ b/.github/workflows/ci-binary-installer.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '>=1.26.2'
+          go-version: '>=1.26.3'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Test: Unit'
         run: make test

--- a/.github/workflows/release-binary-installer.yml
+++ b/.github/workflows/release-binary-installer.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '>=1.26.2'
+          go-version: '>=1.26.3'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0

--- a/binary-installer/go.mod
+++ b/binary-installer/go.mod
@@ -1,6 +1,6 @@
 module sf-core
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
## Summary
- Bumps the `go` directive in `binary-installer/go.mod` from `1.26.2` to `1.26.3`.
- Bumps the `setup-go` version constraint from `>=1.26.2` to `>=1.26.3` in both installer workflows (`ci-binary-installer.yml`, `release-binary-installer.yml`).
- Picks up the stdlib `net/http` fix for [CVE-2026-33814](https://nvd.nist.gov/vuln/detail/CVE-2026-33814) (HTTP/2 CONTINUATION-frame infinite loop on `SETTINGS_MAX_FRAME_SIZE=0`).

## Test plan
- [x] `ci-binary-installer` workflow passes (unit tests + prod build).