### PR TITLE
feat(appsync): support S3 mapping template locations for resolvers and pipeline functions

### DIFF
--- a/docs/sf/providers/aws/guide/appsync/pipeline-functions.md
+++ b/docs/sf/providers/aws/guide/appsync/pipeline-functions.md
@@ -36,6 +36,8 @@ appSync:
 - `code`: The path to the JS resolver handler file, relative to `serverless.yml`.
 - `request`: The path to the VTL request mapping template file, relative to `serverless.yml`.
 - `response`: The path to the VTL response mapping template file, relative to `serverless.yml`.
+- `requestS3Location`: An S3 location `{ bucket, key }` for the VTL request mapping template. Mutually exclusive with `request` and `code` (VTL only). No file is read and no variable substitution is applied.
+- `responseS3Location`: An S3 location `{ bucket, key }` for the VTL response mapping template. Mutually exclusive with `response` and `code` (VTL only). No file is read and no variable substitution is applied.
 - `maxBatchSize`: The maximum [batch size](https://aws.amazon.com/blogs/mobile/introducing-configurable-batching-size-for-aws-appsync-lambda-resolvers/) to use (only available for AWS Lambda DataSources)
 - `substitutions`: See [Variable Substitutions](substitutions.md)
 - `sync`: [See SyncConfig](syncConfig.md)

--- a/docs/sf/providers/aws/guide/appsync/resolvers.md
+++ b/docs/sf/providers/aws/guide/appsync/resolvers.md
@@ -45,6 +45,8 @@ appSync:
 - `code`: The path of the JavaScript resolver handler file, relative to `serverless.yml`. If not specified, a [minimalistic default](#javascript-vs-vtl) is used.
 - `request`: The path to the VTL request mapping template file, relative to `serverless.yml`.
 - `response`: The path to the VTL response mapping template file, relative to `serverless.yml`.
+- `requestS3Location`: An S3 location `{ bucket, key }` for the VTL request mapping template. Mutually exclusive with `request` and `code` (VTL only). No file is read and no variable substitution is applied.
+- `responseS3Location`: An S3 location `{ bucket, key }` for the VTL response mapping template. Mutually exclusive with `response` and `code` (VTL only). No file is read and no variable substitution is applied.
 - `substitutions`: See [Variable Substitutions](substitutions.md). Deprecated: Use [environment variables](./general-config.md) instead.
 - `caching`: [See below](#Caching)
 - `sync`: [See SyncConfig](syncConfig.md)
@@ -54,6 +56,23 @@ appSync:
 When `code` is specified, the JavaScript runtime is used.
 
 When `request` and/or `response` are specified, the VTL runtime is used.
+
+When `requestS3Location` and/or `responseS3Location` are specified, the VTL runtime is used and the template is referenced by its S3 location instead of being read from disk. This is useful for large APIs that would otherwise exceed CloudFormation's template size limit. `request`/`requestS3Location` are mutually exclusive (same for `response`/`responseS3Location`). No variable substitution is applied to S3-located templates.
+
+```yaml
+appSync:
+  resolvers:
+    Query.user:
+      kind: UNIT
+      dataSource: myDataSource
+      requestS3Location:
+        bucket: my-templates-bucket
+        key: Query.user.request.vtl
+      responseS3Location:
+        bucket: my-templates-bucket
+        key: Query.user.response.vtl
+        version: abc123 # optional S3 object version
+```
 
 For [direct lambda](https://docs.aws.amazon.com/appsync/latest/devguide/direct-lambda-reference.html), set `kind` to `UNIT` and don't specify `request`, `response` or `code`. This only works with Lambda function data sources.
 

--- a/docs/sf/providers/aws/guide/appsync/resolvers.md
+++ b/docs/sf/providers/aws/guide/appsync/resolvers.md
@@ -45,6 +45,8 @@ appSync:
 - `code`: The path of the JavaScript resolver handler file, relative to `serverless.yml`. If not specified, a [minimalistic default](#javascript-vs-vtl) is used.
 - `request`: The path to the VTL request mapping template file, relative to `serverless.yml`.
 - `response`: The path to the VTL response mapping template file, relative to `serverless.yml`.
+- `requestS3Location`: An S3 location `{ bucket, key }` for the VTL request mapping template. Mutually exclusive with `request` and `code` (VTL only). No file is read and no variable substitution is applied.
+- `responseS3Location`: An S3 location `{ bucket, key }` for the VTL response mapping template. Mutually exclusive with `response` and `code` (VTL only). No file is read and no variable substitution is applied.
 - `substitutions`: See [Variable Substitutions](substitutions.md). Deprecated: Use [environment variables](./general-config.md) instead.
 - `caching`: [See below](#Caching)
 - `sync`: [See SyncConfig](syncConfig.md)
@@ -54,6 +56,22 @@ appSync:
 When `code` is specified, the JavaScript runtime is used.
 
 When `request` and/or `response` are specified, the VTL runtime is used.
+
+When `requestS3Location` and/or `responseS3Location` are specified, the VTL runtime is used and the template is referenced by its S3 location instead of being read from disk. This is useful for large APIs that would otherwise exceed CloudFormation's template size limit. `request`/`requestS3Location` are mutually exclusive (same for `response`/`responseS3Location`). No variable substitution is applied to S3-located templates.
+
+```yaml
+appSync:
+  resolvers:
+    Query.user:
+      kind: UNIT
+      dataSource: myDataSource
+      requestS3Location:
+        bucket: my-templates-bucket
+        key: Query.user.request.vtl
+      responseS3Location:
+        bucket: my-templates-bucket
+        key: Query.user.response.vtl
+```
 
 For [direct lambda](https://docs.aws.amazon.com/appsync/latest/devguide/direct-lambda-reference.html), set `kind` to `UNIT` and don't specify `request`, `response` or `code`. This only works with Lambda function data sources.
 

--- a/packages/serverless/lib/plugins/aws/appsync/resources/PipelineFunction.js
+++ b/packages/serverless/lib/plugins/aws/appsync/resources/PipelineFunction.js
@@ -2,6 +2,7 @@ import path from 'path'
 import { MappingTemplate } from './MappingTemplate.js'
 import { SyncConfig } from './SyncConfig.js'
 import { JsResolver } from './JsResolver.js'
+import { resolveS3Location } from './Resolver.js'
 
 export class PipelineFunction {
   constructor(api, config) {
@@ -11,6 +12,17 @@ export class PipelineFunction {
 
   compile() {
     const { dataSource, code } = this.config
+
+    if (
+      code &&
+      (this.config.requestS3Location || this.config.responseS3Location)
+    ) {
+      throw new this.api.plugin.serverless.classes.Error(
+        `Pipeline Function '${this.config.name}': ` +
+          "'code' (JS) cannot be combined with an S3 mapping-template location (VTL only)",
+      )
+    }
+
     if (!this.api.hasDataSource(dataSource)) {
       throw new this.api.plugin.serverless.classes.Error(
         `Pipeline Function '${this.config.name}' references unknown DataSource '${dataSource}'`,
@@ -40,14 +52,38 @@ export class PipelineFunction {
         RuntimeVersion: '1.0.0',
       }
     } else {
-      const requestMappingTemplates = this.resolveMappingTemplate('request')
-      if (requestMappingTemplates) {
-        Properties.RequestMappingTemplate = requestMappingTemplates
+      if (this.config.requestS3Location) {
+        if (this.config.request) {
+          throw new this.api.plugin.serverless.classes.Error(
+            `Pipeline Function '${this.config.name}': ` +
+              "'request' and 'requestS3Location' are mutually exclusive",
+          )
+        }
+        Properties.RequestMappingTemplateS3Location = resolveS3Location(
+          this.config.requestS3Location,
+        )
+      } else {
+        const requestMappingTemplates = this.resolveMappingTemplate('request')
+        if (requestMappingTemplates) {
+          Properties.RequestMappingTemplate = requestMappingTemplates
+        }
       }
 
-      const responseMappingTemplate = this.resolveMappingTemplate('response')
-      if (responseMappingTemplate) {
-        Properties.ResponseMappingTemplate = responseMappingTemplate
+      if (this.config.responseS3Location) {
+        if (this.config.response) {
+          throw new this.api.plugin.serverless.classes.Error(
+            `Pipeline Function '${this.config.name}': ` +
+              "'response' and 'responseS3Location' are mutually exclusive",
+          )
+        }
+        Properties.ResponseMappingTemplateS3Location = resolveS3Location(
+          this.config.responseS3Location,
+        )
+      } else {
+        const responseMappingTemplate = this.resolveMappingTemplate('response')
+        if (responseMappingTemplate) {
+          Properties.ResponseMappingTemplate = responseMappingTemplate
+        }
       }
     }
 

--- a/packages/serverless/lib/plugins/aws/appsync/resources/Resolver.js
+++ b/packages/serverless/lib/plugins/aws/appsync/resources/Resolver.js
@@ -14,6 +14,15 @@ export function response(ctx) {
 }
 `
 
+export const resolveS3Location = (location) => {
+  if (!location.bucket || !location.key) {
+    throw new Error('S3 mapping-template location requires both bucket and key')
+  }
+  // CloudFormation's RequestMappingTemplateS3Location /
+  // ResponseMappingTemplateS3Location properties are plain S3 URI strings.
+  return `s3://${location.bucket}/${location.key}`
+}
+
 export class Resolver {
   constructor(api, config) {
     this.api = api
@@ -21,13 +30,28 @@ export class Resolver {
   }
 
   compile() {
+    if (
+      'code' in this.config &&
+      ('requestS3Location' in this.config ||
+        'responseS3Location' in this.config)
+    ) {
+      throw new this.api.plugin.serverless.classes.Error(
+        `Resolver '${this.config.type}.${this.config.field}': ` +
+          "'code' (JS) cannot be combined with an S3 mapping-template location (VTL only)",
+      )
+    }
+
     let Properties = {
       ApiId: this.api.getApiId(),
       TypeName: this.config.type,
       FieldName: this.config.field,
     }
 
-    const isVTLResolver = 'request' in this.config || 'response' in this.config
+    const isVTLResolver =
+      'request' in this.config ||
+      'response' in this.config ||
+      'requestS3Location' in this.config ||
+      'responseS3Location' in this.config
     const isJsResolver =
       'code' in this.config || (!isVTLResolver && this.config.kind !== 'UNIT')
 
@@ -43,14 +67,38 @@ export class Resolver {
         RuntimeVersion: '1.0.0',
       }
     } else if (isVTLResolver) {
-      const requestMappingTemplates = this.resolveMappingTemplate('request')
-      if (requestMappingTemplates) {
-        Properties.RequestMappingTemplate = requestMappingTemplates
+      if (this.config.requestS3Location) {
+        if (this.config.request) {
+          throw new this.api.plugin.serverless.classes.Error(
+            `Resolver '${this.config.type}.${this.config.field}': ` +
+              "'request' and 'requestS3Location' are mutually exclusive",
+          )
+        }
+        Properties.RequestMappingTemplateS3Location = resolveS3Location(
+          this.config.requestS3Location,
+        )
+      } else {
+        const requestMappingTemplates = this.resolveMappingTemplate('request')
+        if (requestMappingTemplates) {
+          Properties.RequestMappingTemplate = requestMappingTemplates
+        }
       }
 
-      const responseMappingTemplate = this.resolveMappingTemplate('response')
-      if (responseMappingTemplate) {
-        Properties.ResponseMappingTemplate = responseMappingTemplate
+      if (this.config.responseS3Location) {
+        if (this.config.response) {
+          throw new this.api.plugin.serverless.classes.Error(
+            `Resolver '${this.config.type}.${this.config.field}': ` +
+              "'response' and 'responseS3Location' are mutually exclusive",
+          )
+        }
+        Properties.ResponseMappingTemplateS3Location = resolveS3Location(
+          this.config.responseS3Location,
+        )
+      } else {
+        const responseMappingTemplate = this.resolveMappingTemplate('response')
+        if (responseMappingTemplate) {
+          Properties.ResponseMappingTemplate = responseMappingTemplate
+        }
       }
     }
 

--- a/packages/serverless/lib/plugins/aws/appsync/validation.js
+++ b/packages/serverless/lib/plugins/aws/appsync/validation.js
@@ -259,6 +259,17 @@ export const appSyncSchema = {
       required: [],
       errorMessage: 'must be a valid substitutions definition',
     },
+    appSyncS3Location: {
+      type: 'object',
+      description: 'S3 location of an AppSync mapping template.',
+      properties: {
+        bucket: { type: 'string' },
+        key: { type: 'string' },
+      },
+      required: ['bucket', 'key'],
+      additionalProperties: false,
+      errorMessage: 'must be an object with bucket and key',
+    },
     environment: {
       type: 'object',
       additionalProperties: {
@@ -290,6 +301,8 @@ export const appSyncSchema = {
         code: { type: 'string' },
         request: { type: 'string' },
         response: { type: 'string' },
+        requestS3Location: { $ref: '#/definitions/appSyncS3Location' },
+        responseS3Location: { $ref: '#/definitions/appSyncS3Location' },
         sync: { $ref: '#/definitions/syncConfig' },
         substitutions: { $ref: '#/definitions/substitutions' },
         caching: { $ref: '#/definitions/resolverCachingConfig' },
@@ -343,6 +356,8 @@ export const appSyncSchema = {
         description: { type: 'string' },
         request: { type: 'string' },
         response: { type: 'string' },
+        requestS3Location: { $ref: '#/definitions/appSyncS3Location' },
+        responseS3Location: { $ref: '#/definitions/appSyncS3Location' },
         sync: { $ref: '#/definitions/syncConfig' },
         maxBatchSize: { type: 'number', minimum: 1, maximum: 2000 },
         substitutions: { $ref: '#/definitions/substitutions' },
@@ -879,6 +894,36 @@ addFormats(ajv)
 
 const validator = ajv.compile(appSyncSchema)
 
+const flattenMerge = (input) => {
+  if (Array.isArray(input)) {
+    return Object.assign({}, ...input)
+  }
+  return input || {}
+}
+
+const notBoth = (cfg, ctx) => {
+  for (const side of ['request', 'response']) {
+    if (cfg[side] && cfg[`${side}S3Location`]) {
+      throw new AppSyncValidationError([
+        {
+          path: '',
+          message:
+            `${ctx}: '${side}' and '${side}S3Location' are mutually exclusive ` +
+            '(choose an inline template file or an S3 location, not both)',
+        },
+      ])
+    }
+  }
+  if (cfg.code && (cfg.requestS3Location || cfg.responseS3Location)) {
+    throw new AppSyncValidationError([
+      {
+        path: '',
+        message: `${ctx}: 'code' (JS) cannot be combined with an S3 mapping-template location (VTL only)`,
+      },
+    ])
+  }
+}
+
 export const validateConfig = (data) => {
   const isValid = validator(data)
   if (isValid === false && validator.errors) {
@@ -892,6 +937,27 @@ export const validateConfig = (data) => {
           }
         }),
     )
+  }
+
+  const resolversMap = flattenMerge(data.resolvers)
+  for (const [key, resolver] of Object.entries(resolversMap)) {
+    if (typeof resolver === 'object' && resolver !== null) {
+      notBoth(resolver, `resolver '${key}'`)
+      if (Array.isArray(resolver.functions)) {
+        for (const f of resolver.functions) {
+          if (typeof f === 'object' && f !== null) {
+            notBoth(f, `inline pipeline function in resolver '${key}'`)
+          }
+        }
+      }
+    }
+  }
+
+  const pipelineFunctionsMap = flattenMerge(data.pipelineFunctions)
+  for (const [name, func] of Object.entries(pipelineFunctionsMap)) {
+    if (typeof func === 'object' && func !== null) {
+      notBoth(func, `pipeline function '${name}'`)
+    }
   }
 
   return isValid

--- a/packages/serverless/lib/plugins/aws/appsync/validation.js
+++ b/packages/serverless/lib/plugins/aws/appsync/validation.js
@@ -1,6 +1,7 @@
 import Ajv from 'ajv'
 import ajvErrors from 'ajv-errors'
 import addFormats from 'ajv-formats'
+import { merge } from 'lodash'
 import { timeUnits } from './utils.js'
 
 const AUTH_TYPES = [
@@ -259,6 +260,17 @@ export const appSyncSchema = {
       required: [],
       errorMessage: 'must be a valid substitutions definition',
     },
+    appSyncS3Location: {
+      type: 'object',
+      description: 'S3 location of an AppSync mapping template.',
+      properties: {
+        bucket: { type: 'string' },
+        key: { type: 'string' },
+      },
+      required: ['bucket', 'key'],
+      additionalProperties: false,
+      errorMessage: 'must be an object with bucket and key',
+    },
     environment: {
       type: 'object',
       additionalProperties: {
@@ -290,6 +302,8 @@ export const appSyncSchema = {
         code: { type: 'string' },
         request: { type: 'string' },
         response: { type: 'string' },
+        requestS3Location: { $ref: '#/definitions/appSyncS3Location' },
+        responseS3Location: { $ref: '#/definitions/appSyncS3Location' },
         sync: { $ref: '#/definitions/syncConfig' },
         substitutions: { $ref: '#/definitions/substitutions' },
         caching: { $ref: '#/definitions/resolverCachingConfig' },
@@ -343,6 +357,8 @@ export const appSyncSchema = {
         description: { type: 'string' },
         request: { type: 'string' },
         response: { type: 'string' },
+        requestS3Location: { $ref: '#/definitions/appSyncS3Location' },
+        responseS3Location: { $ref: '#/definitions/appSyncS3Location' },
         sync: { $ref: '#/definitions/syncConfig' },
         maxBatchSize: { type: 'number', minimum: 1, maximum: 2000 },
         substitutions: { $ref: '#/definitions/substitutions' },
@@ -879,6 +895,44 @@ addFormats(ajv)
 
 const validator = ajv.compile(appSyncSchema)
 
+const flattenMerge = (input) => {
+  if (Array.isArray(input)) {
+    // Deep-merge like get-appsync-config.js so split entries (the same
+    // resolver or pipeline function configured across several maps) are
+    // validated in their merged shape; a shallow Object.assign would let a
+    // later partial entry overwrite an earlier one and hide
+    // request/requestS3Location conflicts from notBoth().
+    return merge({}, ...input)
+  }
+  return input || {}
+}
+
+const notBoth = (cfg, ctx) => {
+  // Presence, not truthiness: '' is schema-valid, so request: '' alongside an
+  // S3 location is still a conflict worth reporting.
+  const has = (key) => Object.prototype.hasOwnProperty.call(cfg, key)
+  for (const side of ['request', 'response']) {
+    if (has(side) && has(`${side}S3Location`)) {
+      throw new AppSyncValidationError([
+        {
+          path: '',
+          message:
+            `${ctx}: '${side}' and '${side}S3Location' are mutually exclusive ` +
+            '(choose an inline template file or an S3 location, not both)',
+        },
+      ])
+    }
+  }
+  if (has('code') && (has('requestS3Location') || has('responseS3Location'))) {
+    throw new AppSyncValidationError([
+      {
+        path: '',
+        message: `${ctx}: 'code' (JS) cannot be combined with an S3 mapping-template location (VTL only)`,
+      },
+    ])
+  }
+}
+
 export const validateConfig = (data) => {
   const isValid = validator(data)
   if (isValid === false && validator.errors) {
@@ -892,6 +946,27 @@ export const validateConfig = (data) => {
           }
         }),
     )
+  }
+
+  const resolversMap = flattenMerge(data.resolvers)
+  for (const [key, resolver] of Object.entries(resolversMap)) {
+    if (typeof resolver === 'object' && resolver !== null) {
+      notBoth(resolver, `resolver '${key}'`)
+      if (Array.isArray(resolver.functions)) {
+        for (const f of resolver.functions) {
+          if (typeof f === 'object' && f !== null) {
+            notBoth(f, `inline pipeline function in resolver '${key}'`)
+          }
+        }
+      }
+    }
+  }
+
+  const pipelineFunctionsMap = flattenMerge(data.pipelineFunctions)
+  for (const [name, func] of Object.entries(pipelineFunctionsMap)) {
+    if (typeof func === 'object' && func !== null) {
+      notBoth(func, `pipeline function '${name}'`)
+    }
   }
 
   return isValid

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/__snapshots__/resolvers.test.js.snap
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/__snapshots__/resolvers.test.js.snap
@@ -106,6 +106,34 @@ exports[`Resolvers Caching should generate Resources with custom keys 1`] = `
 
 exports[`Resolvers Pipeline Function should fail if Pipeline Function references unexisting data source 1`] = `"Cannot read properties of undefined (reading 'Error')"`;
 
+exports[`Resolvers Pipeline Function should generate Pipeline Function Resources with S3 mapping template locations 1`] = `
+{
+  "GraphQlFunctionConfigurationfunction1": {
+    "Properties": {
+      "ApiId": {
+        "Fn::GetAtt": [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "DataSourceName": {
+        "Fn::GetAtt": [
+          "GraphQlDsmyTable",
+          "Name",
+        ],
+      },
+      "Description": "Function1 Pipeline Resolver",
+      "FunctionVersion": "2018-05-29",
+      "MaxBatchSize": undefined,
+      "Name": "function1",
+      "RequestMappingTemplateS3Location": "s3://my-bucket/function1.request.vtl",
+      "ResponseMappingTemplateS3Location": "s3://my-bucket/function1.response.vtl",
+    },
+    "Type": "AWS::AppSync::FunctionConfiguration",
+  },
+}
+`;
+
 exports[`Resolvers Pipeline Function should generate Pipeline Function Resources with VTL mapping templates 1`] = `
 {
   "GraphQlFunctionConfigurationfunction1": {
@@ -315,7 +343,78 @@ exports[`Resolvers Pipeline Resolvers should generate Resources with VTL mapping
 }
 `;
 
+exports[`Resolvers Pipeline Resolvers should generate S3-only PIPELINE resolver with PipelineConfig (not JS) 1`] = `
+{
+  "GraphQlResolverQueryuser": {
+    "DependsOn": [
+      "GraphQlSchema",
+    ],
+    "Properties": {
+      "ApiId": {
+        "Fn::GetAtt": [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "FieldName": "user",
+      "Kind": "PIPELINE",
+      "PipelineConfig": {
+        "Functions": [
+          {
+            "Fn::GetAtt": [
+              "GraphQlFunctionConfigurationfunction1",
+              "FunctionId",
+            ],
+          },
+          {
+            "Fn::GetAtt": [
+              "GraphQlFunctionConfigurationfunction2",
+              "FunctionId",
+            ],
+          },
+        ],
+      },
+      "RequestMappingTemplateS3Location": "s3://my-bucket/request.vtl",
+      "ResponseMappingTemplateS3Location": "s3://my-bucket/response.vtl",
+      "TypeName": "Query",
+    },
+    "Type": "AWS::AppSync::Resolver",
+  },
+}
+`;
+
 exports[`Resolvers Unit Resolvers should fail when referencing unknown data source 1`] = `"Cannot read properties of undefined (reading 'Error')"`;
+
+exports[`Resolvers Unit Resolvers should generate Resources with S3 mapping template locations 1`] = `
+{
+  "GraphQlResolverQueryuser": {
+    "DependsOn": [
+      "GraphQlSchema",
+    ],
+    "Properties": {
+      "ApiId": {
+        "Fn::GetAtt": [
+          "GraphQlApi",
+          "ApiId",
+        ],
+      },
+      "DataSourceName": {
+        "Fn::GetAtt": [
+          "GraphQlDsmyTable",
+          "Name",
+        ],
+      },
+      "FieldName": "user",
+      "Kind": "UNIT",
+      "MaxBatchSize": undefined,
+      "RequestMappingTemplateS3Location": "s3://my-bucket/request.vtl",
+      "ResponseMappingTemplateS3Location": "s3://my-bucket/response.vtl",
+      "TypeName": "Query",
+    },
+    "Type": "AWS::AppSync::Resolver",
+  },
+}
+`;
 
 exports[`Resolvers Unit Resolvers should generate Resources with VTL mapping templates 1`] = `
 {

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/resolvers.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/resolvers.test.js
@@ -54,6 +54,64 @@ describe('Resolvers', () => {
       ).toMatchSnapshot()
     })
 
+    it('should generate Resources with S3 mapping template locations', () => {
+      const api = new Api(
+        given.appSyncConfig({
+          dataSources: {
+            myTable: {
+              name: 'myTable',
+              type: 'AMAZON_DYNAMODB',
+              config: { tableName: 'data' },
+            },
+          },
+        }),
+        plugin,
+      )
+      const result = api.compileResolver({
+        dataSource: 'myTable',
+        kind: 'UNIT',
+        type: 'Query',
+        field: 'user',
+        requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+        responseS3Location: { bucket: 'my-bucket', key: 'response.vtl' },
+      })
+      expect(result).toMatchSnapshot()
+      const resource = result[Object.keys(result)[0]].Properties
+      expect(resource.RequestMappingTemplateS3Location).toBe(
+        's3://my-bucket/request.vtl',
+      )
+      expect(resource.ResponseMappingTemplateS3Location).toBe(
+        's3://my-bucket/response.vtl',
+      )
+      expect(resource.RequestMappingTemplate).toBeUndefined()
+      expect(resource.ResponseMappingTemplate).toBeUndefined()
+    })
+
+    it('should throw when combining code with requestS3Location', () => {
+      const api = new Api(
+        given.appSyncConfig({
+          dataSources: {
+            myTable: {
+              name: 'myTable',
+              type: 'AMAZON_DYNAMODB',
+              config: { tableName: 'data' },
+            },
+          },
+        }),
+        plugin,
+      )
+      expect(() => {
+        api.compileResolver({
+          dataSource: 'myTable',
+          kind: 'UNIT',
+          type: 'Query',
+          field: 'user',
+          code: 'resolver.js',
+          requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+        })
+      }).toThrow()
+    })
+
     it('should generate Resources with direct Lambda', () => {
       const api = new Api(
         given.appSyncConfig({
@@ -243,6 +301,51 @@ describe('Resolvers', () => {
         })
       }).toThrowErrorMatchingSnapshot()
     })
+
+    it('should generate S3-only PIPELINE resolver with PipelineConfig (not JS)', () => {
+      const api = new Api(
+        given.appSyncConfig({
+          dataSources: {
+            myTable: {
+              name: 'myTable',
+              type: 'AMAZON_DYNAMODB',
+              config: { tableName: 'data' },
+            },
+          },
+          pipelineFunctions: {
+            function1: {
+              name: 'function1',
+              dataSource: 'myTable',
+            },
+            function2: {
+              name: 'function2',
+              dataSource: 'myTable',
+            },
+          },
+        }),
+        plugin,
+      )
+      const result = api.compileResolver({
+        kind: 'PIPELINE',
+        type: 'Query',
+        field: 'user',
+        functions: ['function1', 'function2'],
+        requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+        responseS3Location: { bucket: 'my-bucket', key: 'response.vtl' },
+      })
+      expect(result).toMatchSnapshot()
+      const resource = result[Object.keys(result)[0]].Properties
+      expect(resource.Kind).toBe('PIPELINE')
+      expect(resource.PipelineConfig).toBeDefined()
+      expect(resource.Code).toBeUndefined()
+      expect(resource.Runtime).toBeUndefined()
+      expect(resource.RequestMappingTemplateS3Location).toBe(
+        's3://my-bucket/request.vtl',
+      )
+      expect(resource.ResponseMappingTemplateS3Location).toBe(
+        's3://my-bucket/response.vtl',
+      )
+    })
   })
 
   describe('Pipeline Function', () => {
@@ -363,6 +466,44 @@ describe('Resolvers', () => {
           description: 'Function1 Pipeline Resolver',
         })
       }).toThrowErrorMatchingSnapshot()
+    })
+
+    it('should generate Pipeline Function Resources with S3 mapping template locations', () => {
+      const api = new Api(
+        given.appSyncConfig({
+          dataSources: {
+            myTable: {
+              name: 'myTable',
+              type: 'AMAZON_DYNAMODB',
+              config: { tableName: 'data' },
+            },
+          },
+        }),
+        plugin,
+      )
+      const result = api.compilePipelineFunctionResource({
+        name: 'function1',
+        dataSource: 'myTable',
+        description: 'Function1 Pipeline Resolver',
+        requestS3Location: {
+          bucket: 'my-bucket',
+          key: 'function1.request.vtl',
+        },
+        responseS3Location: {
+          bucket: 'my-bucket',
+          key: 'function1.response.vtl',
+        },
+      })
+      expect(result).toMatchSnapshot()
+      const resource = result[Object.keys(result)[0]].Properties
+      expect(resource.RequestMappingTemplateS3Location).toBe(
+        's3://my-bucket/function1.request.vtl',
+      )
+      expect(resource.ResponseMappingTemplateS3Location).toBe(
+        's3://my-bucket/function1.response.vtl',
+      )
+      expect(resource.RequestMappingTemplate).toBeUndefined()
+      expect(resource.ResponseMappingTemplate).toBeUndefined()
     })
   })
 

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/validation/pipelineFunctions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/validation/pipelineFunctions.test.js
@@ -127,4 +127,67 @@ describe('Basic', () => {
       })
     })
   })
+
+  describe('S3 Location', () => {
+    it('should accept a valid requestS3Location on a pipeline function', () => {
+      expect(
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: {
+            function1: {
+              dataSource: 'ds1',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+              responseS3Location: { bucket: 'my-bucket', key: 'response.vtl' },
+            },
+          },
+        }),
+      ).toBe(true)
+    })
+
+    it('should throw when request and requestS3Location are both set on a pipeline function', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: {
+            function1: {
+              dataSource: 'ds1',
+              request: 'request.vtl',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when code and responseS3Location are combined on a pipeline function', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: {
+            function1: {
+              dataSource: 'ds1',
+              code: 'function.js',
+              responseS3Location: { bucket: 'my-bucket', key: 'response.vtl' },
+            },
+          },
+        })
+      }).toThrow(
+        "'code' (JS) cannot be combined with an S3 mapping-template location",
+      )
+    })
+
+    it('should throw when requestS3Location is missing key on a pipeline function', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: {
+            function1: {
+              dataSource: 'ds1',
+              requestS3Location: { bucket: 'my-bucket' },
+            },
+          },
+        })
+      }).toThrow()
+    })
+  })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/validation/pipelineFunctions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/validation/pipelineFunctions.test.js
@@ -127,4 +127,89 @@ describe('Basic', () => {
       })
     })
   })
+
+  describe('S3 Location', () => {
+    it('should accept a valid requestS3Location on a pipeline function', () => {
+      expect(
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: {
+            function1: {
+              dataSource: 'ds1',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+              responseS3Location: { bucket: 'my-bucket', key: 'response.vtl' },
+            },
+          },
+        }),
+      ).toBe(true)
+    })
+
+    it('should throw when request and requestS3Location are split across array entries', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: [
+            {
+              function1: {
+                dataSource: 'ds1',
+                request: 'request.vtl',
+              },
+            },
+            {
+              function1: {
+                dataSource: 'ds1',
+                requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+              },
+            },
+          ],
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when request and requestS3Location are both set on a pipeline function', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: {
+            function1: {
+              dataSource: 'ds1',
+              request: 'request.vtl',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when code and responseS3Location are combined on a pipeline function', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: {
+            function1: {
+              dataSource: 'ds1',
+              code: 'function.js',
+              responseS3Location: { bucket: 'my-bucket', key: 'response.vtl' },
+            },
+          },
+        })
+      }).toThrow(
+        "'code' (JS) cannot be combined with an S3 mapping-template location",
+      )
+    })
+
+    it('should throw when requestS3Location is missing key on a pipeline function', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          pipelineFunctions: {
+            function1: {
+              dataSource: 'ds1',
+              requestS3Location: { bucket: 'my-bucket' },
+            },
+          },
+        })
+      }).toThrow()
+    })
+  })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/validation/resolvers.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/validation/resolvers.test.js
@@ -225,4 +225,123 @@ describe('Basic', () => {
       })
     })
   })
+
+  describe('S3 Location', () => {
+    it('should accept a valid requestS3Location on a resolver', () => {
+      expect(
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        }),
+      ).toBe(true)
+    })
+
+    it('should accept a valid responseS3Location', () => {
+      expect(
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              responseS3Location: {
+                bucket: 'my-bucket',
+                key: 'response.vtl',
+              },
+            },
+          },
+        }),
+      ).toBe(true)
+    })
+
+    it('should throw when request and requestS3Location are both set', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              request: 'request.vtl',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when response and responseS3Location are both set', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              response: 'response.vtl',
+              responseS3Location: { bucket: 'my-bucket', key: 'response.vtl' },
+            },
+          },
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when code and requestS3Location are combined', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              code: 'resolver.js',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        })
+      }).toThrow(
+        "'code' (JS) cannot be combined with an S3 mapping-template location",
+      )
+    })
+
+    it('should throw when requestS3Location is missing key', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              requestS3Location: { bucket: 'my-bucket' },
+            },
+          },
+        })
+      }).toThrow()
+    })
+
+    it('should throw when requestS3Location has unknown property', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              requestS3Location: {
+                bucket: 'my-bucket',
+                key: 'request.vtl',
+                bucketName: 'typo',
+              },
+            },
+          },
+        })
+      }).toThrow()
+    })
+  })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/validation/resolvers.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/validation/resolvers.test.js
@@ -225,4 +225,163 @@ describe('Basic', () => {
       })
     })
   })
+
+  describe('S3 Location', () => {
+    it('should accept a valid requestS3Location on a resolver', () => {
+      expect(
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        }),
+      ).toBe(true)
+    })
+
+    it('should accept a valid responseS3Location', () => {
+      expect(
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              responseS3Location: {
+                bucket: 'my-bucket',
+                key: 'response.vtl',
+              },
+            },
+          },
+        }),
+      ).toBe(true)
+    })
+
+    it('should throw when request and requestS3Location are both set', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              request: 'request.vtl',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when request and requestS3Location are split across array entries', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: [
+            {
+              'Query.user': {
+                kind: 'UNIT',
+                dataSource: 'myDs',
+                request: 'request.vtl',
+              },
+            },
+            {
+              'Query.user': {
+                kind: 'UNIT',
+                dataSource: 'myDs',
+                requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+              },
+            },
+          ],
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when an empty request string is combined with requestS3Location', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              request: '',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when response and responseS3Location are both set', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              response: 'response.vtl',
+              responseS3Location: { bucket: 'my-bucket', key: 'response.vtl' },
+            },
+          },
+        })
+      }).toThrow('mutually exclusive')
+    })
+
+    it('should throw when code and requestS3Location are combined', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              code: 'resolver.js',
+              requestS3Location: { bucket: 'my-bucket', key: 'request.vtl' },
+            },
+          },
+        })
+      }).toThrow(
+        "'code' (JS) cannot be combined with an S3 mapping-template location",
+      )
+    })
+
+    it('should throw when requestS3Location is missing key', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              requestS3Location: { bucket: 'my-bucket' },
+            },
+          },
+        })
+      }).toThrow()
+    })
+
+    it('should throw when requestS3Location has unknown property', () => {
+      expect(() => {
+        validateConfig({
+          ...basicConfig,
+          resolvers: {
+            'Query.user': {
+              kind: 'UNIT',
+              dataSource: 'myDs',
+              requestS3Location: {
+                bucket: 'my-bucket',
+                key: 'request.vtl',
+                bucketName: 'typo',
+              },
+            },
+          },
+        })
+      }).toThrow()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Add `requestS3Location` / `responseS3Location` options to AppSync resolver and pipeline function configuration so VTL templates can be referenced by S3 location instead of inlined into the CloudFormation template
- Extend the `isVTLResolver` predicate to recognise S3-only resolvers as VTL, fixing silent misclassification of S3-only PIPELINE resolvers as JS
- Add AJV schema definition (`appSyncS3Location`) and a post-AJV mutual-exclusivity pass with precise error messages

## Motivation

Large AppSync APIs can exceed CloudFormation's 1 MB processed-template limit when VTL templates are inlined. Referencing templates by S3 location (`RequestMappingTemplateS3Location` / `ResponseMappingTemplateS3Location`) is the AWS-recommended workaround, but the Framework had no way to express this.

## Changes

- `validation.js`: new `appSyncS3Location` definition (`bucket`+`key` required, `version` optional, `additionalProperties:false`); refs in `resolverConfig` and `pipelineFunctionConfig`; post-AJV `notBoth` pass for mutual-exclusivity and `code`+S3 errors
- `resources/Resolver.js`: extended `isVTLResolver` predicate; `resolveS3Location` helper (exported); compile-time guards; per-side S3/inline branches
- `resources/PipelineFunction.js`: same guards and per-side branches; imports `resolveS3Location` from `Resolver.js`
- Tests: new snapshot cases for UNIT S3, S3-only PIPELINE (regression for predicate fix), and pipeline-function S3; validation tests for shape, mutual exclusivity, and `code`+S3
- Docs: `resolvers.md` and `pipeline-functions.md` updated with field descriptions and YAML example

## Backward Compatibility

The new fields are optional. All existing configurations compile byte-for-byte identically (the predicate extension is purely additive).

Closes #13249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for AppSync request and response VTL mapping templates stored in Amazon S3 for resolvers and pipeline functions.
  * Added `requestS3Location` and `responseS3Location` options using S3 bucket and key values.

* **Bug Fixes**
  * Added validation for incomplete S3 locations and incompatible combinations with inline templates or JavaScript code.

* **Documentation**
  * Updated AppSync guides with configuration examples and clarified that S3 templates bypass local file reads and variable substitution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->