### PR TITLE
Support enterprise SSO dashboard login (sls login --sso <connection>)

### DIFF
--- a/packages/sf-core/src/lib/auth/index.js
+++ b/packages/sf-core/src/lib/auth/index.js
@@ -164,6 +164,10 @@ export class Authentication {
           authenticateMessage ||
           'Serverless Framework V4 CLI is free for developers and organizations making less than $2 million annually, but requires an account or a license key.\n\nPlease login/register or enter your license key:',
         baseFilename,
+        // Optional enterprise SSO connection (e.g. `--sso <connection>`): opens
+        // the dedicated /sso/<connection> dashboard route instead of the normal
+        // login page, so the browser redirects straight to the customer's IdP.
+        ssoConnection: options?.sso,
       })
 
       // Track that the user required authentication
@@ -686,7 +690,11 @@ export class Authentication {
    * login/register or provide a License Key. This is also the
    * way to add a new License Key to .{baseFilename}rc, if it doesn't exist.
    */
-  async authenticateInteractive({ message, baseFilename = 'serverless' } = {}) {
+  async authenticateInteractive({
+    message,
+    baseFilename = 'serverless',
+    ssoConnection,
+  } = {}) {
     const logger = log.get('core:auth:authenticate')
     const progressMain = progress.get('main')
 
@@ -823,7 +831,7 @@ export class Authentication {
       progressMain.notice('Opening web browser')
 
       const { loginUrl, loginData: loginDataDeferred } =
-        await this.loginViaBrowser()
+        await this.loginViaBrowser(ssoConnection)
       logger.aside(
         'If your browser does not open automatically, please open this URL:',
         loginUrl,
@@ -1164,8 +1172,13 @@ export class Authentication {
   /**
    * Login via web browser to Serverless Dashboard,
    * supporting both prod and dev environments
+   *
+   * @param {string} [ssoConnection] Optional Auth0 enterprise connection name.
+   *   When provided, the browser is opened to the dedicated SSO route
+   *   (/sso/<connection>) which redirects straight to the customer's IdP,
+   *   instead of the normal login page.
    */
-  async loginViaBrowser() {
+  async loginViaBrowser(ssoConnection) {
     // Determine URLs based on environment
     const serverlessStage = process.env.SERVERLESS_PLATFORM_STAGE || 'prod'
     const coreUrl =
@@ -1256,7 +1269,13 @@ export class Authentication {
       client: 'cli',
       transactionId,
     }).toString()
-    const loginUrl = `${dashboardUrl}?${auth0Queries}`
+    // When an SSO connection is given, open the dedicated SSO route so the
+    // dashboard redirects straight to the customer's IdP. The client and
+    // transactionId params are preserved so the CLI flow completes the same
+    // way as a normal login.
+    const loginUrl = ssoConnection
+      ? `${dashboardUrl}/sso/${encodeURIComponent(ssoConnection)}?${auth0Queries}`
+      : `${dashboardUrl}?${auth0Queries}`
 
     return {
       loginUrl,

--- a/packages/sf-core/src/lib/auth/index.js
+++ b/packages/sf-core/src/lib/auth/index.js
@@ -993,6 +993,7 @@ export class Authentication {
       return await this.authenticateInteractive({
         message: 'What would you like to do?',
         baseFilename,
+        ssoConnection,
       })
     } else if (answer === 'purchase') {
       logger.aside(
@@ -1027,6 +1028,7 @@ export class Authentication {
       return await this.authenticateInteractive({
         message: 'What would you like to do?',
         baseFilename,
+        ssoConnection,
       })
     }
   }

--- a/packages/sf-core/src/lib/runners/core/core.js
+++ b/packages/sf-core/src/lib/runners/core/core.js
@@ -98,7 +98,13 @@ class CoreRunner extends Runner {
             ],
           },
         ],
-        options: {},
+        options: {
+          sso: {
+            description:
+              'Log in with an enterprise SSO connection (its Auth0 connection name)',
+            type: 'string',
+          },
+        },
       },
       {
         command: 'logout',

--- a/packages/sf-core/src/lib/runners/core/core.js
+++ b/packages/sf-core/src/lib/runners/core/core.js
@@ -97,14 +97,17 @@ class CoreRunner extends Runner {
               },
             ],
           },
-        ],
-        options: {
-          sso: {
-            description:
-              'Log in with an enterprise SSO connection (its Auth0 connection name)',
-            type: 'string',
+          {
+            options: {
+              sso: {
+                description:
+                  'Log in with an enterprise SSO connection (its Auth0 connection name)',
+                type: 'string',
+              },
+            },
           },
-        },
+        ],
+        options: {},
       },
       {
         command: 'logout',


### PR DESCRIPTION
## What

Adds enterprise SSO support to dashboard login (`sls login --sso <connection>`).

`loginViaBrowser(ssoConnection)` opens `app.serverless.com/sso/<connection>` (preserving `client` + `transactionId`) instead of the normal login page, so the browser redirects straight to the customer's IdP and the existing login-broker WebSocket flow completes unchanged. Threaded through `authenticateInteractive`, sourced from `options.sso`.

## Notes

- `sls login` is the dashboard login (vs `sls login aws`), so `--sso` belongs here.
- Pairs with the dashboard `/sso/:connection` route (serverlessinc/platform-dashboard#925) and the backend re-key/enforcement (serverlessinc/dashboard-backend#3777).
- **To verify:** that `--sso` is registered in the `login` command's option schema so `options.sso` actually populates — confirm in a dev end-to-end test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the authentication entry URL and CLI option wiring for login; token handling and the broker are unchanged, but misconfiguration could send users to the wrong IdP route.
> 
> **Overview**
> Adds **`sls login --sso <connection>`** so enterprise users can open the dashboard at **`/sso/<connection>`** (Auth0 connection name) instead of the default login page, sending the browser straight to their IdP while keeping the same **`client`** and **`transactionId`** query params and unchanged login-broker WebSocket flow.
> 
> The new **`sso`** flag is registered on the top-level **`login`** command schema; **`options.sso`** is passed into interactive auth when credentials are missing, and **`ssoConnection`** is threaded through **`authenticateInteractive`** (including re-prompt paths after “info” or “purchase”) into **`loginViaBrowser`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb91483e69e412297b29ed85159ba948ef82ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive authentication now supports an optional enterprise SSO connection and retains that SSO context across interactive steps.
  * Browser-based login will route to an SSO-specific dashboard login page when an SSO connection is provided; otherwise it uses the standard login flow.
* **CLI Enhancements**
  * The `login aws sso` command now offers an `sso` option to specify the enterprise SSO connection name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->