### PR TITLE
docs(reconcile): clarify reconcile is a global, account-wide command

### DIFF
--- a/docs/sf/providers/aws/cli-reference/reconcile.md
+++ b/docs/sf/providers/aws/cli-reference/reconcile.md
@@ -18,7 +18,9 @@ The `reconcile` command reconciles your org's list of billable instances with th
 
 We generally recommend to always use the `remove` command to remove Serverless Framework stacks to ensure the removal is reported, but if you must remove stacks manually or your organization has a custom workflow, this command is the only way for us to know that your service instance was removed and that it should no longer be consuming credits.
 
-If you have Serverless Framework stacks in multiple AWS accounts, you should run this command for each AWS account for a complete reconciliation and more accurate usage reporting and billing.
+**Note:** The `reconcile` command is a global, account-wide command. It is **not** a per-service command and does **not** need to be run from inside a service directory. A single invocation reconciles every billable instance reported for your org against all CloudFormation stacks in the AWS account associated with the credentials it is run with, so you only need to run it once per AWS account — not once per service or per `serverless.yml`.
+
+If you have Serverless Framework stacks in multiple AWS accounts, you should run this command once for each AWS account (using credentials for that account) for a complete reconciliation and more accurate usage reporting and billing.
 
 **Note:** This command might take a few minutes to complete depending on how many CloudFormation stacks you have in your AWS account.
 
@@ -36,18 +38,22 @@ AWS_REGION=eu-central-1 serverless reconcile
 serverless reconcile
 ```
 
+The command can be run from **any directory** — it does not need to be executed inside a service directory and does not read your `serverless.yml`. It operates at the AWS account level using the AWS credentials available in your environment.
+
 ## Options
 
 - `--org` The org name to reconcile instances for. Defaults to your service org if found, or your default personal org.
 
 ## Example
 
+The example below runs `reconcile` from an arbitrary directory (no `serverless.yml` required):
+
 ```
-my-service $ serverless reconcile
+~ $ serverless reconcile
 
 Successfully recovered 3 Instance Credits from the 123456789012 AWS account.
 
 If you have any questions about your usage, please contact support@serverless.com.
 
-my-service $
+~ $
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documentation-only change.

Some users assume the `serverless reconcile` command must be run from inside each service directory (one run per `serverless.yml`). It is actually a global, account-wide command that reconciles every billable instance for the org against all CloudFormation stacks in the AWS account associated with the active credentials — a single run per AWS account is sufficient.

This PR updates `docs/sf/providers/aws/cli-reference/reconcile.md` to make that explicit:

- Adds a prominent note that `reconcile` is **not** a per-service command and does not need to be run from inside a service directory.
- Clarifies that a single invocation covers all instances in the AWS account tied to the current credentials, and that users with multiple AWS accounts only need to run it once per account.
- Notes under "Usage" that the command can be run from any directory and does not read `serverless.yml`.
- Updates the example shell prompt from `my-service $` to `~ $` so the example no longer implies the command must be run from inside a service directory.

No code changes; no tests required.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e660a28c-e232-45fd-bc5f-f94d40f79b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e660a28c-e232-45fd-bc5f-f94d40f79b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `reconcile` command is a global, account-wide operation executable from any directory
  * Updated guidance for multi-account AWS setups and when to run the command per account
  * Refined option descriptions and examples for improved clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->