### PR TITLE
fix(sandboxes): honor custom hooks.port in dev mode

### DIFF
--- a/packages/serverless/lib/plugins/aws/sandboxes/dev/index.js
+++ b/packages/serverless/lib/plugins/aws/sandboxes/dev/index.js
@@ -185,11 +185,18 @@ class SandboxesDevMode {
       imageArn: `arn:aws:lambda:local:000000000000:microvm-image:${this.serverless.service.service}-${name}`,
     })
     const self = this
+    // The app serves on 8080 (the `invoke --port` default); the hook server port is
+    // user-configurable via `hooks.port` (default 9000). Honor it for both the published
+    // container ports and the control plane's hook delivery, so a sandbox with a custom
+    // hook port has its hooks delivered in dev exactly as on AWS. Deduped in case the user
+    // points hooks at 8080.
+    const hookPort = Number(this.ctx.cfg.hooks?.port) || 9000
     const containerManager = await this.makeContainerManager({
       docker: this.docker,
       imageUri: this.ctx.imageUri,
       serviceName: this.serverless.service.service,
       sandboxName: name,
+      ports: Array.from(new Set([8080, hookPort])),
       get env() {
         return { ...(self.ctx.cfg.environment || {}), ...(self.credsEnv || {}) }
       },
@@ -219,6 +226,7 @@ class SandboxesDevMode {
         containerManager,
         fireHook,
         hooksEnabled: enabledHooks.size > 0,
+        hookPort,
         port: this.ctx.controlPlanePort,
         logger: this.logger,
         attachLogs: (containerName, microvmId) =>

--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/dev/index.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/dev/index.test.js
@@ -351,6 +351,102 @@ test('run() starts the control-plane and prints the endpoint; SIGINT+SIGTERM shu
   expect(shutdown).toHaveBeenCalled()
 })
 
+test('honors a custom hooks.port: publishes it as a container port and passes it to the control plane', async () => {
+  let cmArgs
+  const startControlPlane = jest.fn(async () => ({
+    url: 'http://127.0.0.1:45010',
+    port: 45010,
+    server: {},
+    shutdown: async () => {},
+  }))
+  const signals = {}
+  const dev = new SandboxesDevMode(
+    {
+      service: {
+        service: 'svc',
+        sandboxes: {
+          echo: { artifact: './app', hooks: { port: 9100, run: true } },
+        },
+      },
+      serviceDir: '/tmp',
+      getProvider: () => ({}),
+    },
+    { sandbox: 'echo', 'assume-role': false },
+    {
+      log: { notice() {}, debug() {} },
+      progress: { notice() {}, remove() {} },
+    },
+    {
+      docker: { ensureIsRunning: async () => {}, buildImage: async () => {} },
+      fileExists: () => true,
+      onSignal: (sig, h) => {
+        signals[sig] = h
+      },
+      createWatcher: () => ({ on() {}, close: async () => {} }),
+      startControlPlane,
+      makeContainerManager: (args) => {
+        cmArgs = args
+        return { run: async () => ({ portMap: {}, stop: async () => {} }) }
+      },
+      makeRegistry: () => ({}),
+    },
+  )
+  const runP = dev.run()
+  await new Promise((r) => setImmediate(r))
+  // App port 8080 + the custom hook port, deduped.
+  expect(cmArgs.ports).toEqual([8080, 9100])
+  expect(startControlPlane).toHaveBeenCalledWith(
+    expect.objectContaining({ hookPort: 9100 }),
+  )
+  await signals.SIGTERM()
+  await runP
+})
+
+test('defaults the hook port to 9000 when hooks.port is not set', async () => {
+  let cmArgs
+  const startControlPlane = jest.fn(async () => ({
+    url: 'http://127.0.0.1:45011',
+    port: 45011,
+    server: {},
+    shutdown: async () => {},
+  }))
+  const signals = {}
+  const dev = new SandboxesDevMode(
+    {
+      service: { service: 'svc', sandboxes: { echo: { artifact: './app' } } },
+      serviceDir: '/tmp',
+      getProvider: () => ({}),
+    },
+    { sandbox: 'echo', 'assume-role': false },
+    {
+      log: { notice() {}, debug() {} },
+      progress: { notice() {}, remove() {} },
+    },
+    {
+      docker: { ensureIsRunning: async () => {}, buildImage: async () => {} },
+      fileExists: () => true,
+      onSignal: (sig, h) => {
+        signals[sig] = h
+      },
+      createWatcher: () => ({ on() {}, close: async () => {} }),
+      startControlPlane,
+      makeContainerManager: (args) => {
+        cmArgs = args
+        return { run: async () => ({ portMap: {}, stop: async () => {} }) }
+      },
+      makeRegistry: () => ({}),
+    },
+  )
+  const runP = dev.run()
+  await new Promise((r) => setImmediate(r))
+  expect(cmArgs.ports).toEqual([8080, 9000])
+  expect(startControlPlane).toHaveBeenCalledWith(
+    expect.objectContaining({ hookPort: 9000 }),
+  )
+  await signals.SIGTERM()
+  await runP
+})
+
 test('--port overrides the control-plane port', async () => {
   const startControlPlane = jest.fn(async () => ({
     url: 'http://127.0.0.1:7777',


### PR DESCRIPTION
## Summary

The local MicroVMs dev emulator (`serverless dev --sandbox`) always published container port **9000** and probed 9000 for lifecycle-hook delivery, ignoring a sandbox's configured `hooks.port`. A sandbox that sets a custom hook port would build and deploy fine, but under `serverless dev` its hooks were silently never delivered — a divergence from its deployed behavior, contrary to dev mode's "same code runs in dev and prod" contract.

## Fix

Derive the hook port from `hooks.port` (default 9000), publish it as a container port alongside the application port (8080, deduped in case they coincide), and pass it to the control plane so readiness probing and hook delivery target the port the application actually listens on.

## Testing

Unit tests added: a custom `hooks.port` is published as a container port and forwarded to the control plane; the default remains 9000 when unset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local development now respects a sandbox’s configured hook port, matching the port behavior used in AWS.
  * Container port exposure now includes the hook port alongside the app port, with duplicates removed when both use the same value.
  * If no hook port is set, the default of `9000` is used consistently during startup and hook delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->