### PR TITLE
fix(aws): wait for sandbox app port before marking dev MicroVM running

### DIFF
--- a/packages/serverless/lib/plugins/aws/sandboxes/dev/api-emulator/control-plane.js
+++ b/packages/serverless/lib/plugins/aws/sandboxes/dev/api-emulator/control-plane.js
@@ -251,6 +251,28 @@ export async function startControlPlane({
         // Stream this MicroVM's container logs to the dev terminal (prefixed per MicroVM).
         const stop = attachLogs(c.containerName, microvmId)
         if (typeof stop === 'function') logStops.set(microvmId, stop)
+        // Wait for the application port(s) to actually serve HTTP before this RunMicrovm
+        // response advertises the VM as RUNNING. Docker's published-port proxy accepts a TCP
+        // connect the instant the container starts — well before the in-VM server binds — so an
+        // invoke that races the bind reaches the proxy, fails to connect upstream, and gets a 502.
+        // Unlike the hook-port wait below this runs regardless of `hooksEnabled`: the application
+        // port is what serves invocations. The hook port (never a serving app port) is excluded —
+        // when hooks are enabled it has its own wait below; when disabled nothing ever binds it.
+        // HTTP-level probe (a bare TCP connect returns prematurely against docker-proxy).
+        const appPorts = Object.keys(inst.portMap)
+          .map(Number)
+          .filter((p) => p !== hookPort)
+        for (const appPort of appPorts) {
+          const appReady = await waitForPort(
+            '127.0.0.1',
+            inst.portMap[appPort],
+            readinessTimeoutMs,
+          )
+          if (!appReady)
+            logger.aside(
+              `⚠ ${short} app port ${appPort} not serving after ${Math.round(readinessTimeoutMs / 1000)}s — invokes may 502 until it binds`,
+            )
+        }
         // Let the container bind its hook server before delivering lifecycle hooks, so the
         // run-hook payload isn't POSTed to a not-yet-listening :9000 and lost. Best-effort + bounded.
         // The hook port is published on loopback regardless of which interface the control-plane

--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/dev/api-emulator/control-plane.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/dev/api-emulator/control-plane.test.js
@@ -606,8 +606,15 @@ test('CreateMicrovmAuthToken accepts the {allPorts: {}} and {range} spec shapes 
   }
 })
 
-test('RunMicrovm skips the hook-port readiness wait (and its warning) when hooks are disabled', async () => {
-  const waitForPort = jest.fn(async () => false) // would warn if it ran
+test('RunMicrovm waits for the application port even when hooks are disabled (but not the hook port)', async () => {
+  // Regression: a no-hooks sandbox must still gate RUNNING on the app port actually serving —
+  // otherwise an invoke races the container bind and the proxy returns 502. The hook port,
+  // which nothing binds without hooks, must NOT be waited on (it would only time out).
+  const probed = []
+  const waitForPort = jest.fn(async (_host, port) => {
+    probed.push(port)
+    return true
+  })
   const asides = []
   const { cp } = await harness({
     hooksEnabled: false,
@@ -620,8 +627,29 @@ test('RunMicrovm skips the hook-port readiness wait (and its warning) when hooks
     })
     expect(run.status).toBe(200)
     expect(run.json.state).toBe('RUNNING')
-    expect(waitForPort).not.toHaveBeenCalled()
-    expect(asides.join('\n')).not.toMatch(/not ready after/)
+    // App port 8080 → host 50080 IS probed; hook port 9000 → host 50090 is NOT.
+    expect(probed).toContain(50080)
+    expect(probed).not.toContain(50090)
+    expect(asides.join('\n')).not.toMatch(/hooks may not have been delivered/)
+  } finally {
+    await cp.shutdown()
+  }
+})
+
+test('RunMicrovm warns and still returns RUNNING when the app port never serves', async () => {
+  const asides = []
+  const { cp } = await harness({
+    hooksEnabled: false,
+    waitForPort: async () => false, // app port never becomes ready
+    logger: { aside: (l) => asides.push(l), notice() {}, debug() {} },
+  })
+  try {
+    const run = await req(cp.port, 'POST', '/microvms', {
+      imageIdentifier: 'arn:local',
+    })
+    // Non-fatal: launch proceeds (matches AWS best-effort readiness), but the user is warned.
+    expect(run.json.state).toBe('RUNNING')
+    expect(asides.join('\n')).toMatch(/app port 8080 not serving/)
   } finally {
     await cp.shutdown()
   }


### PR DESCRIPTION
## Summary

Fixes a race in the local MicroVMs emulator used by `serverless dev --sandbox` that caused local invokes to intermittently return **HTTP 502**, even though the same image served correctly when run standalone or when deployed.

The emulator only waited for the **hook port** to become ready before marking a MicroVM as `RUNNING`, and only when the sandbox declared lifecycle hooks. The **application port** was never awaited. As a result the MicroVM could be advertised as `RUNNING` before the in-VM server had actually bound its socket. An invoke that arrived in that window reached the emulator's proxy, which failed to connect upstream and returned `502 Bad Gateway`.

## Fix

Before returning `RUNNING`, probe the application port(s) over HTTP and wait for the container to actually serve — independent of whether hooks are enabled.

- A bare TCP connect succeeds against the published-port proxy before the in-VM server binds, so an HTTP-level readiness probe is used (the same probe already used for the hook port).
- The hook port is excluded from this wait: when hooks are enabled it has its own readiness wait; when they are disabled nothing binds it.
- Readiness is best-effort — a timeout emits a warning rather than failing the launch.

## Testing

- Unit tests for the emulator updated and extended: the app port is now awaited even when hooks are disabled (and the hook port is not), plus a regression test for the "app port never serves" path.
- Verified end-to-end against a container that deliberately delays its bind: before the fix the invoke returns 502; after the fix the launch waits for the bind and the invoke returns 200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup readiness checks so application ports are verified before the service is marked running.
  * Added a warning when an app port is not serving yet, helping explain possible failed requests until the port is available.
  * Kept hook-related readiness checks separate, reducing false warnings when hooks are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->