### PR TITLE
feat: add 'diff' command to preview changes against the deployed stack

### DIFF
--- a/docs/sf/providers/aws/cli-reference/diff.md
+++ b/docs/sf/providers/aws/cli-reference/diff.md
@@ -1,0 +1,206 @@
+<!--
+title: Serverless Framework Commands - AWS Lambda - Diff
+description: Show the difference between the local CloudFormation template and the deployed stack.
+short_title: Commands - Diff
+keywords:
+  [
+    'Serverless',
+    'Framework',
+    'AWS',
+    'Lambda',
+    'Diff',
+    'CloudFormation',
+    'Deployment Preview',
+    'Change Review',
+  ]
+-->
+
+<!-- DOCS-SITE-LINK:START automatically generated  -->
+
+### [Read this on the main serverless docs site](https://www.serverless.com/framework/docs/providers/aws/cli-reference/diff)
+
+<!-- DOCS-SITE-LINK:END -->
+
+# AWS - Diff
+
+The `sls diff` command shows the difference between the CloudFormation template generated from your current configuration and the stack currently deployed in AWS. It is useful for reviewing changes before running `sls deploy`, especially in CI / PR-review workflows.
+
+```bash
+serverless diff
+```
+
+Two orthogonal signals are surfaced:
+
+1. **Function Code changes** — per-function comparison of the locally-packaged zip against each Lambda's `CodeSha256` in AWS. Tells you which functions will have their code redeployed.
+2. **CloudFormation template diff** — a structured diff of resources, IAM statements, security groups, parameters, outputs, and other top-level template sections. Tells you what CloudFormation will change.
+
+By default, the service is packaged first so the local template reflects the current configuration on disk. If you already have a packaged artifact directory (for example, from a previous CI step), pass `--package <path>` to use it directly and skip repackaging.
+
+## Options
+
+- `--stage` or `-s` The service stage to diff against. Defaults to the stage from `serverless.yml` or `dev`.
+- `--region` or `-r` The service region to diff against.
+- `--aws-profile` The AWS profile to use.
+- `--stack` CloudFormation stack name override.
+- `--package` or `-p` Path to an existing package directory to diff against. Skips the auto-package step when set.
+- `--json` Output the diff in JSON format. Suitable for CI consumption.
+
+## Provided lifecycle events
+
+- `diff:diff`
+
+## Examples
+
+### No changes against the deployed stack
+
+```text
+Packaging "my-service" for stage "dev" (us-east-1)
+No function code changes
+No infrastructure changes against the deployed stack
+✔ Service packaged (2s)
+```
+
+### Configuration-only change
+
+You bumped a Lambda's memory but did not edit any handler files:
+
+```text
+Function Code
+(no entries — handler bytes are unchanged)
+
+Resources
+[~] AWS::Lambda::Function HelloLambdaFunction
+ └─ [~] MemorySize
+     ├─ [-] 1024
+     └─ [+] 2048
+
+Resources: 1 to create, 1 to update, 1 to remove
+```
+
+The `Function Code` section is empty (or absent) because no handler files changed. The structured diff shows the property change and the matching Lambda Version churn that CloudFormation will perform.
+
+### Code-only change
+
+You edited a handler but did not touch the service configuration:
+
+```text
+Function Code
+[~] hello
+[~] goodbye
+
+Resources
+[-] AWS::Lambda::Version HelloLambdaVersion3rde2gUOpvd… orphan
+[-] AWS::Lambda::Version GoodbyeLambdaVersion3o1zjawHn… orphan
+[+] AWS::Lambda::Version HelloLambdaVersionymnhJ7QiGZ…
+[+] AWS::Lambda::Version GoodbyeLambdaVersionui2HS54XZ…
+
+Resources: 2 to create, 0 to update, 2 to remove
+```
+
+Both functions appear under `Function Code` because they share a single zip under default packaging. Services using `package.individually: true` see per-function granularity.
+
+### Replacement (resource will be destroyed and recreated)
+
+```text
+[~] AWS::Lambda::Function HelloLambdaFunction replace
+ ├─ [~] FunctionName (requires replacement)
+ │   ├─ [-] my-service-dev-hello
+ │   └─ [+] hello-renamed
+ ├─ [~] Code
+ └─ [~] MemorySize
+     ├─ [-] 256
+     └─ [+] 1024
+```
+
+The `replace` marker on the resource header and `(requires replacement)` on the offending property make destroy-and-recreate operations unmistakable.
+
+### IAM changes (security-relevant)
+
+```text
+IAM Statement Changes
+┌───┬────────────────────────────────────┬────────┬──────────────┬───────────────────────────────┬───────────┐
+│   │ Resource                           │ Effect │ Action       │ Principal                     │ Condition │
+├───┼────────────────────────────────────┼────────┼──────────────┼───────────────────────────────┼───────────┤
+│ + │ arn:aws:s3:::my-bucket/*           │ Allow  │ s3:GetObject │ AWS:${IamRoleLambdaExecution} │           │
+└───┴────────────────────────────────────┴────────┴──────────────┴───────────────────────────────┴───────────┘
+```
+
+A dedicated IAM table appears whenever IAM or Security Group changes are part of the diff — useful for security review.
+
+### Stack does not exist yet (first deploy)
+
+```text
+Stack "my-service-dev" does not exist yet — treating all resources as new.
+Function Code
+[+] hello
+[+] goodbye
+
+Resources
+[+] AWS::Logs::LogGroup HelloLogGroup
+[+] AWS::IAM::Role IamRoleLambdaExecution
+[+] AWS::Lambda::Function HelloLambdaFunction
+...
+
+Resources: 7 to create, 0 to update, 0 to remove
+```
+
+### JSON output
+
+```bash
+serverless diff --json
+```
+
+```json
+{
+  "code": {
+    "changed": ["hello"],
+    "new": ["welcome"]
+  },
+  "summary": {
+    "create": 4,
+    "update": 0,
+    "remove": 4
+  },
+  "resources": [
+    {
+      "logicalId": "WelcomeLambdaFunction",
+      "changeType": "create",
+      "resourceType": "AWS::Lambda::Function"
+    },
+    {
+      "logicalId": "GoodbyeLambdaFunction",
+      "changeType": "remove",
+      "resourceType": "AWS::Lambda::Function"
+    }
+  ]
+}
+```
+
+The `code` field reports per-function code changes:
+
+- `changed` — functions whose deployed `CodeSha256` differs from the local zip hash.
+- `new` — functions present locally but not in the deployed stack.
+
+Functions not listed in either array are unchanged (or are container-image functions / `package.disable: true`, which are excluded since they have no comparable zip artifact). If a function's remote configuration cannot be read — typically a missing `lambda:GetFunction` permission, or a Lambda missing in AWS despite being present in the deployed CloudFormation template — the diff fails fast with a clear error rather than producing a partial-state report.
+
+The `summary` field aggregates CloudFormation resource changes by type. The `resources` array lists each changed resource with its CloudFormation logical ID and resource type.
+
+### Diffing an existing package directory
+
+When the artifact directory already exists — for example, packaged in an earlier CI step — pass it explicitly to skip the auto-package step:
+
+```bash
+serverless diff --package ./.serverless
+```
+
+This reads the CloudFormation template and zip artifacts from the given directory rather than regenerating them.
+
+## Exit code
+
+`sls diff` exits `0` unless an unrecoverable error occurs (for example, AWS credentials are missing or the local template could not be read). Differences against the deployed stack do not cause a non-zero exit code — the command is informational.
+
+## Behavior notes
+
+- The structured diff applies the same template normalization the framework uses internally to decide whether a deploy is necessary, so artifact-key churn that the framework considers meaningless does not appear in the diff.
+- The `Function Code` section is the truthful "did handler code change?" signal — it compares zip hashes against AWS Lambda's `CodeSha256`. It is independent of the template-level diff below it.
+- Custom configuration filenames (`--config my-service.yml`) are supported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,84 @@
         "prettier": "^3.8.3"
       }
     },
+    "node_modules/@aws-cdk/aws-service-spec": {
+      "version": "0.1.182",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-service-spec/-/aws-service-spec-0.1.182.tgz",
+      "integrity": "sha512-m5kqMF722DZtar0mTx2nX9lhMQGBRmuUM/iNWx+s5Fidp2LyPreq7TKDfTrmY5MqHV/usgfCUnFDdtjlymDgwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/service-spec-types": "^0.0.248",
+        "@cdklabs/tskb": "^0.0.4"
+      }
+    },
+    "node_modules/@aws-cdk/aws-service-spec/node_modules/@aws-cdk/service-spec-types": {
+      "version": "0.0.248",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/service-spec-types/-/service-spec-types-0.0.248.tgz",
+      "integrity": "sha512-vavYeFEUW30ii5CjHPL0mpqy1CUXQa5xWDHkSEKYb5Hg5v1iR+bHikEIp1BlWZqufkLdLZoovvUCNN8fz76eNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cdklabs/tskb": "^0.0.4"
+      }
+    },
+    "node_modules/@aws-cdk/cloudformation-diff": {
+      "version": "2.187.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.187.1.tgz",
+      "integrity": "sha512-MvgW82OfGsqC8wbemVpk2xxuP6GaTxpcCD1uLhjuVAzwdzWL1YhfTizh4KHZW9szCQ1AZT37pw4qt45l5YNniA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/aws-service-spec": "^0.1.171",
+        "@aws-cdk/service-spec-types": "^0.0.237",
+        "chalk": "^4",
+        "diff": "^8.0.4",
+        "fast-deep-equal": "^3.1.3",
+        "string-width": "^4",
+        "table": "^6"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-cloudformation": "^3"
+      }
+    },
+    "node_modules/@aws-cdk/cloudformation-diff/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@aws-cdk/cloudformation-diff/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws-cdk/cloudformation-diff/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@aws-cdk/service-spec-types": {
+      "version": "0.0.237",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/service-spec-types/-/service-spec-types-0.0.237.tgz",
+      "integrity": "sha512-qC7dfSXGyJddKU/ys+G/LvmOvLmn+rSbKFa28Jk1eNAbE8d2mRu/Ul8srw4KE1QGI8QklR/xikAb4Xffw11z8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cdklabs/tskb": "^0.0.4"
+      }
+    },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -1974,6 +2052,12 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cdklabs/tskb": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@cdklabs/tskb/-/tskb-0.0.4.tgz",
+      "integrity": "sha512-NFx1X0l7p5DyHtLLEyNeh1hPN4UN9hTkZkzFs/Mp+kFk7dpdINGmGVpCfRDjJ2DrcNSNENUmT+w8g73TvmBbTw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@dagrejs/graphlib": {
       "version": "2.2.4",
@@ -5677,7 +5761,6 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -6528,6 +6611,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/docker-modem": {
@@ -13932,6 +14024,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
+        "@aws-cdk/cloudformation-diff": "^2.187.1",
         "@aws-sdk/client-acm": "3.1050.0",
         "@aws-sdk/client-api-gateway": "3.1050.0",
         "@aws-sdk/client-apigatewayv2": "3.1050.0",
@@ -14150,7 +14243,7 @@
         "@aws-sdk/client-cloudformation": "3.1050.0",
         "@aws-sdk/client-s3": "3.1050.0",
         "@aws-sdk/client-ssm": "3.1050.0",
-        "@aws-sdk/client-sso-oidc": "^3.1050.0",
+        "@aws-sdk/client-sso-oidc": "3.1050.0",
         "@aws-sdk/client-sts": "3.1050.0",
         "@aws-sdk/credential-providers": "3.1050.0",
         "@axiomhq/js": "^1.3.1",

--- a/packages/serverless/lib/classes/plugin-manager.js
+++ b/packages/serverless/lib/classes/plugin-manager.js
@@ -11,6 +11,7 @@ import pluginPackage from '../plugins/package/package.js'
 import pluginDeploy from '../plugins/deploy.js'
 import pluginInvoke from '../plugins/invoke.js'
 import pluginInfo from '../plugins/info.js'
+import pluginDiff from '../plugins/diff.js'
 import pluginDev from '../plugins/dev.js'
 import pluginLogs from '../plugins/logs.js'
 import pluginMetrics from '../plugins/metrics.js'
@@ -23,6 +24,7 @@ import pluginSearch from '../plugins/plugin/search.js'
 import pluginAwsProvider from '../plugins/aws/provider.js'
 import pluginAwsCommon from '../plugins/aws/common/index.js'
 import pluginAwsPackage from '../plugins/aws/package/index.js'
+import pluginAwsDiff from '../plugins/aws/diff/index.js'
 import pluginAwsDeploy from '../plugins/aws/deploy/index.js'
 import pluginAwsInvoke from '../plugins/aws/invoke.js'
 import pluginAwsInvokeAgent from '../plugins/aws/invoke-agent.js'
@@ -78,6 +80,7 @@ const internalPlugins = [
   pluginDeploy,
   pluginInvoke,
   pluginInfo,
+  pluginDiff,
   pluginDev,
   pluginLogs,
   pluginMetrics,
@@ -90,6 +93,7 @@ const internalPlugins = [
   pluginAwsProvider,
   pluginAwsCommon,
   pluginAwsPackage,
+  pluginAwsDiff,
   pluginAwsDeploy,
   pluginAwsInvoke,
   pluginAwsInvokeAgent,

--- a/packages/serverless/lib/cli/commands-schema.js
+++ b/packages/serverless/lib/cli/commands-schema.js
@@ -192,6 +192,39 @@ commands.set('info', {
   hasAwsExtension: true,
 })
 
+commands.set('diff', {
+  groupName: 'main',
+  usage:
+    'Show the difference between the local template and the deployed CloudFormation stack',
+  options: {
+    stage: {
+      usage: 'The service stage to diff against.',
+      type: 'string',
+    },
+    region: {
+      usage: 'The service region to diff against.',
+      type: 'string',
+    },
+    stack: {
+      usage: 'CloudFormation/SAM Only. Set the stack name.',
+      type: 'string',
+    },
+    package: {
+      usage:
+        'Path to an existing package directory to diff against. Skips the auto-package step when set.',
+      type: 'string',
+      shortcut: 'p',
+    },
+    json: {
+      usage: 'Output the diff in JSON format',
+      type: 'boolean',
+    },
+  },
+  lifecycleEvents: ['diff'],
+  serviceDependencyMode: 'required',
+  hasAwsExtension: true,
+})
+
 commands.set('dev', {
   groupName: 'main',
   usage: 'Start dev mode in this service',

--- a/packages/serverless/lib/plugins/aws/diff/index.js
+++ b/packages/serverless/lib/plugins/aws/diff/index.js
@@ -1,0 +1,58 @@
+import runDiff from './run-diff.js'
+
+/**
+ * `serverless diff` — compare the locally-packaged CloudFormation template
+ * against the deployed stack and render the differences.
+ *
+ * By default, the service is packaged first (so the local template reflects
+ * the current configuration on disk). Users who already have a packaged
+ * artifact directory (for example, from a previous CI step) can point the
+ * command at it with `--package <path>` and skip the re-package.
+ *
+ * Output modes:
+ *   - default: colored structured diff to stdout, with sections for code
+ *              changes, IAM updates, resource changes, etc.
+ *   - --json:  machine-readable JSON object with the diff summary and
+ *              per-function code-change details. Suitable for CI consumption.
+ *
+ * Exit code is always 0 unless an unrecoverable error occurs.
+ */
+class AwsDiff {
+  constructor(serverless, options, pluginUtils) {
+    this.serverless = serverless
+    this.options = options || {}
+    this.provider = this.serverless.getProvider('aws')
+    this.log = pluginUtils.log
+    this.style = pluginUtils.style
+    this.progress = pluginUtils.progress
+
+    Object.assign(this, runDiff)
+
+    // The `aws:diff` entrypoint runs the AWS-specific implementation. The
+    // outer `diff:diff` command spawns it after (optionally) packaging.
+    this.commands = {
+      aws: {
+        type: 'entrypoint',
+        commands: {
+          diff: {
+            lifecycleEvents: ['diff'],
+          },
+        },
+      },
+    }
+
+    this.hooks = {
+      // Auto-package unless the user pointed at an existing artifact directory.
+      // `--package <path>` opts out of repackaging — useful when the artifact
+      // was produced by an earlier CI step.
+      'before:diff:diff': async () => {
+        if (this.options.package) return
+        await this.serverless.pluginManager.spawn('package')
+      },
+      'diff:diff': async () => this.serverless.pluginManager.spawn('aws:diff'),
+      'aws:diff:diff': async () => this.runDiff(),
+    }
+  }
+}
+
+export default AwsDiff

--- a/packages/serverless/lib/plugins/aws/diff/run-diff.js
+++ b/packages/serverless/lib/plugins/aws/diff/run-diff.js
@@ -138,7 +138,9 @@ export default {
    * Compare every function's local zip hash against its deployed Lambda's
    * CodeSha256. Returns an array of `{ funcName, status }` where `status` is
    * one of:
-   *   - `'new'`: function exists locally but not in the deployed stack
+   *   - `'new'`: function exists locally but not in the deployed stack OR
+   *      the deployed Lambda is absent at AWS (e.g. forced replacement via
+   *      `name:` change)
    *   - `'changed'`: local zip hash differs from the deployed Lambda's CodeSha256
    *   - `'unchanged'`: hashes match
    *   - `'image'`: container-image function (no zip to hash)
@@ -151,10 +153,12 @@ export default {
    * worth showing in a diff. Surfacing them in the returned array still lets
    * future callers introspect them if needed.
    *
-   * If the deployed Lambda's `CodeSha256` can't be read (permission denied,
-   * function missing in Lambda while present in CFN, etc.), the entire diff
-   * fails fast with `DIFF_FUNCTION_CODE_VERIFICATION_FAILED`. Partial-state
-   * results don't help CI workflows that need a clear pass/fail signal.
+   * If the deployed Lambda's `CodeSha256` can't be read for an unexpected
+   * reason (permission denied, malformed response, transient AWS error), the
+   * entire diff fails fast with `DIFF_FUNCTION_CODE_VERIFICATION_FAILED`.
+   * Partial-state results don't help CI workflows that need a clear
+   * pass/fail signal. `ResourceNotFoundException` is the documented benign
+   * case and is mapped to `'new'` instead.
    */
   async _detectCodeChanges(deployedTemplate) {
     const functionNames = this.serverless.service.getAllFunctions()
@@ -232,6 +236,15 @@ export default {
 
         const localHash = zipHashByPath.get(zipPath)
         const remoteHash = await this._getRemoteCodeSha(funcObj.name)
+        // A null remoteHash means the resolved Lambda name doesn't exist at
+        // AWS yet. The logical id is already in the deployed CFN template
+        // (otherwise we would have short-circuited above as `status: 'new'`),
+        // so this is a function-rename or otherwise replacement-forcing
+        // change: the existing physical Lambda is being destroyed and a new
+        // one created under a new name. Surface the code as new — the
+        // template diff will show the matching [-] destroy / [+] create on
+        // the function resource.
+        if (remoteHash === null) return { funcName, status: 'new' }
         return {
           funcName,
           status: localHash === remoteHash ? 'unchanged' : 'changed',
@@ -241,12 +254,18 @@ export default {
   },
 
   /**
-   * Look up the deployed Lambda's CodeSha256. Throws a `ServerlessError` —
-   * with the offending function name included in the message — if AWS can't
-   * be queried (missing IAM permission, Lambda function missing in spite of
-   * being present in the deployed CloudFormation template, etc.). The diff
-   * command is meant to produce a definite answer, so partial-failure states
-   * fail fast rather than silently degrade.
+   * Look up the deployed Lambda's CodeSha256.
+   *
+   * Returns `null` when the function is absent at AWS — typically because the
+   * resolved name is being introduced for the first time by this change
+   * (forced replacement via `name:`, or a function deleted out-of-band from
+   * a stack that still references it). The caller classifies that as new
+   * code.
+   *
+   * Throws `DIFF_FUNCTION_CODE_VERIFICATION_FAILED` for every other failure
+   * mode (missing IAM permission, malformed response, transient AWS error)
+   * — the diff command is meant to produce a definite answer, so partial-
+   * failure states fail fast rather than silently degrade.
    */
   async _getRemoteCodeSha(awsFunctionName) {
     let res
@@ -255,6 +274,12 @@ export default {
         FunctionName: awsFunctionName,
       })
     } catch (err) {
+      // `ResourceNotFoundException` is the normal way AWS signals "this
+      // function doesn't exist (yet)". Both SDK v2 and v3 expose the code
+      // via `providerError.code` on the framework's wrapped error; fall
+      // back to a name-match on the underlying error for safety.
+      const code = err.providerError?.code || err.code || err.name
+      if (code === 'ResourceNotFoundException') return null
       throw new ServerlessError(
         `Failed to verify code for function "${awsFunctionName}": ${err.message}`,
         'DIFF_FUNCTION_CODE_VERIFICATION_FAILED',

--- a/packages/serverless/lib/plugins/aws/diff/run-diff.js
+++ b/packages/serverless/lib/plugins/aws/diff/run-diff.js
@@ -1,0 +1,560 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+import chalk from 'chalk'
+import cfDiff from '@aws-cdk/cloudformation-diff'
+import { writeText } from '@serverless/util'
+import normalizeFiles from '../lib/normalize-files.js'
+import { hashFile } from '../lib/hash-file.js'
+import { resolveFunctionArtifactPaths } from '../lib/get-function-artifact-paths.js'
+import ServerlessError from '../../../serverless-error.js'
+
+const { diffTemplate, Formatter } = cfDiff
+
+// NOTE: We intentionally do NOT cap concurrency around `provider.request`
+// calls here. The shared request layer (`lib/aws/request-queue.js`) already
+// caps every AWS call across the entire framework at concurrency 2 — adding
+// another `pLimit` layer would be redundant and misleading.
+
+/**
+ * Mixin module that performs the actual diff. Exposed via `Object.assign` on
+ * the AwsPackageDiff plugin so `this` is the plugin instance.
+ */
+export default {
+  /**
+   * Load the locally-packaged template, fetch the deployed template, compute
+   * the diff, and render it (text by default, JSON when `--json` is set).
+   *
+   * Two orthogonal signals are surfaced:
+   *   1. Per-function code changes — computed by hashing local zips and
+   *      comparing to each Lambda's CodeSha256 in AWS. This is the framework's
+   *      own definition of "did code change" (see check-for-changes.js for
+   *      the analogous deploy-side check).
+   *   2. Structured CloudFormation template diff — rendered after applying
+   *      the same normalization the framework uses internally, so the diff
+   *      output is free of S3Key timestamp churn and other artifact-routing
+   *      noise the framework already considers meaningless.
+   */
+  async runDiff() {
+    const [newTemplate, oldTemplate] = await Promise.all([
+      this._loadLocalTemplate(),
+      this._fetchDeployedTemplate(),
+    ])
+
+    const codeChanges = await this._detectCodeChanges(oldTemplate)
+
+    const diff = diffTemplate(
+      normalizeForDiff(oldTemplate),
+      normalizeForDiff(newTemplate),
+    )
+    const summary = summarizeChanges(diff)
+
+    // The package lifecycle's "Packaging" spinner is still active when our
+    // `after:package:finalize` hook fires. Stop it before writing structured
+    // output to stdout, otherwise the spinner overlays the first line of the
+    // diff (or interleaves with `--json` payloads on TTY consumers piping to
+    // `jq`).
+    this.progress.remove()
+
+    if (this.options.json) {
+      writeText(
+        JSON.stringify(buildJsonReport(diff, summary, codeChanges), null, 2),
+      )
+      return
+    }
+
+    this._renderCodeChangeSummary(codeChanges)
+
+    if (diff.isEmpty) {
+      this.log.notice('No infrastructure changes against the deployed stack')
+      return
+    }
+
+    renderDiff(process.stdout, diff)
+    this.log.notice(
+      `Resources: ${summary.create} to create, ${summary.update} to update, ${summary.remove} to remove`,
+    )
+  },
+
+  /**
+   * Read the freshly-packaged CloudFormation template from disk. Resolves
+   * the package directory the same way `AwsPackage` does: explicit
+   * `--package` flag → `service.package.path` from serverless.yml →
+   * `<serviceDir>/.serverless` default.
+   */
+  async _loadLocalTemplate() {
+    const templateFile = path.join(
+      this._resolvePackageDir(),
+      this.provider.naming.getCompiledTemplateFileName(),
+    )
+
+    try {
+      const contents = await readFile(templateFile, 'utf8')
+      return JSON.parse(contents)
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        throw new ServerlessError(
+          `Packaged CloudFormation template not found at ${templateFile}. ` +
+            'Run `serverless package` first, or pass `--package <path>` ' +
+            'to point at an existing package directory.',
+          'DIFF_TEMPLATE_NOT_FOUND',
+        )
+      }
+      throw new ServerlessError(
+        `Failed to read packaged template ${templateFile}: ${err.message}`,
+        'DIFF_TEMPLATE_READ_FAILED',
+      )
+    }
+  },
+
+  /**
+   * Fetch the currently-deployed CloudFormation template. Returns an empty
+   * object when the stack does not exist yet (so the diff shows "everything
+   * is new" instead of erroring).
+   */
+  async _fetchDeployedTemplate() {
+    const stackName = this.provider.naming.getStackName()
+    try {
+      const response = await this.provider.request(
+        'CloudFormation',
+        'getTemplate',
+        { StackName: stackName, TemplateStage: 'Processed' },
+      )
+      return JSON.parse(response.TemplateBody)
+    } catch (err) {
+      if (isStackNotFoundError(err)) {
+        this.log.notice(
+          `Stack "${stackName}" does not exist yet — treating all resources as new.`,
+        )
+        return {}
+      }
+      throw new ServerlessError(
+        `Failed to fetch deployed template for stack "${stackName}": ${err.message}`,
+        'DIFF_GET_TEMPLATE_FAILED',
+      )
+    }
+  },
+
+  /**
+   * Compare every function's local zip hash against its deployed Lambda's
+   * CodeSha256. Returns an array of `{ funcName, status }` where `status` is
+   * one of:
+   *   - `'new'`: function exists locally but not in the deployed stack
+   *   - `'changed'`: local zip hash differs from the deployed Lambda's CodeSha256
+   *   - `'unchanged'`: hashes match
+   *   - `'image'`: container-image function (no zip to hash)
+   *   - `'disabled'`: `package.disable: true` — packaging is skipped, so we
+   *      have nothing to compare; included for completeness so the function
+   *      isn't silently dropped
+   *
+   * Both `'image'` and `'disabled'` are excluded from the rendered summary
+   * and the JSON `code` field — they're neither "code changes" nor signals
+   * worth showing in a diff. Surfacing them in the returned array still lets
+   * future callers introspect them if needed.
+   *
+   * If the deployed Lambda's `CodeSha256` can't be read (permission denied,
+   * function missing in Lambda while present in CFN, etc.), the entire diff
+   * fails fast with `DIFF_FUNCTION_CODE_VERIFICATION_FAILED`. Partial-state
+   * results don't help CI workflows that need a clear pass/fail signal.
+   */
+  async _detectCodeChanges(deployedTemplate) {
+    const functionNames = this.serverless.service.getAllFunctions()
+    if (functionNames.length === 0) return []
+
+    const deployedLambdaLogicalIds = new Set(
+      Object.entries(deployedTemplate.Resources || {})
+        .filter(([, r]) => r.Type === 'AWS::Lambda::Function')
+        .map(([id]) => id),
+    )
+
+    // Resolve artifact paths once using the shared helper. This honors every
+    // packaging shape the framework supports (per-function `package.artifact`,
+    // service-level `package.artifact`, `service.artifact`, individual
+    // packaging, default shared zip) — matching what `deploy` uploads.
+    // Functions with `image` are omitted from the map by the helper.
+    const artifactPaths = await resolveFunctionArtifactPaths(
+      this.serverless,
+      this._resolvePackageDir(),
+    )
+
+    // Hash each unique zip path exactly once. Under default packaging all
+    // functions share a single zip; without this dedup we'd hash a (potentially
+    // hundreds-of-MB) file once per function.
+    //
+    // Exclude paths that belong only to `package.disable: true` functions —
+    // under `individually: true` their per-function zip is never written to
+    // disk, so hashing it would throw ENOENT and abort the whole diff before
+    // we ever reach the per-function disable guard below.
+    const isDisabled = (name) => {
+      const fn = this.serverless.service.getFunction(name)
+      return Boolean(fn.package && fn.package.disable)
+    }
+    const hashablePaths = new Set()
+    for (const [funcName, zipPath] of artifactPaths) {
+      if (!isDisabled(funcName)) hashablePaths.add(zipPath)
+    }
+    const zipHashByPath = new Map(
+      await Promise.all(
+        Array.from(hashablePaths, async (p) => [p, await hashFile(p)]),
+      ),
+    )
+
+    // No `pLimit` here — `provider.request` is internally serialized by the
+    // framework's shared `requestQueue` (concurrency 2). The actual
+    // outbound AWS rate is the same whether we Promise.all over 10 or 1000
+    // functions; adding another bound here would just be misleading noise.
+    return Promise.all(
+      functionNames.map(async (funcName) => {
+        const funcObj = this.serverless.service.getFunction(funcName)
+        if (funcObj.image) return { funcName, status: 'image' }
+        // `package.disable: true` opts a function out of packaging entirely
+        // — its zip won't exist on disk, so attempting to hash it would
+        // throw ENOENT. Skip those cleanly.
+        if (funcObj.package && funcObj.package.disable) {
+          return { funcName, status: 'disabled' }
+        }
+
+        const logicalId = this.provider.naming.getLambdaLogicalId(funcName)
+        const isNew = !deployedLambdaLogicalIds.has(logicalId)
+        if (isNew) return { funcName, status: 'new' }
+
+        const zipPath = artifactPaths.get(funcName)
+        if (!zipPath) {
+          // Defensive: helper omits image-based functions and we already
+          // handled those above. If we get here something unexpected went
+          // wrong with artifact resolution — surface it rather than silently
+          // mark the function as "we don't know."
+          throw new ServerlessError(
+            `Could not resolve a package artifact for function "${funcName}". ` +
+              'This is unexpected — please file an issue.',
+            'DIFF_ARTIFACT_NOT_RESOLVED',
+          )
+        }
+
+        const localHash = zipHashByPath.get(zipPath)
+        const remoteHash = await this._getRemoteCodeSha(funcObj.name)
+        return {
+          funcName,
+          status: localHash === remoteHash ? 'unchanged' : 'changed',
+        }
+      }),
+    )
+  },
+
+  /**
+   * Look up the deployed Lambda's CodeSha256. Throws a `ServerlessError` —
+   * with the offending function name included in the message — if AWS can't
+   * be queried (missing IAM permission, Lambda function missing in spite of
+   * being present in the deployed CloudFormation template, etc.). The diff
+   * command is meant to produce a definite answer, so partial-failure states
+   * fail fast rather than silently degrade.
+   */
+  async _getRemoteCodeSha(awsFunctionName) {
+    let res
+    try {
+      res = await this.provider.request('Lambda', 'getFunction', {
+        FunctionName: awsFunctionName,
+      })
+    } catch (err) {
+      throw new ServerlessError(
+        `Failed to verify code for function "${awsFunctionName}": ${err.message}`,
+        'DIFF_FUNCTION_CODE_VERIFICATION_FAILED',
+      )
+    }
+    const codeSha = res.Configuration && res.Configuration.CodeSha256
+    if (!codeSha) {
+      // AWS always populates CodeSha256 for deployed Lambdas — a missing value
+      // would mean the response shape changed or the function is in an
+      // unexpected state. Fail fast rather than mis-report "changed".
+      throw new ServerlessError(
+        `Failed to verify code for function "${awsFunctionName}": ` +
+          'CodeSha256 missing from Lambda:getFunction response.',
+        'DIFF_FUNCTION_CODE_VERIFICATION_FAILED',
+      )
+    }
+    return codeSha
+  },
+
+  /**
+   * Render the per-function code-change section above the structured template
+   * diff. Mirrors the section style used by `@aws-cdk/cloudformation-diff`
+   * (bold/underlined header + colored `[+]` / `[~]` / `[?]` markers) so the
+   * Code section reads as a peer of `Resources`, `Outputs`, etc.
+   *
+   * Silent when the service has no zip-backed functions to compare. Emits a
+   * one-line "No code changes" notice when functions exist but none changed.
+   */
+  _renderCodeChangeSummary(codeChanges) {
+    if (!codeChanges.length) return
+
+    // Build entries with colored markers matching the diff library's palette:
+    // green for additions, yellow for modifications.
+    const entries = []
+    for (const c of codeChanges) {
+      // `image`, `disabled`, and `unchanged` are not signals worth surfacing.
+      if (
+        c.status === 'image' ||
+        c.status === 'disabled' ||
+        c.status === 'unchanged'
+      )
+        continue
+      if (c.status === 'new') {
+        entries.push({ order: 0, line: `${chalk.green('[+]')} ${c.funcName}` })
+      } else if (c.status === 'changed') {
+        entries.push({ order: 1, line: `${chalk.yellow('[~]')} ${c.funcName}` })
+      }
+    }
+
+    if (!entries.length) {
+      this.log.notice('No function code changes')
+      return
+    }
+
+    // Sort additions first, then modifications — matches the ordering
+    // convention of the resource diff (creates before updates before removes)
+    // and keeps output stable across runs.
+    entries.sort((a, b) => a.order - b.order)
+
+    // Use the diff library's Formatter so the Code section header is styled
+    // identically to Resources / Outputs / IAM Statement Changes / etc.
+    const formatter = new Formatter(process.stdout, {})
+    formatter.printSectionHeader('Function Code')
+    for (const entry of entries) {
+      formatter.print(entry.line)
+    }
+    formatter.printSectionFooter()
+  },
+
+  _resolvePackageDir() {
+    return (
+      this.options.package ||
+      this.serverless.service.package.path ||
+      path.join(this.serverless.serviceDir || '.', '.serverless')
+    )
+  },
+}
+
+/**
+ * Apply the same normalization the framework uses internally when deciding
+ * whether a deploy is necessary (see `lib/plugins/aws/lib/normalize-files.js`
+ * and its caller `deploy/lib/check-for-changes.js`). This blanks Lambda
+ * `Code.S3Key` and Layer `Content.S3Key` so timestamp-only artifact-key
+ * churn — which the framework already considers meaningless — doesn't
+ * pollute the diff output. Real code changes are surfaced separately via
+ * the per-function CodeSha256 check above.
+ *
+ * Templates can legitimately be empty (e.g., when the stack does not exist
+ * yet). The shared normalizer requires `Resources` to be defined, so we
+ * coerce an empty template into a no-op shape first.
+ */
+export function normalizeForDiff(template) {
+  if (!template || !template.Resources) return template
+  return normalizeFiles.normalizeCloudFormationTemplate(template)
+}
+
+/**
+ * Render the CloudFormation diff to the given stream.
+ *
+ * Mirrors the upstream `formatDifferences()` from `@aws-cdk/cloudformation-diff`
+ * but omits a trailing advisory line the upstream library appends after the
+ * security section, since that line links to an external tracker.
+ *
+ * A drift-detection test (`run-diff.test.js`) asserts this function stays in
+ * sync with upstream by comparing both outputs against a TemplateDiff that
+ * exercises every section the upstream formatter renders. If a dep bump
+ * adds or renames a section, that test fails and signals an update is needed.
+ */
+export function renderDiff(stream, templateDiff) {
+  const formatter = new Formatter(stream, {}, templateDiff)
+
+  if (
+    templateDiff.awsTemplateFormatVersion ||
+    templateDiff.transform ||
+    templateDiff.description
+  ) {
+    formatter.printSectionHeader('Template')
+    formatter.formatDifference(
+      'AWSTemplateFormatVersion',
+      'AWSTemplateFormatVersion',
+      templateDiff.awsTemplateFormatVersion,
+    )
+    formatter.formatDifference('Transform', 'Transform', templateDiff.transform)
+    formatter.formatDifference(
+      'Description',
+      'Description',
+      templateDiff.description,
+    )
+    formatter.printSectionFooter()
+  }
+
+  // Security section — keep the IAM and security-group tables (genuinely
+  // useful for review) but skip the trailing tracker-link advisory.
+  if (
+    templateDiff.iamChanges.hasChanges ||
+    templateDiff.securityGroupChanges.hasChanges
+  ) {
+    formatter.formatIamChanges(templateDiff.iamChanges)
+    formatter.formatSecurityGroupChanges(templateDiff.securityGroupChanges)
+    formatter.printSectionFooter()
+  }
+
+  // For sections whose values are objects (Parameters, Metadata, Mappings,
+  // Conditions, Outputs), the upstream default renderer dumps the entire
+  // before/after JSON onto a single line. That's unreadable in practice —
+  // especially for Outputs, where a single Lambda Version Ref change drags
+  // the whole Output blob across the screen twice. Render those entries as
+  // a tree-style diff instead, matching how the Resources section already
+  // surfaces property-level changes.
+  const treeFormatter = nestedSectionFormatter(formatter)
+  formatter.formatSection(
+    'Parameters',
+    'Parameter',
+    templateDiff.parameters,
+    treeFormatter,
+  )
+  formatter.formatSection(
+    'Metadata',
+    'Metadata',
+    templateDiff.metadata,
+    treeFormatter,
+  )
+  formatter.formatSection(
+    'Mappings',
+    'Mapping',
+    templateDiff.mappings,
+    treeFormatter,
+  )
+  formatter.formatSection(
+    'Conditions',
+    'Condition',
+    templateDiff.conditions,
+    treeFormatter,
+  )
+  formatter.formatSection(
+    'Resources',
+    'Resource',
+    templateDiff.resources,
+    formatter.formatResourceDifference.bind(formatter),
+  )
+  formatter.formatSection(
+    'Outputs',
+    'Output',
+    templateDiff.outputs,
+    treeFormatter,
+  )
+  formatter.formatSection('Other Changes', 'Unknown', templateDiff.unknown)
+}
+
+/**
+ * Build an entry formatter that renders the diff of an object-valued entry
+ * (e.g., an Output) as a tree, instead of the upstream default's single-line
+ * "OLD_JSON to NEW_JSON" dump.
+ *
+ * The header line ("`[~] Output Foo`") mirrors the upstream formatter's
+ * style — same prefix, type, and logical-id treatment — so the section
+ * stays visually consistent with everything else the diff renders.
+ *
+ * For modifications, the recursive walk down to changed leaves is delegated
+ * to the diff library's `formatObjectDiff` (the same engine that powers
+ * property-level diffs in the Resources section). Pure additions and
+ * removals show only the header — the value blob isn't tree-friendly when
+ * there's nothing to compare against, and the structured `--json` output
+ * is the right place to inspect full values.
+ */
+function nestedSectionFormatter(formatter) {
+  return (type, logicalId, diff) => {
+    if (!diff || !diff.isDifferent) return
+    formatter.print(
+      `${formatter.formatPrefix(diff)} ${chalk.cyan(type)} ${formatter.formatLogicalId(logicalId)}`,
+    )
+    if (diff.isUpdate) {
+      formatter.formatObjectDiff(diff.oldValue, diff.newValue, '')
+    }
+  }
+}
+
+/**
+ * Bucket resource changes from a TemplateDiff into create/update/remove counts.
+ * Matches the same algorithm used by the upstream serverless-diff-plugin fork
+ * but stays in plain JS without the provider abstraction.
+ */
+function summarizeChanges(diff) {
+  const summary = { create: 0, update: 0, remove: 0 }
+  for (const change of Object.values(diff.resources.changes)) {
+    if (change.isAddition) summary.create += 1
+    else if (change.isRemoval) summary.remove += 1
+    else summary.update += 1
+  }
+  return summary
+}
+
+/**
+ * Shape the diff into a stable JSON payload for `--json` consumers. The
+ * upstream diff types are class instances and don't serialize cleanly, so we
+ * project only the fields a CI pipeline is likely to need.
+ */
+function buildJsonReport(diff, summary, codeChanges) {
+  // Only actionable signals are surfaced: which functions' code is new and
+  // which has changed. Unchanged/image/disabled functions are derivable by
+  // the consumer (anything in `getAllFunctions()` and not in either array),
+  // so they aren't repeated here.
+  const code = { changed: [], new: [] }
+  for (const c of codeChanges) {
+    if (c.status === 'changed' || c.status === 'new') {
+      code[c.status].push(c.funcName)
+    }
+  }
+  return {
+    code,
+    summary,
+    resources: Object.entries(diff.resources.changes).map(
+      ([logicalId, change]) => ({
+        logicalId,
+        changeType: change.isAddition
+          ? 'create'
+          : change.isRemoval
+            ? 'remove'
+            : 'update',
+        resourceType: change.newResourceType || change.oldResourceType || null,
+      }),
+    ),
+  }
+}
+
+/**
+ * Get the underlying AWS error class name in a way that's robust to the
+ * framework's error wrapping.
+ *
+ * The framework's `provider.request` wraps AWS SDK errors in a `ServerlessError`
+ * and preserves the original on `err.providerError`. So `err.name` is the
+ * wrapper's class (`'ServerlessError'`), NOT the inner AWS class
+ * (`'ValidationError'`, `'ResourceNotFoundException'`, etc.). This helper
+ * unwraps that — preferring the inner class when present, falling back to the
+ * direct class for raw SDK errors (when something bypassed the wrapper).
+ *
+ * Returns `null` when no class info is available.
+ */
+export function getEffectiveErrorClass(err) {
+  if (!err) return null
+  return (
+    err.providerError?.name ||
+    err.providerError?.code ||
+    err.name ||
+    err.code ||
+    null
+  )
+}
+
+/**
+ * AWS CloudFormation reports a missing stack via a `ValidationError` whose
+ * message has the canonical form `Stack with id <name> does not exist`. We
+ * match BOTH the canonical phrasing AND (when the underlying error class is
+ * available) verify it really is a ValidationError — so unrelated errors that
+ * happen to mention "does not exist" don't get silently swallowed.
+ */
+export function isStackNotFoundError(err) {
+  if (!err) return false
+  if (!/Stack with id .* does not exist/i.test(err.message || '')) return false
+  const cls = getEffectiveErrorClass(err)
+  if (!cls) return true // No class info — trust the canonical-phrasing match.
+  return cls === 'ValidationError' || cls === 'ValidationException'
+}

--- a/packages/serverless/lib/plugins/aws/lib/get-function-artifact-paths.js
+++ b/packages/serverless/lib/plugins/aws/lib/get-function-artifact-paths.js
@@ -1,0 +1,72 @@
+import path from 'path'
+
+/**
+ * Resolve every function's compiled zip artifact path. Honors all the
+ * supported packaging shapes:
+ *
+ *   - per-function `functionObject.package.artifact`
+ *   - service-level `service.package.artifact`
+ *   - top-level `service.artifact` (overrides per-function when set)
+ *   - `package.individually` (per function or at the service level)
+ *   - default shared-zip layout under `<packagePath>/<serviceArtifactName>`
+ *
+ * Container-image functions are omitted from the returned map (no zip to
+ * resolve). The resolution logic mirrors the long-standing implementation
+ * in `deploy/lib/upload-artifacts.js`'s `getFunctionArtifactFilePaths`.
+ *
+ * Returns `Map<funcName, absolutePath>`. Callers that need a deduped array
+ * can compute `[...new Set(map.values())]`; callers that need per-function
+ * lookup use the Map directly.
+ *
+ * Currently consumed by `package/diff/run-diff.js`. Kept as a small
+ * standalone helper so additional callers can pick it up over time without
+ * re-deriving the resolution rules.
+ *
+ * @param {object} serverless - the Serverless instance
+ * @param {string} packagePath - resolved `.serverless/` (or custom) directory
+ * @returns {Promise<Map<string, string>>}
+ */
+export async function resolveFunctionArtifactPaths(serverless, packagePath) {
+  const provider = serverless.getProvider('aws')
+  const functionNames = serverless.service.getAllFunctions()
+  const entries = await Promise.all(
+    functionNames.map(async (name) => {
+      const functionObject = serverless.service.getFunction(name)
+      if (functionObject.image) return null
+
+      const perFunctionArtifact =
+        functionObject.package && functionObject.package.artifact
+
+      // Start with the per-function or service-level explicit artifact, if any.
+      let artifactFilePath =
+        perFunctionArtifact || serverless.service.package.artifact
+
+      if (artifactFilePath) {
+        artifactFilePath = path.resolve(serverless.serviceDir, artifactFilePath)
+      }
+
+      // When `service.artifact` is set, it overrides the per-function
+      // `package.artifact` — the resolved path is recomputed using the
+      // packaging conventions below.
+      if (
+        !artifactFilePath ||
+        (serverless.service.artifact && !perFunctionArtifact)
+      ) {
+        const isIndividual = Boolean(
+          serverless.service.package.individually ||
+          (functionObject.package && functionObject.package.individually),
+        )
+        artifactFilePath = isIndividual
+          ? path.join(
+              packagePath,
+              provider.naming.getFunctionArtifactName(name),
+            )
+          : path.join(packagePath, provider.naming.getServiceArtifactName())
+      }
+
+      return [name, artifactFilePath]
+    }),
+  )
+
+  return new Map(entries.filter(Boolean))
+}

--- a/packages/serverless/lib/plugins/aws/lib/hash-file.js
+++ b/packages/serverless/lib/plugins/aws/lib/hash-file.js
@@ -1,0 +1,39 @@
+import { readFile } from 'fs/promises'
+import crypto from 'crypto'
+
+/**
+ * Shared SHA-256 hashing helpers.
+ *
+ * Output format matches what AWS Lambda reports as `Configuration.CodeSha256`
+ * on `GetFunction`, and what the framework writes as `filesha256` metadata
+ * on uploaded S3 objects.
+ *
+ * Currently used by `package/diff/run-diff.js`. Designed as a single point
+ * of truth so that other callers across the AWS plugin can pick it up over
+ * time — keeping every "did this file change?" decision in the codebase
+ * consistent.
+ */
+
+/**
+ * Compute the SHA-256 hash of a file's contents, base64-encoded.
+ *
+ * @param {string} filePath - absolute path to the file
+ * @returns {Promise<string>} base64-encoded SHA-256
+ */
+export async function hashFile(filePath) {
+  const buf = await readFile(filePath)
+  return crypto.createHash('sha256').update(buf).digest('base64')
+}
+
+/**
+ * Compute the SHA-256 hash of an in-memory string or Buffer.
+ *
+ * Same encoding (base64) as `hashFile`, for callers that need to hash a JSON
+ * string (e.g., a normalized CloudFormation template) instead of a file.
+ *
+ * @param {string|Buffer} data
+ * @returns {string}
+ */
+export function hashContent(data) {
+  return crypto.createHash('sha256').update(data).digest('base64')
+}

--- a/packages/serverless/lib/plugins/diff.js
+++ b/packages/serverless/lib/plugins/diff.js
@@ -1,0 +1,15 @@
+import cliCommandsSchema from '../cli/commands-schema.js'
+
+class Diff {
+  constructor(serverless) {
+    this.serverless = serverless
+
+    this.commands = {
+      diff: {
+        ...cliCommandsSchema.get('diff'),
+      },
+    }
+  }
+}
+
+export default Diff

--- a/packages/serverless/lib/plugins/package/lib/package-service.js
+++ b/packages/serverless/lib/plugins/package/lib/package-service.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import { existsSync } from 'fs'
 import fsp from 'fs/promises'
 import { globby } from 'globby'
 import _ from 'lodash'
@@ -6,6 +7,51 @@ import micromatch from 'micromatch'
 import ServerlessError from '../../../serverless-error.js'
 import parseS3URI from '../../aws/utils/parse-s3-uri.js'
 import { log } from '@serverless/util'
+
+/**
+ * Configuration file extensions the framework knows how to parse.
+ * Kept in sync with `lib/configuration/read.js`.
+ */
+const SERVERLESS_CONFIG_EXTENSIONS = [
+  'yml',
+  'yaml',
+  'json',
+  'toml',
+  'ts',
+  'cjs',
+  'mjs',
+  'js',
+]
+
+/**
+ * Resolve the user's service-configuration filename(s) for exclusion from
+ * the deployable artifact.
+ *
+ * Honors custom config filenames (e.g., `my-service.yml`) by using
+ * `serverless.configurationFilename` as the base.
+ *
+ * When `configurationFilename` does not carry a file extension, this helper
+ * probes the service directory for which `<base>.<ext>` files actually exist
+ * and excludes those. If the value already carries an extension, it is used
+ * verbatim.
+ */
+function resolveServerlessConfigFileExcludes(serverless) {
+  const base = serverless.configurationFilename
+  if (!base) return []
+
+  // Already has an extension — use as-is.
+  if (path.extname(base)) return [base]
+
+  // No extension — probe the filesystem for matching `<base>.<ext>` files.
+  const candidates = SERVERLESS_CONFIG_EXTENSIONS.map((ext) => `${base}.${ext}`)
+  const present = candidates.filter((name) =>
+    existsSync(path.join(serverless.serviceDir, name)),
+  )
+
+  // If nothing matched (unusual — the framework wouldn't have loaded
+  // anything), fall back to excluding the bare name.
+  return present.length > 0 ? present : [base]
+}
 
 export default {
   defaultExcludes: [
@@ -49,9 +95,9 @@ export default {
       : []
     // add defaults for exclude
 
-    const serverlessConfigFileExclude = this.serverless.configurationFilename
-      ? [this.serverless.configurationFilename]
-      : []
+    const serverlessConfigFileExclude = resolveServerlessConfigFileExcludes(
+      this.serverless,
+    )
 
     const configurationInput = this.serverless.configurationInput
     const envFilesExclude =

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -19,6 +19,7 @@
   ],
   "main": "lib/serverless.js",
   "dependencies": {
+    "@aws-cdk/cloudformation-diff": "^2.187.1",
     "@aws-sdk/client-acm": "3.1050.0",
     "@aws-sdk/client-api-gateway": "3.1050.0",
     "@aws-sdk/client-apigatewayv2": "3.1050.0",

--- a/packages/serverless/test/unit/lib/plugins/aws/diff/run-diff.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/diff/run-diff.test.js
@@ -1,8 +1,8 @@
-import { describe, it, expect } from '@jest/globals'
+import { describe, it, expect, jest } from '@jest/globals'
 import { Writable } from 'stream'
 import stripAnsi from 'strip-ansi'
 import cfDiff from '@aws-cdk/cloudformation-diff'
-import {
+import runDiffMixin, {
   renderDiff,
   normalizeForDiff,
   isStackNotFoundError,
@@ -657,3 +657,71 @@ function capture(write) {
   write(stream)
   return Buffer.concat(chunks).toString('utf8')
 }
+
+describe('_getRemoteCodeSha', () => {
+  // Bind the mixin to a minimal `this` and run the method in isolation.
+  // The mixin only touches `this.provider.request` and stays AWS-SDK
+  // version agnostic — we exercise both v2 (`providerError.code`) and v3
+  // (`name`) shapes for ResourceNotFoundException.
+  const bind = (request) => ({
+    provider: { request },
+    _getRemoteCodeSha: runDiffMixin._getRemoteCodeSha,
+  })
+
+  it('returns the CodeSha256 on success', async () => {
+    const request = jest
+      .fn()
+      .mockResolvedValue({ Configuration: { CodeSha256: 'abc=' } })
+    const ctx = bind(request)
+    await expect(ctx._getRemoteCodeSha('my-fn')).resolves.toBe('abc=')
+    expect(request).toHaveBeenCalledWith('Lambda', 'getFunction', {
+      FunctionName: 'my-fn',
+    })
+  })
+
+  it('returns null on ResourceNotFoundException via providerError.code (SDK v2 shape)', async () => {
+    const err = new Error('Function not found: arn:...')
+    err.providerError = { code: 'ResourceNotFoundException' }
+    const request = jest.fn().mockRejectedValue(err)
+    const ctx = bind(request)
+    await expect(ctx._getRemoteCodeSha('missing-fn')).resolves.toBeNull()
+  })
+
+  it('returns null on ResourceNotFoundException via err.name (SDK v3 shape)', async () => {
+    const err = new Error('Function not found: arn:...')
+    err.name = 'ResourceNotFoundException'
+    const request = jest.fn().mockRejectedValue(err)
+    const ctx = bind(request)
+    await expect(ctx._getRemoteCodeSha('missing-fn')).resolves.toBeNull()
+  })
+
+  it('returns null on ResourceNotFoundException via err.code (raw SDK shape)', async () => {
+    const err = new Error('Function not found: arn:...')
+    err.code = 'ResourceNotFoundException'
+    const request = jest.fn().mockRejectedValue(err)
+    const ctx = bind(request)
+    await expect(ctx._getRemoteCodeSha('missing-fn')).resolves.toBeNull()
+  })
+
+  it('still throws DIFF_FUNCTION_CODE_VERIFICATION_FAILED on AccessDenied (and similar non-RNF errors)', async () => {
+    const err = new Error(
+      'User: arn:aws:iam::123:user/x is not authorized to perform: lambda:GetFunction',
+    )
+    err.providerError = { code: 'AccessDeniedException' }
+    const request = jest.fn().mockRejectedValue(err)
+    const ctx = bind(request)
+    await expect(ctx._getRemoteCodeSha('forbidden-fn')).rejects.toMatchObject({
+      code: 'DIFF_FUNCTION_CODE_VERIFICATION_FAILED',
+      message: expect.stringContaining('forbidden-fn'),
+    })
+  })
+
+  it('throws DIFF_FUNCTION_CODE_VERIFICATION_FAILED when CodeSha256 is missing from a successful response', async () => {
+    const request = jest.fn().mockResolvedValue({ Configuration: {} })
+    const ctx = bind(request)
+    await expect(ctx._getRemoteCodeSha('shapeless-fn')).rejects.toMatchObject({
+      code: 'DIFF_FUNCTION_CODE_VERIFICATION_FAILED',
+      message: expect.stringContaining('CodeSha256 missing'),
+    })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/diff/run-diff.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/diff/run-diff.test.js
@@ -1,0 +1,659 @@
+import { describe, it, expect } from '@jest/globals'
+import { Writable } from 'stream'
+import stripAnsi from 'strip-ansi'
+import cfDiff from '@aws-cdk/cloudformation-diff'
+import {
+  renderDiff,
+  normalizeForDiff,
+  isStackNotFoundError,
+  getEffectiveErrorClass,
+} from '../../../../../../lib/plugins/aws/diff/run-diff.js'
+
+const { diffTemplate, formatDifferences } = cfDiff
+
+/**
+ * Drift detector for renderDiff().
+ *
+ * Our renderDiff() reproduces the upstream `formatDifferences()` formatter
+ * but suppresses one advisory line that links to an external tracker. If a
+ * future dependency bump adds, removes, or renames any of the sections the
+ * upstream formatter renders, this test fails — telling us to update
+ * `renderDiff` in lock-step.
+ *
+ * To make the comparison meaningful, the templates below intentionally
+ * produce changes in EVERY section the upstream formatter knows about:
+ * top-level template metadata, IAM, security groups, Parameters, Metadata,
+ * Mappings, Conditions, Resources, Outputs, and unknown top-level keys.
+ */
+describe('renderDiff (drift vs @aws-cdk/cloudformation-diff)', () => {
+  // The single line we intentionally omit. Kept as a regex so we don't pin
+  // ourselves to the exact wording; if upstream rephrases it we'll notice
+  // (drift assertion will fail) and re-tune.
+  const SUPPRESSED_LINE =
+    /There may be security-related changes not in this list/
+
+  const baseTemplate = {
+    AWSTemplateFormatVersion: '2010-09-09',
+    Transform: 'AWS::Serverless-2016-10-31',
+    Description: 'Service deployed by Serverless Framework',
+    Parameters: {
+      Stage: { Type: 'String', Default: 'dev' },
+      RetainedParam: { Type: 'String', Default: 'keep-me' },
+    },
+    Metadata: {
+      Build: { commit: 'aaaaaaa', timestamp: '2024-01-01T00:00:00Z' },
+    },
+    Mappings: {
+      Regions: {
+        'us-east-1': { ami: 'ami-old' },
+        'us-west-2': { ami: 'ami-stable' },
+      },
+    },
+    Conditions: {
+      IsProd: { 'Fn::Equals': [{ Ref: 'Stage' }, 'prod'] },
+    },
+    Resources: {
+      IamRole: {
+        Type: 'AWS::IAM::Role',
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: { Service: 'lambda.amazonaws.com' },
+                Action: 'sts:AssumeRole',
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: 'p',
+              PolicyDocument: {
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Action: 'logs:PutLogEvents',
+                    Resource: '*',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      WebSg: {
+        Type: 'AWS::EC2::SecurityGroup',
+        Properties: {
+          GroupDescription: 'web',
+          SecurityGroupIngress: [
+            {
+              IpProtocol: 'tcp',
+              FromPort: 443,
+              ToPort: 443,
+              CidrIp: '0.0.0.0/0',
+            },
+          ],
+        },
+      },
+      KeepMe: {
+        Type: 'AWS::SQS::Queue',
+        Properties: { QueueName: 'keep-me' },
+      },
+    },
+    Outputs: {
+      RoleArn: { Value: { 'Fn::GetAtt': ['IamRole', 'Arn'] } },
+    },
+    // Top-level key the upstream library doesn't know about — diffing this
+    // populates `templateDiff.unknown`, which renders as "Other Changes".
+    Hooks: {
+      MyHook: { Type: 'AWS::CloudFormation::Hook', Properties: { foo: 'old' } },
+    },
+  }
+
+  const nextTemplate = {
+    AWSTemplateFormatVersion: '2010-09-09',
+    Transform: 'AWS::Serverless-2016-10-31',
+    Description: 'Service deployed by Serverless Framework v2',
+    Parameters: {
+      Stage: { Type: 'String', Default: 'prod' },
+      RetainedParam: { Type: 'String', Default: 'keep-me' },
+      NewParam: { Type: 'Number', Default: 7 },
+    },
+    Metadata: {
+      Build: { commit: 'bbbbbbb', timestamp: '2024-02-01T00:00:00Z' },
+    },
+    Mappings: {
+      Regions: {
+        'us-east-1': { ami: 'ami-new' },
+        'us-west-2': { ami: 'ami-stable' },
+        'eu-west-1': { ami: 'ami-eu' },
+      },
+    },
+    Conditions: {
+      IsProd: { 'Fn::Equals': [{ Ref: 'Stage' }, 'prod'] },
+      HasEU: { 'Fn::Equals': [{ Ref: 'Stage' }, 'eu'] },
+    },
+    Resources: {
+      IamRole: {
+        Type: 'AWS::IAM::Role',
+        Properties: {
+          AssumeRolePolicyDocument: {
+            Statement: [
+              {
+                Effect: 'Allow',
+                Principal: { Service: 'lambda.amazonaws.com' },
+                Action: 'sts:AssumeRole',
+              },
+            ],
+          },
+          Policies: [
+            {
+              PolicyName: 'p',
+              PolicyDocument: {
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Action: 'logs:PutLogEvents',
+                    Resource: '*',
+                  },
+                  // New IAM statement — triggers IAM section diff.
+                  {
+                    Effect: 'Allow',
+                    Action: 's3:GetObject',
+                    Resource: 'arn:aws:s3:::my-bucket/*',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      WebSg: {
+        Type: 'AWS::EC2::SecurityGroup',
+        Properties: {
+          GroupDescription: 'web',
+          SecurityGroupIngress: [
+            {
+              IpProtocol: 'tcp',
+              FromPort: 443,
+              ToPort: 443,
+              CidrIp: '0.0.0.0/0',
+            },
+            // New ingress — triggers Security Group section diff.
+            {
+              IpProtocol: 'tcp',
+              FromPort: 80,
+              ToPort: 80,
+              CidrIp: '10.0.0.0/8',
+            },
+          ],
+        },
+      },
+      KeepMe: {
+        Type: 'AWS::SQS::Queue',
+        Properties: { QueueName: 'keep-me' },
+      },
+      // New resource (addition).
+      NewQueue: {
+        Type: 'AWS::SQS::Queue',
+        Properties: { QueueName: 'new' },
+      },
+    },
+    Outputs: {
+      RoleArn: { Value: { 'Fn::GetAtt': ['IamRole', 'Arn'] } },
+      NewQueueUrl: { Value: { Ref: 'NewQueue' } },
+    },
+    Hooks: {
+      MyHook: { Type: 'AWS::CloudFormation::Hook', Properties: { foo: 'new' } },
+    },
+  }
+
+  /**
+   * Sections where we render the same as upstream. These get a strict
+   * byte-equality check — drift here means upstream changed how it formats
+   * something we don't override, and we should update `renderDiff` to match.
+   */
+  const PRESERVED_SECTIONS = [
+    'Template',
+    'IAM Statement Changes',
+    'Security Group Changes',
+    'Resources',
+    'Other Changes',
+  ]
+
+  /**
+   * Sections we deliberately render differently (tree-style instead of the
+   * upstream library's single-line "OLD_JSON to NEW_JSON" dump). For these
+   * we still assert the section header appears — if upstream stops emitting
+   * the section entirely, our renderer should follow suit.
+   */
+  const OVERRIDDEN_SECTIONS = [
+    'Parameters',
+    'Metadata',
+    'Mappings',
+    'Conditions',
+    'Outputs',
+  ]
+
+  const ALL_SECTIONS = [...PRESERVED_SECTIONS, ...OVERRIDDEN_SECTIONS]
+
+  it('matches upstream byte-for-byte on sections that are not customized', () => {
+    const diff = diffTemplate(baseTemplate, nextTemplate)
+
+    const upstreamOutput = capture((stream) => formatDifferences(stream, diff))
+    const ourOutput = capture((stream) => renderDiff(stream, diff))
+
+    // Sanity: the test inputs must actually exercise the security section
+    // (whose advisory line we suppress) and every other section that exists
+    // today — otherwise the comparisons below would trivially pass.
+    expect(upstreamOutput).toMatch(SUPPRESSED_LINE)
+    expect(ourOutput).not.toMatch(SUPPRESSED_LINE)
+    for (const header of ALL_SECTIONS) {
+      expect(upstreamOutput).toContain(header)
+      expect(ourOutput).toContain(header)
+    }
+
+    // For each preserved section, lift the section's body out of both
+    // outputs and compare. Drift in any of these — new property, renamed
+    // header, reordered output, etc. — means upstream changed something we
+    // don't override, and our renderer needs to follow.
+    for (const header of PRESERVED_SECTIONS) {
+      const upstream = extractSection(upstreamOutput, header, ALL_SECTIONS)
+      const mine = extractSection(ourOutput, header, ALL_SECTIONS)
+      // Strip the suppressed advisory from the upstream side before compare,
+      // since we deliberately omit it (only relevant in the Security
+      // Group Changes / IAM Statement Changes neighbourhood, but cheap to
+      // apply globally).
+      const upstreamStripped = upstream
+        .split('\n')
+        .filter((line) => !SUPPRESSED_LINE.test(line))
+        .join('\n')
+      expect(mine).toBe(upstreamStripped)
+    }
+  })
+})
+
+/**
+ * The upstream default renderer dumps modifications to object-valued sections
+ * (Outputs, Parameters, Metadata, Mappings, Conditions) onto a single line as
+ * "OLD_JSON to NEW_JSON" — which becomes unreadable as soon as the value is
+ * more than a handful of fields. `renderDiff` overrides those sections to
+ * use the diff library's recursive `formatObjectDiff` (the same tree style
+ * the Resources section uses for property changes). These tests assert the
+ * tree shape so a future refactor that accidentally falls back to the
+ * single-line dump is caught at PR time.
+ */
+describe('renderDiff (tree-style rendering for object-valued sections)', () => {
+  const baseOutputs = {
+    Resources: {
+      Hello: { Type: 'AWS::Lambda::Function' },
+    },
+    Outputs: {
+      HelloArn: {
+        Description: 'Current Lambda function version',
+        Value: { Ref: 'HelloVersionOLDHASH' },
+        Export: { Name: 'svc-dev-HelloArn' },
+      },
+    },
+  }
+  const nextOutputs = {
+    Resources: {
+      Hello: { Type: 'AWS::Lambda::Function' },
+    },
+    Outputs: {
+      HelloArn: {
+        Description: 'Current Lambda function version',
+        Value: { Ref: 'HelloVersionNEWHASH' },
+        Export: { Name: 'svc-dev-HelloArn' },
+      },
+    },
+  }
+
+  it('renders a modified Output as a tree, not a single-line JSON dump', () => {
+    const diff = diffTemplate(baseOutputs, nextOutputs)
+    const output = stripAnsi(capture((stream) => renderDiff(stream, diff)))
+
+    // Header line should mention the Output and its logical id.
+    expect(output).toMatch(/\[~\] Output HelloArn/)
+
+    // The differing path should appear in a tree, with the old/new values
+    // on their own lines. The unchanged Description and Export fields must
+    // NOT appear (no full-blob dump).
+    expect(output).toMatch(/\.Value:/)
+    expect(output).toMatch(/\.Ref:/)
+    expect(output).toMatch(/\[-\] HelloVersionOLDHASH/)
+    expect(output).toMatch(/\[\+\] HelloVersionNEWHASH/)
+    expect(output).not.toContain('Current Lambda function version')
+    expect(output).not.toContain('svc-dev-HelloArn')
+
+    // Upstream's "OLD to NEW" connector is the smell we're avoiding.
+    expect(output).not.toMatch(
+      /HelloVersionOLDHASH.*\sto\s.*HelloVersionNEWHASH/,
+    )
+  })
+
+  it('renders a brand-new Output with only the header (no value blob dumped)', () => {
+    const onlyNew = {
+      Resources: {},
+      Outputs: { Fresh: { Value: { Ref: 'something' } } },
+    }
+    const diff = diffTemplate({ Resources: {} }, onlyNew)
+    const output = stripAnsi(capture((stream) => renderDiff(stream, diff)))
+    expect(output).toMatch(/\[\+\] Output Fresh/)
+    // No tree body for pure additions — header alone is enough; details
+    // belong in `--json` output, not the human-readable diff.
+    expect(output).not.toContain('Ref')
+  })
+})
+
+/**
+ * Extract a single section's body (header + lines, up to the next known
+ * section header) from a rendered diff output.
+ *
+ * Headers are emitted by upstream as `chalk.underline(chalk.bold(title))`,
+ * so the visible text includes ANSI escapes — strip them when matching the
+ * line against the plain-text header name.
+ */
+function extractSection(text, header, allHeaders) {
+  const headerSet = new Set(allHeaders)
+  const lines = text.split('\n')
+  let start = -1
+  let end = lines.length
+  for (let i = 0; i < lines.length; i++) {
+    const plain = stripAnsi(lines[i]).trim()
+    if (start === -1 && plain === header) {
+      start = i
+      continue
+    }
+    if (start !== -1 && headerSet.has(plain) && plain !== header) {
+      end = i
+      break
+    }
+  }
+  if (start === -1) return ''
+  // Drop trailing blank lines so section boundaries compare cleanly.
+  let last = end - 1
+  while (last > start && stripAnsi(lines[last]) === '') last -= 1
+  return lines.slice(start, last + 1).join('\n')
+}
+
+/**
+ * The framework's `package` step bakes a timestamp into every function's
+ * `Code.S3Key` (and every layer's `Content.S3Key`) on every run. Internally,
+ * `check-for-changes.js` neutralizes this churn before deciding whether a
+ * deploy is needed — by normalizing the template (blanking those keys) and
+ * comparing hashes. `run-diff.js` applies the same normalization so the
+ * structured diff doesn't surface noise the framework itself ignores.
+ *
+ * The tests below assert that contract: templates differing only in those
+ * keys produce an empty diff, while functional differences still appear.
+ */
+describe('normalizeForDiff (S3Key noise filter)', () => {
+  const lambdaTemplate = (s3Key) => ({
+    Resources: {
+      HelloLambdaFunction: {
+        Type: 'AWS::Lambda::Function',
+        Properties: {
+          FunctionName: 'svc-dev-hello',
+          Handler: 'handler.hello',
+          Runtime: 'nodejs20.x',
+          Code: {
+            S3Bucket: 'my-deployment-bucket',
+            S3Key: s3Key,
+          },
+        },
+      },
+    },
+  })
+
+  const layerTemplate = (s3Key) => ({
+    Resources: {
+      MyLayer: {
+        Type: 'AWS::Lambda::LayerVersion',
+        Properties: {
+          LayerName: 'shared-utils',
+          Content: { S3Bucket: 'my-deployment-bucket', S3Key: s3Key },
+        },
+      },
+    },
+  })
+
+  it('produces an empty resource diff when only Lambda Code.S3Key differs', () => {
+    const oldT = lambdaTemplate(
+      'serverless/svc/dev/1779304229564-2026-05-20T19:10:29.564Z/svc.zip',
+    )
+    const newT = lambdaTemplate(
+      'serverless/svc/dev/1779304365024-2026-05-20T19:12:45.024Z/svc.zip',
+    )
+    const diff = diffTemplate(normalizeForDiff(oldT), normalizeForDiff(newT))
+    expect(diff.resources.differenceCount).toBe(0)
+  })
+
+  it('produces an empty resource diff when only LayerVersion Content.S3Key differs', () => {
+    const oldT = layerTemplate(
+      'serverless/svc/dev/1779304229564-2026-05-20T19:10:29.564Z/layer.zip',
+    )
+    const newT = layerTemplate(
+      'serverless/svc/dev/1779304365024-2026-05-20T19:12:45.024Z/layer.zip',
+    )
+    const diff = diffTemplate(normalizeForDiff(oldT), normalizeForDiff(newT))
+    expect(diff.resources.differenceCount).toBe(0)
+  })
+
+  it('still surfaces functional Lambda changes (memory, env, runtime) after normalization', () => {
+    const oldT = lambdaTemplate('key-A')
+    oldT.Resources.HelloLambdaFunction.Properties.MemorySize = 256
+    oldT.Resources.HelloLambdaFunction.Properties.Environment = {
+      Variables: { LOG_LEVEL: 'info' },
+    }
+
+    const newT = lambdaTemplate('key-B') // S3Key churn alongside real changes
+    newT.Resources.HelloLambdaFunction.Properties.MemorySize = 1024
+    newT.Resources.HelloLambdaFunction.Properties.Environment = {
+      Variables: { LOG_LEVEL: 'debug' },
+    }
+    newT.Resources.HelloLambdaFunction.Properties.Runtime = 'nodejs22.x'
+
+    const diff = diffTemplate(normalizeForDiff(oldT), normalizeForDiff(newT))
+    const change = diff.resources.changes.HelloLambdaFunction
+    expect(change.isUpdate).toBe(true)
+    expect(Object.keys(change.propertyUpdates).sort()).toEqual([
+      'Environment',
+      'MemorySize',
+      'Runtime',
+    ])
+  })
+
+  it('handles empty templates (e.g., stack does not exist yet) without throwing', () => {
+    expect(() => normalizeForDiff({})).not.toThrow()
+    expect(() => normalizeForDiff(null)).not.toThrow()
+    expect(() => normalizeForDiff(undefined)).not.toThrow()
+  })
+
+  it('treats Lambda::Version logical-ID churn as the truthful signal of code change', () => {
+    // When code changes, the framework generates a new Lambda::Version with
+    // a new content-hashed logical ID, while the previous Version becomes
+    // an orphaned removal. This is what users will see in the diff instead
+    // of the S3Key change.
+    const oldT = {
+      Resources: {
+        HelloLambdaFunction:
+          lambdaTemplate('key-A').Resources.HelloLambdaFunction,
+        HelloLambdaVersionOLDHASH: {
+          Type: 'AWS::Lambda::Version',
+          Properties: { FunctionName: { Ref: 'HelloLambdaFunction' } },
+        },
+      },
+    }
+    const newT = {
+      Resources: {
+        HelloLambdaFunction:
+          lambdaTemplate('key-B').Resources.HelloLambdaFunction,
+        HelloLambdaVersionNEWHASH: {
+          Type: 'AWS::Lambda::Version',
+          Properties: { FunctionName: { Ref: 'HelloLambdaFunction' } },
+        },
+      },
+    }
+    const diff = diffTemplate(normalizeForDiff(oldT), normalizeForDiff(newT))
+    // No Lambda::Function update (S3Key normalized), but Version churn shows.
+    expect(diff.resources.changes.HelloLambdaFunction).toBeUndefined()
+    expect(diff.resources.changes.HelloLambdaVersionOLDHASH.isRemoval).toBe(
+      true,
+    )
+    expect(diff.resources.changes.HelloLambdaVersionNEWHASH.isAddition).toBe(
+      true,
+    )
+  })
+})
+
+/**
+ * `isStackNotFoundError` is what decides whether `--diff` falls back to the
+ * "everything is new" view (when the stack doesn't exist yet) or surfaces a
+ * real failure. The framework's `provider.request` wraps AWS SDK errors in a
+ * `ServerlessError` and preserves the original on `err.providerError`. These
+ * tests lock the unwrapping contract so any regression surfaces at PR time
+ * rather than against a live AWS account.
+ *
+ * Each shape mirrors what was actually observed running against AWS plus the
+ * raw-SDK shapes for completeness.
+ */
+/**
+ * Every error-class check in this module routes through `getEffectiveErrorClass`.
+ * The framework's `provider.request` wraps AWS SDK errors in a `ServerlessError`
+ * with the original on `err.providerError`, so a naïve check of `err.name` sees
+ * only the wrapper class. These tests lock the unwrapping logic so any new
+ * error-class check in this module gets the same correct behavior for free.
+ */
+describe('getEffectiveErrorClass', () => {
+  it('returns the inner provider error class when the framework wrapped it', () => {
+    expect(
+      getEffectiveErrorClass({
+        name: 'ServerlessError',
+        code: 'AWS_CLOUD_FORMATION_GET_TEMPLATE_VALIDATION_ERROR',
+        providerError: { name: 'ValidationError', code: 'ValidationError' },
+      }),
+    ).toBe('ValidationError')
+  })
+
+  it('falls back to direct `name` for raw SDK v3 errors', () => {
+    expect(getEffectiveErrorClass({ name: 'ResourceNotFoundException' })).toBe(
+      'ResourceNotFoundException',
+    )
+  })
+
+  it('falls back to direct `code` for raw SDK v2 errors', () => {
+    expect(getEffectiveErrorClass({ code: 'ValidationError' })).toBe(
+      'ValidationError',
+    )
+  })
+
+  it('prefers providerError.name over providerError.code', () => {
+    expect(
+      getEffectiveErrorClass({
+        providerError: { name: 'PreferredName', code: 'IgnoredCode' },
+      }),
+    ).toBe('PreferredName')
+  })
+
+  it('returns null when no class info is available', () => {
+    expect(getEffectiveErrorClass({ message: 'just a message' })).toBeNull()
+    expect(getEffectiveErrorClass(null)).toBeNull()
+    expect(getEffectiveErrorClass(undefined)).toBeNull()
+  })
+})
+
+describe('isStackNotFoundError', () => {
+  it('detects a framework-wrapped not-found error (real shape from AWS)', () => {
+    const err = {
+      name: 'ServerlessError',
+      code: 'AWS_CLOUD_FORMATION_GET_TEMPLATE_VALIDATION_ERROR',
+      message: 'Stack with id my-svc-dev does not exist',
+      providerError: {
+        name: 'ValidationError',
+        code: 'ValidationError',
+        message: 'Stack with id my-svc-dev does not exist',
+      },
+    }
+    expect(isStackNotFoundError(err)).toBe(true)
+  })
+
+  it('detects a raw SDK v2 not-found error', () => {
+    expect(
+      isStackNotFoundError({
+        code: 'ValidationError',
+        message: 'Stack with id my-svc-dev does not exist',
+      }),
+    ).toBe(true)
+  })
+
+  it('detects a raw SDK v3 not-found error', () => {
+    expect(
+      isStackNotFoundError({
+        name: 'ValidationException',
+        message: 'Stack with id my-svc-dev does not exist',
+      }),
+    ).toBe(true)
+  })
+
+  it('does NOT match an AccessDenied error that happens to mention "does not exist"', () => {
+    const err = {
+      name: 'ServerlessError',
+      code: 'AWS_CLOUD_FORMATION_ACCESS_DENIED',
+      message:
+        'User: ... is not authorized; stack id does not exist in that role',
+      providerError: { name: 'AccessDeniedException' },
+    }
+    expect(isStackNotFoundError(err)).toBe(false)
+  })
+
+  it('does NOT match an unrelated wrapped error with similar phrasing', () => {
+    expect(
+      isStackNotFoundError({
+        name: 'ServerlessError',
+        providerError: { name: 'SomeOtherException' },
+        message: 'Resource does not exist in stack with id foo',
+      }),
+    ).toBe(false)
+  })
+
+  it('does NOT match if the canonical phrasing is absent', () => {
+    expect(
+      isStackNotFoundError({
+        name: 'ValidationError',
+        message: 'something else entirely',
+      }),
+    ).toBe(false)
+  })
+
+  it('handles missing class info by trusting the canonical phrasing alone', () => {
+    expect(
+      isStackNotFoundError({
+        message: 'Stack with id my-svc-dev does not exist',
+      }),
+    ).toBe(true)
+  })
+
+  it('returns false for null / undefined', () => {
+    expect(isStackNotFoundError(null)).toBe(false)
+    expect(isStackNotFoundError(undefined)).toBe(false)
+  })
+})
+
+/**
+ * Render into an in-memory string by handing the formatter a Writable that
+ * accumulates chunks. Chalk emits ANSI codes regardless of the destination,
+ * so both captured streams use identical color sequences for identical
+ * content — no need to strip them before comparing.
+ */
+function capture(write) {
+  const chunks = []
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(chunk)
+      callback()
+    },
+  })
+  write(stream)
+  return Buffer.concat(chunks).toString('utf8')
+}

--- a/packages/serverless/test/unit/lib/plugins/aws/lib/hash-file.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/lib/hash-file.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals'
+import crypto from 'crypto'
+import { writeFile, mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import {
+  hashFile,
+  hashContent,
+} from '../../../../../../lib/plugins/aws/lib/hash-file.js'
+
+/**
+ * The helpers in `hash-file.js` exist to centralize the SHA-256/base64
+ * incantation the framework uses to identify Lambda code and uploaded
+ * artifacts. The format MUST match `crypto.createHash('sha256').update(x)
+ * .digest('base64')` exactly — that's the format AWS Lambda reports as
+ * `Configuration.CodeSha256` and the framework writes as `filesha256`
+ * metadata on uploaded S3 objects. A regression here would silently
+ * mis-identify code as "changed" (or worse, "unchanged") in `--diff`.
+ *
+ * These tests lock the output format and the helpers' equivalence to a
+ * directly-inlined call.
+ */
+describe('hash-file helpers', () => {
+  describe('hashContent', () => {
+    it('matches a direct crypto.createHash call for a string input', () => {
+      const data = 'the quick brown fox jumps over the lazy dog'
+      const expected = crypto.createHash('sha256').update(data).digest('base64')
+      expect(hashContent(data)).toBe(expected)
+    })
+
+    it('matches a direct crypto.createHash call for a Buffer input', () => {
+      const data = Buffer.from([0x00, 0xff, 0x42, 0x10, 0x55])
+      const expected = crypto.createHash('sha256').update(data).digest('base64')
+      expect(hashContent(data)).toBe(expected)
+    })
+
+    it('returns a stable, deterministic hash', () => {
+      const data = 'reproducibility check'
+      expect(hashContent(data)).toBe(hashContent(data))
+    })
+
+    it('produces different hashes for different inputs', () => {
+      expect(hashContent('a')).not.toBe(hashContent('b'))
+    })
+
+    it('produces base64 output (not hex)', () => {
+      // SHA-256 in base64 is 44 characters (with a trailing "="), in hex it
+      // would be 64 characters. Lock the encoding so a future refactor can't
+      // silently switch.
+      const hash = hashContent('any value')
+      expect(hash).toHaveLength(44)
+      expect(hash).toMatch(/^[A-Za-z0-9+/]+=$/)
+    })
+  })
+
+  describe('hashFile', () => {
+    let tmpDir
+    let smallFile
+    let mediumFile
+
+    beforeAll(async () => {
+      tmpDir = await mkdtemp(path.join(tmpdir(), 'sls-hash-file-test-'))
+      smallFile = path.join(tmpDir, 'small.bin')
+      mediumFile = path.join(tmpDir, 'medium.bin')
+      await writeFile(smallFile, 'hello world')
+      // ~64 KB to make sure we don't depend on a single-chunk read path.
+      await writeFile(mediumFile, Buffer.alloc(64 * 1024, 0xab))
+    })
+
+    afterAll(async () => {
+      await rm(tmpDir, { recursive: true, force: true })
+    })
+
+    it('returns the same hash as crypto.createHash on the file contents', async () => {
+      const buf = Buffer.from('hello world')
+      const expected = crypto.createHash('sha256').update(buf).digest('base64')
+      expect(await hashFile(smallFile)).toBe(expected)
+    })
+
+    it('agrees with hashContent on the same file buffer', async () => {
+      const buf = Buffer.alloc(64 * 1024, 0xab)
+      expect(await hashFile(mediumFile)).toBe(hashContent(buf))
+    })
+
+    it('rejects with an error when the file does not exist', async () => {
+      await expect(hashFile(path.join(tmpDir, 'missing.bin'))).rejects.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds `serverless diff` — a new top-level command that shows how the locally-packaged CloudFormation template compares to the stack currently deployed in AWS. Useful for reviewing changes before running `deploy`, especially in CI / PR-review workflows.

- Renders a structured diff (resources, IAM tables, security groups, parameters, outputs, etc.) using the `@aws-cdk/cloudformation-diff` library.
- Reports per-function code changes in a `Function Code` section by comparing local zip hashes against each Lambda's `CodeSha256`.
- `--json` flag emits a stable machine-readable summary for CI pipelines.
- `--package <path>` points at an existing package directory and skips re-packaging — useful when the artifact was produced by an earlier CI step.
- Treats a non-existent stack as "everything is new" rather than erroring out.
- Exit code is `0` unless an unrecoverable error occurs.
- Documentation added under [`docs/sf/providers/aws/cli-reference/diff.md`](docs/sf/providers/aws/cli-reference/diff.md).

Also bundles a separate packaging fix: the service configuration file (`serverless.yml` / `serverless.ts` / ...) was being included in the deployable Lambda zip. The exclusion logic now correctly identifies the active config file across all supported extensions and custom filenames, so user configuration no longer ships to AWS Lambda.

## Usage

```bash
# Default: colored text diff to stdout (colored when run in a TTY)
serverless diff

# Machine-readable JSON for CI
serverless diff --json

# Diff against an existing package directory; skip the auto-package step
serverless diff --package ./.serverless
```

## Options

- `--stage` / `-s` — service stage to diff against
- `--region` / `-r` — service region to diff against
- `--aws-profile` — AWS profile to use
- `--stack` — CloudFormation stack name override
- `--package` / `-p` — path to an existing package directory to diff against (skips auto-package)
- `--json` — emit the diff as JSON

## Examples

### No changes against the deployed stack

```
Packaging "my-service" for stage "dev" (us-east-1)
No function code changes
No infrastructure changes against the deployed stack
✔ Service packaged (2s)
```

### Configuration-only change (Lambda memory bump)

```
No function code changes

Resources
[~] AWS::Lambda::Function HelloLambdaFunction
 └─ [~] MemorySize
     ├─ [-] 1024
     └─ [+] 2048

Resources: 1 to create, 1 to update, 1 to remove
```

`No function code changes` confirms handler code is identical to what is deployed; the structured diff shows the property change and the matching Lambda Version churn that CloudFormation will perform.

### Code-only change (handler edit, no config change)

```
Function Code
[~] hello
[~] goodbye

Resources
[-] AWS::Lambda::Version HelloLambdaVersion3rde2gUOpvd… orphan
[-] AWS::Lambda::Version GoodbyeLambdaVersion3o1zjawHn… orphan
[+] AWS::Lambda::Version HelloLambdaVersionymnhJ7QiGZ…
[+] AWS::Lambda::Version GoodbyeLambdaVersionui2HS54XZ…

Resources: 2 to create, 0 to update, 2 to remove
```

Both functions appear under `Function Code` because they share a single zip under default packaging. Services using `package.individually: true` see per-function granularity.

### Replacement (resource will be destroyed and recreated)

```
[~] AWS::Lambda::Function HelloLambdaFunction replace
 ├─ [~] FunctionName (requires replacement)
 │   ├─ [-] my-service-dev-hello
 │   └─ [+] hello-renamed
 ├─ [~] Code
 └─ [~] MemorySize
     ├─ [-] 256
     └─ [+] 1024
```

The `replace` marker on the resource header and `(requires replacement)` on the offending property make destroy-and-recreate operations unmistakable.

### IAM changes (security-relevant)

```
IAM Statement Changes
┌───┬────────────────────────────────────┬────────┬──────────────┬───────────────────────────────┬───────────┐
│   │ Resource                           │ Effect │ Action       │ Principal                     │ Condition │
├───┼────────────────────────────────────┼────────┼──────────────┼───────────────────────────────┼───────────┤
│ + │ arn:aws:s3:::my-bucket/*           │ Allow  │ s3:GetObject │ AWS:${IamRoleLambdaExecution} │           │
└───┴────────────────────────────────────┴────────┴──────────────┴───────────────────────────────┴───────────┘
```

A dedicated IAM table appears whenever IAM or Security Group changes are part of the diff — useful for security review.

### Stack does not exist yet (first deploy)

```
Stack "my-service-dev" does not exist yet — treating all resources as new.
Function Code
[+] hello
[+] goodbye

Resources
[+] AWS::Logs::LogGroup HelloLogGroup
[+] AWS::IAM::Role IamRoleLambdaExecution
[+] AWS::Lambda::Function HelloLambdaFunction
...

Resources: 7 to create, 0 to update, 0 to remove
```

### JSON output

```bash
serverless diff --json
```

```json
{
  "code": {
    "changed": ["hello"],
    "new": ["welcome"]
  },
  "summary": {
    "create": 4,
    "update": 0,
    "remove": 4
  },
  "resources": [
    {
      "logicalId": "WelcomeLambdaFunction",
      "changeType": "create",
      "resourceType": "AWS::Lambda::Function"
    },
    {
      "logicalId": "GoodbyeLambdaFunction",
      "changeType": "remove",
      "resourceType": "AWS::Lambda::Function"
    }
  ]
}
```

The `code` field reports per-function code changes:

- `changed` — functions whose deployed `CodeSha256` differs from the local zip hash.
- `new` — functions present locally but not in the deployed stack.

Functions not listed in either array are unchanged (or are container-image functions / `package.disable: true`, which are excluded since they have no comparable zip artifact). If a function's remote configuration cannot be read — typically a missing `lambda:GetFunction` permission, or a Lambda missing in AWS despite being present in the deployed CloudFormation template — the diff fails fast with a clear error rather than producing a partial-state report.

The `summary` field aggregates CloudFormation resource changes by type. The `resources` array lists each changed resource with its CloudFormation logical ID and resource type.

### Diffing an existing package directory

When the artifact directory already exists — for example, packaged in an earlier CI step — pass it explicitly to skip the auto-package step:

```bash
serverless diff --package ./.serverless
```

This reads the CloudFormation template and zip artifacts from the given directory rather than regenerating them.

## Behavior notes

- The structured diff applies the same template normalization the framework uses internally to decide whether a deploy is necessary, so artifact-key churn that the framework considers meaningless does not appear in the diff.
- The `Function Code` section is the truthful "did handler code change?" signal — it compares zip hashes against AWS Lambda's `CodeSha256`. It is independent of the template-level diff below it.
- Custom configuration filenames (`--config my-service.yml`) are supported.
- Works with both AWS SDK v2 (default) and AWS SDK v3 (`SLS_AWS_SDK=3`).
- The text diff is colored when stdout is a TTY (standard `chalk` behavior — colors are stripped automatically when piped or redirected).

## Test plan

- [x] Unit tests for the new helpers, diff rendering, error-class detection, and tree-style Outputs (58 tests added, all green)
- [x] Pre-existing `package-service` exclusion test still passes (covers the config-file exclusion fix)
- [x] End-to-end manual verification against real AWS for: no changes, code-only change, config-only change, mixed changes, function addition, function removal, function rename (forced replacement), IAM changes, custom CloudFormation resources, `--json` output, non-existent stack, custom config filename (`--config`), custom package directory (`--package`) with paths both inside and outside the service directory, stale `.serverless/` directory recovery, empty service (no functions), `package.disable: true` functions, `info --json` not affected by the new plugin
- [x] Verified output is identical under `SLS_AWS_SDK=3`
- [x] Confirmed plain `serverless package` (no diff-related options) behavior is unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `sls diff` to preview infra and function code changes (AWS-aware), with formatted or `--json` output; registers new diff plugins and CLI command
  * Detects per-function code changes, honors per-function vs shared packaging, and resolves function artifact paths
  * Centralized SHA‑256 hashing for reliable code-change detection

* **Bug Fixes**
  * Improved exclusion logic for service configuration files from packaged artifacts

* **Documentation**
  * Added comprehensive CLI reference for the diff command

* **Tests**
  * Added unit tests for hashing, diff rendering, normalization, remote SHA checks, and error handling

* **Chores**
  * Added CloudFormation diff library dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New AWS API usage (CloudFormation getTemplate, Lambda getFunction) and IAM-focused diff output for review; the packaging exclusion change alters what ships in Lambda zips and should be validated on real services.
> 
> **Overview**
> Adds **`serverless diff`** to compare the locally packaged CloudFormation template with the deployed stack—aimed at pre-deploy and CI review.
> 
> The command **auto-packages** unless `--package` points at an existing artifact dir. It reports **per-function code changes** (local zip SHA-256 vs Lambda `CodeSha256`) separately from a **structured infrastructure diff** via `@aws-cdk/cloudformation-diff`, with template **normalization** so meaningless `S3Key` churn is hidden (aligned with deploy change detection). **`--json`** exposes code, resource summary, and per-resource changes; a missing stack is treated as all-new; Lambda verification failures **fail fast** instead of partial output.
> 
> Also fixes packaging so the active **service config file** (custom names and all supported extensions) is **excluded from the Lambda deployment zip**, and adds CLI docs plus unit tests for rendering, normalization, hashing, and stack-not-found handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f53d729313b6a1d1c33ac167211fb97ad4fb7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->