### PR TITLE
chore(deps): ignore https-proxy-agent >=9 (drops Node 18 support)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,6 +95,9 @@ updates:
       - dependency-name: 'toml'
         # toml v4 drops support for Node.js 18
         versions: ['>= 4.0.0']
+      - dependency-name: 'https-proxy-agent'
+        # https-proxy-agent v9 (and agent-base v9) drop support for Node.js 18
+        versions: ['>= 9.0.0']
 
   # Maintain Go dependencies
   - package-ecosystem: 'gomod'


### PR DESCRIPTION
## What

Adds an `ignore` rule to `.github/dependabot.yml` so Dependabot stops proposing `https-proxy-agent` v9+.

```yaml
- dependency-name: 'https-proxy-agent'
  # https-proxy-agent v9 (and agent-base v9) drop support for Node.js 18
  versions: ['>= 9.0.0']
```

## Why

`https-proxy-agent` is a **runtime** dependency of `packages/serverless` and `packages/sf-core`, used in core proxy code paths (AWS SDK v2/v3 handlers, plugin install, platform auth). Its v9 release — along with its `agent-base@9` dependency — raises `engines.node` from `>= 14` to `>= 20`, which conflicts with the framework's declared support for Node.js 18 (`packages/serverless` → `engines.node: >=18.0`).

CI runs on Node 24, so a green pipeline would not catch a Node 18 regression from this bump.

This follows the existing convention in the same `ignore` block (ora, open, p-limit, joi, undici, yargs, glob, etc.), each pinned below the version that drops Node 18. `agent-base` is transitive (pulled by `https-proxy-agent`) so it needs no separate entry — blocking the direct dep keeps it on 8.x.

Supersedes/blocks #13679.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to skip a specific package version range that is incompatible with older runtime support, helping prevent problematic automatic upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->