### PR TITLE
test(sandboxes): skip Docker integration tests when `docker build --load` is unavailable

### DIFF
--- a/packages/sf-core/tests/integration/sandboxes/dev-api-emulation.test.js
+++ b/packages/sf-core/tests/integration/sandboxes/dev-api-emulation.test.js
@@ -44,7 +44,29 @@ function forceRemoveByPrefix() {
   }
 }
 
-describe('dev API emulation — real SDK against the local control-plane', () => {
+// These tests build and run real Docker containers via `docker build --load`
+// (a buildx/BuildKit flag). Skip cleanly where that build can't run rather than
+// hard-failing:
+//   - a runner with no Docker daemon (arm-linux release runner) → `docker`
+//     throws `ENOENT`;
+//   - a runner whose `docker build` is the classic builder (Windows runner) →
+//     rejects `--load` with "unknown flag: --load".
+// Probe the exact capability the build needs (does `docker build` accept
+// `--load`) so the suite still runs wherever buildx-backed builds work (ubuntu
+// CI, macOS Docker Desktop). No implementation change.
+function dockerBuildSupportsLoad() {
+  try {
+    const help = execFileSync('docker', ['build', '--help'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString()
+    return help.includes('--load')
+  } catch {
+    return false
+  }
+}
+const d = dockerBuildSupportsLoad() ? describe : describe.skip
+
+d('dev API emulation — real SDK against the local control-plane', () => {
   jest.setTimeout(180000)
   const docker = new DockerClient()
   let cp, client

--- a/packages/sf-core/tests/integration/sandboxes/dev-mode-hooks.test.js
+++ b/packages/sf-core/tests/integration/sandboxes/dev-mode-hooks.test.js
@@ -92,7 +92,29 @@ function forceRemoveByPrefix() {
   }
 }
 
-describe('dev mode — lifecycle hook delivery to a real container', () => {
+// These tests build and run real Docker containers via `docker build --load`
+// (a buildx/BuildKit flag). Skip cleanly where that build can't run rather than
+// hard-failing:
+//   - a runner with no Docker daemon (arm-linux release runner) → `docker`
+//     throws `ENOENT`;
+//   - a runner whose `docker build` is the classic builder (Windows runner) →
+//     rejects `--load` with "unknown flag: --load".
+// Probe the exact capability the build needs (does `docker build` accept
+// `--load`) so the suite still runs wherever buildx-backed builds work (ubuntu
+// CI, macOS Docker Desktop). No implementation change.
+function dockerBuildSupportsLoad() {
+  try {
+    const help = execFileSync('docker', ['build', '--help'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString()
+    return help.includes('--load')
+  } catch {
+    return false
+  }
+}
+const d = dockerBuildSupportsLoad() ? describe : describe.skip
+
+d('dev mode — lifecycle hook delivery to a real container', () => {
   jest.setTimeout(180000)
   const docker = new DockerClient()
   let cp, client, logs


### PR DESCRIPTION
## What

Two sandbox integration suites build and run real Docker containers via `docker build --load` (a buildx/BuildKit flag):
- `tests/integration/sandboxes/dev-api-emulation.test.js`
- `tests/integration/sandboxes/dev-mode-hooks.test.js`

They failed on two runners in the release cross-platform matrix, for two different reasons — both because `docker build --load` couldn't run:
- **`latest-arm-linux`** — no Docker daemon → `spawnSync docker ENOENT`.
- **`gh-windows-latest`** — Docker present but the **classic builder** rejects the buildx flag → `unknown flag: --load`.

`ubuntu-latest` (buildx-backed `docker build`) passed.

## Fix

Gate each suite on the exact capability the build needs — whether `docker build` accepts `--load` — using the existing `const d = … ? describe : describe.skip` idiom (already in `dev-api-fidelity.test.js`):

```js
function dockerBuildSupportsLoad() {
  try {
    const help = execFileSync('docker', ['build', '--help'], { stdio: ['ignore','pipe','ignore'] }).toString()
    return help.includes('--load')
  } catch { return false }
}
const d = dockerBuildSupportsLoad() ? describe : describe.skip
```

The suites still run wherever buildx-backed builds work (ubuntu CI, macOS Docker Desktop) and skip cleanly on runners that can't build the image, instead of hard-failing. No production code changes.

## Test plan

- [x] Docker + buildx (local macOS): `docker build --help` lists `--load` → `dev-api-emulation` runs, 2/2 pass.
- [x] Docker absent (docker removed from PATH): suite reports `1 skipped` — no ENOENT failure. (Same skip path a classic-only `docker build` without `--load` takes.)

Fixes the red `latest-arm-linux` and `gh-windows-latest` integration checks on the release cross-platform matrix (surfaced after #13663 merged; complements the unit-test fix in #13681).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integration test suites now detect whether `docker build` supports `--load` and conditionally skip incompatible Docker-dependent tests, preventing environment-related failures.
  * Improves test reliability in CI and local runs by avoiding hard failures when required Docker build capabilities aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->