### PR TITLE
fix: Error while deploying to localstack or MinIo resolved as S3 was always pointing to the default aws environment and failing to save artifacts metadata

### DIFF
--- a/packages/engine/src/lib/aws/s3.js
+++ b/packages/engine/src/lib/aws/s3.js
@@ -24,6 +24,13 @@ export class AwsS3Client {
    * @returns {AwsS3Client} The initialized S3 service.
    */
   constructor(awsConfig = {}) {
+    if (process.env.AWS_ENDPOINT_URL) {
+      awsConfig = {
+        ...awsConfig,
+        forcePathStyle: true,
+        endpoint: process.env.AWS_ENDPOINT_URL,
+      }
+    }
     this.client = addProxyToAwsClient(
       new S3Client({
         ...awsConfig,


### PR DESCRIPTION
# feat(s3): support custom endpoint via AWS_ENDPOINT_URL env var

## Summary

Adds support for local/custom S3-compatible endpoints (e.g. LocalStack, MinIO) by
reading the `AWS_ENDPOINT_URL` environment variable at client initialization time.

## Problem

The `AwsS3Client` constructor had no way to target a non-AWS S3-compatible endpoint.
This made local development and integration testing difficult — developers had to either
work against real AWS buckets or monkey-patch the client after instantiation.

## Solution

Before constructing the `S3Client`, the constructor now checks for `AWS_ENDPOINT_URL`.
If present, it merges two additional options into `awsConfig`:

- `endpoint` — points the client at the custom URL
- `forcePathStyle: true` — required by most S3-compatible services (LocalStack, MinIO,
  etc.) which do not support virtual-hosted-style bucket addressing

```js
// Before
constructor(awsConfig = {}) {
  this.client = addProxyToAwsClient(
    new S3Client({ ...awsConfig, followRegionRedirects: true }),
  )
}

// After
constructor(awsConfig = {}) {
  if (process.env.AWS_ENDPOINT_URL) {
    awsConfig = {
      ...awsConfig,
      forcePathStyle: true,
      endpoint: process.env.AWS_ENDPOINT_URL,
    }
  }
  this.client = addProxyToAwsClient(
    new S3Client({ ...awsConfig, followRegionRedirects: true }),
  )
}
```

## Why this approach

- **Zero breaking changes** — the env var is optional; existing behavior is fully
  preserved when it is unset.
- **Convention over configuration** — `AWS_ENDPOINT_URL` is the de-facto standard
  variable used by the AWS CLI, LocalStack, and many CI setups, so no extra
  documentation is needed.
- **Minimal surface area** — the change is self-contained in the constructor; no new
  parameters, no new public methods.

## Testing

Set `AWS_ENDPOINT_URL=http://localhost:4566` (or your local stack URL) and run the
existing S3 integration tests — all bucket operations should route to the local
endpoint without any code changes.

## Checklist

- [x] No breaking changes
- [x] Works with existing `awsConfig` overrides
- [x] Compatible with LocalStack and MinIO
- [x] No new dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom S3 endpoint configuration via environment variable, enabling path-style addressing for S3-compatible storage services. This allows seamless integration with alternative endpoint providers without requiring code modifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13586)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->