### PR TITLE
fix(sf-core-installer): bump binary cache key from 0.0.2 to 0.0.3

### DIFF
--- a/packages/sf-core-installer/binary.js
+++ b/packages/sf-core-installer/binary.js
@@ -254,7 +254,7 @@ const getBinaryName = () => {
 const getBinary = () => {
   const binaryName = getBinaryName()
   const url = `https://install.serverless.com/installer-builds/${binaryName}`
-  const binary = new Binary(binaryName, url, '0.0.2')
+  const binary = new Binary(binaryName, url, '0.0.3')
   return binary
 }
 


### PR DESCRIPTION
## Summary

This is a small cache-bust change in the npm installer: I bumped the binary suffix from `0.0.2` to `0.0.3`.

## Why

Right now the installer caches the binary locally with a hardcoded suffix. If `0.0.2` is already present, it won’t fetch again.  
Changing to `0.0.3` forces a new cache path, so existing installs download the latest installer binary instead of reusing the old one.

## What Changed

- Updated `packages/sf-core-installer/binary.js`:
  - `new Binary(..., '0.0.2')` -> `new Binary(..., '0.0.3')`

## Notes

I kept this intentionally minimal and low risk.  
This doesn’t introduce new flags or alter CLI behavior; it just makes sure stale cached installer binaries are refreshed.

## Testing

The change is a single constant update in one file.  

Addresses #13654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Serverless installer binary version to the latest 0.0.3 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->