### PR TITLE
chore: bump Go to 1.26.4 for binary-installer

### DIFF
--- a/.github/workflows/ci-binary-installer.yml
+++ b/.github/workflows/ci-binary-installer.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '>=1.26.3'
+          go-version: '>=1.26.4'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Test: Unit'
         run: make test

--- a/.github/workflows/release-binary-installer.yml
+++ b/.github/workflows/release-binary-installer.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '>=1.26.3'
+          go-version: '>=1.26.4'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1

--- a/binary-installer/go.mod
+++ b/binary-installer/go.mod
@@ -1,6 +1,6 @@
 module sf-core
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
## What

Bumps the `binary-installer` Go toolchain from `1.26.3` to `1.26.4`.

## Changes

- `binary-installer/go.mod` — `go 1.26.4`
- `.github/workflows/ci-binary-installer.yml` — `go-version: '>=1.26.4'`
- `.github/workflows/release-binary-installer.yml` — `go-version: '>=1.26.4'`

Picks up the latest upstream Go patch release. No dependency or source changes; `go build ./...` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version requirement to `>= 1.26.4` for binary installer builds and related CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->