### PR TITLE
fix(lambda): publish stable alias for durable functions

### DIFF
--- a/docs/sf/providers/aws/guide/functions.md
+++ b/docs/sf/providers/aws/guide/functions.md
@@ -452,7 +452,7 @@ functions:
       retentionPeriodInDays: 14 # Optional. How long to retain execution history (1-90 days, default: 14)
 ```
 
-**Note:** Durable Functions are currently supported only for Node.js 22+ and Python 3.13+ runtimes. Enabling `durableConfig` will automatically enable function versioning (`versionFunctions: true`) as durable functions require qualified ARNs.
+**Note:** Durable Functions are currently supported only for Node.js 22+ and Python 3.13+ runtimes. Enabling `durableConfig` will automatically enable function versioning (`versionFunctions: true`) and publish an `AWS::Lambda::Alias` named `durable` pointing at the latest version, because AWS rejects unqualified invocations of durable functions. All event-source integrations (schedule, EventBridge, SNS, API Gateway, etc.) target this alias so invocations succeed without further configuration. Setting `versionFunction: false` together with `durableConfig` is rejected.
 
 When using the default IAM role, the `AWSLambdaBasicDurableExecutionRolePolicy` managed policy is automatically attached to grant necessary permissions. If you provide a custom role, you must ensure it has the required permissions.
 

--- a/packages/serverless/lib/plugins/aws/lib/naming.js
+++ b/packages/serverless/lib/plugins/aws/lib/naming.js
@@ -219,6 +219,12 @@ export default {
   getLambdaSnapStartEnabledAliasName() {
     return 'snapstart'
   },
+  getLambdaDurableAliasLogicalId(functionName) {
+    return `${this.getNormalizedFunctionName(functionName)}DurableLambdaAlias`
+  },
+  getLambdaDurableEnabledAliasName() {
+    return 'durable'
+  },
   getLambdaFunctionUrlOutputLogicalId(functionName) {
     return `${this.getNormalizedFunctionName(functionName)}LambdaFunctionUrl`
   },

--- a/packages/serverless/lib/plugins/aws/package/compile/functions.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/functions.js
@@ -467,6 +467,14 @@ class AwsCompileFunctions {
           )
         }
 
+        if (functionObject.versionFunction === false) {
+          throw new ServerlessError(
+            `Function "${functionName}" has "durableConfig" set but "versionFunction" is explicitly disabled. Durable Functions require versioning to publish a stable alias for qualified invocations.`,
+            'FUNCTION_DURABLE_REQUIRES_VERSIONING',
+            { stack: false },
+          )
+        }
+
         // Convert camelCase config to PascalCase for CloudFormation
         const { executionTimeout, retentionPeriodInDays } =
           functionObject.durableConfig
@@ -1006,6 +1014,34 @@ class AwsCompileFunctions {
         }
 
         cfTemplate.Resources[aliasLogicalId] = aliasResource
+      }
+
+      // AWS rejects unqualified invocations of durable functions and also rejects
+      // `$LATEST` as a qualifier on `Lambda::Permission`, so every event source that
+      // gates via a resource-based permission needs a real version or alias. Publish
+      // a stable `durable` alias so all event-source integrations target it via the
+      // existing `targetAlias` plumbing. Mirrors the snapStart/provisionedConcurrency
+      // blocks above; skipped if either of those features already set `targetAlias`.
+      if (functionObject.durableConfig && !functionObject.targetAlias) {
+        const aliasLogicalId =
+          this.provider.naming.getLambdaDurableAliasLogicalId(functionName)
+        const aliasName =
+          this.provider.naming.getLambdaDurableEnabledAliasName()
+
+        functionObject.targetAlias = {
+          name: aliasName,
+          logicalId: aliasLogicalId,
+        }
+
+        cfTemplate.Resources[aliasLogicalId] = {
+          Type: 'AWS::Lambda::Alias',
+          Properties: {
+            FunctionName: { Ref: functionLogicalId },
+            FunctionVersion: { 'Fn::GetAtt': [versionLogicalId, 'Version'] },
+            Name: aliasName,
+          },
+          DependsOn: functionLogicalId,
+        }
       }
     }
 

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -327,6 +327,16 @@ describe('AwsCompileFunctions', () => {
   })
 
   describe('Durable Functions Support', () => {
+    beforeEach(() => {
+      provider.naming.getLambdaDurableAliasLogicalId = jest.fn(
+        (name) =>
+          `${name.charAt(0).toUpperCase() + name.slice(1)}DurableLambdaAlias`,
+      )
+      provider.naming.getLambdaDurableEnabledAliasName = jest.fn(
+        () => 'durable',
+      )
+    })
+
     it('should add DurableConfig and basic execution role policy', async () => {
       awsCompileFunctions.serverless.service.functions = {
         func: {
@@ -383,6 +393,129 @@ describe('AwsCompileFunctions', () => {
       await expect(awsCompileFunctions.compileFunctions()).rejects.toThrow(
         /Durable Functions are only supported for Node.js 22\+ and Python 3.13\+ runtimes/,
       )
+    })
+
+    describe('Alias', () => {
+      it('should create AWS::Lambda::Alias named "durable" when durableConfig is set', async () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'handler',
+            name: 'func',
+            runtime: 'nodejs22.x',
+            durableConfig: { executionTimeout: 100 },
+          },
+        }
+        const resources =
+          awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources
+        resources.IamRoleLambdaExecution = {
+          Properties: { ManagedPolicyArns: [] },
+        }
+
+        await awsCompileFunctions.compileFunctions()
+
+        const alias = resources.FuncDurableLambdaAlias
+        expect(alias).toBeDefined()
+        expect(alias.Type).toBe('AWS::Lambda::Alias')
+        expect(alias.Properties.Name).toBe('durable')
+        expect(alias.Properties.FunctionName).toEqual({
+          Ref: 'FuncLambdaFunction',
+        })
+        expect(alias.Properties.FunctionVersion['Fn::GetAtt'][1]).toBe(
+          'Version',
+        )
+        expect(alias.DependsOn).toBe('FuncLambdaFunction')
+      })
+
+      it('should set functionObject.targetAlias so downstream consumers pick it up', async () => {
+        const func = {
+          handler: 'handler',
+          name: 'func',
+          runtime: 'nodejs22.x',
+          durableConfig: { executionTimeout: 100 },
+        }
+        awsCompileFunctions.serverless.service.functions = { func }
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution =
+          { Properties: { ManagedPolicyArns: [] } }
+
+        await awsCompileFunctions.compileFunctions()
+
+        expect(func.targetAlias).toEqual({
+          name: 'durable',
+          logicalId: 'FuncDurableLambdaAlias',
+        })
+      })
+
+      it('should not overwrite a targetAlias already set by snapStart or provisionedConcurrency', async () => {
+        provider.naming.getLambdaSnapStartAliasLogicalId = jest.fn(
+          (name) =>
+            `${name.charAt(0).toUpperCase() + name.slice(1)}SnapStartAlias`,
+        )
+        provider.naming.getLambdaSnapStartEnabledAliasName = jest.fn(
+          () => 'snapstart',
+        )
+
+        const func = {
+          handler: 'handler',
+          name: 'func',
+          runtime: 'nodejs22.x',
+          durableConfig: { executionTimeout: 100 },
+          snapStart: true,
+        }
+        awsCompileFunctions.serverless.service.functions = { func }
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution =
+          { Properties: { ManagedPolicyArns: [] } }
+
+        await awsCompileFunctions.compileFunctions()
+
+        const resources =
+          awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources
+
+        // snapStart's alias wins
+        expect(func.targetAlias.name).toBe('snapstart')
+        expect(resources.FuncSnapStartAlias).toBeDefined()
+        // durable does NOT create its own alias
+        expect(resources.FuncDurableLambdaAlias).toBeUndefined()
+      })
+
+      it('should create alias when durableConfig is combined with explicit versionFunction: true', async () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'handler',
+            name: 'func',
+            runtime: 'nodejs22.x',
+            durableConfig: { executionTimeout: 100 },
+            versionFunction: true,
+          },
+        }
+        awsCompileFunctions.serverless.service.provider.compiledCloudFormationTemplate.Resources.IamRoleLambdaExecution =
+          { Properties: { ManagedPolicyArns: [] } }
+
+        await awsCompileFunctions.compileFunctions()
+
+        const resources =
+          awsCompileFunctions.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources
+        expect(resources.FuncDurableLambdaAlias).toBeDefined()
+        expect(resources.FuncDurableLambdaAlias.Properties.Name).toBe('durable')
+      })
+
+      it('should throw error when durableConfig is combined with versionFunction: false', async () => {
+        awsCompileFunctions.serverless.service.functions = {
+          func: {
+            handler: 'handler',
+            name: 'func',
+            runtime: 'nodejs22.x',
+            durableConfig: { executionTimeout: 100 },
+            versionFunction: false,
+          },
+        }
+
+        await expect(awsCompileFunctions.compileFunctions()).rejects.toThrow(
+          /Durable Functions require versioning/i,
+        )
+      })
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes durable Lambda functions failing to be invoked through any event source the framework wires with an unqualified ARN (`Fn::GetAtt: [Function, Arn]`). AWS rejects unqualified invocations of durable functions with:

> `InvalidParameterValueException: You cannot invoke a durable function using an unqualified ARN.`

Affected event sources include scheduled events (both `method: scheduler` and `method: eventBus`), SNS, API Gateway, and every other source that relies on the framework's standard target wiring.

## Why an alias and not `$LATEST`

A blanket `$LATEST` qualifier is not viable: AWS rejects `$LATEST` on `AWS::Lambda::Permission` (`"We currently do not support adding policies for $LATEST"`), which is required by most non-scheduler event sources. The only qualifier that works uniformly across `Rule.Target.Arn`, `Subscription.Endpoint`, `Lambda::Permission.FunctionName`, `EventInvokeConfig.Qualifier`, etc. is a real alias or numeric version. An alias is the stable choice — same rationale used for `snapStart` and `provisionedConcurrency` aliases.

## Changes

- **`packages/serverless/lib/plugins/aws/package/compile/functions.js`** — when `functionObject.durableConfig` is set and `functionObject.targetAlias` is not already set by snapStart/provisionedConcurrency, auto-create an `AWS::Lambda::Alias` named `durable` pointing at the published `AWS::Lambda::Version`, and populate `functionObject.targetAlias`. Mirrors the existing snapStart block at the same line region.
- **`packages/serverless/lib/plugins/aws/package/compile/functions.js`** — throw `FUNCTION_DURABLE_REQUIRES_VERSIONING` early when `durableConfig` is combined with `versionFunction: false`, since that combination would generate broken CloudFormation referencing a non-existent Version resource.
- **`packages/serverless/lib/plugins/aws/lib/naming.js`** — add `getLambdaDurableAliasLogicalId(functionName)` and `getLambdaDurableEnabledAliasName()` helpers, following the `snapStart` naming convention.
- **`docs/sf/providers/aws/guide/functions.md`** — update the Durable Functions note to describe the alias and the `versionFunction: false` rejection.
- **`packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js`** — five new tests inside `Durable Functions Support > Alias`:
  1. Alias resource is created with correct properties
  2. `functionObject.targetAlias` is populated for downstream consumers
  3. Pre-existing `targetAlias` (e.g. from `snapStart`) wins; no double-aliasing
  4. `versionFunction: true` + `durableConfig` positive case
  5. `versionFunction: false` + `durableConfig` rejection

## IAM impact

None on identity-based policies — the scheduler role's `lambda:InvokeFunction` already covers `function:NAME:*`, which matches any alias name. The AWS-managed `AWSLambdaBasicDurableExecutionRolePolicy` is `Resource: "*"` and works for any qualifier. Resource-based `Lambda::Permission` resources have their `FunctionName` change from unqualified to alias-qualified — this is the actual fix mechanism.

## Test plan

- [x] `npm test` — 1710/1710 unit tests pass
- [x] `npm run lint` — clean
- [x] `npm run prettier` — clean
- [x] End-to-end against real AWS using a durable function with each affected event source:
  - `events.schedule` `method: scheduler` — verified invocations succeed, alias-qualified target
  - `events.schedule` `method: eventBus` — verified invocations succeed, alias-qualified Target and Permission
  - `events.sns` — verified SNS delivery succeeds and Lambda is invoked through the alias

## Backwards compatibility

For functions without `durableConfig`, the generated CloudFormation is byte-identical. For existing durable users, the upgrade deploy adds one `AWS::Lambda::Alias` resource and changes `Lambda::Permission.FunctionName` to alias-qualified (a CFN resource replacement). Since durable + event sources was not working before this fix, the transition turns a broken stack into a working one without regressing any previously-working path.

Closes #13587

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Durable Functions support for AWS Lambda: durable-configured functions now auto-enable versioning and get a stable "durable" alias; supported on Node.js 22+ and Python 3.13+ runtimes.

* **Bug Fixes / Validation**
  * Compilation now rejects pairing durable configuration with disabled versioning (explicit versionFunction: false).

* **Documentation**
  * Updated provider guide with Durable Functions requirements and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CloudFormation for durable functions (new alias, qualified permissions/targets) and affects all event-source wiring via `targetAlias`, though non-durable stacks are unchanged and behavior matches existing snapStart alias patterns.
> 
> **Overview**
> Fixes **durable Lambda** deployments so framework-wired event sources invoke a **qualified** target instead of an unqualified function ARN, which AWS rejects for durable functions.
> 
> When `durableConfig` is set and no other feature already chose an alias (`snapStart`, provisioned concurrency), compile now emits an **`AWS::Lambda::Alias` named `durable`** on the latest published version and sets **`functionObject.targetAlias`** so schedules, SNS, API Gateway, permissions, and similar integrations follow the same alias path as other versioned features. **`versionFunction: false` with `durableConfig`** fails fast with `FUNCTION_DURABLE_REQUIRES_VERSIONING`. Naming helpers and docs describe the alias and rejection; unit tests cover alias creation, `targetAlias`, precedence, and the versioning guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1414b30714688191d8fb41c9d01ab9a00491a5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->