### PR TITLE
feat: support PreTokenGeneration V2_0 and V3_0 for Cognito User Pool

### DIFF
--- a/docs/sf/providers/aws/events/cognito-user-pool.md
+++ b/docs/sf/providers/aws/events/cognito-user-pool.md
@@ -143,6 +143,27 @@ resources:
 
 **NOTE:** The only supported value for lambdaVersion is `V1_0`, as documented [by AWS](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-customsmssender.html).
 
+### PreTokenGeneration Trigger
+
+The `PreTokenGeneration` trigger supports multiple Lambda contract versions, [documented by AWS](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html). Set `lambdaVersion` to opt into a newer contract:
+
+- `V1_0` (default behavior when `lambdaVersion` is omitted): ID token customization only.
+- `V2_0`: ID and access token customization.
+- `V3_0`: Adds machine-to-machine (M2M) client-credentials grants.
+
+```yml
+functions:
+  preTokenGenerationV2:
+    handler: preToken.handler
+    events:
+      - cognitoUserPool:
+          pool: MyUserPool
+          trigger: PreTokenGeneration
+          lambdaVersion: V2_0
+```
+
+**NOTE:** `V2_0` and `V3_0` require the Cognito User Pool to be on the Essentials or Plus feature plan.
+
 ### Custom Sender Triggers Handlers
 
 For custom senders, the `event.triggerSource` type does not get populated by the type of custom sender, rather may be populated by another trigger source. Instead, `event.request.type` is populated with either `customEmailSenderRequestV1` or `customSMSSenderRequestV1`, respectively documented by AWS [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-email-sender.html) and [here](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-sms-sender.html)

--- a/packages/serverless/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
+++ b/packages/serverless/lib/plugins/aws/custom-resources/resources/cognito-user-pool/lib/user-pool.js
@@ -95,6 +95,14 @@ async function updateConfiguration(config) {
           LambdaVersion: poolConfig.LambdaVersion,
         }
         LambdaConfig.KMSKeyID = poolConfig.KMSKeyID
+      } else if (
+        poolConfig.Trigger === 'PreTokenGeneration' &&
+        poolConfig.LambdaVersion
+      ) {
+        LambdaConfig.PreTokenGenerationConfig = {
+          LambdaArn: lambdaArn,
+          LambdaVersion: poolConfig.LambdaVersion,
+        }
       } else {
         LambdaConfig[poolConfig.Trigger] = lambdaArn
       }
@@ -135,6 +143,13 @@ async function removeConfiguration(config) {
 function removeExistingLambdas(lambdaConfig, lambdaArn) {
   const res = Object.fromEntries(
     Object.entries(lambdaConfig).filter(([key, value]) => {
+      if (
+        key === 'PreTokenGenerationConfig' &&
+        value &&
+        value.LambdaArn === lambdaArn
+      ) {
+        return false
+      }
       return (
         !(customSenderSources.includes(key) && value.LambdaArn === lambdaArn) &&
         value !== lambdaArn

--- a/packages/serverless/lib/plugins/aws/package/compile/events/cognito-user-pool.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/cognito-user-pool.js
@@ -17,7 +17,34 @@ const validTriggerSources = [
   'UserMigration',
 ].concat(customSenderSources)
 
-const validLambdaVersions = ['V1_0']
+const customSenderLambdaVersions = ['V1_0']
+const preTokenGenerationLambdaVersions = ['V1_0', 'V2_0', 'V3_0']
+
+function validateLambdaVersion(trigger, lambdaVersion) {
+  if (!lambdaVersion) return
+  if (customSenderSources.includes(trigger)) {
+    if (!customSenderLambdaVersions.includes(lambdaVersion)) {
+      throw new ServerlessError(
+        `Invalid lambdaVersion "${lambdaVersion}" for "${trigger}". Allowed: ${customSenderLambdaVersions.join(', ')}.`,
+        'COGNITO_INVALID_LAMBDA_VERSION',
+      )
+    }
+    return
+  }
+  if (trigger === 'PreTokenGeneration') {
+    if (!preTokenGenerationLambdaVersions.includes(lambdaVersion)) {
+      throw new ServerlessError(
+        `Invalid lambdaVersion "${lambdaVersion}" for "${trigger}". Allowed: ${preTokenGenerationLambdaVersions.join(', ')}.`,
+        'COGNITO_INVALID_LAMBDA_VERSION',
+      )
+    }
+    return
+  }
+  throw new ServerlessError(
+    `lambdaVersion is only supported for CustomSMSSender, CustomEmailSender, and PreTokenGeneration triggers. Got "${trigger}".`,
+    'COGNITO_LAMBDA_VERSION_NOT_SUPPORTED',
+  )
+}
 
 class AwsCompileCognitoUserPoolEvents {
   constructor(serverless, options) {
@@ -70,6 +97,10 @@ cognitoUserPool:
           kmsKeyId: {
             description: `KMS key id or ARN for custom sender triggers.`,
             $ref: '#/definitions/awsKmsArn',
+          },
+          lambdaVersion: {
+            description: `Trigger contract version. Valid for CustomSMSSender/CustomEmailSender (V1_0 only) and PreTokenGeneration (V1_0, V2_0, V3_0). V2_0/V3_0 require Cognito feature plan Essentials or Plus.`,
+            enum: ['V1_0', 'V2_0', 'V3_0'],
           },
         },
         required: ['pool', 'trigger'],
@@ -189,6 +220,8 @@ cognitoUserPool:
               event.cognitoUserPool
             usesExistingCognitoUserPool = funcUsesExistingCognitoUserPool = true
 
+            validateLambdaVersion(trigger, lambdaVersion)
+
             if (!currentPoolName) {
               currentPoolName = pool
             }
@@ -233,12 +266,14 @@ cognitoUserPool:
               userPoolConfig = {
                 ...userPoolConfig,
                 ...{
-                  LambdaVersion: lambdaVersion || validLambdaVersions[0],
+                  LambdaVersion: lambdaVersion || customSenderLambdaVersions[0],
                 },
               }
 
               this.checkKmsArn(kmsKeyId, poolKmsIdMap, pool)
               userPoolConfig.KMSKeyID = kmsKeyId
+            } else if (trigger === 'PreTokenGeneration' && lambdaVersion) {
+              userPoolConfig.LambdaVersion = lambdaVersion
             }
 
             if (numEventsForFunc === 1) {
@@ -375,6 +410,11 @@ cognitoUserPool:
           if (event.cognitoUserPool) {
             if (event.cognitoUserPool.existing) return
 
+            validateLambdaVersion(
+              event.cognitoUserPool.trigger,
+              event.cognitoUserPool.lambdaVersion,
+            )
+
             // Save trigger functions so we can use them to generate
             // IAM permissions later
             cognitoUserPoolTriggerFunctions.push({
@@ -408,11 +448,21 @@ cognitoUserPool:
         triggerObject = {
           [value.triggerSource]: {
             LambdaArn: resolveLambdaTarget(value.functionName, functionObj),
-            LambdaVersion: value.lambdaVersion || validLambdaVersions[0],
+            LambdaVersion: value.lambdaVersion || customSenderLambdaVersions[0],
           },
         }
         this.checkKmsArn(value.kmsKeyId, poolKmsIdMap, poolName)
         triggerObject.KMSKeyID = value.kmsKeyId
+      } else if (
+        value.triggerSource === 'PreTokenGeneration' &&
+        value.lambdaVersion
+      ) {
+        triggerObject = {
+          PreTokenGenerationConfig: {
+            LambdaArn: resolveLambdaTarget(value.functionName, functionObj),
+            LambdaVersion: value.lambdaVersion,
+          },
+        }
       } else {
         triggerObject = {
           [value.triggerSource]: resolveLambdaTarget(

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/cognito-user-pool.test.js
@@ -569,4 +569,299 @@ describe('AwsCompileCognitoUserPoolEvents', () => {
       expect(customResources.length).toBe(2)
     })
   })
+
+  describe('PreTokenGeneration lambdaVersion', () => {
+    const getPool = (resources) =>
+      Object.entries(resources).find(
+        ([, r]) => r.Type === 'AWS::Cognito::UserPool',
+      )[1]
+
+    it('emits PreTokenGenerationConfig when lambdaVersion: V2_0', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreTokenGeneration',
+                lambdaVersion: 'V2_0',
+              },
+            },
+          ],
+        },
+      }
+
+      awsCompileCognitoUserPoolEvents.newCognitoUserPools()
+
+      const pool = getPool(
+        awsCompileCognitoUserPoolEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources,
+      )
+      expect(
+        pool.Properties.LambdaConfig.PreTokenGenerationConfig,
+      ).toBeDefined()
+      expect(
+        pool.Properties.LambdaConfig.PreTokenGenerationConfig.LambdaVersion,
+      ).toBe('V2_0')
+      expect(
+        pool.Properties.LambdaConfig.PreTokenGenerationConfig.LambdaArn,
+      ).toBeDefined()
+      expect(pool.Properties.LambdaConfig.PreTokenGeneration).toBeUndefined()
+    })
+
+    it('emits PreTokenGenerationConfig when lambdaVersion: V3_0', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreTokenGeneration',
+                lambdaVersion: 'V3_0',
+              },
+            },
+          ],
+        },
+      }
+
+      awsCompileCognitoUserPoolEvents.newCognitoUserPools()
+
+      const pool = getPool(
+        awsCompileCognitoUserPoolEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources,
+      )
+      expect(
+        pool.Properties.LambdaConfig.PreTokenGenerationConfig.LambdaVersion,
+      ).toBe('V3_0')
+      expect(pool.Properties.LambdaConfig.PreTokenGeneration).toBeUndefined()
+    })
+
+    it('preserves the legacy flat shape when lambdaVersion is omitted', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreTokenGeneration',
+              },
+            },
+          ],
+        },
+      }
+
+      awsCompileCognitoUserPoolEvents.newCognitoUserPools()
+
+      const pool = getPool(
+        awsCompileCognitoUserPoolEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources,
+      )
+      expect(pool.Properties.LambdaConfig.PreTokenGeneration).toBeDefined()
+      expect(
+        pool.Properties.LambdaConfig.PreTokenGenerationConfig,
+      ).toBeUndefined()
+    })
+
+    it('propagates LambdaVersion in UserPoolConfigs for existing pool', async () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyExistingPool',
+                trigger: 'PreTokenGeneration',
+                lambdaVersion: 'V2_0',
+                existing: true,
+              },
+            },
+          ],
+        },
+      }
+
+      await awsCompileCognitoUserPoolEvents.existingCognitoUserPools()
+
+      const resources =
+        awsCompileCognitoUserPoolEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const [, customResource] = Object.entries(resources).find(
+        ([, r]) => r.Type === 'Custom::CognitoUserPool',
+      )
+      expect(customResource.Properties.UserPoolConfigs[0]).toMatchObject({
+        Trigger: 'PreTokenGeneration',
+        LambdaVersion: 'V2_0',
+      })
+    })
+
+    it('omits LambdaVersion in UserPoolConfigs when not set (existing pool)', async () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyExistingPool',
+                trigger: 'PreTokenGeneration',
+                existing: true,
+              },
+            },
+          ],
+        },
+      }
+
+      await awsCompileCognitoUserPoolEvents.existingCognitoUserPools()
+
+      const resources =
+        awsCompileCognitoUserPoolEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const [, customResource] = Object.entries(resources).find(
+        ([, r]) => r.Type === 'Custom::CognitoUserPool',
+      )
+      expect(customResource.Properties.UserPoolConfigs[0]).toEqual({
+        Trigger: 'PreTokenGeneration',
+      })
+    })
+
+    it('throws on invalid version for PreTokenGeneration', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreTokenGeneration',
+                lambdaVersion: 'V99_0',
+              },
+            },
+          ],
+        },
+      }
+
+      expect(() =>
+        awsCompileCognitoUserPoolEvents.newCognitoUserPools(),
+      ).toThrow(/Invalid lambdaVersion "V99_0" for "PreTokenGeneration"/)
+    })
+
+    it('throws when V2_0 is set on CustomEmailSender', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'CustomEmailSender',
+                kmsKeyId:
+                  'arn:aws:kms:eu-west-1:111111111111:key/11111111-9abc-def0-1234-56789abcdef1',
+                lambdaVersion: 'V2_0',
+              },
+            },
+          ],
+        },
+      }
+
+      expect(() =>
+        awsCompileCognitoUserPoolEvents.newCognitoUserPools(),
+      ).toThrow(/Invalid lambdaVersion "V2_0" for "CustomEmailSender"/)
+    })
+
+    it('throws when lambdaVersion is set on an unsupported trigger', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreSignUp',
+                lambdaVersion: 'V1_0',
+              },
+            },
+          ],
+        },
+      }
+
+      expect(() =>
+        awsCompileCognitoUserPoolEvents.newCognitoUserPools(),
+      ).toThrow(/lambdaVersion is only supported for/)
+    })
+
+    it('emits PreTokenGenerationConfig when lambdaVersion: V1_0 is set explicitly', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyUserPool',
+                trigger: 'PreTokenGeneration',
+                lambdaVersion: 'V1_0',
+              },
+            },
+          ],
+        },
+      }
+
+      awsCompileCognitoUserPoolEvents.newCognitoUserPools()
+
+      const pool = getPool(
+        awsCompileCognitoUserPoolEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources,
+      )
+      expect(
+        pool.Properties.LambdaConfig.PreTokenGenerationConfig.LambdaVersion,
+      ).toBe('V1_0')
+      expect(pool.Properties.LambdaConfig.PreTokenGeneration).toBeUndefined()
+    })
+
+    it('propagates LambdaVersion: V3_0 in UserPoolConfigs for existing pool', async () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyExistingPool',
+                trigger: 'PreTokenGeneration',
+                lambdaVersion: 'V3_0',
+                existing: true,
+              },
+            },
+          ],
+        },
+      }
+
+      await awsCompileCognitoUserPoolEvents.existingCognitoUserPools()
+
+      const resources =
+        awsCompileCognitoUserPoolEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const [, customResource] = Object.entries(resources).find(
+        ([, r]) => r.Type === 'Custom::CognitoUserPool',
+      )
+      expect(customResource.Properties.UserPoolConfigs[0]).toMatchObject({
+        Trigger: 'PreTokenGeneration',
+        LambdaVersion: 'V3_0',
+      })
+    })
+
+    it('throws on invalid lambdaVersion for existing pool trigger', () => {
+      awsCompileCognitoUserPoolEvents.serverless.service.functions = {
+        first: {
+          name: 'first',
+          events: [
+            {
+              cognitoUserPool: {
+                pool: 'MyExistingPool',
+                trigger: 'PreTokenGeneration',
+                lambdaVersion: 'V99_0',
+                existing: true,
+              },
+            },
+          ],
+        },
+      }
+
+      expect(() =>
+        awsCompileCognitoUserPoolEvents.existingCognitoUserPools(),
+      ).toThrow(/Invalid lambdaVersion "V99_0" for "PreTokenGeneration"/)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Add opt-in `lambdaVersion` property to the `cognitoUserPool` event for the `PreTokenGeneration` trigger.
- Accepted values: `V1_0`, `V2_0`, `V3_0`. When set, the framework emits `LambdaConfig.PreTokenGenerationConfig: { LambdaArn, LambdaVersion }` instead of the flat `LambdaConfig.PreTokenGeneration: <arn>` form, unlocking the V2 and V3 contracts ([AWS docs](https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html)):
  - V1_0: ID token customization (default behavior when `lambdaVersion` is omitted)
  - V2_0: ID and access token customization
  - V3_0: V2 capabilities plus machine-to-machine (M2M) client-credentials grants
- When `lambdaVersion` is omitted, generated CloudFormation is unchanged. Existing services see no template diff on upgrade.
- Per-trigger validation rejects:
  - Invalid versions on `PreTokenGeneration` (only `V1_0`/`V2_0`/`V3_0` allowed)
  - `V2_0`/`V3_0` on `CustomSMSSender`/`CustomEmailSender` (AWS only supports `V1_0` for custom senders)
  - `lambdaVersion` on any other trigger
- Custom resource handler updated to honor `lambdaVersion` when wiring triggers on existing user pools (`existing: true`) and to clean up `PreTokenGenerationConfig` entries when triggers are removed or rewired.
- Docs updated with usage example and a note about the Cognito feature plan requirement (Essentials or Plus) for V2/V3.

```yml
functions:
  preTokenGeneration:
    handler: preToken.handler
    events:
      - cognitoUserPool:
          pool: MyUserPool
          trigger: PreTokenGeneration
          lambdaVersion: V2_0
```

Closes [#12336](https://github.com/serverless/serverless/issues/12336)

## Test plan

- [x] Unit tests for the new emission paths (V1_0, V2_0, V3_0), backward-compat regression (omitted `lambdaVersion`), and validation error paths (invalid version, wrong trigger) for both new and existing pool flows
- [x] Full unit suite passes locally
- [x] Snyk SAST clean on modified source files
- [x] Manual verification: byte-identical CloudFormation output vs the published v4.36.1 CLI for services that do not opt in
- [x] Manual verification: opted-in services correctly emit `PreTokenGenerationConfig` for V1/V2/V3 and propagate `LambdaVersion` to the custom resource payload for existing pools
- [x] Live AWS smoke test: deployed a V2_0 service to a real Cognito User Pool on Essentials tier, created a user, authenticated via `ADMIN_USER_PASSWORD_AUTH`, and confirmed:
  - The Lambda received a V2-shaped event (`version: "2"`, `request.scopes` populated, `response.claimsAndScopeOverrideDetails` template)
  - The V2 response (`claimsAndScopeOverrideDetails` with both `idTokenGeneration` and `accessTokenGeneration`) was honored: custom claims appeared on both the ID token and the access token (the access token customization is a V2-only capability)
  - In-place V2_0 → V3_0 update is a no-replacement Modify: pool ID and CreationDate unchanged; stack events showed only `UPDATE_IN_PROGRESS → UPDATE_COMPLETE` for the pool
  - `serverless remove` cleanly tears down the stack

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how auth token triggers are compiled and updated on user pools (security-adjacent), but behavior is opt-in with validation and backward-compatible defaults.
> 
> **Overview**
> Adds optional **`lambdaVersion`** on **`cognitoUserPool`** events for **`PreTokenGeneration`**, supporting **`V1_0`**, **`V2_0`**, and **`V3_0`**. When set, packaging emits **`LambdaConfig.PreTokenGenerationConfig`** (`LambdaArn` + `LambdaVersion`) instead of the legacy flat **`PreTokenGeneration`** ARN, matching AWS’s newer token/M2M contracts. Omitting **`lambdaVersion`** keeps prior CloudFormation behavior.
> 
> **`validateLambdaVersion`** now enforces per-trigger rules: custom senders stay **`V1_0` only**; **`PreTokenGeneration`** allows **`V1_0`/`V2_0`/`V3_0`**; other triggers cannot use **`lambdaVersion`**. The existing-pool custom resource applies and removes **`PreTokenGenerationConfig`** when triggers are wired or cleared. Docs describe usage and the Essentials/Plus plan requirement for V2/V3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f56754a5c1500bcf5bf98f9de17c0a43fd9d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `lambdaVersion` configuration option for Cognito User Pool events, supporting V1_0, V2_0, and V3_0 contract versions for PreTokenGeneration and custom sender triggers
  * V2_0 and V3_0 versions require Essentials or Plus feature plan

* **Documentation**
  * Added documentation for PreTokenGeneration trigger with `lambdaVersion` configuration examples

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->