### PR TITLE
feat(agentcore): support Python 3.14 and improve agent runtime validation

### DIFF
--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/dev/code-mode.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/dev/code-mode.js
@@ -5,11 +5,12 @@ import os from 'os'
 import fs from 'fs'
 import { spawn } from 'child_process'
 import { promisify } from 'util'
-import { exec } from 'child_process'
+import { execFile } from 'child_process'
 import { setTimeout as asyncSetTimeout } from 'node:timers/promises'
-import { log } from '@serverless/util'
+import { log, ServerlessError } from '@serverless/util'
+import { SUPPORTED_AGENT_RUNTIMES } from '../validators/schema.js'
 
-const execP = promisify(exec)
+const execFileP = promisify(execFile)
 const logger = log.get('agentcore:code-mode')
 
 /**
@@ -45,6 +46,26 @@ export class AgentCoreCodeMode {
     const handler = this.#agentConfig.handler
     const handlerPath = path.resolve(this.#projectPath, handler)
     const runtime = this.#agentConfig.runtime || 'python3.13'
+
+    // Reject unsupported/malformed runtimes before deriving any command.
+    // The config schema can't be relied on here: `dev` reads the raw
+    // `initialServerlessConfig`, never runs the package lifecycle, and ajv
+    // config validation is advisory by default (configValidationMode 'warn'
+    // logs but does not block). So we enforce the same allowlist at the point
+    // of use. Normalize via the same logic as #getPythonCommand so a value
+    // that passes is guaranteed to map onto a supported `python3.x` binary name.
+    const normalizedRuntime = this.#normalizePythonRuntime(runtime)
+    if (!SUPPORTED_AGENT_RUNTIMES.includes(normalizedRuntime)) {
+      throw new ServerlessError(
+        `Unsupported agent runtime "${runtime}". The "runtime" option only ` +
+          `selects the Python version and must be one of: ` +
+          `${SUPPORTED_AGENT_RUNTIMES.join(', ')}. To use a specific Python ` +
+          `installation (a pyenv build, Homebrew, a custom location), activate ` +
+          `a virtualenv or adjust your PATH — "runtime" only chooses the ` +
+          `version, and the matching interpreter is resolved from your environment.`,
+        'AGENTCORE_INVALID_RUNTIME',
+      )
+    }
 
     // Get Python command
     const pythonCmd = this.#getPythonCommand(runtime)
@@ -218,6 +239,17 @@ export class AgentCoreCodeMode {
       return 'python.exe'
     }
 
+    return this.#normalizePythonRuntime(runtime)
+  }
+
+  /**
+   * Normalize a user-supplied runtime string to its canonical `python3.x`
+   * command form (e.g. 'PYTHON_3_12' -> 'python3.12'). Used both to validate
+   * the runtime against the supported allowlist and to derive the command on
+   * non-Windows platforms.
+   * @private
+   */
+  #normalizePythonRuntime(runtime) {
     const version = runtime
       .toLowerCase()
       .replace(/^python/, '')
@@ -250,7 +282,7 @@ export class AgentCoreCodeMode {
    */
   async #checkPythonVersion(pythonCmd, expectedRuntime) {
     try {
-      const { stdout } = await execP(`${pythonCmd} --version`)
+      const { stdout } = await execFileP(pythonCmd, ['--version'])
       const installedVersion = stdout.trim() // "Python 3.13.1"
       const expectedVersion = expectedRuntime
         .toLowerCase()

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/dev/code-mode.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/dev/code-mode.js
@@ -54,8 +54,14 @@ export class AgentCoreCodeMode {
     // logs but does not block). So we enforce the same allowlist at the point
     // of use. Normalize via the same logic as #getPythonCommand so a value
     // that passes is guaranteed to map onto a supported `python3.x` binary name.
-    const normalizedRuntime = this.#normalizePythonRuntime(runtime)
-    if (!SUPPORTED_AGENT_RUNTIMES.includes(normalizedRuntime)) {
+    // Guard for non-string values (e.g. an unquoted `runtime: 3.13` parsed as a
+    // number) so they yield the clear error below rather than a raw TypeError.
+    const normalizedRuntime =
+      typeof runtime === 'string' ? this.#normalizePythonRuntime(runtime) : null
+    if (
+      normalizedRuntime === null ||
+      !SUPPORTED_AGENT_RUNTIMES.includes(normalizedRuntime)
+    ) {
       throw new ServerlessError(
         `Unsupported agent runtime "${runtime}". The "runtime" option only ` +
           `selects the Python version and must be one of: ` +

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/utils/runtime.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/utils/runtime.js
@@ -8,12 +8,17 @@
  * the BedrockAgentCore Runtime resource.
  */
 
-const RUNTIME_MAP = {
-  'python3.10': 'PYTHON_3_10',
-  'python3.11': 'PYTHON_3_11',
-  'python3.12': 'PYTHON_3_12',
-  'python3.13': 'PYTHON_3_13',
-}
+import { SUPPORTED_AGENT_RUNTIMES } from '../validators/schema.js'
+
+// Derived from the single supported-runtimes allowlist so the deploy mapping
+// and the config/dev validation can never drift. The CloudFormation enum is a
+// deterministic transform of the Lambda-style id, e.g. python3.14 -> PYTHON_3_14.
+const RUNTIME_MAP = Object.fromEntries(
+  SUPPORTED_AGENT_RUNTIMES.map((runtime) => [
+    runtime,
+    `PYTHON_${runtime.replace(/^python/, '').replace('.', '_')}`,
+  ]),
+)
 
 /**
  * Normalize a Lambda-style runtime identifier to CloudFormation format.

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/validators/schema.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/validators/schema.js
@@ -16,6 +16,19 @@ function caseInsensitive(str) {
 }
 
 /**
+ * Python runtimes supported by AgentCore code-deployment agents.
+ * Single source of truth shared by the config schema (below) and the dev-mode
+ * runtime validation in `dev/code-mode.js`.
+ */
+const SUPPORTED_AGENT_RUNTIMES = [
+  'python3.10',
+  'python3.11',
+  'python3.12',
+  'python3.13',
+  'python3.14',
+]
+
+/**
  * IAM policy statement schema for role customization
  * Based on AWS IAM policy statement structure
  * Allows users to add custom IAM statements to auto-generated roles
@@ -628,9 +641,7 @@ const runtimeAgentSchema = {
       // Python file for the agent entry point, e.g., 'agent.py'
     },
     runtime: {
-      anyOf: ['python3.10', 'python3.11', 'python3.12', 'python3.13'].map(
-        caseInsensitive,
-      ),
+      anyOf: SUPPORTED_AGENT_RUNTIMES.map(caseInsensitive),
       // Defaults to python3.13 for code deployment
     },
 
@@ -799,4 +810,5 @@ export {
   codeInterpreterConfigSchema,
   runtimeAgentSchema,
   caseInsensitive,
+  SUPPORTED_AGENT_RUNTIMES,
 }

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/validators/schema.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/validators/schema.js
@@ -12,7 +12,11 @@
  * { anyOf: ['NONE', 'AWS_IAM'].map(caseInsensitive) }
  */
 function caseInsensitive(str) {
-  return { type: 'string', regexp: new RegExp(`^${str}$`, 'i').toString() }
+  // Escape regex metacharacters so literals match exactly — without this the
+  // '.' in values like 'python3.13' would act as a wildcard (e.g. 'python3x13'
+  // would incorrectly match).
+  const escaped = str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return { type: 'string', regexp: new RegExp(`^${escaped}$`, 'i').toString() }
 }
 
 /**

--- a/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/dev/code-mode.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/dev/code-mode.test.js
@@ -18,8 +18,8 @@ const mockExecP = jest.fn()
 
 jest.unstable_mockModule('child_process', () => ({
   spawn: mockSpawn,
-  exec: (cmd, cb) => {
-    mockExecP(cmd)
+  execFile: (file, args, cb) => {
+    mockExecP(file, args)
       .then((result) => cb(null, result))
       .catch((err) => cb(err))
   },
@@ -38,6 +38,13 @@ jest.unstable_mockModule('@serverless/util', () => ({
       error: jest.fn(),
       aside: jest.fn(),
     }),
+  },
+  ServerlessError: class ServerlessError extends Error {
+    constructor(message, code) {
+      super(message)
+      this.name = 'ServerlessError'
+      this.code = code
+    }
   },
 }))
 
@@ -268,6 +275,69 @@ describe('AgentCoreCodeMode', () => {
       mockExecP.mockRejectedValue(new Error('command not found'))
       const mode = new AgentCoreCodeMode(defaultOpts)
       await expect(mode.start(mockCredentials)).resolves.toBeDefined()
+    })
+
+    test('runs the version check without a shell (execFile + args array)', async () => {
+      const mode = new AgentCoreCodeMode(defaultOpts)
+      await mode.start(mockCredentials)
+      // The command and its flag are passed as separate argv entries
+      // (execFile), not assembled into a single string.
+      expect(mockExecP).toHaveBeenCalledWith(
+        isWin ? 'python.exe' : 'python3.13',
+        ['--version'],
+      )
+    })
+  })
+
+  describe('runtime validation', () => {
+    const startWith = (runtime) =>
+      new AgentCoreCodeMode({
+        ...defaultOpts,
+        agentConfig: { handler: 'agents/main.py', runtime },
+      }).start(mockCredentials)
+
+    test.each([
+      'python3.13;id',
+      'python3.13 && touch x',
+      'python3.13`id`',
+      'python3.13$(id)',
+      'python3.13|id',
+    ])('rejects malformed runtime %p without spawning', async (runtime) => {
+      await expect(startWith(runtime)).rejects.toThrow(
+        /Unsupported agent runtime/,
+      )
+      // Validation happens before any process is launched.
+      expect(mockSpawn).not.toHaveBeenCalled()
+      expect(mockExecP).not.toHaveBeenCalled()
+    })
+
+    test.each(['python4.0', 'python2.7', 'ruby', 'python'])(
+      'rejects unsupported runtime %p without spawning',
+      async (runtime) => {
+        await expect(startWith(runtime)).rejects.toThrow(
+          /Unsupported agent runtime/,
+        )
+        expect(mockSpawn).not.toHaveBeenCalled()
+      },
+    )
+
+    test('rejected error carries the AGENTCORE_INVALID_RUNTIME code', async () => {
+      await expect(startWith('python3.13;id')).rejects.toMatchObject({
+        code: 'AGENTCORE_INVALID_RUNTIME',
+      })
+    })
+
+    test.each([
+      'python3.10',
+      'python3.11',
+      'python3.12',
+      'python3.13',
+      'python3.14',
+      'Python3.13',
+      'PYTHON_3_11',
+    ])('accepts supported runtime %p', async (runtime) => {
+      await expect(startWith(runtime)).resolves.toBeDefined()
+      expect(mockSpawn).toHaveBeenCalled()
     })
   })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/dev/code-mode.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/dev/code-mode.test.js
@@ -327,6 +327,15 @@ describe('AgentCoreCodeMode', () => {
       })
     })
 
+    test('rejects a non-string runtime without crashing', async () => {
+      // e.g. an unquoted `runtime: 3.13` in serverless.yml parses as a number.
+      await expect(startWith(3.13)).rejects.toMatchObject({
+        code: 'AGENTCORE_INVALID_RUNTIME',
+      })
+      expect(mockSpawn).not.toHaveBeenCalled()
+      expect(mockExecP).not.toHaveBeenCalled()
+    })
+
     test.each([
       'python3.10',
       'python3.11',

--- a/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/utils/runtime.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/utils/runtime.test.js
@@ -20,6 +20,10 @@ describe('Runtime Utilities', () => {
       expect(normalizeRuntime('python3.13')).toBe('PYTHON_3_13')
     })
 
+    test('maps python3.14 to PYTHON_3_14', () => {
+      expect(normalizeRuntime('python3.14')).toBe('PYTHON_3_14')
+    })
+
     test('handles case-insensitive input', () => {
       expect(normalizeRuntime('Python3.12')).toBe('PYTHON_3_12')
       expect(normalizeRuntime('PYTHON3.13')).toBe('PYTHON_3_13')

--- a/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/validators/schema.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/validators/schema.test.js
@@ -125,7 +125,7 @@ describe('Schema Validator', () => {
             .runtime
         expect(runtimeSchema).toBeDefined()
         expect(runtimeSchema.anyOf).toBeDefined()
-        expect(runtimeSchema.anyOf).toHaveLength(4)
+        expect(runtimeSchema.anyOf).toHaveLength(5)
         // Each entry should be a case-insensitive regex pattern
         runtimeSchema.anyOf.forEach((entry) => {
           expect(entry.type).toBe('string')

--- a/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/validators/schema.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/validators/schema.test.js
@@ -133,6 +133,27 @@ describe('Schema Validator', () => {
         })
       })
 
+      test('runtime values match literally (regex metacharacters escaped)', () => {
+        defineAgentsSchema(mockServerless)
+
+        const runtimeSchema =
+          capturedAiSchema.properties.agents.additionalProperties.properties
+            .runtime
+        // Rebuild RegExp objects from their serialized `.toString()` form.
+        const toRegExp = (str) => {
+          const lastSlash = str.lastIndexOf('/')
+          return new RegExp(str.slice(1, lastSlash), str.slice(lastSlash + 1))
+        }
+        const patterns = runtimeSchema.anyOf.map((entry) =>
+          toRegExp(entry.regexp),
+        )
+        // A supported value matches (case-insensitively)...
+        expect(patterns.some((re) => re.test('python3.13'))).toBe(true)
+        expect(patterns.some((re) => re.test('PYTHON3.13'))).toBe(true)
+        // ...but a look-alike with the dot replaced must not (escaped '.').
+        expect(patterns.some((re) => re.test('python3x13'))).toBe(false)
+      })
+
       test('includes artifact property with image and s3', () => {
         defineAgentsSchema(mockServerless)
 


### PR DESCRIPTION
## What

- Add **Python 3.14** as a supported runtime for AgentCore agents (`ai.agents.<name>.runtime`), matching AgentCore Runtime's Direct Code Deploy support.
- Consolidate the supported-runtime list into a single source of truth (`SUPPORTED_AGENT_RUNTIMES`), shared by the config schema and the deploy-time CloudFormation runtime mapping (`PYTHON_3_x`). Adding a future version is now a one-line change in one place.
- Validate `runtime` in `serverless dev` (code mode) **before** launching the local Python process, returning a clear, actionable error for unsupported values instead of an obscure failure later. The error points users to virtualenv/PATH for selecting a specific interpreter.
- Run the dev-mode Python version check via `execFile` (command + args passed separately) instead of `exec`.

## Why

- AgentCore Runtime now supports Python 3.14 for Direct Code Deploy ([AWS release notes](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/release-notes.html)).
- Dev mode previously read the runtime value without validating it, so an unsupported or malformed value failed in confusing ways. Validating up front keeps dev consistent with the deploy schema and gives a helpful error.

## Tests

- `utils/runtime.test.js` — `python3.14` → `PYTHON_3_14` mapping.
- `validators/schema.test.js` — updated runtime `anyOf` length.
- `dev/code-mode.test.js` — dev-mode runtime validation: accepts supported runtimes (incl. `python3.14`, case-insensitive and underscore variants), rejects unsupported/malformed values with a clear error before any process is launched, and verifies the `execFile`-based version check.
- Full bedrock-agentcore unit suite passes (22 suites / 606 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded AgentCore supported Python runtimes and improved runtime normalization for consistent matching.

* **Bug Fixes**
  * Improved runtime validation to catch missing, malformed, or unsupported values early with clearer error details.
  * Updated Python version detection to run without shell execution for more reliable behavior.
  * Strengthened case-insensitive runtime matching to avoid accidental regex misinterpretation.

* **Tests**
  * Added and updated unit tests for runtime normalization, validation errors, and version-check execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->