### PR TITLE
fix: externalize esbuild from the bundle

### DIFF
--- a/packages/sf-core/bin/sf-core.js
+++ b/packages/sf-core/bin/sf-core.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'fs'
 import gracefulFs from 'graceful-fs'
+import { isMainThread } from 'node:worker_threads'
 import './blankLine.js'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
@@ -60,12 +61,18 @@ export const errorHandler = (error) => {
   }
   process.exit(1)
 }
-run()
-  .catch(errorHandler)
-  .finally(() => {
-    // Remove all Progress renderers
-    progress.cleanup()
-  })
+// Only run the CLI entry on the main thread. When this bundle is loaded by a
+// Worker thread (e.g. esbuild's transformSync spawns `new Worker(__filename)`),
+// re-running the CLI causes duplicate startup and can deadlock the main thread
+// via Atomics.wait. See issue #13574.
+if (isMainThread) {
+  run()
+    .catch(errorHandler)
+    .finally(() => {
+      // Remove all Progress renderers
+      progress.cleanup()
+    })
 
-process.once('uncaughtException', errorHandler)
-process.once('unhandledRejection', errorHandler)
+  process.once('uncaughtException', errorHandler)
+  process.once('unhandledRejection', errorHandler)
+}

--- a/packages/sf-core/bin/sf-core.js
+++ b/packages/sf-core/bin/sf-core.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import fs from 'fs'
 import gracefulFs from 'graceful-fs'
-import { isMainThread } from 'node:worker_threads'
 import './blankLine.js'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
@@ -61,18 +60,12 @@ export const errorHandler = (error) => {
   }
   process.exit(1)
 }
-// Only run the CLI entry on the main thread. When this bundle is loaded by a
-// Worker thread (e.g. esbuild's transformSync spawns `new Worker(__filename)`),
-// re-running the CLI causes duplicate startup and can deadlock the main thread
-// via Atomics.wait. See issue #13574.
-if (isMainThread) {
-  run()
-    .catch(errorHandler)
-    .finally(() => {
-      // Remove all Progress renderers
-      progress.cleanup()
-    })
+run()
+  .catch(errorHandler)
+  .finally(() => {
+    // Remove all Progress renderers
+    progress.cleanup()
+  })
 
-  process.once('uncaughtException', errorHandler)
-  process.once('unhandledRejection', errorHandler)
-}
+process.once('uncaughtException', errorHandler)
+process.once('unhandledRejection', errorHandler)

--- a/packages/sf-core/esbuild.js
+++ b/packages/sf-core/esbuild.js
@@ -17,6 +17,13 @@ await esbuild.build({
   outfile: '../framework-dist/dist/sf-core.js',
   inject: ['injects-shim.js'],
   bundle: true,
+  // Keep esbuild external so its lib/main.js stays a separate file in the
+  // dist. Bundling esbuild inlines its code, which makes __filename inside
+  // the Worker it spawns for transformSync point at the bundle — that causes
+  // the Worker to re-execute the entire CLI. esbuild's docs and upstream
+  // guard explicitly warn that "the esbuild JavaScript API cannot be
+  // bundled". See issue #13574.
+  external: ['esbuild'],
   minify: false,
   minifyIdentifiers: false,
   minifySyntax: true,

--- a/packages/sf-core/injects-shim.js
+++ b/packages/sf-core/injects-shim.js
@@ -1,23 +1,7 @@
 import { createRequire } from 'node:module'
-import { existsSync } from 'node:fs'
 import path from 'node:path'
 import url from 'node:url'
 
 globalThis.require = createRequire(import.meta.url)
 globalThis.__filename = url.fileURLToPath(import.meta.url)
 globalThis.__dirname = path.dirname(__filename)
-
-if (!process.env.ESBUILD_BINARY_PATH) {
-  const platform = `${process.platform}-${process.arch}`
-  const map = {
-    'darwin-arm64': '@esbuild/darwin-arm64/bin/esbuild',
-    'darwin-x64': '@esbuild/darwin-x64/bin/esbuild',
-    'linux-arm64': '@esbuild/linux-arm64/bin/esbuild',
-    'linux-x64': '@esbuild/linux-x64/bin/esbuild',
-    'win32-x64': '@esbuild/win32-x64/esbuild.exe',
-  }
-  if (map[platform]) {
-    const p = path.join(__dirname, 'node_modules', map[platform])
-    if (existsSync(p)) process.env.ESBUILD_BINARY_PATH = p
-  }
-}

--- a/packages/sf-core/scripts/prepareDistributionTarballs.js
+++ b/packages/sf-core/scripts/prepareDistributionTarballs.js
@@ -168,10 +168,34 @@ await Promise.all([
   ),
 ])
 
+// --- Ship esbuild's Node API as a sibling file ---
+// sf-core.js marks esbuild as external (see packages/sf-core/esbuild.js) so
+// that __filename inside esbuild's Worker spawn resolves to esbuild's own
+// runtime entry, not the framework bundle. Without this, esbuild's
+// transformSync would re-execute the entire CLI inside the Worker. See
+// issue #13574 and upstream esbuild's "cannot be bundled" guard.
+//
+// Copy the entire esbuild package minus `bin/`. The `bin/` entry holds
+// the build-host's native binary, which we don't need — the per-platform
+// binaries are shipped separately below into `@esbuild/<platform>/`,
+// which is what esbuild's runtime resolves via
+// `require.resolve('@esbuild/<platform>/…')`. Everything else (lib/,
+// package.json, LICENSE, README, etc.) ships verbatim so we stay correct
+// even if upstream reorganizes the JS or adds new files.
+const esbuildPkgPath = resolveFromServerless.resolve('esbuild/package.json')
+const esbuildSrcDir = path.dirname(esbuildPkgPath)
+const esbuildPkg = JSON.parse(await readFile(esbuildPkgPath, 'utf8'))
+const esbuildDistDir = `${distNodeModules}/esbuild`
+
+await cp(esbuildSrcDir, esbuildDistDir, {
+  recursive: true,
+  filter: (src) => {
+    const [first] = path.relative(esbuildSrcDir, src).split(path.sep)
+    return first !== 'bin'
+  },
+})
+
 // --- Download esbuild platform binaries for all 5 supported platforms ---
-const esbuildPkg = JSON.parse(
-  await readFile(resolveFromServerless.resolve('esbuild/package.json'), 'utf8'),
-)
 const esbuildVersion = esbuildPkg.version
 
 // Load the workspace's package-lock.json so we can verify each downloaded


### PR DESCRIPTION
## Summary

Treat esbuild as an external dependency at bundle time and ship it as a sibling package in the dist instead of inlining its JavaScript API into `sf-core.js`. This matches what the esbuild authors explicitly recommend ("The esbuild JavaScript API cannot be bundled") and what comparable tools like [tsx](https://github.com/privatenumber/tsx) do.

Fixes #13580. Also resolves the symptom reported in #13574.

## Problem 1 — Worker re-entry deadlock (#13574)

esbuild's synchronous API (`transformSync`, `buildSync`) works by spawning a worker thread:

```js
new Worker(__filename, { workerData: { workerPort, ..., esbuildVersion } })
```

When esbuild's `lib/main.js` is **inlined** into a larger bundle, `__filename` inside that code resolves to the host bundle's file. The worker then re-executes the entire bundled CLI on every sync esbuild call. That second execution can hit interactive prompts or other code paths that don't terminate cleanly in non-interactive environments, and because the main thread is in `Atomics.wait` waiting for the worker, the whole process deadlocks. (Worker stdout is queued via MessagePort through the main thread's libuv loop, which is blocked by `Atomics.wait`, so the worker's output never becomes visible — the hang looks like the framework's `findRunner`/`tsxRequire` stalling for no apparent reason.)

## Problem 2 — esbuild version leak into user plugins (#13580)

To make the inlined-esbuild path find its native binary, the framework set `process.env.ESBUILD_BINARY_PATH` to the bundled platform binary inside `injects-shim.js`. Environment variables propagate process-wide, so this also affected any **other** esbuild instance loaded by user code (e.g. `serverless-esbuild` requiring `esbuild` from the user's own `node_modules`). When the user's esbuild was a different patch version than the bundled one, esbuild's strict JS-binary version check failed:

```
Cannot start service: Host version "0.27.3" does not match binary version "0.27.4"
```

## Fix

Both problems share the same root cause: bundling esbuild puts a single inlined copy in a state where it has to be coerced into finding its binary via global state. Externalizing it eliminates the coercion and the leak.

Changes:

1. **`packages/sf-core/esbuild.js`** — mark `esbuild` as `external` in the bundler config so the bundle emits `require('esbuild')` instead of inlining its source.

2. **`packages/sf-core/scripts/prepareDistributionTarballs.js`** — copy esbuild's package (everything except the build-host's native binary in `bin/`) into `dist/node_modules/esbuild/`. Same pattern already used in this script for `ajv`, `ajv-formats`, and `fast-deep-equal`. The per-platform binaries continue to ship into `dist/node_modules/@esbuild/<platform>/` via the existing `downloadEsbuildBinary` loop.

3. **`packages/sf-core/injects-shim.js`** — drop the `ESBUILD_BINARY_PATH` env-var workaround. esbuild now resolves its platform binary via the standard `require.resolve('@esbuild/<platform>/...')` from its own `lib/main.js` location, which walks up to find the sibling `@esbuild/<platform>` package.

4. **`packages/sf-core/bin/sf-core.js`** — revert the `isMainThread` guard added in the previous commit on this branch. It's no longer needed once esbuild is external (the worker thread spawned by `transformSync` now loads only `esbuild/lib/main.js`, not the framework bundle).

## Resulting runtime layout

```
dist/sf-core.js                                                   # the framework bundle (esbuild now external)
dist/node_modules/esbuild/                                         # esbuild's JS API as a real installable package
dist/node_modules/esbuild/lib/main.js
dist/node_modules/esbuild/package.json                             # verbatim from upstream
dist/node_modules/@esbuild/<platform>/bin/esbuild                  # per-platform native binaries (unchanged)
```

Each esbuild copy in the process resolves its own binary from its own sibling tree:
- Framework's `dist/node_modules/esbuild` → `dist/node_modules/@esbuild/<platform>` (matched versions)
- User's `<project>/node_modules/esbuild` → `<project>/node_modules/@esbuild/<platform>` (matched versions)

No shared environment variable, no cross-contamination.

## Test plan

- [x] Locally rebuild bundle + run `prepareDistributionTarballs.js`, install over `~/.serverless/releases/4.36.0/package/dist/`
- [x] Verify #13574 minimal repro (wrapper TS importing sibling TS via `import`) — `serverless print --config wrapper.ts` reaches `Selected runner: TraditionalRunner` and renders the resolved config. Only one `s:core: { ... }` debug block (no worker re-entry).
- [x] Verify #13580 minimal repro — service with `serverless-esbuild@1.57.0` + `esbuild@0.27.3` pinned in user `node_modules`, while framework ships `esbuild@0.27.4`. `serverless invoke local --function hello` succeeds (no "Host version does not match binary version" error). Confirmed both esbuild copies resolve their own siblings independently.
- [x] Full `serverless package` against a service that exercises all three esbuild paths in the framework: TS config (`tsxRequire` → `transformSync`), AppSync JS resolver (`buildSync` in `JsResolver.js`), and TS Lambda handlers (async `esbuild.build` in the built-in esbuild plugin). All artifacts generated correctly.
- [x] Confirm `dist/node_modules/esbuild/lib/main.js` is the resolved path at runtime (not the bundled copy).
- [x] Cross-platform simulated install layout (`/tmp/sls-prod-sim/releases/<version>/package/`) behaves identically to the dev workspace layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for dependency handling
  * Improved distribution preparation process
  * Refactored global initialization setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13581)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->