### PR TITLE
fix(aws): allow Fn::If in awsArn config validation

### DIFF
--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -340,6 +340,7 @@ class AwsProvider {
             anyOf: [
               { $ref: '#/definitions/awsArnString' },
               { $ref: '#/definitions/awsCfFunction' },
+              { $ref: '#/definitions/awsCfIf' },
             ],
           },
           awsArnString: {

--- a/packages/serverless/test/unit/lib/plugins/aws/provider.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/provider.test.js
@@ -654,4 +654,52 @@ describe('AwsProvider', () => {
       expect(messages[0]).toContain('INFREQUENT_ACCESS')
     })
   })
+
+  describe('awsCfIf in awsArn schema', () => {
+    let schemaServerless
+
+    beforeEach(() => {
+      schemaServerless = new Serverless({ commands: [], options: {} })
+      schemaServerless.credentialProviders = {
+        aws: { getCredentials: jest.fn() },
+      }
+      schemaServerless.service.provider.name = 'aws'
+      new AwsProvider(schemaServerless, options)
+    })
+
+    it('includes awsCfIf alongside awsCfFunction in awsArn', () => {
+      const awsArn =
+        schemaServerless.configSchemaHandler.schema.definitions.awsArn
+
+      expect(awsArn.anyOf).toEqual(
+        expect.arrayContaining([
+          { $ref: '#/definitions/awsCfFunction' },
+          { $ref: '#/definitions/awsCfIf' },
+        ]),
+      )
+    })
+
+    it('accepts Fn::If authorizer arn values', async () => {
+      const Ajv = (await import('ajv')).default
+      const { default: regexpKeyword } =
+        await import('../../../../../lib/classes/config-schema-handler/regexp-keyword.js')
+      const schema = schemaServerless.configSchemaHandler.schema
+      const ajv = new Ajv({ allErrors: true, strict: false })
+      ajv.addKeyword(regexpKeyword)
+      const validate = ajv.compile({
+        ...schema.definitions.awsArn,
+        definitions: schema.definitions,
+      })
+
+      expect(
+        validate({
+          'Fn::If': [
+            'CreateUserPool',
+            { 'Fn::GetAtt': ['UserPool', 'Arn'] },
+            '${env:COGNITO_USER_POOL_ARN}',
+          ],
+        }),
+      ).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
Fixes #11611

## Summary
- Allow `Fn::If` (YAML `!If`) on `awsArn`, which is used by HTTP API authorizer `arn` fields
- Reuse the existing `awsCfIf` schema definition as a sibling ref on `awsArn`, matching the `cfValue()` pattern already used elsewhere in the AWS provider schema
- Avoid adding `awsCfIf` to `awsCfFunction` directly, which causes AJV recursion at schema compile time

## Test plan
- [x] `npm run test:unit -- --testPathPatterns=provider.test.js` (53/53 passed)
- [x] Verified `awsArn` accepts the exact `Fn::If` + `Fn::GetAtt` + env var shape from #11611

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended ARN configuration validation to accept CloudFormation conditional expressions (Fn::If) alongside standard ARN strings and other CloudFormation intrinsic functions.

* **Tests**
  * Added test suite for ARN configuration schema, verifying support for conditional expressions and CloudFormation functions in authorizer ARN configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->