### PR TITLE
test(sandboxes): fix Windows-only path assertion failures

### DIFF
--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/dev/index.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/dev/index.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import { jest } from '@jest/globals'
+import path from 'path'
 import SandboxesDevMode from '../../../../../../../lib/plugins/aws/sandboxes/dev/index.js'
 
 function make(options, sandboxes, { fileExists = () => true } = {}) {
@@ -89,7 +90,11 @@ test('resolveSandboxName throws when no sandboxes defined', () => {
 
 test('resolveArtifactDir resolves a local dir against serviceDir', () => {
   const d = make({ sandbox: 'api' }, { api: { artifact: './app' } })
-  expect(d.resolveArtifactDir({ artifact: './app' })).toBe('/svc/app')
+  // serviceDir is '/svc'; resolve the same way the impl does so this holds on
+  // Windows too (where path.resolve yields a drive-prefixed, backslash path).
+  expect(d.resolveArtifactDir({ artifact: './app' })).toBe(
+    path.resolve('/svc', './app'),
+  )
 })
 
 test('resolveArtifactDir throws SANDBOX_DEV_ARTIFACT_MISSING when artifact is missing', () => {

--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/packaging/artifact.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/packaging/artifact.test.js
@@ -92,8 +92,9 @@ describe('computeCodeArtifact', () => {
       },
     )
     // A cwd-relative './app' would silently zip the wrong/empty dir when the CLI
-    // runs from a different cwd (test harness, `-c path`, compose).
-    expect(seen[0]).toBe('/svc/root/app')
+    // runs from a different cwd (test harness, `-c path`, compose). Resolve the
+    // expected path the same way the impl does so this holds on Windows too.
+    expect(seen[0]).toBe(path.resolve('/svc/root', './app'))
   })
 
   test('throws a clear error when the artifact directory does not exist (no silent empty zip)', async () => {

--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/packaging/persist.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/packaging/persist.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals'
+import path from 'path'
 import {
   persistArtifacts,
   readUploadManifest,
@@ -45,11 +46,15 @@ test('persistArtifacts writes each zip + a manifest into the package dir', async
       file: 'sandboxes/runner-abc123.zip',
     },
   ])
-  // the zip is written under the package dir, and the manifest alongside it
-  expect(fs.files['/pkg/sandboxes/runner-abc123.zip']).toEqual(
+  // the zip is written under the package dir, and the manifest alongside it.
+  // The write path uses native path.join (backslashes on Windows), so key the
+  // lookup the same way rather than a hard-coded POSIX string.
+  expect(fs.files[path.join('/pkg', 'sandboxes', 'runner-abc123.zip')]).toEqual(
     Buffer.from('zip-bytes'),
   )
-  expect(JSON.parse(fs.files[`/pkg/${UPLOAD_MANIFEST}`])).toEqual(entries)
+  expect(JSON.parse(fs.files[path.join('/pkg', UPLOAD_MANIFEST)])).toEqual(
+    entries,
+  )
 })
 
 test('persistArtifacts writes no manifest when there are no artifacts (s3:// only)', async () => {


### PR DESCRIPTION
## What

Three sandbox unit tests hard-coded POSIX paths and failed on the Windows CI runner (`Test: Framework (Cross-Platform) (gh-windows-latest)`) after #13663 merged:

- `sandboxes/dev/index.test.js` — `resolveArtifactDir` expected `/svc/app`; Windows `path.resolve` yields `C:\\svc\\app`.
- `sandboxes/packaging/artifact.test.js` — `computeCodeArtifact` expected `/svc/root/app`.
- `sandboxes/packaging/persist.test.js` — fake-fs keyed by a POSIX string; the impl writes via native `path.join` (backslashes on Windows), so the lookup missed.

## Why it's test-only

The implementation was already cross-platform — it uses `path.resolve`/`path.join` throughout, and the upload manifest deliberately stores POSIX-relative paths via `path.posix.join`. Only the test assertions hard-coded separators. Each now computes its expected value with the same `path` function the implementation uses, so it holds on both POSIX and Windows. No production code changes.

## Test plan

- [x] macOS: the 3 suites pass (49 tests).
- [x] Assertions now derive from `path.resolve`/`path.join`, matching the impl on Windows.

Fixes the red Windows check introduced by #13663.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated path-related unit test expectations to use native path resolution instead of hardcoded POSIX paths.
  * Improved coverage for artifact directory resolution and artifact persistence behavior across platforms, including Windows-style path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->