### PR TITLE
feat: improve analytics events

### DIFF
--- a/packages/serverless/lib/classes/plugin-manager.js
+++ b/packages/serverless/lib/classes/plugin-manager.js
@@ -270,6 +270,9 @@ class PluginManager {
     this.commands = {}
     this.aliases = {}
     this.hooks = {}
+    // Wall-clock duration (ms) spent in each lifecycle event's hooks,
+    // accumulated across invocations; keyed by lifecycle event name
+    this.lifecycleEventDurations = {}
     this.deprecatedEvents = {}
     // Track service-declared plugin names to coordinate bundled overrides per invocation
     this.servicePluginNames = new Set()
@@ -933,9 +936,16 @@ class PluginManager {
         lifecycleEventName,
         hooksData: { before, at, after },
       } of lifecycleEventsData) {
-        await this.runHooks(`before:${lifecycleEventName}`, before)
-        await this.runHooks(lifecycleEventName, at)
-        await this.runHooks(`after:${lifecycleEventName}`, after)
+        const lifecycleStart = Date.now()
+        try {
+          await this.runHooks(`before:${lifecycleEventName}`, before)
+          await this.runHooks(lifecycleEventName, at)
+          await this.runHooks(`after:${lifecycleEventName}`, after)
+        } finally {
+          this.lifecycleEventDurations[lifecycleEventName] =
+            (this.lifecycleEventDurations[lifecycleEventName] ?? 0) +
+            (Date.now() - lifecycleStart)
+        }
       }
     } catch (error) {
       if (error instanceof TerminateHookChain) {

--- a/packages/sf-core/src/lib/router.js
+++ b/packages/sf-core/src/lib/router.js
@@ -333,6 +333,7 @@ const createUsageEvent = ({
  * @param {string} params.orgId - Organization ID.
  * @param {string} params.versionFramework - Version of the Serverless Framework being used.
  * @param {string[]} params.command - The command executed as part of the Serverless action.
+ * @param {number} [params.commandStartTime] - Epoch ms timestamp of command start, used to compute commandDurationMs.
  * @param {string} params.configFileName - Name of the configuration file.
  * @param {boolean} params.isCompose - Indicates if this is within a Compose project.
  * @param {string[]} params.cliOptions - CLI options passed during execution.
@@ -516,6 +517,7 @@ export const getRunner = async ({
  * @param logger
  * @param versionFramework
  * @param command
+ * @param commandStartTime
  * @param options
  * @param resolverManager
  * @param compose

--- a/packages/sf-core/src/lib/router.js
+++ b/packages/sf-core/src/lib/router.js
@@ -58,6 +58,7 @@ const runners = [
  * @returns {Promise<void>} - Resolves when routing is complete.
  */
 const route = async ({ command, options, versions, compose }) => {
+  const commandStartTime = Date.now()
   const logger = log.get('core:router')
   const progressMain = progress.get('main')
   progressMain.notice('Initializing')
@@ -136,6 +137,7 @@ const route = async ({ command, options, versions, compose }) => {
       logger,
       versionFramework: versions?.serverless_framework,
       command,
+      commandStartTime,
       options,
       resolverManager,
       compose,
@@ -155,6 +157,7 @@ const route = async ({ command, options, versions, compose }) => {
     await handleFinalizationError({
       versionFramework: versions?.serverless_framework,
       command,
+      commandStartTime,
       options,
       configFilePath,
       resolverManager,
@@ -346,6 +349,7 @@ const createAnalysisEvent = ({
   orgId,
   versionFramework,
   command,
+  commandStartTime,
   configFileName,
   isCompose,
   userId,
@@ -377,6 +381,10 @@ const createAnalysisEvent = ({
     configurationFileName: configFileName,
     resolvers: Array.from(new Set(resolvers)),
     ...runnerSpecificDetails,
+  }
+
+  if (typeof commandStartTime === 'number') {
+    analysisEvent.commandDurationMs = Date.now() - commandStartTime
   }
 
   if (error instanceof Error) {
@@ -525,6 +533,7 @@ const finalize = async ({
   logger,
   versionFramework,
   command,
+  commandStartTime,
   options,
   resolverManager,
   compose,
@@ -562,6 +571,7 @@ const finalize = async ({
       orgId,
       versionFramework,
       command,
+      commandStartTime,
       configFilePath,
       runner,
       compose,
@@ -619,6 +629,7 @@ const finalize = async ({
 const handleFinalizationError = async ({
   versionFramework,
   command,
+  commandStartTime,
   options,
   configFilePath,
   resolverManager,
@@ -635,6 +646,7 @@ const handleFinalizationError = async ({
       orgId: authenticatedData?.orgId,
       versionFramework,
       command,
+      commandStartTime,
       configFileName: configFilePath && path.basename(configFilePath),
       isCompose:
         runner.constructor.name === 'ComposeRunner' ||
@@ -715,6 +727,7 @@ async function sendAnalysisAndUsageEvent({
   orgId,
   versionFramework,
   command,
+  commandStartTime,
   configFilePath,
   runner,
   compose,
@@ -730,6 +743,7 @@ async function sendAnalysisAndUsageEvent({
     orgId,
     versionFramework,
     command,
+    commandStartTime,
     configFileName: configFilePath && path.basename(configFilePath),
     isCompose:
       runner.constructor.name === 'ComposeRunner' ||

--- a/packages/sf-core/src/lib/runners/framework-analytics.js
+++ b/packages/sf-core/src/lib/runners/framework-analytics.js
@@ -125,8 +125,11 @@ export const deriveAnalysisEnrichment = ({
       details.resourceCount = Object.keys(compiledResources).length
     }
 
+    // Only the plain `deploy` command can create the stack — sub-commands
+    // (`deploy function`, `deploy list`) never do, so they don't report it
     if (
       Array.isArray(command) &&
+      command.length === 1 &&
       command[0] === 'deploy' &&
       serviceUniqueId &&
       typeof analyticsMetrics?.stackExistedBeforeRun === 'boolean'

--- a/packages/sf-core/src/lib/runners/framework-analytics.js
+++ b/packages/sf-core/src/lib/runners/framework-analytics.js
@@ -1,0 +1,150 @@
+/**
+ * Pure helpers deriving bounded analytics fields from service config and the
+ * compiled CloudFormation template. Every function here must be total (never
+ * throw on malformed input): a throw escaping the analytics path aborts
+ * finalization and silently drops the billing usage event.
+ *
+ * Breakdown maps use a closed key vocabulary (AWS::* / Custom / other /
+ * unknown) — open-ended keys break Glue schema inference on the events lake.
+ */
+
+const MAX_RESOURCE_TYPE_KEYS = 50
+
+export const tallyResourceTypes = (resources) => {
+  if (!resources || typeof resources !== 'object' || Array.isArray(resources)) {
+    return undefined
+  }
+  const tally = {}
+  for (const resource of Object.values(resources)) {
+    const rawType = resource?.Type
+    let type
+    if (typeof rawType !== 'string' || rawType.length === 0) {
+      type = 'unknown'
+    } else if (rawType.startsWith('AWS::')) {
+      type = rawType
+    } else if (rawType.startsWith('Custom::')) {
+      type = 'Custom'
+    } else {
+      type = 'other'
+    }
+    if (
+      !(type in tally) &&
+      Object.keys(tally).length >= MAX_RESOURCE_TYPE_KEYS
+    ) {
+      type = 'other'
+    }
+    tally[type] = (tally[type] ?? 0) + 1
+  }
+  return Object.keys(tally).length > 0 ? tally : undefined
+}
+
+export const deriveEventSourceTypes = (functions) => {
+  const types = new Set()
+  if (!functions || typeof functions !== 'object') return []
+  for (const fn of Object.values(functions)) {
+    const events = Array.isArray(fn?.events) ? fn.events : []
+    for (const event of events) {
+      const type =
+        typeof event === 'string' ? event : Object.keys(event ?? {})[0]
+      if (typeof type === 'string' && type.length > 0) types.add(type)
+    }
+  }
+  return [...types].sort()
+}
+
+export const countUniqueLayers = (config) => {
+  const definedCount =
+    config?.layers &&
+    typeof config.layers === 'object' &&
+    !Array.isArray(config.layers)
+      ? Object.keys(config.layers).length
+      : 0
+  const externalRefs = new Set()
+  const collect = (layers) => {
+    if (!Array.isArray(layers)) return
+    for (const layer of layers) {
+      // Object refs ({Ref}/{Fn::GetAtt}) target layers defined in this
+      // service's own layers block, which are already counted above.
+      if (typeof layer === 'string') externalRefs.add(layer)
+    }
+  }
+  collect(config?.provider?.layers)
+  if (config?.functions && typeof config.functions === 'object') {
+    for (const fn of Object.values(config.functions)) collect(fn?.layers)
+  }
+  return definedCount + externalRefs.size
+}
+
+export const collectArtifactPaths = (service) => {
+  const paths = new Set()
+  if (typeof service?.package?.artifact === 'string') {
+    paths.add(service.package.artifact)
+  }
+  const functions =
+    service?.functions && typeof service.functions === 'object'
+      ? Object.values(service.functions)
+      : []
+  for (const fn of functions) {
+    if (typeof fn?.package?.artifact === 'string') {
+      paths.add(fn.package.artifact)
+    }
+  }
+  return [...paths]
+}
+
+export const deriveAnalysisEnrichment = ({
+  config,
+  compiledCloudFormationTemplate,
+  command,
+  serviceUniqueId,
+  analyticsMetrics,
+} = {}) => {
+  const details = {}
+  try {
+    details.lambdaArchitecture = config?.provider?.architecture ?? 'x86_64'
+    details.functionCount =
+      config?.functions && typeof config.functions === 'object'
+        ? Object.keys(config.functions).length
+        : 0
+    details.layerCount = countUniqueLayers(config)
+
+    const eventSourceTypes = deriveEventSourceTypes(config?.functions)
+    if (eventSourceTypes.length > 0) details.eventSourceTypes = eventSourceTypes
+
+    const customResourceTypeBreakdown = tallyResourceTypes(
+      config?.resources?.Resources,
+    )
+    if (customResourceTypeBreakdown) {
+      details.customResourceTypeBreakdown = customResourceTypeBreakdown
+    }
+
+    const compiledResources = compiledCloudFormationTemplate?.Resources
+    const resourceTypeBreakdown = tallyResourceTypes(compiledResources)
+    if (resourceTypeBreakdown) {
+      details.resourceTypeBreakdown = resourceTypeBreakdown
+      details.resourceCount = Object.keys(compiledResources).length
+    }
+
+    if (
+      Array.isArray(command) &&
+      command[0] === 'deploy' &&
+      serviceUniqueId &&
+      typeof analyticsMetrics?.stackExistedBeforeRun === 'boolean'
+    ) {
+      details.isFirstDeploy = !analyticsMetrics.stackExistedBeforeRun
+    }
+
+    if (typeof analyticsMetrics?.buildDurationMs === 'number') {
+      details.buildDurationMs = analyticsMetrics.buildDurationMs
+    }
+    if (
+      Array.isArray(analyticsMetrics?.artifactSizesBytes) &&
+      analyticsMetrics.artifactSizesBytes.every((s) => typeof s === 'number')
+    ) {
+      details.artifactSizesBytes = analyticsMetrics.artifactSizesBytes
+    }
+  } catch {
+    // Last-resort guard: return whatever was derived before the failure.
+  }
+  return details
+}

--- a/packages/sf-core/src/lib/runners/framework-analytics.js
+++ b/packages/sf-core/src/lib/runners/framework-analytics.js
@@ -111,11 +111,11 @@ export const deriveAnalysisEnrichment = ({
     const eventSourceTypes = deriveEventSourceTypes(config?.functions)
     if (eventSourceTypes.length > 0) details.eventSourceTypes = eventSourceTypes
 
-    const customResourceTypeBreakdown = tallyResourceTypes(
+    const configResourceTypeBreakdown = tallyResourceTypes(
       config?.resources?.Resources,
     )
-    if (customResourceTypeBreakdown) {
-      details.customResourceTypeBreakdown = customResourceTypeBreakdown
+    if (configResourceTypeBreakdown) {
+      details.configResourceTypeBreakdown = configResourceTypeBreakdown
     }
 
     const compiledResources = compiledCloudFormationTemplate?.Resources

--- a/packages/sf-core/src/lib/runners/framework.js
+++ b/packages/sf-core/src/lib/runners/framework.js
@@ -578,31 +578,36 @@ const runFramework = async ({
     analyticsMetrics.buildDurationMs = buildDurationMs
   }
 
-  try {
-    // Classic individually-packaged artifacts are recorded relative to the
-    // service dir; resolve and dedupe before stat
-    const artifactPaths = [
-      ...new Set(
-        collectArtifactPaths(serverless.service).map((artifactPath) =>
-          path.resolve(servicePath, artifactPath),
+  // Only packaging commands produce artifacts; other commands (e.g. info)
+  // may still carry a pre-configured package.artifact path, which is not an
+  // output of this run
+  if (['package', 'deploy', 'deploy function'].includes(fullCommand)) {
+    try {
+      // Classic individually-packaged artifacts are recorded relative to the
+      // service dir; resolve and dedupe before stat
+      const artifactPaths = [
+        ...new Set(
+          collectArtifactPaths(serverless.service).map((artifactPath) =>
+            path.resolve(servicePath, artifactPath),
+          ),
         ),
-      ),
-    ]
-    const artifactSizesBytes = []
-    for (const artifactPath of artifactPaths) {
-      try {
-        artifactSizesBytes.push((await stat(artifactPath)).size)
-      } catch (err) {
-        // e.g. a disabled function whose configured artifact was never
-        // written — skip it and keep the sizes of the artifacts that exist
-        logger.debug(`error reading artifact size for ${artifactPath}`, err)
+      ]
+      const artifactSizesBytes = []
+      for (const artifactPath of artifactPaths) {
+        try {
+          artifactSizesBytes.push((await stat(artifactPath)).size)
+        } catch (err) {
+          // e.g. a disabled function whose configured artifact was never
+          // written — skip it and keep the sizes of the artifacts that exist
+          logger.debug(`error reading artifact size for ${artifactPath}`, err)
+        }
       }
+      if (artifactSizesBytes.length > 0) {
+        analyticsMetrics.artifactSizesBytes = artifactSizesBytes
+      }
+    } catch (err) {
+      logger.debug('error collecting artifact sizes', err)
     }
-    if (artifactSizesBytes.length > 0) {
-      analyticsMetrics.artifactSizesBytes = artifactSizesBytes
-    }
-  } catch (err) {
-    logger.debug('error collecting artifact sizes', err)
   }
 
   return {

--- a/packages/sf-core/src/lib/runners/framework.js
+++ b/packages/sf-core/src/lib/runners/framework.js
@@ -18,7 +18,12 @@ import { convertPluginToResolverProvider } from '../resolvers/providers.js'
 import { Runner } from './index.js'
 import { configureLocalstackAWSEndpoint } from '../../utils/local/localstack.js'
 import path from 'path'
+import { stat } from 'node:fs/promises'
 import Esbuild from '@serverless/framework/lib/plugins/esbuild/index.js'
+import {
+  collectArtifactPaths,
+  deriveAnalysisEnrichment,
+} from './framework-analytics.js'
 import { Deployment } from '../platform/deployments.js'
 
 export class TraditionalRunner extends Runner {
@@ -93,12 +98,18 @@ export class TraditionalRunner extends Runner {
       })
     )?.serviceUniqueId
 
+    // Captured pre-run so isFirstDeploy can distinguish create vs update —
+    // awsCfStack.timeUpdated is unreliable for this (still null on the 2nd
+    // deploy, since stack info is snapshotted before the update runs)
+    this.analyticsMetrics = { stackExistedBeforeRun: Boolean(serviceUniqueId) }
+
     // Run the command
     const {
       state,
       integrations,
       compiledCloudFormationTemplate,
       coreCloudFormationTemplate,
+      analyticsMetrics,
     } = await runFramework({
       accessKeyV1: authenticatedData.accessKeyV1,
       accessKeyV2: authenticatedData.accessKeyV2,
@@ -122,6 +133,7 @@ export class TraditionalRunner extends Runner {
     this.integrations = integrations
     this.compiledCloudFormationTemplate = compiledCloudFormationTemplate
     this.coreCloudFormationTemplate = coreCloudFormationTemplate
+    Object.assign(this.analyticsMetrics, analyticsMetrics)
 
     if (!serviceUniqueId) {
       serviceUniqueId = (
@@ -232,6 +244,16 @@ export class TraditionalRunner extends Runner {
         this.configFilePath,
       ),
       integrations: this.integrations,
+      // Service-shape and build metrics; deriveAnalysisEnrichment is total
+      // (never throws) — a throw escaping this method aborts finalization
+      // and silently drops the billing usage event
+      ...deriveAnalysisEnrichment({
+        config: this.config,
+        compiledCloudFormationTemplate: this.compiledCloudFormationTemplate,
+        command: this.command,
+        serviceUniqueId: this.serviceUniqueId,
+        analyticsMetrics: this.analyticsMetrics,
+      }),
     }
 
     // plugins
@@ -545,6 +567,38 @@ const runFramework = async ({
   if (fullCommand === 'remove') {
     state = {}
   }
+
+  const analyticsMetrics = {}
+  const lifecycleEventDurations =
+    serverless.pluginManager?.lifecycleEventDurations ?? {}
+  const buildDurationMs =
+    (lifecycleEventDurations['package:createDeploymentArtifacts'] ?? 0) +
+    (lifecycleEventDurations['deploy:function:packageFunction'] ?? 0)
+  if (buildDurationMs > 0) {
+    analyticsMetrics.buildDurationMs = buildDurationMs
+  }
+
+  try {
+    // Classic individually-packaged artifacts are recorded relative to the
+    // service dir; resolve and dedupe before stat
+    const artifactPaths = [
+      ...new Set(
+        collectArtifactPaths(serverless.service).map((artifactPath) =>
+          path.resolve(servicePath, artifactPath),
+        ),
+      ),
+    ]
+    if (artifactPaths.length > 0) {
+      const artifactSizesBytes = []
+      for (const artifactPath of artifactPaths) {
+        artifactSizesBytes.push((await stat(artifactPath)).size)
+      }
+      analyticsMetrics.artifactSizesBytes = artifactSizesBytes
+    }
+  } catch (err) {
+    logger.debug('error collecting artifact sizes', err)
+  }
+
   return {
     state,
     integrations: serverless.integrations,
@@ -552,6 +606,7 @@ const runFramework = async ({
       serverless.service?.provider?.compiledCloudFormationTemplate,
     coreCloudFormationTemplate:
       serverless.service?.provider?.coreCloudFormationTemplate,
+    analyticsMetrics,
   }
 }
 

--- a/packages/sf-core/src/lib/runners/framework.js
+++ b/packages/sf-core/src/lib/runners/framework.js
@@ -588,11 +588,17 @@ const runFramework = async ({
         ),
       ),
     ]
-    if (artifactPaths.length > 0) {
-      const artifactSizesBytes = []
-      for (const artifactPath of artifactPaths) {
+    const artifactSizesBytes = []
+    for (const artifactPath of artifactPaths) {
+      try {
         artifactSizesBytes.push((await stat(artifactPath)).size)
+      } catch (err) {
+        // e.g. a disabled function whose configured artifact was never
+        // written — skip it and keep the sizes of the artifacts that exist
+        logger.debug(`error reading artifact size for ${artifactPath}`, err)
       }
+    }
+    if (artifactSizesBytes.length > 0) {
       analyticsMetrics.artifactSizesBytes = artifactSizesBytes
     }
   } catch (err) {

--- a/packages/sf-core/tests/unit/lib/runners/framework-analytics.test.js
+++ b/packages/sf-core/tests/unit/lib/runners/framework-analytics.test.js
@@ -182,6 +182,16 @@ describe('deriveAnalysisEnrichment', () => {
         .isFirstDeploy,
     ).toBeUndefined()
     expect(
+      deriveAnalysisEnrichment({ ...fullInput, command: ['deploy', 'list'] })
+        .isFirstDeploy,
+    ).toBeUndefined()
+    expect(
+      deriveAnalysisEnrichment({
+        ...fullInput,
+        command: ['deploy', 'function'],
+      }).isFirstDeploy,
+    ).toBeUndefined()
+    expect(
       deriveAnalysisEnrichment({ ...fullInput, serviceUniqueId: null })
         .isFirstDeploy,
     ).toBeUndefined()

--- a/packages/sf-core/tests/unit/lib/runners/framework-analytics.test.js
+++ b/packages/sf-core/tests/unit/lib/runners/framework-analytics.test.js
@@ -155,7 +155,7 @@ describe('deriveAnalysisEnrichment', () => {
       functionCount: 2,
       layerCount: 1,
       eventSourceTypes: ['httpApi', 'sqs'],
-      customResourceTypeBreakdown: { 'AWS::S3::Bucket': 1, Custom: 1 },
+      configResourceTypeBreakdown: { 'AWS::S3::Bucket': 1, Custom: 1 },
       resourceTypeBreakdown: {
         'AWS::Lambda::Function': 1,
         'AWS::IAM::Role': 1,

--- a/packages/sf-core/tests/unit/lib/runners/framework-analytics.test.js
+++ b/packages/sf-core/tests/unit/lib/runners/framework-analytics.test.js
@@ -1,0 +1,212 @@
+import {
+  tallyResourceTypes,
+  deriveEventSourceTypes,
+  countUniqueLayers,
+  collectArtifactPaths,
+  deriveAnalysisEnrichment,
+} from '../../../../src/lib/runners/framework-analytics.js'
+
+describe('tallyResourceTypes', () => {
+  test('tallies AWS resource types verbatim', () => {
+    expect(
+      tallyResourceTypes({
+        A: { Type: 'AWS::S3::Bucket' },
+        B: { Type: 'AWS::S3::Bucket' },
+        C: { Type: 'AWS::SQS::Queue' },
+      }),
+    ).toEqual({ 'AWS::S3::Bucket': 2, 'AWS::SQS::Queue': 1 })
+  })
+
+  test('collapses open-ended namespaces to closed keys', () => {
+    expect(
+      tallyResourceTypes({
+        A: { Type: 'Custom::MySpecialThing' },
+        B: { Type: 'Custom::OtherThing' },
+        C: { Type: 'MongoDB::Atlas::Cluster' },
+        D: { Type: 7 },
+        E: {},
+      }),
+    ).toEqual({ Custom: 2, other: 1, unknown: 2 })
+  })
+
+  test('returns undefined for missing/empty/non-object input', () => {
+    expect(tallyResourceTypes(undefined)).toBeUndefined()
+    expect(tallyResourceTypes(null)).toBeUndefined()
+    expect(tallyResourceTypes({})).toBeUndefined()
+    expect(tallyResourceTypes([])).toBeUndefined()
+    expect(tallyResourceTypes('nope')).toBeUndefined()
+  })
+
+  test('caps distinct keys at 50 with overflow under other', () => {
+    const resources = {}
+    for (let i = 0; i < 55; i += 1) {
+      resources[`R${i}`] = { Type: `AWS::Fake::Type${i}` }
+    }
+    const tally = tallyResourceTypes(resources)
+    expect(Object.keys(tally)).toHaveLength(51)
+    expect(tally.other).toBe(5)
+  })
+})
+
+describe('deriveEventSourceTypes', () => {
+  test('collects unique sorted event types across functions', () => {
+    expect(
+      deriveEventSourceTypes({
+        a: { events: [{ http: { path: '/', method: 'get' } }, { sqs: 'arn' }] },
+        b: { events: [{ http: 'GET /x' }, { schedule: 'rate(1 hour)' }] },
+      }),
+    ).toEqual(['http', 'schedule', 'sqs'])
+  })
+
+  test('supports string events and tolerates malformed shapes', () => {
+    expect(
+      deriveEventSourceTypes({
+        a: { events: ['schedule', {}, null] },
+        b: { events: 'not-an-array' },
+        c: {},
+        d: null,
+      }),
+    ).toEqual(['schedule'])
+    expect(deriveEventSourceTypes(undefined)).toEqual([])
+  })
+})
+
+describe('countUniqueLayers', () => {
+  test('counts defined layers plus unique string ARN references', () => {
+    expect(
+      countUniqueLayers({
+        layers: { myLayer: { path: 'layer' } },
+        provider: { layers: ['arn:aws:lambda:us-east-1:1:layer:ext:1'] },
+        functions: {
+          a: {
+            layers: [
+              'arn:aws:lambda:us-east-1:1:layer:ext:1', // dupe of provider ref
+              { Ref: 'MyLayerLambdaLayer' }, // points at defined layer, skipped
+            ],
+          },
+        },
+      }),
+    ).toBe(2)
+  })
+
+  test('returns 0 for empty/malformed config', () => {
+    expect(countUniqueLayers(undefined)).toBe(0)
+    expect(countUniqueLayers({})).toBe(0)
+    expect(countUniqueLayers({ layers: null, provider: { layers: 'x' } })).toBe(
+      0,
+    )
+  })
+})
+
+describe('collectArtifactPaths', () => {
+  test('collects service and per-function artifacts, deduplicated', () => {
+    expect(
+      collectArtifactPaths({
+        package: { artifact: '/x/service.zip' },
+        functions: {
+          a: { package: { artifact: '/x/a.zip' } },
+          b: { package: { artifact: '/x/a.zip' } },
+          c: {},
+        },
+      }),
+    ).toEqual(['/x/service.zip', '/x/a.zip'])
+  })
+
+  test('returns empty array when nothing is packaged', () => {
+    expect(collectArtifactPaths(undefined)).toEqual([])
+    expect(collectArtifactPaths({ functions: {} })).toEqual([])
+  })
+})
+
+describe('deriveAnalysisEnrichment', () => {
+  const fullInput = {
+    config: {
+      provider: { architecture: 'arm64' },
+      functions: {
+        a: { events: [{ httpApi: { path: '/', method: 'get' } }] },
+        b: { events: [{ sqs: 'arn' }] },
+      },
+      layers: { l1: {} },
+      resources: {
+        Resources: {
+          Bucket: { Type: 'AWS::S3::Bucket' },
+          Thing: { Type: 'Custom::Thing' },
+        },
+      },
+    },
+    compiledCloudFormationTemplate: {
+      Resources: {
+        F: { Type: 'AWS::Lambda::Function' },
+        R: { Type: 'AWS::IAM::Role' },
+      },
+    },
+    command: ['deploy'],
+    serviceUniqueId: 'arn:aws:cloudformation:...',
+    analyticsMetrics: {
+      stackExistedBeforeRun: false,
+      buildDurationMs: 1234,
+      artifactSizesBytes: [5000, 678],
+    },
+  }
+
+  test('derives all fields from a full input', () => {
+    expect(deriveAnalysisEnrichment(fullInput)).toEqual({
+      lambdaArchitecture: 'arm64',
+      functionCount: 2,
+      layerCount: 1,
+      eventSourceTypes: ['httpApi', 'sqs'],
+      customResourceTypeBreakdown: { 'AWS::S3::Bucket': 1, Custom: 1 },
+      resourceTypeBreakdown: {
+        'AWS::Lambda::Function': 1,
+        'AWS::IAM::Role': 1,
+      },
+      resourceCount: 2,
+      isFirstDeploy: true,
+      buildDurationMs: 1234,
+      artifactSizesBytes: [5000, 678],
+    })
+  })
+
+  test('isFirstDeploy is false when stack existed, absent for non-deploy commands', () => {
+    expect(
+      deriveAnalysisEnrichment({
+        ...fullInput,
+        analyticsMetrics: {
+          ...fullInput.analyticsMetrics,
+          stackExistedBeforeRun: true,
+        },
+      }).isFirstDeploy,
+    ).toBe(false)
+    expect(
+      deriveAnalysisEnrichment({ ...fullInput, command: ['print'] })
+        .isFirstDeploy,
+    ).toBeUndefined()
+    expect(
+      deriveAnalysisEnrichment({ ...fullInput, serviceUniqueId: null })
+        .isFirstDeploy,
+    ).toBeUndefined()
+  })
+
+  test('defaults architecture and omits unavailable fields on minimal input', () => {
+    expect(deriveAnalysisEnrichment({ config: {} })).toEqual({
+      lambdaArchitecture: 'x86_64',
+      functionCount: 0,
+      layerCount: 0,
+    })
+  })
+
+  test('never throws on hostile input', () => {
+    const hostile = [
+      {},
+      undefined,
+      { config: null },
+      { config: { functions: 'x', layers: 7, resources: { Resources: [] } } },
+      { config: { provider: 'aws' }, compiledCloudFormationTemplate: 'tpl' },
+      { command: 'deploy', analyticsMetrics: null },
+      { analyticsMetrics: { artifactSizesBytes: 'big' } },
+    ]
+    for (const input of hostile) {
+      expect(() => deriveAnalysisEnrichment(input)).not.toThrow()
+    }
+  })
+})


### PR DESCRIPTION
Adds a few fields to the CLI analytics event to better understand how the Framework is used:

- Service shape: Lambda architecture, function/layer/resource counts, event source types, resource type breakdowns (closed key vocabulary)
- Timings: command wall-clock duration and packaging duration
- Packaged artifact sizes (bare byte values only)
- First-deploy indicator on `deploy`

Supporting changes:

- New pure derivation module with unit tests; it never throws, so event finalization is unaffected
- Plugin manager now records per-lifecycle-event hook durations (additive, no behavior change)

No user-facing behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer usage and performance analytics during runs, including command duration, build time, and selected artifact size details.
  * Improved service analysis data with additional insight into resource types, event sources, layers, and deploy status.

* **Bug Fixes**
  * Analytics data is now captured even when hook execution or post-run tasks fail, helping ensure more complete reporting.
  * Safer handling of unusual or incomplete service inputs prevents analytics generation from breaking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->