### PR TITLE
fix(agent): inspect returns a graceful not-deployed result for a missing stack

### DIFF
--- a/packages/serverless/lib/plugins/agent/inspect.js
+++ b/packages/serverless/lib/plugins/agent/inspect.js
@@ -216,6 +216,30 @@ class AgentInspect {
       })
       this.render(payload)
     } catch (error) {
+      // A not-yet-deployed stack is a legitimate state for an agent to observe,
+      // not a failure. Return a clean "not-deployed" envelope (exit 0) with a
+      // deploy hint instead of surfacing the raw CloudFormation ValidationError.
+      if (
+        /stack/i.test(error.message || '') &&
+        /does not exist/i.test(error.message || '')
+      ) {
+        let stackName
+        try {
+          stackName = this.provider.naming.getStackName()
+        } catch {
+          /* naming unavailable — omit */
+        }
+        this.render({
+          service: this.serverless.service.service,
+          stage,
+          region,
+          ...(stackName ? { stackName } : {}),
+          mode: 'not-deployed',
+          hint: `No deployed stack found for stage "${stage}" in ${region}. Run "serverless deploy" first, then re-run inspect.`,
+          resources: {},
+        })
+        return
+      }
       // Fatal: emit ONE structured JSON error object on stdout naming the
       // profile/region/stage that were used, then rethrow so the framework
       // maps it to a non-zero exit. Never silently try other profiles.

--- a/packages/serverless/lib/plugins/agent/inspect.js
+++ b/packages/serverless/lib/plugins/agent/inspect.js
@@ -144,6 +144,9 @@ class AgentInspect {
     this.provider = this.serverless.getProvider('aws')
     const region = this.options.region || this.provider.getRegion()
     const stage = this.provider.getStage()
+    // Declared out here (assigned once the provider is known to be AWS) so the
+    // catch can name the stack in a not-deployed result without re-deriving it.
+    let stackName
 
     try {
       // Guard: --format takes exactly two values. Validated up front so a typo
@@ -167,7 +170,7 @@ class AgentInspect {
         )
       }
 
-      const stackName = this.provider.naming.getStackName()
+      stackName = this.provider.naming.getStackName()
 
       // Discovery: one paginated listStackResources, recursing into nested
       // stacks. The lister is injected so discovery stays provider-agnostic.
@@ -219,16 +222,11 @@ class AgentInspect {
       // A not-yet-deployed stack is a legitimate state for an agent to observe,
       // not a failure. Return a clean "not-deployed" envelope (exit 0) with a
       // deploy hint instead of surfacing the raw CloudFormation ValidationError.
-      if (
-        /stack/i.test(error.message || '') &&
-        /does not exist/i.test(error.message || '')
-      ) {
-        let stackName
-        try {
-          stackName = this.provider.naming.getStackName()
-        } catch {
-          /* naming unavailable — omit */
-        }
+      // Match the canonical CloudFormation "stack does not exist" phrasing
+      // (anchored, not two loose word tests) so an unrelated error that merely
+      // mentions "stack" and "does not exist" stays fatal rather than being
+      // misread as not-deployed.
+      if (/Stack with id .+ does not exist/i.test(error.message || '')) {
         this.render({
           service: this.serverless.service.service,
           stage,

--- a/packages/serverless/test/unit/lib/plugins/agent/inspect.test.js
+++ b/packages/serverless/test/unit/lib/plugins/agent/inspect.test.js
@@ -581,7 +581,9 @@ describe('fatal errors (non-zero exit, single JSON error on stdout)', () => {
     expect(provider.request).not.toHaveBeenCalled()
   })
 
-  test('stack-not-deployed surfaces a structured error naming region/stage', async () => {
+  // A not-yet-deployed stack is NOT fatal: it's a legitimate state for an agent
+  // to observe, so inspect returns a clean "not-deployed" envelope and exits 0.
+  test('stack-not-deployed returns a graceful not-deployed envelope (exit 0), not an error', async () => {
     const requestImpl = jest.fn(async () => {
       const err = new Error('Stack with id orders-api-dev does not exist')
       err.code = 'ValidationError'
@@ -591,13 +593,16 @@ describe('fatal errors (non-zero exit, single JSON error on stdout)', () => {
     const { serverless } = buildHarness({ requestImpl })
     const instance = new AgentInspect(serverless, { functions: true })
 
-    await expect(instance.inspect()).rejects.toBeDefined()
+    await expect(instance.inspect()).resolves.toBeUndefined()
 
-    expect(mockWriteText).toHaveBeenCalledTimes(1)
-    const payload = JSON.parse(mockWriteText.mock.calls[0][0])
-    expect(payload.error).toBeDefined()
-    expect(payload.error.region).toBe('us-east-1')
-    expect(payload.error.stage).toBe('dev')
+    const payload = lastPayload()
+    expect(payload.error).toBeUndefined()
+    expect(payload.mode).toBe('not-deployed')
+    expect(payload.region).toBe('us-east-1')
+    expect(payload.stage).toBe('dev')
+    expect(payload.stackName).toBe('orders-api-dev')
+    expect(payload.hint).toMatch(/serverless deploy/i)
+    expect(payload.resources).toEqual({})
   })
 
   test('a bad --name emits a structured error and exits non-zero', async () => {

--- a/packages/serverless/test/unit/lib/plugins/agent/inspect.test.js
+++ b/packages/serverless/test/unit/lib/plugins/agent/inspect.test.js
@@ -597,6 +597,7 @@ describe('fatal errors (non-zero exit, single JSON error on stdout)', () => {
 
     const payload = lastPayload()
     expect(payload.error).toBeUndefined()
+    expect(payload.service).toBe('orders-api')
     expect(payload.mode).toBe('not-deployed')
     expect(payload.region).toBe('us-east-1')
     expect(payload.stage).toBe('dev')


### PR DESCRIPTION
## Summary

`serverless agent inspect` run against a stage whose CloudFormation stack does not exist surfaced the raw `ValidationError` ("Stack with id … does not exist") as a fatal error with a non-zero exit. For an agent-facing, read-only command, a not-yet-deployed stack is a legitimate state to observe — not a failure.

## Fix

Detect the missing-stack error and return a clean, structured envelope with `mode: "not-deployed"`, the service/stage/region/stackName, an empty `resources` object, and a `hint` to run `serverless deploy` — on a **zero exit**. All other errors remain fatal and keep emitting the existing structured error document with a non-zero exit.

## Testing

The existing "stack-not-deployed" test is updated to assert the new behavior: `inspect()` resolves (exit 0), emits `mode: "not-deployed"` with no `error`, and includes the deploy hint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `serverless agent inspect` now treats non-existent or not-yet-deployed CloudFormation stacks as a non-fatal outcome.
  * The command returns successfully with a structured “not deployed” response, including a deploy hint and an empty `resources` list.
  * Includes `stackName` when available.
* **Tests**
  * Updated unit coverage to reflect the new graceful “not-deployed” behavior (successful inspect instead of failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->