### PR TITLE
feat: add ruby4.0 runtime

### DIFF
--- a/packages/serverless/lib/plugins/aws/invoke-local/index.js
+++ b/packages/serverless/lib/plugins/aws/invoke-local/index.js
@@ -416,7 +416,9 @@ class AwsInvokeLocal {
       )
     }
 
-    if (['ruby2.7', 'ruby3.2', 'ruby3.3', 'ruby3.4'].includes(runtime)) {
+    if (
+      ['ruby2.7', 'ruby3.2', 'ruby3.3', 'ruby3.4', 'ruby4.0'].includes(runtime)
+    ) {
       const handlerComponents = handler.split(/\./)
       const handlerPath = handlerComponents[0]
       const handlerName = handlerComponents.slice(1).join('.')

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -764,6 +764,7 @@ environment:
               'ruby3.2',
               'ruby3.3',
               'ruby3.4',
+              'ruby4.0',
             ],
           },
           awsLambdaRuntimeManagement: {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/TESTING.md
--

<!-- ⚠️⚠️ Ensure that support for Node.js v18 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/test/TESTING.md#integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

AWS recently added support for Ruby 4.0.
https://aws.amazon.com/about-aws/whats-new/2026/04/aws-lambda-adds-ruby/

- [x] npm run prettier
- [x] npm run lint
- [x] npm test

I have read the CLA Document and I hereby sign the CLA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ruby 4.0 Lambda runtime. You can now use Ruby 4.0 as a runtime option for deploying and locally testing serverless functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/serverless/serverless/pull/13613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->