### PR TITLE
fix(resolvers): reliably resolve variables referenced via JS/TS file resolvers

### DIFF
--- a/packages/sf-core/src/lib/resolvers/manager.js
+++ b/packages/sf-core/src/lib/resolvers/manager.js
@@ -576,36 +576,56 @@ export class ResolverManager {
     selectedProviders = [],
     selectedPaths = [],
     graph,
-    state = this.processingState,
   } = {}) {
     const filteredGraph = this.#createFilteredGraph(
       graph,
       selectedPaths,
       selectedProviders,
     )
+    // Save the active-pass context on entry and restore it on exit; each pass
+    // also gets its own `state`. Do NOT clear `graphBeingProcessed` or share one
+    // `processingState` across passes.
+    //
+    // Resolution is re-entrant: a JS/TS file resolver can call resolveVariable()
+    // or resolveConfigurationProperty(), which open a nested pass here. The
+    // fields must always point at the innermost running pass and fall back to
+    // its parent when it exits. If a nested pass cleared them instead, the
+    // still-running outer pass would look inactive, and a later re-entrant call
+    // would start its own narrow pass (scoped to a temporary property) that runs
+    // alongside the outer pass and can leave nested placeholders unresolved.
+    // Stacking the context keeps re-entrant calls on the outermost (unscoped)
+    // pass so the full dependency chain resolves cooperatively.
+    const previousGraph = this.graphBeingProcessed
+    const previousState = this.processingState
+    const state = {}
     this.graphBeingProcessed = filteredGraph
-    await processGraphInParallel(
-      filteredGraph,
-      async (nodeName) => {
-        const nodeLabel = filteredGraph.node(nodeName)
-        if (nodeLabel?.provider) {
-          this.#handleProviderNode(nodeName)
-        } else if (nodeLabel?.dedicatedResolverConfig) {
-          this.#handleDedicatedResolverNode(nodeName, filteredGraph)
-        } else {
-          await this.#handlePlaceholderNode(
-            nodeName,
-            nodeLabel,
-            filteredGraph,
-            selectedProviders,
-            selectedPaths,
-          )
-        }
-      },
-      graph,
-      state,
-    )
-    this.graphBeingProcessed = null
+    this.processingState = state
+    try {
+      await processGraphInParallel(
+        filteredGraph,
+        async (nodeName) => {
+          const nodeLabel = filteredGraph.node(nodeName)
+          if (nodeLabel?.provider) {
+            this.#handleProviderNode(nodeName)
+          } else if (nodeLabel?.dedicatedResolverConfig) {
+            this.#handleDedicatedResolverNode(nodeName, filteredGraph)
+          } else {
+            await this.#handlePlaceholderNode(
+              nodeName,
+              nodeLabel,
+              filteredGraph,
+              selectedProviders,
+              selectedPaths,
+            )
+          }
+        },
+        graph,
+        state,
+      )
+    } finally {
+      this.graphBeingProcessed = previousGraph
+      this.processingState = previousState
+    }
   }
 
   #addResolverProvider = (nodeName) => {

--- a/packages/sf-core/tests/unit/resolvers/manager.test.js
+++ b/packages/sf-core/tests/unit/resolvers/manager.test.js
@@ -642,6 +642,71 @@ describe('ResolverManager', () => {
     })
   })
 
+  describe('Re-entrant resolution (pass context)', () => {
+    // Regression guard: a JS/TS file resolver can call resolveVariable() or
+    // resolveConfigurationProperty() while the framework is already resolving a
+    // value. Each such call opens a nested resolution pass. The nested pass must
+    // NOT strand the outer pass — previously it reset `graphBeingProcessed` to
+    // null on exit, so a subsequent re-entrant call saw "no pass running" and
+    // spun up its own narrow, racing pass that could leave nested placeholders
+    // unresolved (observed only under certain async schedules, e.g. jest 30.4.x).
+    // The active-pass context must be saved and restored, not cleared.
+    test('nested resolution restores the outer pass context', async () => {
+      const serviceConfig = {
+        service: 'test-service',
+        provider: { stage: 'dev' },
+        custom: { simple: 'plain' },
+        target: '${probe:run}',
+      }
+      // Use a local manager so this test does not mutate the shared `manager`
+      // that sibling describes rely on.
+      const reentrantManager = new ResolverManager(
+        mockLogger,
+        serviceConfig,
+        '/path/to/config',
+        { stage: 'dev' },
+        null,
+        null,
+        null,
+        false,
+        '4.0.0',
+      )
+
+      let graphDuringOuterPass
+      let graphAfterNestedPass
+      const probe = jest.fn(async () => {
+        // We are inside the outer pass that is resolving `target`.
+        graphDuringOuterPass = reentrantManager.graphBeingProcessed
+        // Mirror a file resolver reaching back into the manager mid-resolution.
+        await reentrantManager.resolveConfigurationProperty([
+          'custom',
+          'simple',
+        ])
+        // The outer pass must still be active after the nested pass returns.
+        graphAfterNestedPass = reentrantManager.graphBeingProcessed
+        return 'done'
+      })
+
+      reentrantManager.addResolverProvider('probe', {
+        instance: { constructor: { type: 'probe', defaultResolver: 'run' } },
+        resolvers: { run: probe, default: probe },
+      })
+
+      await reentrantManager.loadPlaceholders()
+      await reentrantManager.resolveAndReplacePlaceholdersInConfig({
+        selectedPaths: [['target']],
+      })
+
+      expect(probe).toHaveBeenCalled()
+      // The outer pass was active when the resolver ran...
+      expect(graphDuringOuterPass).toBeTruthy()
+      // ...and remained the SAME active pass after the nested resolution,
+      // rather than being cleared to null (the pre-fix behavior).
+      expect(graphAfterNestedPass).toBe(graphDuringOuterPass)
+      expect(reentrantManager.serviceConfigFile.target).toBe('done')
+    })
+  })
+
   describe('Resolution Scenarios (Edge Cases)', () => {
     test('resolves fallback when source is missing', async () => {
       // Fallback string must be valid JSON (quoted)


### PR DESCRIPTION
## Summary

When a configuration value is resolved through a JavaScript or TypeScript file (for example `${file(resolver.js):export}`) and that file resolves additional variables while it runs (via `resolveVariable` / `resolveConfigurationProperty`), nested variables in the returned value could, in some edge cases, be left unresolved — returned as the literal `${...}` text instead of the resolved value.

It only happened in specific cases, and only sometimes: it depended on the order in which variables happened to resolve, so the large majority of configurations were never affected.

## What changed

A file resolver can ask the framework to resolve additional variables while the configuration itself is still being resolved. Those nested requests now join the resolution already in progress, instead of running as a separate one that could miss part of the dependency chain. As a result, dependent variables resolve consistently regardless of order.

## Impact

- Configurations that already resolved correctly are unaffected — same output, same behavior.
- Configurations that previously hit the edge case now resolve fully and consistently.
- No changes to configuration syntax or public APIs.

## Testing

- Added a regression test covering the nested-resolution case.
- Existing resolver unit and integration test suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where resolvers triggered during configuration placeholder resolution could interfere with parent resolution contexts, preventing proper handling of nested resolver invocations in complex configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->