### PR TITLE
fix: include esbuild build output assets in packages

### DIFF
--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -789,6 +789,7 @@ class Esbuild {
                 `.${functionName}`,
                 '',
               )
+              const addedFiles = new Set()
 
               const packageJsonPath = path.join(
                 this.serverless.config.serviceDir,
@@ -799,6 +800,7 @@ class Esbuild {
 
               if (existsSync(packageJsonPath)) {
                 zip.file(packageJsonPath, { name: `package.json` })
+                addedFiles.add(packageJsonPath)
               }
 
               // Add lockfiles if they exist
@@ -817,6 +819,7 @@ class Esbuild {
                 )
                 if (existsSync(lockFilePath)) {
                   zip.file(lockFilePath, { name: destName })
+                  addedFiles.add(lockFilePath)
                 }
               }
 
@@ -828,11 +831,13 @@ class Esbuild {
               )
 
               zip.file(handlerZipPath, { name: `${handlerPath}.js` })
+              addedFiles.add(handlerZipPath)
 
               if (existsSync(`${handlerZipPath}.map`)) {
                 zip.file(`${handlerZipPath}.map`, {
                   name: `${handlerPath}.js.map`,
                 })
+                addedFiles.add(`${handlerZipPath}.map`)
               }
 
               zip.directory(
@@ -845,17 +850,23 @@ class Esbuild {
                 'node_modules',
               )
 
+              await this._addBuildFilesToZip(zip, addedFiles)
+
               await Promise.all(
                 includesToPackage.map(async (filePath) => {
                   const absolutePath = path.join(
                     this.serverless.config.serviceDir,
                     filePath,
                   )
+                  if (addedFiles.has(absolutePath)) {
+                    return
+                  }
                   const stats = await stat(absolutePath)
                   if (stats.isDirectory()) {
                     zip.directory(absolutePath, filePath)
                   } else {
                     zip.file(absolutePath, { name: filePath })
+                    addedFiles.add(absolutePath)
                   }
                 }),
               )
@@ -979,9 +990,14 @@ class Esbuild {
           'node_modules',
         )
 
+        await this._addBuildFilesToZip(zip, addedFiles)
+
         await Promise.all(
           packageIncludes.map(async (filePath) => {
             const absolutePath = path.join(this.serverless.serviceDir, filePath)
+            if (addedFiles.has(absolutePath)) {
+              return
+            }
             const stats = await stat(absolutePath)
             if (stats.isDirectory()) {
               zip.directory(absolutePath, filePath)
@@ -1001,6 +1017,37 @@ class Esbuild {
       await zipPromise
     } catch (err) {
       throw new ServerlessError(err.message, 'ESBULD_PACKAGE_ALL_ERROR')
+    }
+  }
+
+  async _addBuildFilesToZip(zip, addedFiles) {
+    const buildDir = path.join(
+      this.serverless.config.serviceDir,
+      '.serverless',
+      'build',
+    )
+
+    const buildFiles = await globby(['**/*'], {
+      cwd: buildDir,
+      dot: true,
+      onlyFiles: true,
+      ignore: [
+        'node_modules/**',
+        'package.json',
+        'package-lock.json',
+        'yarn.lock',
+        'pnpm-lock.yaml',
+      ],
+    })
+
+    for (const filePath of buildFiles) {
+      const absolutePath = path.join(buildDir, filePath)
+      if (addedFiles.has(absolutePath) || addedFiles.has(filePath)) {
+        continue
+      }
+      zip.file(absolutePath, { name: filePath })
+      addedFiles.add(absolutePath)
+      addedFiles.add(filePath)
     }
   }
 

--- a/packages/serverless/test/unit/lib/plugins/esbuild/index.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/index.test.js
@@ -1,0 +1,124 @@
+import {
+  jest,
+  describe,
+  beforeEach,
+  afterEach,
+  it,
+  expect,
+} from '@jest/globals'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import fsp from 'fs/promises'
+import JsZip from 'jszip'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: {
+    debug: jest.fn(),
+    get: jest.fn(() => ({ debug: jest.fn(), warning: jest.fn() })),
+  },
+}))
+
+const { default: Esbuild } =
+  await import('../../../../../lib/plugins/esbuild/index.js')
+
+describe('Esbuild', () => {
+  let tmpDirPath
+  let serverless
+  let esbuildPlugin
+
+  function getTmpDirPath() {
+    return path.join(
+      os.tmpdir(),
+      'serverless-esbuild-test-' +
+        Date.now() +
+        '-' +
+        Math.random().toString(36).slice(2),
+    )
+  }
+
+  function writeFile(filePath, content = '') {
+    const absolutePath = path.join(tmpDirPath, filePath)
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true })
+    fs.writeFileSync(absolutePath, content)
+  }
+
+  function writeBuildOutput() {
+    writeFile('.serverless/build/package.json', '{}')
+    writeFile('.serverless/build/src/api/handler.js', 'exports.main = () => {}')
+    writeFile('.serverless/build/src/api/handler.js.map', '{}')
+    writeFile('.serverless/build/src/locales/en.json', '{"locale":"en"}')
+    writeFile(
+      '.serverless/build/src/workers/locales/en.json',
+      '{"locale":"en"}',
+    )
+    writeFile(
+      '.serverless/build/node_modules/pkg/index.js',
+      'module.exports = {}',
+    )
+  }
+
+  async function expectZipIncludesBuildOutput(artifact) {
+    const data = fs.readFileSync(artifact)
+    const zip = new JsZip()
+    const unzippedData = await zip.loadAsync(data)
+    const unzippedFileData = unzippedData.files
+
+    expect(unzippedFileData['src/api/handler.js']).toBeDefined()
+    expect(unzippedFileData['src/api/handler.js.map']).toBeDefined()
+    expect(unzippedFileData['src/locales/en.json']).toBeDefined()
+    expect(unzippedFileData['src/workers/locales/en.json']).toBeDefined()
+    expect(unzippedFileData['node_modules/pkg/index.js']).toBeDefined()
+  }
+
+  beforeEach(() => {
+    tmpDirPath = getTmpDirPath()
+    fs.mkdirSync(tmpDirPath, { recursive: true })
+
+    serverless = {
+      serviceDir: tmpDirPath,
+      config: { serviceDir: tmpDirPath },
+      service: {
+        service: 'test-service',
+        package: { patterns: [] },
+      },
+      pluginManager: {
+        spawn: jest.fn(),
+      },
+    }
+    esbuildPlugin = new Esbuild(serverless, {})
+  })
+
+  afterEach(async () => {
+    await fsp.rm(tmpDirPath, { recursive: true, force: true })
+  })
+
+  describe('#_packageAll()', () => {
+    it('should include files emitted to the build directory besides handlers', async () => {
+      writeBuildOutput()
+
+      await esbuildPlugin._packageAll({
+        api: { handler: 'src/api/handler.main' },
+      })
+
+      await expectZipIncludesBuildOutput(serverless.service.package.artifact)
+    })
+  })
+
+  describe('#_package()', () => {
+    it('should include files emitted to the build directory when packaging individually', async () => {
+      writeBuildOutput()
+      serverless.service.package.individually = true
+
+      const functionObject = { handler: 'src/api/handler.main' }
+      jest.spyOn(esbuildPlugin, 'functions').mockResolvedValue({
+        api: functionObject,
+      })
+      jest.spyOn(esbuildPlugin, '_buildProperties').mockResolvedValue({})
+
+      await esbuildPlugin._package()
+
+      await expectZipIncludesBuildOutput(functionObject.package.artifact)
+    })
+  })
+})


### PR DESCRIPTION
Closes: #13163

This updates the native esbuild packaging step to include additional files emitted into `.serverless/build`, such as assets copied by esbuild plugins, while still skipping generated package metadata, lockfiles, `node_modules`, handlers, and sourcemaps that are already added explicitly.

The new unit coverage verifies both service-wide packaging and individually packaged functions include copied build output files in the final zip.

AI assistance was used while drafting this patch; I reviewed the diff and verified the results below.

Targeted checks run:
- `npm run test:unit -w @serverless/framework -- test/unit/lib/plugins/esbuild/index.test.js --runInBand`
- `npx prettier -c packages/serverless/lib/plugins/esbuild/index.js packages/serverless/test/unit/lib/plugins/esbuild/index.test.js`
- `npx eslint packages/serverless/lib/plugins/esbuild/index.js packages/serverless/test/unit/lib/plugins/esbuild/index.test.js`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved esbuild output packaging to ensure build artifacts are correctly included in ZIP files without duplicates during both individual and combined function packaging.

* **Tests**
  * Added comprehensive unit tests verifying build artifacts and sourcemaps are properly packaged in generated ZIP files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->