### PR TITLE
feat(sandboxes): summarize sandbox config in the analysis event

### DIFF
--- a/packages/serverless/lib/plugins/aws/sandboxes/analytics.js
+++ b/packages/serverless/lib/plugins/aws/sandboxes/analytics.js
@@ -1,0 +1,275 @@
+/**
+ * Pure builder for the `sandboxes` block of the sfcore.analysis.generated.v1
+ * analytics event. Consumed by the sf-core framework runner's
+ * getAnalysisEventDetails().
+ *
+ * Contract (mirrors the platform-core event schema for this field):
+ *  - Fixed keys only — never sandbox names, ARNs, paths, patterns, env var
+ *    names, or any other user-authored string.
+ *  - Explicit-only: a knob is reported only when a sandbox explicitly sets it
+ *    in serverless.yml (an explicit value equal to the default IS reported).
+ *  - Omit-empty: absent key ≡ empty array ≡ 0 ≡ "all sandboxes on defaults".
+ *  - Counts = "how many sandboxes explicitly set X"; arrays = sorted unique
+ *    values customizers chose.
+ *  - HARD REQUIREMENT: total function — never throws. Malformed input
+ *    degrades to omitted keys or `undefined`; analytics must never break a
+ *    user command.
+ */
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v)
+
+const HOOK_NAMES = [
+  'ready',
+  'validate',
+  'run',
+  'resume',
+  'suspend',
+  'terminate',
+]
+const OS_CAPABILITIES = ['all']
+const MAX_TIMEOUT_SECONDS = 3600
+
+const sortedUnique = (values) => {
+  const unique = [...new Set(values)]
+  return typeof unique[0] === 'number'
+    ? unique.sort((a, b) => a - b)
+    : unique.sort()
+}
+
+const addIfPositive = (target, key, n) => {
+  if (typeof n === 'number' && n > 0) target[key] = n
+}
+
+const addIfNonEmpty = (target, key, arr) => {
+  if (Array.isArray(arr) && arr.length > 0) target[key] = arr
+}
+
+const isValidHookValue = (v) =>
+  v === true ||
+  (isObj(v) &&
+    (v.timeout === undefined ||
+      (typeof v.timeout === 'number' && v.timeout > 0)))
+
+const buildHooks = (cfgs) => {
+  const withHooks = cfgs.filter((c) => isObj(c.hooks))
+  if (withHooks.length === 0) return undefined
+  const out = { sandboxes: withHooks.length }
+
+  addIfNonEmpty(
+    out,
+    'configured',
+    sortedUnique(
+      withHooks.flatMap((c) =>
+        HOOK_NAMES.filter((h) => isValidHookValue(c.hooks[h])),
+      ),
+    ),
+  )
+
+  const timeouts = {}
+  for (const h of HOOK_NAMES) {
+    addIfNonEmpty(
+      timeouts,
+      h,
+      sortedUnique(
+        withHooks
+          .map((c) => c.hooks[h])
+          .filter(isObj)
+          .map((v) => v.timeout)
+          .filter((t) => typeof t === 'number' && t > 0)
+          .map((t) => Math.min(t, MAX_TIMEOUT_SECONDS)),
+      ),
+    )
+  }
+  if (Object.keys(timeouts).length > 0) out.timeouts = timeouts
+
+  addIfPositive(
+    out,
+    'customPort',
+    withHooks.filter((c) => typeof c.hooks.port === 'number').length,
+  )
+  return out
+}
+
+const IAM_ROLES = ['buildRole', 'executionRole']
+
+// 'existing' = user supplies a role (ARN string or CFN intrinsic — generation
+// skipped); 'extended' = generated role extended with statements /
+// managedPolicies / permissionsBoundary. Mirrors validators/schema.js.
+const classifyRole = (v) => {
+  if (typeof v === 'string') return 'existing'
+  if (isObj(v)) {
+    return v.statements || v.managedPolicies || v.permissionsBoundary
+      ? 'extended'
+      : 'existing'
+  }
+  return undefined
+}
+
+const buildIam = (cfgs) => {
+  const out = {}
+  for (const role of IAM_ROLES) {
+    addIfNonEmpty(
+      out,
+      role,
+      sortedUnique(
+        cfgs
+          .map((c) => (isObj(c.iam) ? classifyRole(c.iam[role]) : undefined))
+          .filter(Boolean),
+      ),
+    )
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+// Reports RAW config presence (explicit-only), mirroring — not calling — the
+// interpretation in compilers/observability.js resolveObservability. The
+// anti-drift test in analytics.test.js pins the two together.
+const buildObservability = (cfgs) => {
+  const out = {}
+  const customized = {}
+  let defaults = 0
+  let disabled = 0
+  let logsDisabled = 0
+  let metricsDisabled = 0
+  let dashboardDisabled = 0
+  let alarms = 0
+  let logGroup = 0
+  let metricFilters = 0
+  let alarmThresholds = 0
+  const retentionDays = []
+
+  for (const c of cfgs) {
+    const raw = c.observability
+    if (raw === false) {
+      disabled += 1
+      continue
+    }
+    if (!isObj(raw)) {
+      // absent or `true` (or malformed): the pure default — monitoring on,
+      // no alarms. Keeps the invariant count − defaults − disabled =
+      // sandboxes with a custom observability object.
+      defaults += 1
+      continue
+    }
+    if (raw.logs?.enabled === false) logsDisabled += 1
+    if (raw.metrics?.enabled === false) metricsDisabled += 1
+    if (raw.dashboard?.enabled === false) dashboardDisabled += 1
+    if (raw.logs?.enabled !== false && isObj(raw.alarms) && raw.alarms.notify)
+      alarms += 1
+    if (typeof raw.logs?.retentionDays === 'number') {
+      retentionDays.push(raw.logs.retentionDays)
+    }
+    if (typeof raw.logs?.logGroup === 'string') logGroup += 1
+    if (
+      isObj(raw.metrics?.filters) &&
+      Object.keys(raw.metrics.filters).length > 0
+    ) {
+      metricFilters += 1
+    }
+    if (
+      isObj(raw.alarms?.thresholds) &&
+      Object.keys(raw.alarms.thresholds).length > 0
+    ) {
+      alarmThresholds += 1
+    }
+  }
+
+  addIfPositive(out, 'defaults', defaults)
+  addIfPositive(out, 'disabled', disabled)
+  addIfPositive(out, 'logsDisabled', logsDisabled)
+  addIfPositive(out, 'metricsDisabled', metricsDisabled)
+  addIfPositive(out, 'dashboardDisabled', dashboardDisabled)
+  addIfPositive(out, 'alarms', alarms)
+  addIfNonEmpty(customized, 'retentionDays', sortedUnique(retentionDays))
+  addIfPositive(customized, 'logGroup', logGroup)
+  addIfPositive(customized, 'metricFilters', metricFilters)
+  addIfPositive(customized, 'alarmThresholds', alarmThresholds)
+  if (Object.keys(customized).length > 0) out.customized = customized
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+export const buildSandboxesAnalytics = (sandboxesConfig) => {
+  try {
+    if (!isObj(sandboxesConfig)) return undefined
+    const names = Object.keys(sandboxesConfig)
+    if (names.length === 0) return undefined
+    // Malformed entries still count toward `count` (they exist in config) but
+    // contribute nothing to knob derivation.
+    const cfgs = Object.values(sandboxesConfig).filter(isObj)
+
+    const block = { count: names.length }
+
+    addIfNonEmpty(
+      block,
+      'artifactTypes',
+      sortedUnique(
+        cfgs
+          .map((c) =>
+            typeof c.artifact === 'string'
+              ? c.artifact.startsWith('s3://')
+                ? 's3'
+                : 'source'
+              : undefined,
+          )
+          .filter(Boolean),
+      ),
+    )
+
+    addIfNonEmpty(
+      block,
+      'minimumMemory',
+      sortedUnique(
+        cfgs.map((c) => c.minimumMemory).filter((v) => typeof v === 'number'),
+      ),
+    )
+
+    const hooks = buildHooks(cfgs)
+    if (hooks) block.hooks = hooks
+
+    const iam = buildIam(cfgs)
+    if (iam) block.iam = iam
+
+    addIfPositive(block, 'vpc', cfgs.filter((c) => isObj(c.vpc)).length)
+
+    const observability = buildObservability(cfgs)
+    if (observability) block.observability = observability
+
+    addIfNonEmpty(
+      block,
+      'envVarCounts',
+      cfgs
+        .map((c) =>
+          isObj(c.environment) ? Object.keys(c.environment).length : 0,
+        )
+        .filter((n) => n > 0)
+        .sort((a, b) => a - b),
+    )
+
+    addIfNonEmpty(
+      block,
+      'osCapabilities',
+      sortedUnique(
+        cfgs.flatMap((c) =>
+          Array.isArray(c.osCapabilities)
+            ? c.osCapabilities
+                .filter((v) => typeof v === 'string')
+                .map((v) => v.toLowerCase())
+                .filter((v) => OS_CAPABILITIES.includes(v))
+            : [],
+        ),
+      ),
+    )
+
+    addIfPositive(
+      block,
+      'tags',
+      cfgs.filter((c) => isObj(c.tags) && Object.keys(c.tags).length > 0)
+        .length,
+    )
+
+    return block
+  } catch {
+    // Last-resort guard: analytics must never throw into the CLI run.
+    return undefined
+  }
+}

--- a/packages/serverless/lib/plugins/aws/sandboxes/analytics.js
+++ b/packages/serverless/lib/plugins/aws/sandboxes/analytics.js
@@ -188,7 +188,9 @@ const buildObservability = (cfgs) => {
   return Object.keys(out).length > 0 ? out : undefined
 }
 
-export const buildSandboxesAnalytics = (sandboxesConfig) => {
+// Pure: a `sandboxes` config map -> the analytics block, or undefined when
+// there is nothing to report. Total (never throws) on malformed input.
+const deriveSandboxesBlock = (sandboxesConfig) => {
   try {
     if (!isObj(sandboxesConfig)) return undefined
     const names = Object.keys(sandboxesConfig)
@@ -273,3 +275,25 @@ export const buildSandboxesAnalytics = (sandboxesConfig) => {
     return undefined
   }
 }
+
+/**
+ * Runner-facing entry: takes the full service config and returns a spreadable
+ * details fragment — `{ sandboxes: <block> }` when the service defines
+ * sandboxes, or `{}` otherwise. Mirrors deriveAnalysisEnrichment so it can be
+ * spread directly into the analysis event with no call-site guard.
+ *
+ * The `config?.sandboxes` read happens INSIDE this try/catch (not at the call
+ * site), so a hostile/throwing config getter degrades to `{}` rather than
+ * escaping into getAnalysisEventDetails (which would abort finalization and
+ * drop the billing usage event). Total — never throws.
+ */
+export const buildSandboxesAnalytics = (config) => {
+  try {
+    const block = deriveSandboxesBlock(config?.sandboxes)
+    return block ? { sandboxes: block } : {}
+  } catch {
+    return {}
+  }
+}
+
+export { deriveSandboxesBlock }

--- a/packages/serverless/lib/plugins/aws/sandboxes/index.js
+++ b/packages/serverless/lib/plugins/aws/sandboxes/index.js
@@ -90,7 +90,10 @@ class ServerlessSandboxes {
       throwError: (msg) => errors.push(msg),
     })
     if (errors.length > 0) {
-      throw new this.serverless.classes.Error(errors.join('\n'))
+      throw new this.serverless.classes.Error(
+        errors.join('\n'),
+        'SANDBOXES_VALIDATION_ERROR',
+      )
     }
   }
 
@@ -137,6 +140,7 @@ class ServerlessSandboxes {
         if (resolved !== root && !resolved.startsWith(root + path.sep)) {
           throw new this.serverless.classes.Error(
             `Refusing to upload sandbox artifact from '${file}': path escapes the package directory.`,
+            'SANDBOXES_ARTIFACT_PATH_ESCAPE',
           )
         }
         return uploadArtifact({

--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/analytics.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/analytics.test.js
@@ -1,18 +1,21 @@
-import { buildSandboxesAnalytics } from '../../../../../../lib/plugins/aws/sandboxes/analytics.js'
+import {
+  buildSandboxesAnalytics,
+  deriveSandboxesBlock,
+} from '../../../../../../lib/plugins/aws/sandboxes/analytics.js'
 import { resolveObservability } from '../../../../../../lib/plugins/aws/sandboxes/compilers/observability.js'
 
-describe('buildSandboxesAnalytics — envelope', () => {
+describe('deriveSandboxesBlock — envelope', () => {
   test('returns undefined for absent/empty/malformed top-level config', () => {
-    expect(buildSandboxesAnalytics(undefined)).toBeUndefined()
-    expect(buildSandboxesAnalytics(null)).toBeUndefined()
-    expect(buildSandboxesAnalytics({})).toBeUndefined()
-    expect(buildSandboxesAnalytics('nope')).toBeUndefined()
-    expect(buildSandboxesAnalytics(42)).toBeUndefined()
-    expect(buildSandboxesAnalytics([{ artifact: './x' }])).toBeUndefined()
+    expect(deriveSandboxesBlock(undefined)).toBeUndefined()
+    expect(deriveSandboxesBlock(null)).toBeUndefined()
+    expect(deriveSandboxesBlock({})).toBeUndefined()
+    expect(deriveSandboxesBlock('nope')).toBeUndefined()
+    expect(deriveSandboxesBlock(42)).toBeUndefined()
+    expect(deriveSandboxesBlock([{ artifact: './x' }])).toBeUndefined()
   })
 
   test('count reflects the number of defined sandboxes', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './app' },
       b: { artifact: 's3://bucket/key.zip' },
     })
@@ -20,9 +23,9 @@ describe('buildSandboxesAnalytics — envelope', () => {
   })
 })
 
-describe('buildSandboxesAnalytics — artifactTypes', () => {
+describe('deriveSandboxesBlock — artifactTypes', () => {
   test('classifies s3:// as s3 and everything else as source, sorted unique', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './app' },
       b: { artifact: 's3://bucket/key.zip' },
       c: { artifact: '/abs/dir' },
@@ -31,15 +34,15 @@ describe('buildSandboxesAnalytics — artifactTypes', () => {
   })
 
   test('omits artifactTypes when no sandbox has a string artifact (malformed)', () => {
-    const out = buildSandboxesAnalytics({ a: { artifact: 42 } })
+    const out = deriveSandboxesBlock({ a: { artifact: 42 } })
     expect(out.count).toBe(1)
     expect(out.artifactTypes).toBeUndefined()
   })
 })
 
-describe('buildSandboxesAnalytics — minimumMemory (explicit-only)', () => {
+describe('deriveSandboxesBlock — minimumMemory (explicit-only)', () => {
   test('reports only explicitly set values, sorted unique', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', minimumMemory: 8192 },
       b: { artifact: './b', minimumMemory: 2048 },
       c: { artifact: './c' }, // default by omission — contributes nothing
@@ -49,22 +52,22 @@ describe('buildSandboxesAnalytics — minimumMemory (explicit-only)', () => {
   })
 
   test('explicitly setting the default value (2048) IS reported', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', minimumMemory: 2048 },
     })
     expect(out.minimumMemory).toEqual([2048])
   })
 
   test('omits minimumMemory entirely when nobody sets it (omit-empty)', () => {
-    const out = buildSandboxesAnalytics({ a: { artifact: './a' } })
+    const out = deriveSandboxesBlock({ a: { artifact: './a' } })
     expect(out.minimumMemory).toBeUndefined()
     expect('minimumMemory' in out).toBe(false)
   })
 })
 
-describe('buildSandboxesAnalytics — never throws', () => {
+describe('deriveSandboxesBlock — never throws', () => {
   test('null sandbox entries and wrong-typed knobs degrade, never throw', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: null,
       b: 'string-sandbox',
       c: { artifact: './ok', minimumMemory: 'lots' },
@@ -75,9 +78,9 @@ describe('buildSandboxesAnalytics — never throws', () => {
   })
 })
 
-describe('buildSandboxesAnalytics — hooks', () => {
+describe('deriveSandboxesBlock — hooks', () => {
   test('reports adoption count, configured union, per-hook explicit timeouts', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: {
         artifact: './a',
         hooks: { ready: { timeout: 120 }, run: true, port: 9100 },
@@ -94,7 +97,7 @@ describe('buildSandboxesAnalytics — hooks', () => {
   })
 
   test('true-form hooks appear in configured but never in timeouts', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', hooks: { ready: true } },
     })
     expect(out.hooks.configured).toEqual(['ready'])
@@ -102,19 +105,19 @@ describe('buildSandboxesAnalytics — hooks', () => {
   })
 
   test('clamps timeout values above 3600', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', hooks: { ready: { timeout: 99999 } } },
     })
     expect(out.hooks.timeouts).toEqual({ ready: [3600] })
   })
 
   test('hooks block omitted entirely when no sandbox declares hooks', () => {
-    const out = buildSandboxesAnalytics({ a: { artifact: './a' } })
+    const out = deriveSandboxesBlock({ a: { artifact: './a' } })
     expect(out.hooks).toBeUndefined()
   })
 
   test('unknown hook names and malformed hook values are ignored', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: {
         artifact: './a',
         hooks: { evil: { timeout: 5 }, ready: 'yes', run: { timeout: 'soon' } },
@@ -125,7 +128,7 @@ describe('buildSandboxesAnalytics — hooks', () => {
   })
 
   test('empty-object hook form is configured but contributes no timeout', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', hooks: { ready: {} } },
     })
     expect(out.hooks.configured).toEqual(['ready'])
@@ -133,7 +136,7 @@ describe('buildSandboxesAnalytics — hooks', () => {
   })
 
   test('present-but-invalid timeouts are still rejected from configured', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: {
         artifact: './a',
         hooks: {
@@ -147,9 +150,9 @@ describe('buildSandboxesAnalytics — hooks', () => {
   })
 })
 
-describe('buildSandboxesAnalytics — iam', () => {
+describe('deriveSandboxesBlock — iam', () => {
   test('classifies ARN string and CFN intrinsic as existing, extension object as extended', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', iam: { executionRole: 'arn:aws:iam::123:role/x' } },
       b: {
         artifact: './b',
@@ -164,7 +167,7 @@ describe('buildSandboxesAnalytics — iam', () => {
   })
 
   test('buildRole and executionRole are independent; defaults omit the key', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: {
         artifact: './a',
         iam: { buildRole: { managedPolicies: ['arn:x'] } },
@@ -175,15 +178,13 @@ describe('buildSandboxesAnalytics — iam', () => {
   })
 
   test('iam omitted entirely when every sandbox uses generated roles', () => {
-    expect(
-      buildSandboxesAnalytics({ a: { artifact: './a' } }).iam,
-    ).toBeUndefined()
+    expect(deriveSandboxesBlock({ a: { artifact: './a' } }).iam).toBeUndefined()
   })
 })
 
-describe('buildSandboxesAnalytics — vpc / envVarCounts / osCapabilities / tags', () => {
+describe('deriveSandboxesBlock — vpc / envVarCounts / osCapabilities / tags', () => {
   test('vpc counts sandboxes with a vpc object', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', vpc: { subnetIds: ['s-1'] } },
       b: { artifact: './b' },
     })
@@ -191,7 +192,7 @@ describe('buildSandboxesAnalytics — vpc / envVarCounts / osCapabilities / tags
   })
 
   test('envVarCounts: one ascending entry per sandbox that declares vars — never names', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', environment: { X: '1', Y: '2', Z: '3' } },
       b: { artifact: './b', environment: { ONLY: 'v' } },
       c: { artifact: './c' },
@@ -201,7 +202,7 @@ describe('buildSandboxesAnalytics — vpc / envVarCounts / osCapabilities / tags
   })
 
   test('osCapabilities normalized to lowercase, sorted unique; tags counted', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', osCapabilities: ['ALL'], tags: { team: 'x' } },
       b: { artifact: './b', osCapabilities: ['all'] },
     })
@@ -210,30 +211,30 @@ describe('buildSandboxesAnalytics — vpc / envVarCounts / osCapabilities / tags
   })
 
   test('osCapabilities: out-of-enum values are dropped, not passed through', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', osCapabilities: ['all', 'ACME_INTERNAL_CAP'] },
     })
     expect(out.osCapabilities).toEqual(['all'])
   })
 
   test('osCapabilities: key omitted when only unknown values are present', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', osCapabilities: ['ACME_INTERNAL_CAP'] },
     })
     expect('osCapabilities' in out).toBe(false)
   })
 
   test('all five omitted on a bare sandbox (omit-empty)', () => {
-    const out = buildSandboxesAnalytics({ a: { artifact: './a' } })
+    const out = deriveSandboxesBlock({ a: { artifact: './a' } })
     for (const k of ['iam', 'vpc', 'envVarCounts', 'osCapabilities', 'tags']) {
       expect(k in out).toBe(false)
     }
   })
 })
 
-describe('buildSandboxesAnalytics — observability', () => {
+describe('deriveSandboxesBlock — observability', () => {
   test('absent and `true` count as defaults; false counts as disabled', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a' },
       b: { artifact: './b', observability: true },
       c: { artifact: './c', observability: false },
@@ -242,7 +243,7 @@ describe('buildSandboxesAnalytics — observability', () => {
   })
 
   test('component opt-outs and alarms adoption are counted per sandbox', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: {
         artifact: './a',
         observability: {
@@ -265,7 +266,7 @@ describe('buildSandboxesAnalytics — observability', () => {
   })
 
   test('alarms without notify is NOT counted (mirrors the compiler)', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', observability: { alarms: { thresholds: {} } } },
     })
     // Nothing else in this raw config is reportable (thresholds is empty),
@@ -276,7 +277,7 @@ describe('buildSandboxesAnalytics — observability', () => {
   })
 
   test('customized: explicit retention values, logGroup/filters/thresholds presence counts', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: {
         artifact: './a',
         observability: {
@@ -299,7 +300,7 @@ describe('buildSandboxesAnalytics — observability', () => {
   })
 
   test('explicitly setting retention to the default 14 IS reported (explicit-only)', () => {
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', observability: { logs: { retentionDays: 14 } } },
     })
     expect(out.observability.customized.retentionDays).toEqual([14])
@@ -320,7 +321,7 @@ describe('anti-drift: analytics interpretation agrees with resolveObservability'
   ]
   test.each(grid.map((raw, i) => [i, raw]))('config #%s', (_, raw) => {
     const resolved = resolveObservability(raw)
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       a: { artifact: './a', observability: raw },
     })
     const o = out.observability ?? {}
@@ -344,7 +345,7 @@ describe('anti-drift: analytics interpretation agrees with resolveObservability'
 describe('privacy guard — no user-authored strings ever leak', () => {
   test('marker strings from every free-form knob are absent from the output', () => {
     const M = 'MARKER_SECRET'
-    const out = buildSandboxesAnalytics({
+    const out = deriveSandboxesBlock({
       [`sandbox-${M}`]: {
         artifact: `./path-${M}`,
         description: `desc ${M}`,
@@ -364,5 +365,46 @@ describe('privacy guard — no user-authored strings ever leak', () => {
       },
     })
     expect(JSON.stringify(out)).not.toContain(M)
+  })
+})
+
+describe('buildSandboxesAnalytics — runner entry (spreadable, reads config internally)', () => {
+  test('returns { sandboxes: block } when the service defines sandboxes', () => {
+    const out = buildSandboxesAnalytics({
+      service: 'svc',
+      sandboxes: { runner: { artifact: './app', minimumMemory: 8192 } },
+    })
+    expect(out).toEqual({
+      sandboxes: {
+        count: 1,
+        artifactTypes: ['source'],
+        minimumMemory: [8192],
+        observability: { defaults: 1 },
+      },
+    })
+  })
+
+  test('returns {} when the config defines no sandboxes (spreads to nothing)', () => {
+    expect(buildSandboxesAnalytics({ service: 'svc' })).toEqual({})
+    expect(buildSandboxesAnalytics({ service: 'svc', sandboxes: {} })).toEqual(
+      {},
+    )
+  })
+
+  test('returns {} for absent/malformed config', () => {
+    expect(buildSandboxesAnalytics(undefined)).toEqual({})
+    expect(buildSandboxesAnalytics(null)).toEqual({})
+    expect(buildSandboxesAnalytics('nope')).toEqual({})
+  })
+
+  test('swallows a throwing `sandboxes` getter (the guard the inline spread relies on)', () => {
+    const config = { service: 'svc' }
+    Object.defineProperty(config, 'sandboxes', {
+      enumerable: true,
+      get() {
+        throw new Error('boom')
+      },
+    })
+    expect(buildSandboxesAnalytics(config)).toEqual({})
   })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/analytics.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/analytics.test.js
@@ -1,0 +1,368 @@
+import { buildSandboxesAnalytics } from '../../../../../../lib/plugins/aws/sandboxes/analytics.js'
+import { resolveObservability } from '../../../../../../lib/plugins/aws/sandboxes/compilers/observability.js'
+
+describe('buildSandboxesAnalytics — envelope', () => {
+  test('returns undefined for absent/empty/malformed top-level config', () => {
+    expect(buildSandboxesAnalytics(undefined)).toBeUndefined()
+    expect(buildSandboxesAnalytics(null)).toBeUndefined()
+    expect(buildSandboxesAnalytics({})).toBeUndefined()
+    expect(buildSandboxesAnalytics('nope')).toBeUndefined()
+    expect(buildSandboxesAnalytics(42)).toBeUndefined()
+    expect(buildSandboxesAnalytics([{ artifact: './x' }])).toBeUndefined()
+  })
+
+  test('count reflects the number of defined sandboxes', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './app' },
+      b: { artifact: 's3://bucket/key.zip' },
+    })
+    expect(out.count).toBe(2)
+  })
+})
+
+describe('buildSandboxesAnalytics — artifactTypes', () => {
+  test('classifies s3:// as s3 and everything else as source, sorted unique', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './app' },
+      b: { artifact: 's3://bucket/key.zip' },
+      c: { artifact: '/abs/dir' },
+    })
+    expect(out.artifactTypes).toEqual(['s3', 'source'])
+  })
+
+  test('omits artifactTypes when no sandbox has a string artifact (malformed)', () => {
+    const out = buildSandboxesAnalytics({ a: { artifact: 42 } })
+    expect(out.count).toBe(1)
+    expect(out.artifactTypes).toBeUndefined()
+  })
+})
+
+describe('buildSandboxesAnalytics — minimumMemory (explicit-only)', () => {
+  test('reports only explicitly set values, sorted unique', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', minimumMemory: 8192 },
+      b: { artifact: './b', minimumMemory: 2048 },
+      c: { artifact: './c' }, // default by omission — contributes nothing
+      d: { artifact: './d', minimumMemory: 2048 },
+    })
+    expect(out.minimumMemory).toEqual([2048, 8192])
+  })
+
+  test('explicitly setting the default value (2048) IS reported', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', minimumMemory: 2048 },
+    })
+    expect(out.minimumMemory).toEqual([2048])
+  })
+
+  test('omits minimumMemory entirely when nobody sets it (omit-empty)', () => {
+    const out = buildSandboxesAnalytics({ a: { artifact: './a' } })
+    expect(out.minimumMemory).toBeUndefined()
+    expect('minimumMemory' in out).toBe(false)
+  })
+})
+
+describe('buildSandboxesAnalytics — never throws', () => {
+  test('null sandbox entries and wrong-typed knobs degrade, never throw', () => {
+    const out = buildSandboxesAnalytics({
+      a: null,
+      b: 'string-sandbox',
+      c: { artifact: './ok', minimumMemory: 'lots' },
+    })
+    expect(out.count).toBe(3) // keys counted even when entries are malformed
+    expect(out.artifactTypes).toEqual(['source'])
+    expect(out.minimumMemory).toBeUndefined()
+  })
+})
+
+describe('buildSandboxesAnalytics — hooks', () => {
+  test('reports adoption count, configured union, per-hook explicit timeouts', () => {
+    const out = buildSandboxesAnalytics({
+      a: {
+        artifact: './a',
+        hooks: { ready: { timeout: 120 }, run: true, port: 9100 },
+      },
+      b: { artifact: './b', hooks: { run: { timeout: 60 }, terminate: true } },
+      c: { artifact: './c' }, // no hooks block
+    })
+    expect(out.hooks).toEqual({
+      sandboxes: 2,
+      configured: ['ready', 'run', 'terminate'],
+      timeouts: { ready: [120], run: [60] },
+      customPort: 1,
+    })
+  })
+
+  test('true-form hooks appear in configured but never in timeouts', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', hooks: { ready: true } },
+    })
+    expect(out.hooks.configured).toEqual(['ready'])
+    expect(out.hooks.timeouts).toBeUndefined()
+  })
+
+  test('clamps timeout values above 3600', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', hooks: { ready: { timeout: 99999 } } },
+    })
+    expect(out.hooks.timeouts).toEqual({ ready: [3600] })
+  })
+
+  test('hooks block omitted entirely when no sandbox declares hooks', () => {
+    const out = buildSandboxesAnalytics({ a: { artifact: './a' } })
+    expect(out.hooks).toBeUndefined()
+  })
+
+  test('unknown hook names and malformed hook values are ignored', () => {
+    const out = buildSandboxesAnalytics({
+      a: {
+        artifact: './a',
+        hooks: { evil: { timeout: 5 }, ready: 'yes', run: { timeout: 'soon' } },
+      },
+    })
+    // hooks block exists (a declared a hooks object) but nothing valid inside
+    expect(out.hooks).toEqual({ sandboxes: 1 })
+  })
+
+  test('empty-object hook form is configured but contributes no timeout', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', hooks: { ready: {} } },
+    })
+    expect(out.hooks.configured).toEqual(['ready'])
+    expect(out.hooks.timeouts).toBeUndefined()
+  })
+
+  test('present-but-invalid timeouts are still rejected from configured', () => {
+    const out = buildSandboxesAnalytics({
+      a: {
+        artifact: './a',
+        hooks: {
+          run: { timeout: 'soon' },
+          suspend: { timeout: 0 },
+          resume: 'yes',
+        },
+      },
+    })
+    expect(out.hooks).toEqual({ sandboxes: 1 })
+  })
+})
+
+describe('buildSandboxesAnalytics — iam', () => {
+  test('classifies ARN string and CFN intrinsic as existing, extension object as extended', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', iam: { executionRole: 'arn:aws:iam::123:role/x' } },
+      b: {
+        artifact: './b',
+        iam: { executionRole: { 'Fn::GetAtt': ['Role', 'Arn'] } },
+      },
+      c: {
+        artifact: './c',
+        iam: { executionRole: { statements: [{ Effect: 'Allow' }] } },
+      },
+    })
+    expect(out.iam).toEqual({ executionRole: ['existing', 'extended'] })
+  })
+
+  test('buildRole and executionRole are independent; defaults omit the key', () => {
+    const out = buildSandboxesAnalytics({
+      a: {
+        artifact: './a',
+        iam: { buildRole: { managedPolicies: ['arn:x'] } },
+      },
+      b: { artifact: './b' }, // generated roles everywhere
+    })
+    expect(out.iam).toEqual({ buildRole: ['extended'] })
+  })
+
+  test('iam omitted entirely when every sandbox uses generated roles', () => {
+    expect(
+      buildSandboxesAnalytics({ a: { artifact: './a' } }).iam,
+    ).toBeUndefined()
+  })
+})
+
+describe('buildSandboxesAnalytics — vpc / envVarCounts / osCapabilities / tags', () => {
+  test('vpc counts sandboxes with a vpc object', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', vpc: { subnetIds: ['s-1'] } },
+      b: { artifact: './b' },
+    })
+    expect(out.vpc).toBe(1)
+  })
+
+  test('envVarCounts: one ascending entry per sandbox that declares vars — never names', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', environment: { X: '1', Y: '2', Z: '3' } },
+      b: { artifact: './b', environment: { ONLY: 'v' } },
+      c: { artifact: './c' },
+      d: { artifact: './d', environment: {} }, // empty map = declares nothing
+    })
+    expect(out.envVarCounts).toEqual([1, 3])
+  })
+
+  test('osCapabilities normalized to lowercase, sorted unique; tags counted', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', osCapabilities: ['ALL'], tags: { team: 'x' } },
+      b: { artifact: './b', osCapabilities: ['all'] },
+    })
+    expect(out.osCapabilities).toEqual(['all'])
+    expect(out.tags).toBe(1)
+  })
+
+  test('osCapabilities: out-of-enum values are dropped, not passed through', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', osCapabilities: ['all', 'ACME_INTERNAL_CAP'] },
+    })
+    expect(out.osCapabilities).toEqual(['all'])
+  })
+
+  test('osCapabilities: key omitted when only unknown values are present', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', osCapabilities: ['ACME_INTERNAL_CAP'] },
+    })
+    expect('osCapabilities' in out).toBe(false)
+  })
+
+  test('all five omitted on a bare sandbox (omit-empty)', () => {
+    const out = buildSandboxesAnalytics({ a: { artifact: './a' } })
+    for (const k of ['iam', 'vpc', 'envVarCounts', 'osCapabilities', 'tags']) {
+      expect(k in out).toBe(false)
+    }
+  })
+})
+
+describe('buildSandboxesAnalytics — observability', () => {
+  test('absent and `true` count as defaults; false counts as disabled', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a' },
+      b: { artifact: './b', observability: true },
+      c: { artifact: './c', observability: false },
+    })
+    expect(out.observability).toEqual({ defaults: 2, disabled: 1 })
+  })
+
+  test('component opt-outs and alarms adoption are counted per sandbox', () => {
+    const out = buildSandboxesAnalytics({
+      a: {
+        artifact: './a',
+        observability: {
+          logs: { enabled: false },
+          metrics: { enabled: false },
+          dashboard: { enabled: false },
+        },
+      },
+      b: {
+        artifact: './b',
+        observability: { alarms: { notify: 'arn:aws:sns:us-east-1:1:t' } },
+      },
+    })
+    expect(out.observability).toEqual({
+      logsDisabled: 1,
+      metricsDisabled: 1,
+      dashboardDisabled: 1,
+      alarms: 1,
+    })
+  })
+
+  test('alarms without notify is NOT counted (mirrors the compiler)', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', observability: { alarms: { thresholds: {} } } },
+    })
+    // Nothing else in this raw config is reportable (thresholds is empty),
+    // so per the omit-empty invariant `out.observability` itself is omitted —
+    // hence the optional chaining (the brief's literal `.observability.alarms`
+    // would throw on undefined here).
+    expect(out.observability?.alarms).toBeUndefined()
+  })
+
+  test('customized: explicit retention values, logGroup/filters/thresholds presence counts', () => {
+    const out = buildSandboxesAnalytics({
+      a: {
+        artifact: './a',
+        observability: {
+          logs: { retentionDays: 30, logGroup: '/custom/name' },
+          metrics: { filters: { fatal: '%FATAL%' } },
+          alarms: {
+            notify: 'arn:aws:sns:us-east-1:1:t',
+            thresholds: { fatal: { threshold: 1 } },
+          },
+        },
+      },
+      b: { artifact: './b', observability: { logs: { retentionDays: 30 } } },
+    })
+    expect(out.observability.customized).toEqual({
+      retentionDays: [30],
+      logGroup: 1,
+      metricFilters: 1,
+      alarmThresholds: 1,
+    })
+  })
+
+  test('explicitly setting retention to the default 14 IS reported (explicit-only)', () => {
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', observability: { logs: { retentionDays: 14 } } },
+    })
+    expect(out.observability.customized.retentionDays).toEqual([14])
+  })
+})
+
+describe('anti-drift: analytics interpretation agrees with resolveObservability', () => {
+  const grid = [
+    undefined,
+    true,
+    false,
+    {},
+    { logs: { enabled: false } },
+    {
+      logs: { enabled: false },
+      alarms: { notify: 'arn:aws:sns:us-east-1:1:t' },
+    },
+  ]
+  test.each(grid.map((raw, i) => [i, raw]))('config #%s', (_, raw) => {
+    const resolved = resolveObservability(raw)
+    const out = buildSandboxesAnalytics({
+      a: { artifact: './a', observability: raw },
+    })
+    const o = out.observability ?? {}
+    // "defaults or true" ⇔ monitoring fully on with defaults
+    if (raw === undefined || raw === true) {
+      expect(o.defaults).toBe(1)
+      expect(resolved.metrics.enabled).toBe(true)
+    }
+    // disabled ⇔ compiler turns the monitoring layer off
+    if (raw === false) {
+      expect(o.disabled).toBe(1)
+      expect(resolved.metrics.enabled).toBe(false)
+    }
+    // logsDisabled ⇔ compiler disables logs
+    expect((o.logsDisabled ?? 0) > 0).toBe(resolved.logs.enabled === false)
+    // alarms counted ⇔ compiler builds alarms
+    expect((o.alarms ?? 0) > 0).toBe(resolved.alarms !== null)
+  })
+})
+
+describe('privacy guard — no user-authored strings ever leak', () => {
+  test('marker strings from every free-form knob are absent from the output', () => {
+    const M = 'MARKER_SECRET'
+    const out = buildSandboxesAnalytics({
+      [`sandbox-${M}`]: {
+        artifact: `./path-${M}`,
+        description: `desc ${M}`,
+        environment: { [`ENV_${M}`]: `val-${M}` },
+        tags: { [`tag-${M}`]: `tv-${M}` },
+        iam: { executionRole: `arn:aws:iam::123:role/${M}` },
+        vpc: { subnetIds: [`subnet-${M}`], securityGroupIds: [`sg-${M}`] },
+        osCapabilities: [`CAP_${M}`.replace('${M}', M)],
+        observability: {
+          logs: { logGroup: `/lg/${M}`, retentionDays: 30 },
+          metrics: { filters: { [`f${M}`]: `%${M}%` } },
+          alarms: {
+            notify: `arn:aws:sns:us-east-1:1:${M}`,
+            thresholds: { [`f${M}`]: { threshold: 9 } },
+          },
+        },
+      },
+    })
+    expect(JSON.stringify(out)).not.toContain(M)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/index.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/index.test.js
@@ -2,6 +2,7 @@
 
 import { jest } from '@jest/globals'
 import ServerlessSandboxes from '../../../../../../lib/plugins/aws/sandboxes/index.js'
+import ServerlessError from '../../../../../../lib/serverless-error.js'
 
 function makeProvider(overrides = {}) {
   return {
@@ -40,7 +41,7 @@ const makeServerless = (sandboxes, providerOverride) => {
     configSchemaHandler: { defineTopLevelProperty: jest.fn() },
     addServiceOutputSection: jest.fn(),
     processedInput: { commands: ['deploy'] },
-    classes: { Error },
+    classes: { Error: ServerlessError },
   }
 }
 
@@ -96,7 +97,14 @@ describe('ServerlessSandboxes', () => {
   test('validate() throws when a sandbox is missing artifact', () => {
     const sls = makeServerless({ broken: { minimumMemory: 512 } })
     const p = new ServerlessSandboxes(sls, {}, { log: { debug() {} } })
-    expect(() => p.validate()).toThrow(/artifact/)
+    let thrown
+    try {
+      p.validate()
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown.message).toMatch(/artifact/)
+    expect(thrown.code).toBe('SANDBOXES_VALIDATION_ERROR')
   })
 
   test('validate() is a no-op when sandboxesConfig is null', () => {
@@ -287,6 +295,9 @@ describe('ServerlessSandboxes', () => {
       { fs: fakeFs },
     )
     await expect(p.packageArtifacts()).rejects.toThrow(/escapes the package/i)
+    await expect(p.packageArtifacts()).rejects.toMatchObject({
+      code: 'SANDBOXES_ARTIFACT_PATH_ESCAPE',
+    })
     const s3UploadCalls = provider.request.mock.calls.filter(
       ([svc, method]) => svc === 'S3' && method === 'upload',
     )

--- a/packages/sf-core/src/lib/runners/framework.js
+++ b/packages/sf-core/src/lib/runners/framework.js
@@ -255,16 +255,11 @@ export class TraditionalRunner extends Runner {
         serviceUniqueId: this.serviceUniqueId,
         analyticsMetrics: this.analyticsMetrics,
       }),
-    }
-
-    // Sandboxes config-shape block (only when the service defines sandboxes).
-    // buildSandboxesAnalytics is total (never throws); the guard is defense in
-    // depth — analytics must never break or slow the run.
-    try {
-      const sandboxes = buildSandboxesAnalytics(this.config?.sandboxes)
-      if (sandboxes) details.sandboxes = sandboxes
-    } catch {
-      /* never let analytics fail the command */
+      // Sandboxes config-shape block. buildSandboxesAnalytics reads
+      // config.sandboxes internally under its own guard and is total (never
+      // throws), so it spreads in like deriveAnalysisEnrichment: `{}` when the
+      // service defines no sandboxes, `{ sandboxes: <block> }` otherwise.
+      ...buildSandboxesAnalytics(this.config),
     }
 
     // plugins

--- a/packages/sf-core/src/lib/runners/framework.js
+++ b/packages/sf-core/src/lib/runners/framework.js
@@ -24,6 +24,7 @@ import {
   collectArtifactPaths,
   deriveAnalysisEnrichment,
 } from './framework-analytics.js'
+import { buildSandboxesAnalytics } from '@serverless/framework/lib/plugins/aws/sandboxes/analytics.js'
 import { Deployment } from '../platform/deployments.js'
 
 export class TraditionalRunner extends Runner {
@@ -254,6 +255,16 @@ export class TraditionalRunner extends Runner {
         serviceUniqueId: this.serviceUniqueId,
         analyticsMetrics: this.analyticsMetrics,
       }),
+    }
+
+    // Sandboxes config-shape block (only when the service defines sandboxes).
+    // buildSandboxesAnalytics is total (never throws); the guard is defense in
+    // depth — analytics must never break or slow the run.
+    try {
+      const sandboxes = buildSandboxesAnalytics(this.config?.sandboxes)
+      if (sandboxes) details.sandboxes = sandboxes
+    } catch {
+      /* never let analytics fail the command */
     }
 
     // plugins

--- a/packages/sf-core/tests/unit/lib/runners/framework-sandboxes-analytics.test.js
+++ b/packages/sf-core/tests/unit/lib/runners/framework-sandboxes-analytics.test.js
@@ -1,0 +1,46 @@
+import { TraditionalRunner } from '../../../../src/lib/runners/framework.js'
+
+// getAnalysisEventDetails only reads instance fields — call it on a minimal
+// fake `this` to avoid constructing the full runner.
+const detailsFor = (config) =>
+  TraditionalRunner.prototype.getAnalysisEventDetails.call({
+    config,
+    configFilePath: '/svc/serverless.yml',
+    serviceUniqueId: undefined,
+    integrations: {},
+    analyticsMetrics: undefined,
+    compiledCloudFormationTemplate: undefined,
+    command: ['deploy'],
+  })
+
+test('attaches sandboxes block when config defines sandboxes', () => {
+  const details = detailsFor({
+    service: 'svc',
+    provider: { name: 'aws' },
+    sandboxes: { runner: { artifact: './app', minimumMemory: 8192 } },
+  })
+  expect(details.sandboxes).toEqual({
+    count: 1,
+    artifactTypes: ['source'],
+    minimumMemory: [8192],
+    observability: { defaults: 1 },
+  })
+})
+
+test('omits sandboxes key entirely when config has none', () => {
+  const details = detailsFor({ service: 'svc', provider: { name: 'aws' } })
+  expect('sandboxes' in details).toBe(false)
+})
+
+test('a throw while reading sandboxes config is swallowed (defense in depth)', () => {
+  const config = { service: 'svc', provider: { name: 'aws' } }
+  Object.defineProperty(config, 'sandboxes', {
+    enumerable: true,
+    get() {
+      throw new Error('boom')
+    },
+  })
+  const details = detailsFor(config)
+  expect('sandboxes' in details).toBe(false)
+  expect(details.providerRuntime).toBeUndefined() // rest of details intact
+})


### PR DESCRIPTION
## What

Adds an optional `sandboxes` block to the analysis event for services that define the top-level `sandboxes` property. The block is a config-shape summary aggregated across all sandboxes in the service — counts and bounded, sorted-unique value sets only. It carries no user-authored strings (no names, paths, ARNs, patterns, env var names, tag keys/values).

Also adds error codes to the two previously-uncoded sandbox throw sites so sandbox failures are attributable via `error.code`.

## How

- New pure helper `buildSandboxesAnalytics` (packages/serverless) derives the block from config. It is total — it never throws for any input.
- The framework runner attaches the block in `getAnalysisEventDetails()` behind a guard, so telemetry can never affect a command.
- Observability counts mirror the compiler's resolution (an anti-drift unit test pins the two together).

## Tests

- `analytics.test.js`: 36 cases — field derivation, explicit-only/omit-empty semantics, per-hook timeout attribution, iam classification, the observability anti-drift grid, and a privacy guard asserting no marker strings leak.
- `framework-sandboxes-analytics.test.js`: runner wiring (present / absent / guarded).
- Full sandboxes unit suite green (405/405); full sf-core unit suite green.

## Notes

- The receiving event schema is documented separately. All fields optional; historical events remain valid.
- No user-visible behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added sandbox usage analytics enrichment to generated event data when sandbox settings are present, including detailed reporting for artifact types, memory, hooks, IAM roles, VPC, environment variables, tags, and observability options.

* **Bug Fixes**
  * Validation and artifact path errors now surface clearer error codes.
  * Analytics generation is more resilient: malformed sandbox configuration won’t break processing, and missing/invalid sandbox data is safely omitted (including when sandbox access throws).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->