### PR TITLE
feat: support Lambda recursive loop detection config

### DIFF
--- a/docs/sf/providers/aws/guide/functions.md
+++ b/docs/sf/providers/aws/guide/functions.md
@@ -499,6 +499,17 @@ functions:
 
 **Note:** Lambda SnapStart only supports the Java 11, Java 17 and Java 21 runtimes and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
 
+## Recursive Loop Detection
+
+By default, AWS Lambda [detects and stops recursive invocation loops](https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html) between supported AWS services. To allow recursive loops for a function, set `recursiveLoop` to `Allow`. To explicitly enforce termination (the default behavior), set it to `Terminate`.
+
+```yaml
+functions:
+  hello:
+    handler: handler.hello
+    recursiveLoop: Allow
+```
+
 ## VPC Configuration
 
 You can add VPC configuration to a specific function in `serverless.yml` by adding a `vpc` object property in the function configuration. This object should contain the `securityGroupIds` and `subnetIds` array properties needed to construct VPC for this function. Optionally, you can also enable IPv6 outbound connections for dual-stack subnets with the `ipv6AllowedForDualStack` property. Here's an example configuration:

--- a/docs/sf/providers/aws/guide/functions.md
+++ b/docs/sf/providers/aws/guide/functions.md
@@ -501,13 +501,13 @@ functions:
 
 ## Recursive Loop Detection
 
-By default, AWS Lambda [detects and stops recursive invocation loops](https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html) between supported AWS services. To allow recursive loops for a function, set `recursiveLoop` to `Allow`. To explicitly enforce termination (the default behavior), set it to `Terminate`.
+By default, AWS Lambda [detects and stops recursive invocation loops](https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html) between supported AWS services. To allow recursive loops for a function, set `recursiveLoop` to `allow`. To explicitly enforce termination (the default behavior), set it to `terminate`. The value is case-insensitive.
 
 ```yaml
 functions:
   hello:
     handler: handler.hello
-    recursiveLoop: Allow
+    recursiveLoop: allow
 ```
 
 ## VPC Configuration

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -864,6 +864,8 @@ functions:
     kmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
     # Defines if you want to make use of SnapStart, this feature can only be used in combination with a Java runtime. Configuring this property will result in either None or PublishedVersions for the Lambda function
     snapStart: true
+    # Allow or Terminate recursive invocation loops between supported AWS services (default: Terminate)
+    recursiveLoop: Allow
     # Disable the creation of the CloudWatch log group
     disableLogs: false
     # Duration for CloudWatch log retention (default: forever). Overrides provider setting.

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -864,8 +864,8 @@ functions:
     kmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
     # Defines if you want to make use of SnapStart, this feature can only be used in combination with a Java runtime. Configuring this property will result in either None or PublishedVersions for the Lambda function
     snapStart: true
-    # Allow or Terminate recursive invocation loops between supported AWS services (default: Terminate)
-    recursiveLoop: Allow
+    # allow or terminate recursive invocation loops between supported AWS services (default: terminate). Case-insensitive.
+    recursiveLoop: allow
     # Disable the creation of the CloudWatch log group
     disableLogs: false
     # Duration for CloudWatch log retention (default: forever). Overrides provider setting.

--- a/packages/serverless/lib/plugins/aws/package/compile/functions.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/functions.js
@@ -26,6 +26,10 @@ const runtimeManagementMap = new Map([
   ['onFunctionUpdate', 'FunctionUpdate'],
   ['manual', 'Manual'],
 ])
+const recursiveLoopMap = new Map([
+  ['allow', 'Allow'],
+  ['terminate', 'Terminate'],
+])
 
 class AwsCompileFunctions {
   constructor(serverless, options) {
@@ -771,7 +775,9 @@ class AwsCompileFunctions {
     }
 
     if (functionObject.recursiveLoop) {
-      functionResource.Properties.RecursiveLoop = functionObject.recursiveLoop
+      functionResource.Properties.RecursiveLoop = recursiveLoopMap.get(
+        functionObject.recursiveLoop.toLowerCase(),
+      )
     }
 
     if (

--- a/packages/serverless/lib/plugins/aws/package/compile/functions.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/functions.js
@@ -770,6 +770,10 @@ class AwsCompileFunctions {
         functionObject.reservedConcurrency
     }
 
+    if (functionObject.recursiveLoop) {
+      functionResource.Properties.RecursiveLoop = functionObject.recursiveLoop
+    }
+
     if (
       !functionObject.disableLogs &&
       !functionObject?.logs?.logGroup &&
@@ -861,6 +865,7 @@ class AwsCompileFunctions {
       if (!functionObject.image) delete functionProperties.Code
       // Properties applied to function globally (not specific to version or alias)
       delete functionProperties.ReservedConcurrentExecutions
+      delete functionProperties.RecursiveLoop
       delete functionProperties.Tags
 
       const lambdaHashingVersion =

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -2775,8 +2775,8 @@ destinations:
               ],
             }),
             recursiveLoop: {
-              description: `Recursive loop detection setting for this function.`,
-              enum: ['Allow', 'Terminate'],
+              description: `Recursive loop detection setting for this function. Case-insensitive.`,
+              anyOf: ['Allow', 'Terminate'].map(caseInsensitive),
             },
             reservedConcurrency: cfValue({
               description: `Reserved concurrency limit for this function.`,

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -2774,6 +2774,10 @@ destinations:
                 },
               ],
             }),
+            recursiveLoop: {
+              description: `Recursive loop detection setting for this function.`,
+              enum: ['Allow', 'Terminate'],
+            },
             reservedConcurrency: cfValue({
               description: `Reserved concurrency limit for this function.`,
               type: 'integer',

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1360,6 +1360,64 @@ describe('AwsCompileFunctions', () => {
     })
   })
 
+  describe('Recursive Loop', () => {
+    it('should support functions[].recursiveLoop set to Allow', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          recursiveLoop: 'Allow',
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const props = resources.FuncLambdaFunction.Properties
+
+      expect(props.RecursiveLoop).toBe('Allow')
+    })
+
+    it('should support functions[].recursiveLoop set to Terminate', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          recursiveLoop: 'Terminate',
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const props = resources.FuncLambdaFunction.Properties
+
+      expect(props.RecursiveLoop).toBe('Terminate')
+    })
+
+    it('should not set RecursiveLoop when functions[].recursiveLoop is not provided', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const props = resources.FuncLambdaFunction.Properties
+
+      expect(props.RecursiveLoop).toBeUndefined()
+    })
+  })
+
   describe('Provisioned Concurrency', () => {
     beforeEach(() => {
       // Mock the naming function for provisioned concurrency

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1416,6 +1416,63 @@ describe('AwsCompileFunctions', () => {
 
       expect(props.RecursiveLoop).toBeUndefined()
     })
+
+    it('should normalize lowercase functions[].recursiveLoop to PascalCase', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          recursiveLoop: 'allow',
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const props = resources.FuncLambdaFunction.Properties
+
+      expect(props.RecursiveLoop).toBe('Allow')
+    })
+
+    it('should normalize uppercase functions[].recursiveLoop to PascalCase', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          recursiveLoop: 'TERMINATE',
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const props = resources.FuncLambdaFunction.Properties
+
+      expect(props.RecursiveLoop).toBe('Terminate')
+    })
+
+    it('should normalize mixed-case functions[].recursiveLoop to PascalCase', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          recursiveLoop: 'AlLoW',
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const props = resources.FuncLambdaFunction.Properties
+
+      expect(props.RecursiveLoop).toBe('Allow')
+    })
   })
 
   describe('Provisioned Concurrency', () => {

--- a/packages/sf-core/prepareReleaseTars.sh
+++ b/packages/sf-core/prepareReleaseTars.sh
@@ -16,7 +16,6 @@ echo "Using S3 bucket: ${s3_bucket}"
 # cd $upload_temp_dir
 cd ./scripts
 
-version_folder=$(git describe --tags --abbrev=0)
 aws s3 cp s3://${s3_bucket}/releases.json ./
 node updateReleasesJson.cjs
 node prepareDistributionTarballs.js


### PR DESCRIPTION
## Summary

Adds support for configuring [AWS Lambda recursive loop detection](https://docs.aws.amazon.com/lambda/latest/dg/invocation-recursion.html) on individual functions via a new `recursiveLoop` property, mapped 1:1 to the `RecursiveLoop` property of `AWS::Lambda::Function`.

```yaml
functions:
  hello:
    handler: handler.hello
    recursiveLoop: allow # or terminate (AWS default). Case-insensitive.
```

By default, Lambda terminates a function that it detects invoking itself in a recursive loop. Setting `recursiveLoop: allow` opts out of that protection for designs that intentionally rely on a function writing back to a resource that invokes it (with the appropriate safeguards in place).

## Implementation notes

- Schema entry uses `anyOf: ['Allow', 'Terminate'].map(caseInsensitive)`, matching the existing convention for case-insensitive function-level config in this schema (`tenancy.mode`, `capacityProvider.scaling.mode`, `endpointType`, API Gateway authorizer types).
- The compile step normalizes any casing to canonical PascalCase via a module-level lookup map (`recursiveLoopMap`), mirroring the `runtimeManagementMap` pattern already used in `functions.js`. The normalized value (`Allow` / `Terminate`) is what CloudFormation receives.
- `RecursiveLoop` is excluded from the Lambda version hash. The underlying Lambda API (`PutFunctionRecursionConfig`) is function-scoped and does not accept a version qualifier, so the value is shared across all versions of a function. Treated the same way as `ReservedConcurrentExecutions` and `Tags`, both flagged in code as "Properties applied to function globally (not specific to version or alias)".
- Docs updated in both the functions guide and the annotated `serverless.yml` reference, using the lowercase form to demonstrate the case-insensitive contract.

Closes #12938

## Test plan

- [x] Unit tests added for canonical-case (`Allow`, `Terminate`, unset) and case-insensitive (`allow`, `TERMINATE`, `AlLoW`) inputs, asserting the compiled `Properties.RecursiveLoop` is the canonical PascalCase value.
- [x] Full `functions.test.js` suite passes (66 tests).
- [x] Smoke test: deployed six functions exercising all-canonical / lowercase / uppercase / mixed-case / unset inputs; `aws lambda get-function-recursion-config` returned the expected canonical value for each (`Allow` for `allow`/`AlLoW`, `Terminate` for `TERMINATE`, AWS default `Terminate` for unset).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring AWS Lambda recursive invocation behavior via a new recursiveLoop option (allow or terminate, case-insensitive, default terminate).

* **Documentation**
  * Added "Recursive Loop Detection" guidance with usage details and a YAML example.

* **Tests**
  * Added unit tests validating recursiveLoop behavior, defaulting, and case normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive configuration and CloudFormation mapping with tests; default AWS behavior unchanged when the property is omitted. Opting into `allow` increases operational blast radius for misconfigured loops, which is an explicit user choice.
> 
> **Overview**
> Adds per-function **`recursiveLoop`** in `serverless.yml` (`allow` / `terminate`, case-insensitive), mapped to CloudFormation **`RecursiveLoop`** on `AWS::Lambda::Function` so teams can opt out of Lambda’s default recursive-invocation termination when needed.
> 
> Implementation follows existing patterns: schema validation in `provider.js`, normalization via `recursiveLoopMap` in `compile/functions.js`, and **`RecursiveLoop` omitted from the Lambda version hash** (function-scoped, like reserved concurrency). Docs cover the new option in the functions guide and `serverless.yml` reference; unit tests cover unset, canonical, and mixed-case values.
> 
> The diff also removes an unused `version_folder` assignment in `packages/sf-core/prepareReleaseTars.sh` (release packaging only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3b0e89fcfacc0f1fb3680098d80dae1f0d7d99e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->