### PR TITLE
fix(api-gateway): use resolved API Gateway stage for stage tags and service endpoint

### DIFF
--- a/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/deployment.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/deployment.js
@@ -38,7 +38,7 @@ export default {
                 { Ref: 'AWS::Region' },
                 '.',
                 { Ref: 'AWS::URLSuffix' },
-                `/${this.provider.getStage()}`,
+                `/${this.provider.getApiGatewayStage()}`,
               ],
             ],
           },

--- a/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js
@@ -346,7 +346,7 @@ function handleTags() {
   )
 
   const restApiId = this.apiGatewayRestApiId
-  const stageName = this.options.stage
+  const stageName = this.provider.getApiGatewayStage()
   const region = this.options.region
   const partition = this.partition
   const resourceArn = `arn:${partition}:apigateway:${region}::/restapis/${restApiId}/stages/${stageName}`


### PR DESCRIPTION
## Summary

When `provider.apiGateway.stage` is set to a value different from `provider.stage`, the post-deploy stage update fails and rolls the deployment back:

```yaml
provider:
  stage: prod-eu
  apiGateway:
    stage: prod
  tags:
    team: my-team
```

```
ServerlessError: Stage prod-eu on RestApi <id> was not found
```

Changes:

- `handleTags()` in `packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/hack/update-stage.js` now builds the stage ARN for `tagResource`/`untagResource` from `provider.getApiGatewayStage()` — the stage actually deployed by CloudFormation — instead of `options.stage`. This also makes the read/modify/write of stage tags consistent: `resolveStage()` already read current tags via `getApiGatewayStage()`, while writes targeted a different stage.
- The `ServiceEndpoint` CloudFormation output in `packages/serverless/lib/plugins/aws/package/compile/events/api-gateway/lib/deployment.js` now uses `getApiGatewayStage()`, so the endpoint URL printed after deploy/info points at the real stage instead of returning 403.

Both call sites are exact no-ops when `provider.apiGateway.stage` is not set: `getApiGatewayStage()` falls back to `getStage()`, and `options.stage` is normalized to `getStage()` in `lib/plugins/aws/lib/validate.js` before these code paths run. Verified by diffing compiled templates (latest release vs this branch) for a config without `apiGateway.stage`: byte-identical. For configs with `apiGateway.stage`, the only template change is the `ServiceEndpoint` output path segment.

## Test plan

- [x] Reproduced the failure on the latest release with the config above
- [x] Deployed the same service with this branch: deploy succeeds, tags land on the real stage, endpoint output correct and returns 200
- [x] Untag path: renamed a tag and redeployed — old key removed and new key added on the real stage
- [x] Control service without `apiGateway.stage`: compiled template identical to the latest release output; live deploy applies tags and endpoint works unchanged
- [x] `npm run test:unit -- test/unit/lib/plugins/aws/package/compile/events/api-gateway` (110 tests pass)

## How to test

Deploy a service with the config above plus a single `http` event:

```sh
serverless deploy --stage prod-eu
```

Expect a successful deploy, an endpoint path of `/prod/...`, and `aws apigateway get-stage --rest-api-id <id> --stage-name prod` showing the configured tags.

## Notes

- Known edge case: if a stage named after the provider stage also exists on the same REST API (e.g. leftover from before `apiGateway.stage` was added to the config), tag management moves from that stage to the configured one; tags previously applied to the leftover stage are left in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API Gateway endpoint URL generation to correctly construct stage paths using the proper stage resolution mechanism
  * Corrected stage tagging operations for API Gateway resources to properly resolve and apply stage values during deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->