### PR TITLE
fix(agentcore): unpin heroku/builder digest; add artifact.image.builder override

### DIFF
--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/docker/builder.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/docker/builder.js
@@ -145,12 +145,20 @@ export class DockerBuilder {
     const contextPath = path.resolve(servicePath, context)
     const buildOptions = dockerConfig.buildOptions || []
 
-    // Use heroku builder for ARM64 buildpacks support
-    // AgentCore requires ARM64, and heroku/builder:24 supports --platform flag
+    // Use heroku builder for ARM64 buildpacks support.
+    // AgentCore requires ARM64, and heroku/builder:24 supports --platform flag.
+    //
+    // Do NOT hardcode an @sha256 digest here: heroku/builder is a rolling tag
+    // rebuilt frequently, publishes no immutable versioned tags, and Docker Hub
+    // garbage-collects superseded manifests -- so a pinned digest becomes
+    // unresolvable (MANIFEST_UNKNOWN) within days and breaks every arm64
+    // buildpacks deploy. Users who need a reproducible, supply-chain-hardened
+    // builder can mirror one to a registry they control and set
+    // `artifact.image.builder`. A blank/whitespace value falls back to the
+    // default rather than suppressing it.
     const builder =
-      platform === 'linux/arm64'
-        ? 'heroku/builder:24@sha256:ad175c86d61399f70bbdab31bbd8b22b34f2d0e2c88e329edb49a8416003b734'
-        : null
+      dockerConfig.builder?.trim() ||
+      (platform === 'linux/arm64' ? 'heroku/builder:24' : null)
 
     this.log.info(`Building Docker image: ${imageUri}`)
     this.log.info(`  Context: ${contextPath}`)

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/docker/coordinator.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/docker/coordinator.js
@@ -108,7 +108,13 @@ export async function buildDockerImages(config) {
     const dockerConfig =
       typeof imageConfig === 'string' ? { name: imageConfig } : imageConfig
 
-    if (dockerConfig.path || dockerConfig.repository || dockerConfig.file) {
+    if (
+      dockerConfig.path ||
+      dockerConfig.repository ||
+      dockerConfig.file ||
+      dockerConfig.builder
+    ) {
+      dockerConfig.path = dockerConfig.path || '.'
       log.info(`Building Docker image for runtime: ${name}`)
       const buildMetadataItem = await builder.buildForRuntime(
         name,

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/validators/schema.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/validators/schema.js
@@ -667,6 +667,10 @@ const runtimeAgentSchema = {
                   type: 'object',
                   additionalProperties: { type: 'string' },
                 },
+                // Buildpacks builder image. Defaults to heroku/builder:24 on
+                // arm64. Point this at a digest-pinned image in a registry you
+                // control for reproducible, supply-chain-hardened builds.
+                builder: { type: 'string' },
               },
             },
           ],


### PR DESCRIPTION
Fixes #13647

## Problem

Deploying an AgentCore agent on the default `linux/arm64` platform **without a Dockerfile** (buildpacks auto-build) fails:

```
ERROR: failed to build: failed to fetch builder image
  'index.docker.io/heroku/builder@sha256:ad175c86d61399f70bbdab31bbd8b22b34f2d0e2c88e329edb49a8416003b734':
  MANIFEST_UNKNOWN: manifest unknown
```

`packages/serverless/lib/plugins/aws/bedrock-agentcore/docker/builder.js` hardcodes the buildpacks builder to a digest that Docker Hub no longer serves.

## Root cause

`heroku/builder` is a **rolling tag** (`:24` was last repushed `2026-06-16`), publishes **no immutable versioned tags** (only `20/22/24/26`), and Docker Hub garbage-collects superseded manifests. A hardcoded `@sha256` digest therefore becomes unresolvable within days. `heroku/builder:24` currently resolves to `sha256:c9d9f09a…`; the pinned `ad175c86…` returns `no such manifest`. With no override available, **every arm64 buildpacks deploy is hard-blocked**.

This affects 4.33.0 (feature introduction, #13353) through current 4.37.0.

## Fix

- **Reference `heroku/builder:24` by tag** instead of a digest, restoring the default no-Dockerfile path.
- **Add an `artifact.image.builder` override.** Re-pinning to the new digest would just rot again on the next rebuild — so simply bumping it is not a fix. Instead, the override lets security-conscious users keep digest-pinning the *correct* way: mirror the builder into a registry they control (which won't GC it) and pin that. This preserves the original supply-chain intent while moving the pin somewhere it actually holds.

`util/docker/index.js` already exposes a pass-through `builder` param, so this is consistent with existing design. No test references the removed digest.

## Test plan

- [ ] `serverless deploy` of a no-Dockerfile arm64 Python agent succeeds (previously failed at builder fetch).
- [ ] `artifact.image.builder: <my-registry>/builder@sha256:…` is honored and passes schema validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now specify a custom buildpacks builder image for Bedrock agent runtime artifact container builds.
  * Improved ARM64 container builder selection to better match the target architecture, including more flexible builder-image handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->