### PR TITLE
fix(sf-core-installer): make postinstall binary download non-fatal

### DIFF
--- a/packages/sf-core-installer/binary.js
+++ b/packages/sf-core-installer/binary.js
@@ -135,7 +135,7 @@ class Binary {
     }
   }
 
-  install(suppressLogs = false) {
+  install(suppressLogs = false, bestEffort = false) {
     if (this.exists()) {
       if (!suppressLogs) {
         console.error(
@@ -186,8 +186,18 @@ class Binary {
         }
       })
       .catch((e) => {
-        error(`Error fetching release: ${e.message}`)
         this.removeBinary()
+        if (bestEffort) {
+          // Don't fail `npm install` when the binary can't be downloaded
+          // (e.g. behind a corporate proxy/firewall). It will be fetched
+          // automatically on first use in run().
+          console.error(
+            `Warning: could not download ${this.name}: ${e.message}. ` +
+              `It will be downloaded automatically on first use.`,
+          )
+          return
+        }
+        error(`Error fetching release: ${e.message}`)
       })
   }
 
@@ -260,7 +270,9 @@ const getBinary = () => {
 
 const install = async () => {
   const binary = getBinary()
-  return binary.install(true) // Suppresses logs from binary-install
+  // Best-effort: a failed download must not abort `npm install`. The binary is
+  // fetched lazily on first use in run() if it isn't present here.
+  return binary.install(true, true) // Suppresses logs from binary-install
 }
 
 const run = async () => {


### PR DESCRIPTION
The postinstall script exits 1 when the installer binary can't be downloaded (e.g. behind a corporate proxy/firewall), which aborts the entire `npm install` and forces users to run `npm install --ignore-scripts`.

Since the binary is already fetched lazily on first use in `run()`, the postinstall download is best-effort: it now warns and lets the install succeed, while the runtime path stays strict and still fails if the binary genuinely can't be obtained.

Addresses: obvious bug fix `postInstall.js` failure should not abort `npm install` when the binary is recoverable at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Made the installation process more resilient. If a required component fails to download during installation, the process will now continue and automatically fetch the component when first needed instead of failing immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->