### PR TITLE
fix(agentcore): resolve SSO role ARN via IAM GetRole in dev mode

### DIFF
--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/dev/credentials.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/dev/credentials.js
@@ -7,6 +7,8 @@
  * and STS credential management.
  */
 
+import { GetRoleCommand } from '@aws-sdk/client-iam'
+
 /**
  * The SID used for local dev trust policy statements.
  * This allows Serverless Framework to identify and update
@@ -203,6 +205,51 @@ export function normalizeAssumedRoleArn(arn) {
   }
 
   return `arn:${partition}:iam::${accountId}:role/${roleName}`
+}
+
+/**
+ * Resolve the IAM principal ARN to put in the local dev trust policy.
+ *
+ * normalizeAssumedRoleArn() can only rebuild the IAM role ARN from the STS
+ * assumed-role session ARN, but that session ARN does not carry the role's
+ * IAM path. For IAM Identity Center (SSO) roles the real ARN contains a region
+ * segment that the session ARN omits:
+ *   arn:aws:iam::ACCOUNT:role/aws-reserved/sso.amazonaws.com/<region>/AWSReservedSSO_...
+ * Rebuilding it without that segment yields an ARN that points at no existing
+ * role, so iam:UpdateAssumeRolePolicy rejects it with "Invalid principal in
+ * policy" and dev mode fails for every SSO user whose Identity Center instance
+ * uses the region-scoped path (the modern default).
+ *
+ * For SSO roles we therefore ask IAM for the authoritative ARN via GetRole,
+ * which resolves a role by its name regardless of path. For any other ARN the
+ * pure normalization is already correct, so we avoid the extra IAM call. If the
+ * GetRole lookup fails (e.g. missing iam:GetRole permission) we fall back to
+ * the best-effort normalized ARN, preserving the previous behavior.
+ *
+ * @param {import('@aws-sdk/client-iam').IAMClient} iamClient - IAM client
+ * @param {string} callerArn - The ARN from GetCallerIdentity
+ * @returns {Promise<string>} The IAM principal ARN to use in the trust policy
+ */
+export async function resolvePrincipalArn(iamClient, callerArn) {
+  const assumedRoleMatch = callerArn.match(
+    /^arn:(aws[\w-]*):sts::(\d+):assumed-role\/(.+?)\/[^/]+$/,
+  )
+  const roleName = assumedRoleMatch?.[3]
+
+  if (roleName?.startsWith('AWSReservedSSO_')) {
+    try {
+      const { Role } = await iamClient.send(
+        new GetRoleCommand({ RoleName: roleName }),
+      )
+      if (Role?.Arn) {
+        return Role.Arn
+      }
+    } catch {
+      // Fall back to the best-effort normalized ARN below.
+    }
+  }
+
+  return normalizeAssumedRoleArn(callerArn)
 }
 
 /**

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/dev/index.js
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/dev/index.js
@@ -36,7 +36,7 @@ import {
   getCredentialExpirationMinutes,
   getRoleNameFromArn,
   isPrincipalInPolicy,
-  normalizeAssumedRoleArn,
+  resolvePrincipalArn,
 } from './credentials.js'
 
 const logger = log.get('agentcore:dev-mode')
@@ -194,14 +194,15 @@ export class AgentCoreDevMode {
       logger.debug(`Local user ARN: ${callerArn}`)
 
       /**
-       * Normalize the caller ARN to an IAM role ARN.
+       * Resolve the caller ARN to an IAM role ARN for the trust policy.
        * SSO sessions return arn:aws:sts::ACCOUNT:assumed-role/ROLE/SESSION
-       * but trust policies need arn:aws:iam::ACCOUNT:role/... to work
-       * reliably without waiting for IAM eventual consistency.
+       * but trust policies need arn:aws:iam::ACCOUNT:role/... For SSO roles the
+       * real ARN includes a region segment that the session ARN omits, so this
+       * looks the role up via IAM GetRole instead of rebuilding the ARN.
        */
-      const principalArn = normalizeAssumedRoleArn(callerArn)
+      const principalArn = await resolvePrincipalArn(this.#iamClient, callerArn)
       if (principalArn !== callerArn) {
-        logger.debug(`Normalized principal ARN: ${principalArn}`)
+        logger.debug(`Resolved principal ARN: ${principalArn}`)
       }
 
       // Ensure trust policy allows local user to assume role

--- a/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/dev/credentials.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/bedrock-agentcore/dev/credentials.test.js
@@ -20,6 +20,7 @@ import {
   addPrincipalToPolicy,
   calculateBackoffDelay,
   normalizeAssumedRoleArn,
+  resolvePrincipalArn,
 } from '../../../../../../../lib/plugins/aws/bedrock-agentcore/dev/credentials.js'
 
 describe('dev/credentials', () => {
@@ -293,6 +294,70 @@ describe('dev/credentials', () => {
     it('should respect custom base and max', () => {
       expect(calculateBackoffDelay(1, 1000, 10000)).toBe(1000)
       expect(calculateBackoffDelay(5, 1000, 10000)).toBe(10000) // Capped
+    })
+  })
+
+  describe('resolvePrincipalArn', () => {
+    it('resolves an SSO assumed-role session ARN to the real IAM role ARN via GetRole', async () => {
+      /**
+       * The real IAM Identity Center role ARN includes a region segment in its
+       * path (.../sso.amazonaws.com/<region>/AWSReservedSSO_...). That region is
+       * NOT present in the STS assumed-role ARN, so it can only be obtained by
+       * asking IAM for the role.
+       */
+      const realArn =
+        'arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/eu-central-1/AWSReservedSSO_Admin_abc123'
+      const send = jest.fn().mockResolvedValue({ Role: { Arn: realArn } })
+      const iamClient = { send }
+
+      const result = await resolvePrincipalArn(
+        iamClient,
+        'arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_Admin_abc123/user@example.com',
+      )
+
+      expect(result).toBe(realArn)
+      expect(send).toHaveBeenCalledTimes(1)
+      expect(send.mock.calls[0][0].input).toEqual({
+        RoleName: 'AWSReservedSSO_Admin_abc123',
+      })
+    })
+
+    it('does not call IAM for a standard (non-SSO) assumed-role ARN', async () => {
+      const send = jest.fn()
+      const iamClient = { send }
+
+      const result = await resolvePrincipalArn(
+        iamClient,
+        'arn:aws:sts::123456789012:assumed-role/MyRole/session',
+      )
+
+      expect(result).toBe('arn:aws:iam::123456789012:role/MyRole')
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('returns a non-assumed-role ARN as-is without calling IAM', async () => {
+      const send = jest.fn()
+      const iamClient = { send }
+
+      const arn = 'arn:aws:iam::123456789012:user/dev-user'
+      const result = await resolvePrincipalArn(iamClient, arn)
+
+      expect(result).toBe(arn)
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('falls back to the best-effort ARN when GetRole fails', async () => {
+      const send = jest.fn().mockRejectedValue(new Error('AccessDenied'))
+      const iamClient = { send }
+
+      const result = await resolvePrincipalArn(
+        iamClient,
+        'arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_Admin_abc123/user@example.com',
+      )
+
+      expect(result).toBe(
+        'arn:aws:iam::123456789012:role/aws-reserved/sso.amazonaws.com/AWSReservedSSO_Admin_abc123',
+      )
     })
   })
 })


### PR DESCRIPTION
Closes: #13652

Dev mode rebuilt the SSO IAM role ARN from the STS assumed-role ARN with a hardcoded `aws-reserved/sso.amazonaws.com/<roleName>` path, omitting the region segment that IAM Identity Center includes (`…/sso.amazonaws.com/<region>/AWSReservedSSO_…`). The region is absent from the STS ARN, so the rebuilt principal pointed at a non-existent role and `iam:UpdateAssumeRolePolicy` rejected it with "Invalid principal in policy", breaking `serverless dev` for SSO users.

This adds `resolvePrincipalArn()`, which for `AWSReservedSSO_` roles fetches the authoritative ARN via `iam:GetRole` (resolves a role by name regardless of path). Non-SSO ARNs keep using the pure `normalizeAssumedRoleArn()` (no extra IAM call); a `GetRole` failure falls back to the previous best-effort behavior, so existing setups are unaffected.

- `npm run prettier` ✓ · `npm run lint` ✓ · unit tests ✓ (4 new cases for `resolvePrincipalArn`)
- No new dependencies; Node.js v18 compatible
- Touches only the dev-mode credential resolution path; no integration-test surface change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of AWS SSO credentials during local development workflows.
  * Enhanced IAM role identification for more accurate credential resolution.
  * Added fallback protection to ensure credentials resolve correctly when primary lookups fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->