### PR TITLE
chore(deps): ignore toml v4+ in Dependabot to preserve Node.js 18 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,6 +92,9 @@ updates:
       - dependency-name: 'rimraf'
         # rimraf v6 drops support for Node.js 18
         versions: ['>= 6.0.0']
+      - dependency-name: 'toml'
+        # toml v4 drops support for Node.js 18
+        versions: ['>= 4.0.0']
 
   # Maintain Go dependencies
   - package-ecosystem: 'gomod'


### PR DESCRIPTION
## Summary
- `toml@4.0.0` sets `engines.node` to `>=20`, which is incompatible with the `>=18.0` engine declared in `packages/serverless/package.json`.
- Add a Dependabot ignore entry for `toml >= 4.0.0`, matching the existing pattern used for other dependencies that dropped Node.js 18 support (e.g. `ora`, `joi`, `undici`).
- Allows closing the open Dependabot PR that proposed bumping `toml` from 3.0.0 to 4.1.1.

## Test plan
- [ ] Confirm `.github/dependabot.yml` parses correctly (Dependabot will validate on next run).
- [ ] Verify no further `toml >= 4.x` bump PRs are opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to align with Node.js compatibility constraints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13562)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->