### PR TITLE
fix(deps): bump axios to 1.16.1 to patch security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5307,14 +5307,40 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -14029,7 +14055,7 @@
         "@smithy/node-http-handler": "^4.4.14",
         "@smithy/util-retry": "^4.4.4",
         "adm-zip": "^0.5.17",
-        "ajv": "^8.20.0",
+        "ajv": "8.20.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "3.0.1",
         "appdirectory": "^0.1.0",


### PR DESCRIPTION
## What

Bumps the transitive `axios` dependency from **1.15.2 → 1.16.1** in `package-lock.json`.

axios is not a direct dependency — it is pulled in transitively by `@slack/web-api` (`^1.15.0`) and `aws-crt` (`^1.12.2`). Both ranges accept 1.16.x, so no `package.json` changes were needed. The bump was done with `npm update axios --package-lock-only`.

## Why

Patches four Dependabot advisories, all in axios and all fixed in 1.16.0:

| Alert | Issue |
|-------|-------|
| #679 | Read-side prototype-pollution gadgets (header injection / crash DoS) |
| #678 | `Proxy-Authorization` injection via PP (incomplete null-proto fix) |
| #680 | `NO_PROXY` bypass via IPv4-mapped IPv6 addresses |
| #681 | Full MITM via `config.proxy` PP gadget |

## Notes for reviewer

- Only one axios resolution remains in the lockfile (`axios-1.16.1.tgz`); no nested vulnerable copies. `npm audit` reports no axios advisories.
- The diff also bumps axios's own deps (`follow-redirects`) and adds `https-proxy-agent`/`agent-base` — expected for 1.16.1.
- One incidental line: `ajv` in the `packages/serverless` block changed `^8.20.0 → 8.20.0`. This is npm correcting pre-existing lockfile drift — `packages/serverless/package.json` already pins `ajv` to `8.20.0`.
- One unrelated low-severity advisory (`aws-sdk` v2 region validation) is left untouched; its only fix is a breaking major change, out of scope here.