### PR TITLE
feat(python): allow usePipenv/usePoetry/useUv to accept a custom manifest file path

### DIFF
--- a/docs/sf/providers/aws/guide/python.md
+++ b/docs/sf/providers/aws/guide/python.md
@@ -119,6 +119,16 @@ custom:
     usePipenv: false
 ```
 
+You can also point `usePipenv` at a `Pipfile` that lives outside the service root. Pass a path (relative to the service path, or absolute) instead of a boolean:
+
+```yaml
+custom:
+  pythonRequirements:
+    usePipenv: backend/Pipfile # path to a Pipfile outside the service root
+```
+
+The path is resolved relative to the service path. `true`/`false` continue to work as before. An explicit path overrides the default `Pipfile` detection; pipenv will run with the manifest's directory as its working directory.
+
 ## Poetry support
 
 If you include a `pyproject.toml` and have `poetry` installed instead of a `requirements.txt` this will use
@@ -130,6 +140,16 @@ custom:
   pythonRequirements:
     usePoetry: false
 ```
+
+You can also point `usePoetry` at a `pyproject.toml` that lives outside the service root:
+
+```yaml
+custom:
+  pythonRequirements:
+    usePoetry: ../shared/pyproject.toml # path to a pyproject.toml outside the service root
+```
+
+The path is resolved relative to the service path. `true`/`false` continue to work as before. An explicit path overrides the default `pyproject.toml` detection; poetry will run with the manifest's directory as its working directory.
 
 Be aware that if no `poetry.lock` file is present, a new one will be generated on the fly. To help having predictable builds,
 you can set the `requirePoetryLockFile` flag to true to throw an error when `poetry.lock` is missing.
@@ -180,6 +200,16 @@ bottle = {git = "ssh://git@github.com/bottlepy/bottle.git", tag = "0.12.16"}
 ## uv support
 
 [`uv`](https://docs.astral.sh/uv/) projects behave just like Pipenv or Poetry projects. When a `uv.lock` file is present and `custom.pythonRequirements.useUv` is not disabled, the Framework will run `uv export --no-dev --frozen --no-hashes` to generate an intermediate `requirements.txt` in `.serverless/requirements.txt` before packaging. Set `useUv: false` if you prefer to manage that file yourself.
+
+You can also point `useUv` at a `uv.lock` that lives outside the service root:
+
+```yaml
+custom:
+  pythonRequirements:
+    useUv: infra/uv.lock # path to a uv.lock outside the service root
+```
+
+The path is resolved relative to the service path. `true`/`false` continue to work as before. An explicit path overrides the default `uv.lock` detection; uv will run with the lock file's directory as its working directory.
 
 ### Using uv to install dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5471,6 +5471,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/bare-events": {
@@ -5596,6 +5597,7 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
       "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6188,6 +6190,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -7918,6 +7921,7 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -8478,6 +8482,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -10506,6 +10511,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11230,6 +11236,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/packages/serverless/lib/plugins/python/index.js
+++ b/packages/serverless/lib/plugins/python/index.js
@@ -10,6 +10,8 @@
  */
 
 /* jshint ignore:start */
+import path from 'path'
+import { ServerlessError } from '@serverless/util'
 import {
   addVendorHelper,
   packRequirements,
@@ -21,6 +23,23 @@ import { installAllRequirements } from './lib/pip.js'
 import { pipfileToRequirements } from './lib/pipenv.js'
 import { uvToRequirements } from './lib/uv.js'
 import { cleanup, cleanupCache } from './lib/clean.js'
+
+function normalizeToolFlag(rawValue, servicePath, toolName) {
+  if (typeof rawValue === 'string') {
+    const trimmed = rawValue.trim()
+    if (!trimmed) {
+      throw new ServerlessError(
+        `Python Requirements: use${toolName} must be a boolean or a non-empty path.`,
+        'PYTHON_REQUIREMENTS_INVALID_TOOL_OPTION',
+      )
+    }
+    const filePath = path.isAbsolute(trimmed)
+      ? trimmed
+      : path.resolve(servicePath, trimmed)
+    return { enabled: true, filePath }
+  }
+  return { enabled: Boolean(rawValue), filePath: undefined }
+}
 
 class ServerlessPythonRequirements {
   /**
@@ -124,6 +143,19 @@ class ServerlessPythonRequirements {
         options.layer = {}
       }
     }
+    for (const [flag, key] of [
+      ['usePipenv', 'pipenvFilePath'],
+      ['usePoetry', 'poetryFilePath'],
+      ['useUv', 'uvFilePath'],
+    ]) {
+      const { enabled, filePath } = normalizeToolFlag(
+        options[flag],
+        this.servicePath,
+        flag.replace('use', ''),
+      )
+      options[flag] = enabled
+      options[key] = filePath
+    }
     return options
   }
 
@@ -201,6 +233,21 @@ class ServerlessPythonRequirements {
             description: `Python module directory containing the function handler.
 @remarks Used by the bundled Python requirements integration.`,
             type: 'string',
+          },
+        },
+      })
+    }
+
+    if (this.serverless.configSchemaHandler?.defineCustomProperties) {
+      this.serverless.configSchemaHandler.defineCustomProperties({
+        properties: {
+          pythonRequirements: {
+            type: ['boolean', 'object'],
+            properties: {
+              usePipenv: { type: ['boolean', 'string'] },
+              usePoetry: { type: ['boolean', 'string'] },
+              useUv: { type: ['boolean', 'string'] },
+            },
           },
         },
       })
@@ -381,4 +428,5 @@ ServerlessPythonRequirements.shouldLoad = ({ serverless, log }) => {
   return true
 }
 
+export { normalizeToolFlag }
 export default ServerlessPythonRequirements

--- a/packages/serverless/lib/plugins/python/lib/pip.js
+++ b/packages/serverless/lib/plugins/python/lib/pip.js
@@ -44,6 +44,16 @@ function filterCommands(commands) {
   return commands.filter((cmd) => Boolean(cmd) && cmd.length > 0)
 }
 
+function assertManifestFile(filePath, label) {
+  if (!fse.existsSync(filePath) || !fse.statSync(filePath).isFile()) {
+    throw new ServerlessError(
+      `Python Requirements: ${label} path does not point to a file: ${filePath}`,
+      'PYTHON_REQUIREMENTS_INVALID_MANIFEST_PATH',
+      { stack: false },
+    )
+  }
+}
+
 /**
  * Render zero or more commands as a single command for a Unix environment.
  * In this context, a "command" is a list of arguments. An empty list or falsy value is ommitted.
@@ -80,7 +90,15 @@ function generateRequirementsFile(
 ) {
   const { serverless, servicePath, options, log } = pluginInstance
   const modulePath = path.dirname(requirementsPath)
-  if (options.usePoetry && isPoetryProject(modulePath)) {
+  if (
+    options.usePoetry &&
+    (options.poetryFilePath
+      ? isPoetryProject(
+          path.dirname(options.poetryFilePath),
+          options.poetryFilePath,
+        )
+      : isPoetryProject(modulePath))
+  ) {
     filterRequirementsFile(targetFile, targetFile, pluginInstance)
     if (log) {
       log.info(`Parsed requirements.txt from pyproject.toml in ${targetFile}`)
@@ -91,8 +109,11 @@ function generateRequirementsFile(
     }
   } else if (
     options.usePipenv &&
-    fse.existsSync(path.join(servicePath, 'Pipfile'))
+    (options.pipenvFilePath ||
+      fse.existsSync(path.join(servicePath, 'Pipfile')))
   ) {
+    if (options.pipenvFilePath)
+      assertManifestFile(options.pipenvFilePath, 'Pipenv')
     filterRequirementsFile(
       path.join(servicePath, '.serverless/requirements.txt'),
       targetFile,
@@ -107,8 +128,9 @@ function generateRequirementsFile(
     }
   } else if (
     options.useUv &&
-    fse.existsSync(path.join(servicePath, 'uv.lock'))
+    (options.uvFilePath || fse.existsSync(path.join(servicePath, 'uv.lock')))
   ) {
+    if (options.uvFilePath) assertManifestFile(options.uvFilePath, 'uv')
     filterRequirementsFile(
       path.join(servicePath, '.serverless/requirements.txt'),
       targetFile,
@@ -731,15 +753,33 @@ function copyVendors(vendorFolder, targetFolder, { serverless, log }) {
  * @param {string} fileName
  */
 function requirementsFileExists(servicePath, options, fileName) {
-  if (options.usePoetry && isPoetryProject(path.dirname(fileName))) {
+  if (
+    options.usePoetry &&
+    (options.poetryFilePath
+      ? isPoetryProject(
+          path.dirname(options.poetryFilePath),
+          options.poetryFilePath,
+        )
+      : isPoetryProject(path.dirname(fileName)))
+  ) {
     return true
   }
 
-  if (options.usePipenv && fse.existsSync(path.join(servicePath, 'Pipfile'))) {
+  if (
+    options.usePipenv &&
+    (options.pipenvFilePath ||
+      fse.existsSync(path.join(servicePath, 'Pipfile')))
+  ) {
+    if (options.pipenvFilePath)
+      assertManifestFile(options.pipenvFilePath, 'Pipenv')
     return true
   }
 
-  if (options.useUv && fse.existsSync(path.join(servicePath, 'uv.lock'))) {
+  if (
+    options.useUv &&
+    (options.uvFilePath || fse.existsSync(path.join(servicePath, 'uv.lock')))
+  ) {
+    if (options.uvFilePath) assertManifestFile(options.uvFilePath, 'uv')
     return true
   }
 
@@ -1035,4 +1075,8 @@ async function installAllRequirements() {
   }
 }
 
-export { installAllRequirements }
+export {
+  installAllRequirements,
+  generateRequirementsFile,
+  requirementsFileExists,
+}

--- a/packages/serverless/lib/plugins/python/lib/pipenv.js
+++ b/packages/serverless/lib/plugins/python/lib/pipenv.js
@@ -42,16 +42,33 @@ async function getPipenvVersion(pluginInstance) {
   }
 }
 
+function assertManifestFile(filePath, label) {
+  if (!fse.existsSync(filePath) || !fse.statSync(filePath).isFile()) {
+    throw new ServerlessError(
+      `Python Requirements: ${label} path does not point to a file: ${filePath}`,
+      'PYTHON_REQUIREMENTS_INVALID_MANIFEST_PATH',
+      { stack: false },
+    )
+  }
+}
+
 /**
  * pipenv install
  */
 async function pipfileToRequirements() {
-  if (
-    !this.options.usePipenv ||
-    !fse.existsSync(path.join(this.servicePath, 'Pipfile'))
-  ) {
+  if (!this.options.usePipenv) return
+
+  const pipfilePath =
+    this.options.pipenvFilePath ?? path.join(this.servicePath, 'Pipfile')
+  if (this.options.pipenvFilePath) {
+    assertManifestFile(this.options.pipenvFilePath, 'Pipenv')
+  } else if (!fse.existsSync(pipfilePath)) {
     return
   }
+
+  const pipenvCwd = this.options.pipenvFilePath
+    ? path.dirname(this.options.pipenvFilePath)
+    : this.servicePath
 
   let generateRequirementsProgress
   if (this.progress && this.log) {
@@ -83,7 +100,7 @@ async function pipfileToRequirements() {
       // See: https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt
       try {
         res = await spawn('pipenv', ['requirements'], {
-          cwd: this.servicePath,
+          cwd: pipenvCwd,
         })
       } catch (e) {
         const stderrBufferContent =
@@ -100,10 +117,10 @@ async function pipfileToRequirements() {
             )
           }
           await spawn('pipenv', ['lock'], {
-            cwd: this.servicePath,
+            cwd: pipenvCwd,
           })
           res = await spawn('pipenv', ['requirements'], {
-            cwd: this.servicePath,
+            cwd: pipenvCwd,
           })
         } else {
           throw e
@@ -115,7 +132,7 @@ async function pipfileToRequirements() {
         'pipenv',
         ['lock', '--requirements', '--keep-outdated'],
         {
-          cwd: this.servicePath,
+          cwd: pipenvCwd,
         },
       )
     }

--- a/packages/serverless/lib/plugins/python/lib/poetry.js
+++ b/packages/serverless/lib/plugins/python/lib/poetry.js
@@ -9,11 +9,35 @@ import { ServerlessError } from '@serverless/util'
 /**
  * poetry install
  */
+function assertManifestFile(filePath, label) {
+  if (!fse.existsSync(filePath) || !fse.statSync(filePath).isFile()) {
+    throw new ServerlessError(
+      `Python Requirements: ${label} path does not point to a file: ${filePath}`,
+      'PYTHON_REQUIREMENTS_INVALID_MANIFEST_PATH',
+      { stack: false },
+    )
+  }
+}
+
 async function pyprojectTomlToRequirements(modulePath, pluginInstance) {
   const { serverless, servicePath, options, log, progress } = pluginInstance
 
-  const moduleProjectPath = path.join(servicePath, modulePath)
-  if (!options.usePoetry || !isPoetryProject(moduleProjectPath)) {
+  if (!options.usePoetry) return
+
+  const moduleProjectPath = options.poetryFilePath
+    ? path.dirname(options.poetryFilePath)
+    : path.join(servicePath, modulePath)
+
+  if (options.poetryFilePath) {
+    assertManifestFile(options.poetryFilePath, 'poetry')
+    if (!isPoetryProject(moduleProjectPath, options.poetryFilePath)) {
+      throw new ServerlessError(
+        `Python Requirements: poetry path points to a file that is not a poetry project: ${options.poetryFilePath}`,
+        'PYTHON_REQUIREMENTS_INVALID_MANIFEST_PATH',
+        { stack: false },
+      )
+    }
+  } else if (!isPoetryProject(moduleProjectPath)) {
     return
   }
 
@@ -121,8 +145,8 @@ async function pyprojectTomlToRequirements(modulePath, pluginInstance) {
 /**
  * Check if pyproject.toml file exists and is a poetry project.
  */
-function isPoetryProject(servicePath) {
-  const pyprojectPath = path.join(servicePath, 'pyproject.toml')
+function isPoetryProject(servicePath, filePath) {
+  const pyprojectPath = filePath ?? path.join(servicePath, 'pyproject.toml')
 
   if (!fse.existsSync(pyprojectPath)) {
     return false

--- a/packages/serverless/lib/plugins/python/lib/uv.js
+++ b/packages/serverless/lib/plugins/python/lib/uv.js
@@ -42,14 +42,32 @@ async function getUvVersion(pluginInstance) {
   }
 }
 
+function assertManifestFile(filePath, label) {
+  if (!fse.existsSync(filePath) || !fse.statSync(filePath).isFile()) {
+    throw new ServerlessError(
+      `Python Requirements: ${label} path does not point to a file: ${filePath}`,
+      'PYTHON_REQUIREMENTS_INVALID_MANIFEST_PATH',
+      { stack: false },
+    )
+  }
+}
+
 async function uvToRequirements(pluginInstance) {
   const { servicePath, options, serverless, log, progress } = pluginInstance
 
   if (!options.useUv) return
 
-  const moduleProjectPath = servicePath
-  const uvLockPath = path.join(moduleProjectPath, 'uv.lock')
-  if (!fse.existsSync(uvLockPath)) return
+  const moduleProjectPath = options.uvFilePath
+    ? path.dirname(options.uvFilePath)
+    : servicePath
+  const uvLockPath =
+    options.uvFilePath ?? path.join(moduleProjectPath, 'uv.lock')
+
+  if (options.uvFilePath) {
+    assertManifestFile(options.uvFilePath, 'uv')
+  } else if (!fse.existsSync(uvLockPath)) {
+    return
+  }
 
   let generateRequirementsProgress
   if (progress && log) {

--- a/packages/serverless/test/unit/lib/plugins/python/detection.test.js
+++ b/packages/serverless/test/unit/lib/plugins/python/detection.test.js
@@ -1,0 +1,313 @@
+import path from 'path'
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+const SERVICE_PATH = '/srv/myservice'
+
+// Mock fse before importing the module under test
+const mockFse = {
+  existsSync: jest.fn(),
+  statSync: jest.fn(),
+  ensureDirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  readFileSync: jest.fn(),
+}
+
+jest.unstable_mockModule('fs-extra', () => ({ default: mockFse }))
+
+const mockIsPoetryProject = jest.fn()
+const mockPyprojectTomlToRequirements = jest.fn()
+
+jest.unstable_mockModule(
+  '../../../../../lib/plugins/python/lib/poetry.js',
+  () => ({
+    isPoetryProject: mockIsPoetryProject,
+    pyprojectTomlToRequirements: mockPyprojectTomlToRequirements,
+  }),
+)
+
+jest.unstable_mockModule('../../../../../lib/plugins/python/lib/uv.js', () => ({
+  getUvVersion: jest.fn(),
+}))
+
+const { generateRequirementsFile, requirementsFileExists } =
+  await import('../../../../../lib/plugins/python/lib/pip.js')
+
+const DEFAULT_OPTIONS = {
+  usePoetry: true,
+  usePipenv: true,
+  useUv: true,
+  noDeploy: [],
+}
+
+function makePluginInstance(optionOverrides = {}) {
+  return {
+    servicePath: SERVICE_PATH,
+    options: { ...DEFAULT_OPTIONS, ...optionOverrides },
+    serverless: { cli: { log: jest.fn() } },
+    log: null,
+  }
+}
+
+describe('generateRequirementsFile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFse.existsSync.mockReturnValue(false)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockFse.readFileSync.mockReturnValue('')
+    mockIsPoetryProject.mockReturnValue(false)
+    mockPyprojectTomlToRequirements.mockResolvedValue(undefined)
+  })
+
+  it('takes poetry branch when isPoetryProject returns true (default path)', () => {
+    mockIsPoetryProject.mockReturnValue(true)
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.readFileSync.mockReturnValue('')
+
+    const pluginInstance = makePluginInstance()
+    const requirementsPath = path.join(SERVICE_PATH, 'requirements.txt')
+    const targetFile = path.join(SERVICE_PATH, '.serverless/requirements.txt')
+
+    generateRequirementsFile(requirementsPath, targetFile, pluginInstance)
+
+    expect(mockIsPoetryProject).toHaveBeenCalledWith(SERVICE_PATH)
+  })
+
+  it('takes poetry branch when poetryFilePath is set and isPoetryProject returns true', () => {
+    const poetryFilePath = '/external/pyproject.toml'
+    mockIsPoetryProject.mockReturnValue(true)
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.readFileSync.mockReturnValue('')
+
+    const pluginInstance = makePluginInstance({ poetryFilePath })
+    const requirementsPath = path.join(SERVICE_PATH, 'requirements.txt')
+    const targetFile = path.join(SERVICE_PATH, '.serverless/requirements.txt')
+
+    generateRequirementsFile(requirementsPath, targetFile, pluginInstance)
+
+    expect(mockIsPoetryProject).toHaveBeenCalledWith(
+      path.dirname(poetryFilePath),
+      poetryFilePath,
+    )
+  })
+
+  it('takes pipenv branch when pipenvFilePath is set and file is valid', () => {
+    const pipenvFilePath = '/external/Pipfile'
+    mockIsPoetryProject.mockReturnValue(false)
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockFse.readFileSync.mockReturnValue('')
+
+    const pluginInstance = makePluginInstance({
+      usePoetry: false,
+      pipenvFilePath,
+    })
+    const requirementsPath = path.join(SERVICE_PATH, 'requirements.txt')
+    const targetFile = path.join(SERVICE_PATH, '.serverless/requirements.txt')
+
+    generateRequirementsFile(requirementsPath, targetFile, pluginInstance)
+
+    expect(mockFse.existsSync).toHaveBeenCalledWith(pipenvFilePath)
+  })
+
+  it('throws ServerlessError when pipenvFilePath is set but file is missing', () => {
+    const pipenvFilePath = '/missing/Pipfile'
+    mockFse.existsSync.mockImplementation((p) => p !== pipenvFilePath)
+    mockIsPoetryProject.mockReturnValue(false)
+
+    const pluginInstance = makePluginInstance({
+      usePoetry: false,
+      pipenvFilePath,
+    })
+    const requirementsPath = path.join(SERVICE_PATH, 'requirements.txt')
+    const targetFile = path.join(SERVICE_PATH, '.serverless/requirements.txt')
+
+    expect(() =>
+      generateRequirementsFile(requirementsPath, targetFile, pluginInstance),
+    ).toThrow(/does not point to a file/)
+  })
+
+  it('takes uv branch when uvFilePath is set and file is valid', () => {
+    const uvFilePath = '/external/uv.lock'
+    mockIsPoetryProject.mockReturnValue(false)
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockFse.readFileSync.mockReturnValue('')
+
+    const pluginInstance = makePluginInstance({
+      usePoetry: false,
+      usePipenv: false,
+      uvFilePath,
+    })
+    const requirementsPath = path.join(SERVICE_PATH, 'requirements.txt')
+    const targetFile = path.join(SERVICE_PATH, '.serverless/requirements.txt')
+
+    generateRequirementsFile(requirementsPath, targetFile, pluginInstance)
+
+    expect(mockFse.existsSync).toHaveBeenCalledWith(uvFilePath)
+  })
+
+  it('throws ServerlessError when uvFilePath is set but file is missing', () => {
+    const uvFilePath = '/missing/uv.lock'
+    mockFse.existsSync.mockImplementation((p) => p !== uvFilePath)
+    mockIsPoetryProject.mockReturnValue(false)
+
+    const pluginInstance = makePluginInstance({
+      usePoetry: false,
+      usePipenv: false,
+      uvFilePath,
+    })
+    const requirementsPath = path.join(SERVICE_PATH, 'requirements.txt')
+    const targetFile = path.join(SERVICE_PATH, '.serverless/requirements.txt')
+
+    expect(() =>
+      generateRequirementsFile(requirementsPath, targetFile, pluginInstance),
+    ).toThrow(/does not point to a file/)
+  })
+
+  it('falls through to default when all tools return false', () => {
+    mockIsPoetryProject.mockReturnValue(false)
+    mockFse.existsSync.mockReturnValue(false)
+    mockFse.readFileSync.mockReturnValue('')
+
+    const pluginInstance = makePluginInstance()
+    const requirementsPath = path.join(SERVICE_PATH, 'requirements.txt')
+    const targetFile = path.join(SERVICE_PATH, '.serverless/requirements.txt')
+
+    generateRequirementsFile(requirementsPath, targetFile, pluginInstance)
+
+    // No assertion beyond "did not throw"
+  })
+})
+
+describe('requirementsFileExists', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFse.existsSync.mockReturnValue(false)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockIsPoetryProject.mockReturnValue(false)
+  })
+
+  it('returns true when poetry project detected at default path', () => {
+    mockIsPoetryProject.mockReturnValue(true)
+    const options = { ...DEFAULT_OPTIONS }
+    expect(
+      requirementsFileExists(
+        SERVICE_PATH,
+        options,
+        '/srv/myservice/requirements.txt',
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true when poetryFilePath is set and isPoetryProject confirms', () => {
+    const poetryFilePath = '/external/pyproject.toml'
+    mockIsPoetryProject.mockReturnValue(true)
+    const options = { ...DEFAULT_OPTIONS, poetryFilePath }
+    expect(
+      requirementsFileExists(
+        SERVICE_PATH,
+        options,
+        '/srv/myservice/requirements.txt',
+      ),
+    ).toBe(true)
+    expect(mockIsPoetryProject).toHaveBeenCalledWith(
+      path.dirname(poetryFilePath),
+      poetryFilePath,
+    )
+  })
+
+  it('returns true when default Pipfile exists', () => {
+    mockFse.existsSync.mockImplementation(
+      (p) => p === path.join(SERVICE_PATH, 'Pipfile'),
+    )
+    const options = { ...DEFAULT_OPTIONS, usePoetry: false }
+    expect(
+      requirementsFileExists(
+        SERVICE_PATH,
+        options,
+        '/srv/myservice/requirements.txt',
+      ),
+    ).toBe(true)
+  })
+
+  it('returns true when pipenvFilePath is set and file exists', () => {
+    const pipenvFilePath = '/external/Pipfile'
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    const options = { ...DEFAULT_OPTIONS, usePoetry: false, pipenvFilePath }
+    expect(
+      requirementsFileExists(
+        SERVICE_PATH,
+        options,
+        '/srv/myservice/requirements.txt',
+      ),
+    ).toBe(true)
+  })
+
+  it('throws when pipenvFilePath is set but missing', () => {
+    const pipenvFilePath = '/missing/Pipfile'
+    mockFse.existsSync.mockImplementation((p) => p !== pipenvFilePath)
+    const options = {
+      ...DEFAULT_OPTIONS,
+      usePoetry: false,
+      pipenvFilePath,
+    }
+    expect(() =>
+      requirementsFileExists(
+        SERVICE_PATH,
+        options,
+        '/srv/myservice/requirements.txt',
+      ),
+    ).toThrow(/does not point to a file/)
+  })
+
+  it('returns true when uvFilePath is set and file is valid', () => {
+    const uvFilePath = '/external/uv.lock'
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    const options = {
+      ...DEFAULT_OPTIONS,
+      usePoetry: false,
+      usePipenv: false,
+      uvFilePath,
+    }
+    expect(
+      requirementsFileExists(
+        SERVICE_PATH,
+        options,
+        '/srv/myservice/requirements.txt',
+      ),
+    ).toBe(true)
+  })
+
+  it('throws when uvFilePath is set but missing', () => {
+    const uvFilePath = '/missing/uv.lock'
+    mockFse.existsSync.mockImplementation((p) => p !== uvFilePath)
+    const options = {
+      ...DEFAULT_OPTIONS,
+      usePoetry: false,
+      usePipenv: false,
+      uvFilePath,
+    }
+    expect(() =>
+      requirementsFileExists(
+        SERVICE_PATH,
+        options,
+        '/srv/myservice/requirements.txt',
+      ),
+    ).toThrow(/does not point to a file/)
+  })
+
+  it('returns false when all checks fail and requirements.txt is missing', () => {
+    mockFse.existsSync.mockReturnValue(false)
+    mockIsPoetryProject.mockReturnValue(false)
+    const options = { ...DEFAULT_OPTIONS }
+    expect(
+      requirementsFileExists(
+        SERVICE_PATH,
+        options,
+        '/srv/myservice/requirements.txt',
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/python/options.test.js
+++ b/packages/serverless/test/unit/lib/plugins/python/options.test.js
@@ -1,0 +1,165 @@
+import path from 'path'
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+import ServerlessPythonRequirements, {
+  normalizeToolFlag,
+} from '../../../../../lib/plugins/python/index.js'
+
+const SERVICE_PATH = '/srv/myservice'
+
+function createMockServerless(pythonRequirements = {}) {
+  return {
+    cli: { log: jest.fn() },
+    config: { servicePath: SERVICE_PATH },
+    service: {
+      provider: { runtime: 'python3.12' },
+      custom: { pythonRequirements },
+      functions: {},
+    },
+    processedInput: { options: {} },
+    configSchemaHandler: {
+      defineFunctionProperties: jest.fn(),
+      defineCustomProperties: jest.fn(),
+    },
+  }
+}
+
+function makePlugin(pythonRequirements = {}) {
+  const sls = createMockServerless(pythonRequirements)
+  return new ServerlessPythonRequirements(sls, {})
+}
+
+describe('normalizeToolFlag', () => {
+  it('maps true to enabled=true, filePath=undefined', () => {
+    expect(normalizeToolFlag(true, SERVICE_PATH, 'Pipenv')).toEqual({
+      enabled: true,
+      filePath: undefined,
+    })
+  })
+
+  it('maps false to enabled=false, filePath=undefined', () => {
+    expect(normalizeToolFlag(false, SERVICE_PATH, 'Pipenv')).toEqual({
+      enabled: false,
+      filePath: undefined,
+    })
+  })
+
+  it('maps undefined (falsy) to enabled=false, filePath=undefined', () => {
+    expect(normalizeToolFlag(undefined, SERVICE_PATH, 'Pipenv')).toEqual({
+      enabled: false,
+      filePath: undefined,
+    })
+  })
+
+  it('maps a relative path to enabled=true and an absolute resolved path', () => {
+    const result = normalizeToolFlag('subdir/Pipfile', SERVICE_PATH, 'Pipenv')
+    expect(result.enabled).toBe(true)
+    expect(result.filePath).toBe(path.resolve(SERVICE_PATH, 'subdir/Pipfile'))
+    expect(path.isAbsolute(result.filePath)).toBe(true)
+  })
+
+  it('maps an absolute path to enabled=true and the same absolute path', () => {
+    const abs = '/absolute/path/to/Pipfile'
+    const result = normalizeToolFlag(abs, SERVICE_PATH, 'Pipenv')
+    expect(result.enabled).toBe(true)
+    expect(result.filePath).toBe(abs)
+  })
+
+  it('throws ServerlessError on empty string', () => {
+    expect(() => normalizeToolFlag('', SERVICE_PATH, 'Pipenv')).toThrow(
+      /must be a boolean or a non-empty path/,
+    )
+  })
+
+  it('throws ServerlessError on whitespace-only string', () => {
+    expect(() => normalizeToolFlag('   ', SERVICE_PATH, 'Pipenv')).toThrow(
+      /must be a boolean or a non-empty path/,
+    )
+  })
+})
+
+describe('ServerlessPythonRequirements options getter', () => {
+  describe('boolean flags (backward-compat)', () => {
+    it('usePipenv:true stays true with no filePath', () => {
+      const plugin = makePlugin({ usePipenv: true })
+      expect(plugin.options.usePipenv).toBe(true)
+      expect(plugin.options.pipenvFilePath).toBeUndefined()
+    })
+
+    it('usePipenv:false stays false with no filePath', () => {
+      const plugin = makePlugin({ usePipenv: false })
+      expect(plugin.options.usePipenv).toBe(false)
+      expect(plugin.options.pipenvFilePath).toBeUndefined()
+    })
+
+    it('usePoetry:false with no filePath', () => {
+      const plugin = makePlugin({ usePoetry: false })
+      expect(plugin.options.usePoetry).toBe(false)
+      expect(plugin.options.poetryFilePath).toBeUndefined()
+    })
+
+    it('useUv:false with no filePath', () => {
+      const plugin = makePlugin({ useUv: false })
+      expect(plugin.options.useUv).toBe(false)
+      expect(plugin.options.uvFilePath).toBeUndefined()
+    })
+  })
+
+  describe('string path flags', () => {
+    it('relative usePoetry path resolves to absolute and enables the flag', () => {
+      const plugin = makePlugin({ usePoetry: '../api/pyproject.toml' })
+      expect(plugin.options.usePoetry).toBe(true)
+      expect(plugin.options.poetryFilePath).toBe(
+        path.resolve(SERVICE_PATH, '../api/pyproject.toml'),
+      )
+      expect(path.isAbsolute(plugin.options.poetryFilePath)).toBe(true)
+    })
+
+    it('absolute usePipenv path is used as-is and enables the flag', () => {
+      const abs = '/external/Pipfile'
+      const plugin = makePlugin({ usePipenv: abs })
+      expect(plugin.options.usePipenv).toBe(true)
+      expect(plugin.options.pipenvFilePath).toBe(abs)
+    })
+
+    it('relative useUv path resolves against servicePath', () => {
+      const plugin = makePlugin({ useUv: 'infra/uv.lock' })
+      expect(plugin.options.useUv).toBe(true)
+      expect(plugin.options.uvFilePath).toBe(
+        path.resolve(SERVICE_PATH, 'infra/uv.lock'),
+      )
+    })
+
+    it('empty string usePoetry throws when options are accessed', () => {
+      const plugin = makePlugin({ usePoetry: '' })
+      expect(() => plugin.options).toThrow(
+        /must be a boolean or a non-empty path/,
+      )
+    })
+  })
+
+  describe('schema registration', () => {
+    it('calls defineCustomProperties with pythonRequirements schema', () => {
+      const sls = createMockServerless({})
+      new ServerlessPythonRequirements(sls, {})
+      expect(
+        sls.configSchemaHandler.defineCustomProperties,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            pythonRequirements: expect.objectContaining({
+              properties: expect.objectContaining({
+                usePipenv: expect.objectContaining({
+                  type: ['boolean', 'string'],
+                }),
+                usePoetry: expect.objectContaining({
+                  type: ['boolean', 'string'],
+                }),
+                useUv: expect.objectContaining({ type: ['boolean', 'string'] }),
+              }),
+            }),
+          }),
+        }),
+      )
+    })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/python/pipenv.test.js
+++ b/packages/serverless/test/unit/lib/plugins/python/pipenv.test.js
@@ -1,0 +1,113 @@
+import path from 'path'
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+const SERVICE_PATH = '/srv/myservice'
+
+const mockFse = {
+  existsSync: jest.fn(),
+  statSync: jest.fn(),
+  ensureDirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+}
+
+jest.unstable_mockModule('fs-extra', () => ({ default: mockFse }))
+
+const mockSpawn = jest.fn()
+jest.unstable_mockModule('child-process-ext/spawn.js', () => ({
+  default: mockSpawn,
+}))
+
+jest.unstable_mockModule('semver', () => ({
+  default: {
+    valid: jest.fn().mockReturnValue('2023.0.0'),
+    gt: jest.fn().mockReturnValue(true),
+  },
+}))
+
+const { pipfileToRequirements } =
+  await import('../../../../../lib/plugins/python/lib/pipenv.js')
+
+function makePluginInstance(optionOverrides = {}) {
+  return {
+    servicePath: SERVICE_PATH,
+    options: {
+      usePipenv: true,
+      ...optionOverrides,
+    },
+    serverless: { cli: { log: jest.fn() } },
+    log: null,
+    progress: null,
+  }
+}
+
+describe('pipfileToRequirements', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockFse.ensureDirSync.mockReturnValue(undefined)
+    mockFse.writeFileSync.mockReturnValue(undefined)
+    mockSpawn.mockResolvedValue({
+      stdoutBuffer: Buffer.from('requests==2.28.0\n'),
+    })
+  })
+
+  it('returns early when usePipenv is false', async () => {
+    const plugin = makePluginInstance({ usePipenv: false })
+    await pipfileToRequirements.call(plugin)
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('returns early when default Pipfile does not exist', async () => {
+    mockFse.existsSync.mockReturnValue(false)
+    const plugin = makePluginInstance()
+    await pipfileToRequirements.call(plugin)
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('uses servicePath as cwd when no custom pipenvFilePath', async () => {
+    const plugin = makePluginInstance()
+    await pipfileToRequirements.call(plugin)
+
+    const spawnCalls = mockSpawn.mock.calls
+    const cwds = spawnCalls.map((call) => call[2]?.cwd)
+    expect(cwds.every((cwd) => cwd === SERVICE_PATH)).toBe(true)
+  })
+
+  it('uses dirname of pipenvFilePath as cwd when custom path is set', async () => {
+    const pipenvFilePath = '/external/backend/Pipfile'
+    const plugin = makePluginInstance({ pipenvFilePath })
+    await pipfileToRequirements.call(plugin)
+
+    // getPipenvVersion always uses servicePath for its --version check; only the
+    // requirements/lock spawns should use the custom Pipfile's directory.
+    const cwds = mockSpawn.mock.calls
+      .filter((call) => call[0] === 'pipenv' && !call[1].includes('--version'))
+      .map((call) => call[2]?.cwd)
+    expect(cwds.length).toBeGreaterThan(0)
+    expect(cwds.every((cwd) => cwd === path.dirname(pipenvFilePath))).toBe(true)
+  })
+
+  it('throws ServerlessError when custom pipenvFilePath does not exist', async () => {
+    const pipenvFilePath = '/missing/Pipfile'
+    mockFse.existsSync.mockImplementation((p) => p !== pipenvFilePath)
+    const plugin = makePluginInstance({ pipenvFilePath })
+
+    await expect(pipfileToRequirements.call(plugin)).rejects.toThrow(
+      /does not point to a file/,
+    )
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('throws ServerlessError when custom pipenvFilePath points to a directory', async () => {
+    const pipenvFilePath = '/is/a/directory'
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => false })
+    const plugin = makePluginInstance({ pipenvFilePath })
+
+    await expect(pipfileToRequirements.call(plugin)).rejects.toThrow(
+      /does not point to a file/,
+    )
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/python/poetry.test.js
+++ b/packages/serverless/test/unit/lib/plugins/python/poetry.test.js
@@ -1,0 +1,164 @@
+import path from 'path'
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+const SERVICE_PATH = '/srv/myservice'
+
+const mockFse = {
+  existsSync: jest.fn(),
+  statSync: jest.fn(),
+  readFileSync: jest.fn(),
+  ensureDirSync: jest.fn(),
+  moveSync: jest.fn(),
+  writeFileSync: jest.fn(),
+}
+
+jest.unstable_mockModule('fs-extra', () => ({ default: mockFse }))
+
+const mockFsExistsSync = jest.fn()
+const mockFsReadFileSync = jest.fn()
+jest.unstable_mockModule('fs', () => ({
+  default: {
+    existsSync: mockFsExistsSync,
+    readFileSync: mockFsReadFileSync,
+  },
+}))
+
+const mockSpawn = jest.fn()
+jest.unstable_mockModule('child-process-ext/spawn.js', () => ({
+  default: mockSpawn,
+}))
+
+const mockTomlParse = jest.fn()
+jest.unstable_mockModule('@iarna/toml/parse-string.js', () => ({
+  default: mockTomlParse,
+}))
+
+const { pyprojectTomlToRequirements, isPoetryProject } =
+  await import('../../../../../lib/plugins/python/lib/poetry.js')
+
+const POETRY_TOML = {
+  'build-system': { requires: ['poetry-core>=1.0.0'] },
+}
+
+function makePluginInstance(optionOverrides = {}) {
+  return {
+    servicePath: SERVICE_PATH,
+    options: {
+      usePoetry: true,
+      poetryWithGroups: [],
+      poetryWithoutGroups: [],
+      poetryOnlyGroups: [],
+      requirePoetryLockFile: false,
+      ...optionOverrides,
+    },
+    serverless: { cli: { log: jest.fn() } },
+    log: null,
+    progress: null,
+  }
+}
+
+describe('isPoetryProject', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFse.existsSync.mockReturnValue(false)
+    mockFsReadFileSync.mockReturnValue('')
+    mockTomlParse.mockReturnValue(POETRY_TOML)
+  })
+
+  it('returns false when pyproject.toml does not exist at default location', () => {
+    mockFse.existsSync.mockReturnValue(false)
+    expect(isPoetryProject('/some/dir')).toBe(false)
+  })
+
+  it('returns true when pyproject.toml contains poetry build-system at default location', () => {
+    mockFse.existsSync.mockReturnValue(true)
+    mockFsReadFileSync.mockReturnValue(Buffer.from(''))
+    mockTomlParse.mockReturnValue(POETRY_TOML)
+    expect(isPoetryProject('/some/dir')).toBe(true)
+  })
+
+  it('returns false when filePath is given but does not exist', () => {
+    const filePath = '/external/pyproject.toml'
+    mockFse.existsSync.mockImplementation((p) => p !== filePath)
+    expect(isPoetryProject('/some/dir', filePath)).toBe(false)
+  })
+
+  it('uses provided filePath instead of default pyproject.toml path', () => {
+    const filePath = '/external/pyproject.toml'
+    mockFse.existsSync.mockImplementation((p) => p === filePath)
+    mockFsReadFileSync.mockReturnValue(Buffer.from(''))
+    mockTomlParse.mockReturnValue(POETRY_TOML)
+    expect(isPoetryProject('/different/dir', filePath)).toBe(true)
+    expect(mockFse.existsSync).toHaveBeenCalledWith(filePath)
+  })
+})
+
+describe('pyprojectTomlToRequirements', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockFse.readFileSync.mockReturnValue('')
+    mockFse.ensureDirSync.mockReturnValue(undefined)
+    mockFse.moveSync.mockReturnValue(undefined)
+    mockFsExistsSync.mockReturnValue(false)
+    mockFsReadFileSync.mockReturnValue(Buffer.from(''))
+    mockTomlParse.mockReturnValue(POETRY_TOML)
+    mockSpawn.mockResolvedValue({ stdoutBuffer: Buffer.from('') })
+  })
+
+  it('returns early when usePoetry is false', async () => {
+    const plugin = makePluginInstance({ usePoetry: false })
+    await pyprojectTomlToRequirements('.', plugin)
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('returns early when no pyproject.toml at default location', async () => {
+    mockFse.existsSync.mockReturnValue(false)
+    const plugin = makePluginInstance()
+    await pyprojectTomlToRequirements('.', plugin)
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('uses dirname of poetryFilePath as cwd when custom path is set', async () => {
+    const poetryFilePath = '/external/pyproject.toml'
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockFse.readFileSync.mockReturnValue('')
+    mockTomlParse.mockReturnValue(POETRY_TOML)
+
+    const plugin = makePluginInstance({ poetryFilePath })
+    await pyprojectTomlToRequirements('.', plugin)
+
+    const spawnCalls = mockSpawn.mock.calls.filter((c) => c[0] === 'poetry')
+    expect(spawnCalls.length).toBeGreaterThan(0)
+    expect(spawnCalls[0][2].cwd).toBe(path.dirname(poetryFilePath))
+  })
+
+  it('throws ServerlessError when custom poetryFilePath does not exist', async () => {
+    const poetryFilePath = '/missing/pyproject.toml'
+    mockFse.existsSync.mockImplementation((p) => p !== poetryFilePath)
+
+    const plugin = makePluginInstance({ poetryFilePath })
+    await expect(pyprojectTomlToRequirements('.', plugin)).rejects.toThrow(
+      /does not point to a file/,
+    )
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('throws ServerlessError when custom poetryFilePath exists but is not a poetry project', async () => {
+    const poetryFilePath = '/external/pyproject.toml'
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockFsReadFileSync.mockReturnValue(Buffer.from(''))
+    mockTomlParse.mockReturnValue({
+      'build-system': { requires: ['setuptools'] },
+    })
+
+    const plugin = makePluginInstance({ poetryFilePath })
+    await expect(pyprojectTomlToRequirements('.', plugin)).rejects.toThrow(
+      /not a poetry project/,
+    )
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/python/uv.test.js
+++ b/packages/serverless/test/unit/lib/plugins/python/uv.test.js
@@ -1,0 +1,116 @@
+import path from 'path'
+import { jest, describe, it, expect, beforeEach } from '@jest/globals'
+
+const SERVICE_PATH = '/srv/myservice'
+
+const mockFse = {
+  existsSync: jest.fn(),
+  statSync: jest.fn(),
+  ensureDirSync: jest.fn(),
+}
+
+jest.unstable_mockModule('fs-extra', () => ({ default: mockFse }))
+
+const mockSpawn = jest.fn()
+jest.unstable_mockModule('child-process-ext/spawn.js', () => ({
+  default: mockSpawn,
+}))
+
+jest.unstable_mockModule('semver', () => ({
+  default: {
+    valid: jest.fn().mockReturnValue('0.6.0'),
+    gt: jest.fn().mockReturnValue(true),
+  },
+}))
+
+const { uvToRequirements } =
+  await import('../../../../../lib/plugins/python/lib/uv.js')
+
+function makePluginInstance(optionOverrides = {}) {
+  return {
+    servicePath: SERVICE_PATH,
+    options: {
+      useUv: true,
+      uvOptionalDependencies: [],
+      uvWithGroups: [],
+      uvWithoutGroups: [],
+      uvOnlyGroups: [],
+      ...optionOverrides,
+    },
+    serverless: { cli: { log: jest.fn() } },
+    log: null,
+    progress: null,
+  }
+}
+
+describe('uvToRequirements', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+    mockFse.ensureDirSync.mockReturnValue(undefined)
+    mockSpawn.mockResolvedValue({ stdoutBuffer: Buffer.from('') })
+  })
+
+  it('returns early when useUv is false', async () => {
+    const plugin = makePluginInstance({ useUv: false })
+    await uvToRequirements(plugin)
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('returns early when default uv.lock does not exist', async () => {
+    mockFse.existsSync.mockReturnValue(false)
+    const plugin = makePluginInstance()
+    await uvToRequirements(plugin)
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('uses servicePath as cwd when no custom uvFilePath', async () => {
+    const plugin = makePluginInstance()
+    await uvToRequirements(plugin)
+
+    const uvCalls = mockSpawn.mock.calls.filter((c) => c[0] === 'uv')
+    expect(uvCalls.length).toBeGreaterThan(0)
+    expect(uvCalls[0][2].cwd).toBe(SERVICE_PATH)
+  })
+
+  it('uses dirname of uvFilePath as cwd when custom path is set', async () => {
+    const uvFilePath = '/external/backend/uv.lock'
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => true })
+
+    const plugin = makePluginInstance({ uvFilePath })
+    await uvToRequirements(plugin)
+
+    // getUvVersion uses servicePath for its --version check; only the export
+    // spawn should use the custom lock file's directory.
+    const uvExportCalls = mockSpawn.mock.calls.filter(
+      (c) => c[0] === 'uv' && c[1][0] === 'export',
+    )
+    expect(uvExportCalls.length).toBeGreaterThan(0)
+    expect(uvExportCalls[0][2].cwd).toBe(path.dirname(uvFilePath))
+  })
+
+  it('throws ServerlessError when custom uvFilePath does not exist', async () => {
+    const uvFilePath = '/missing/uv.lock'
+    mockFse.existsSync.mockImplementation((p) => p !== uvFilePath)
+
+    const plugin = makePluginInstance({ uvFilePath })
+    await expect(uvToRequirements(plugin)).rejects.toThrow(
+      /does not point to a file/,
+    )
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('throws ServerlessError when custom uvFilePath points to a directory', async () => {
+    const uvFilePath = '/is/a/directory'
+    mockFse.existsSync.mockReturnValue(true)
+    mockFse.statSync.mockReturnValue({ isFile: () => false })
+
+    const plugin = makePluginInstance({ uvFilePath })
+    await expect(uvToRequirements(plugin)).rejects.toThrow(
+      /does not point to a file/,
+    )
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- `usePipenv`, `usePoetry`, and `useUv` now accept a **string path** in addition to booleans. A non-empty string enables the tool and reads the manifest (Pipfile / pyproject.toml / uv.lock) exclusively from that path, resolved relative to the service root. The tool's `spawn` cwd follows the manifest's directory.
- Boolean `true`/`false` behaviour is completely unchanged.
- An explicit path that is missing or is a directory throws `ServerlessError` at packaging time (no silent fallback).
- Minimal JSON schema added for the three flags (`boolean | string`).
- New unit test suite (`test/unit/lib/plugins/python/`, 52 tests) covers the normalisation helper, detection branches, and all three tool modules via mocked `fs-extra` and `child-process-ext/spawn`.
- Docs updated with YAML examples for the string-path form in the Pipenv, Poetry, and uv sections.

## Test plan

- [ ] `npm run test:unit -w @serverless/framework -- test/unit/lib/plugins/python` — all 52 tests green, no real Python toolchain required
- [ ] `npm run prettier:fix && npm run lint:fix` — no changes
- [ ] Existing integration fixtures (`pipenv`, `poetry`, `uv`, `individually`) unchanged and still valid

Closes #13308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using custom manifest file paths with Python dependency tools.
  * Pipenv, Poetry, and uv can now be configured with paths outside the service root.

* **Bug Fixes**
  * Improved validation for custom manifest paths and clearer errors when paths are missing, empty, or invalid.
  * Dependency generation now uses the correct working directory for custom manifest locations.

* **Documentation**
  * Updated Python support docs to explain path-based configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->