### PR TITLE
chore: release 4.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14092,7 +14092,7 @@
     },
     "packages/sf-core": {
       "name": "@serverlessinc/sf-core",
-      "version": "4.38.1",
+      "version": "4.39.0",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "3.1077.0",
         "@aws-sdk/client-s3": "3.1077.0",

--- a/packages/framework-dist/package.json
+++ b/packages/framework-dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/framework-alpha",
-  "version": "4.38.1",
+  "version": "4.39.0",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/sf-core-installer/npm-shrinkwrap.json
+++ b/packages/sf-core-installer/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless",
-  "version": "4.38.1",
+  "version": "4.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless",
-      "version": "4.38.1",
+      "version": "4.39.0",
       "hasInstallScript": true,
       "dependencies": {
         "rimraf": "5.0.10",

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "4.38.1",
+  "version": "4.39.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/sf-core/package.json
+++ b/packages/sf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/sf-core",
-  "version": "4.38.1",
+  "version": "4.39.0",
   "main": "src/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release 4.39.0.

Version bump across the installer, `sf-core`, `framework-dist`, and lockfiles (`4.38.1` → `4.39.0`), mirroring previous release PRs. Minor bump for the two new features landing this cycle.

**Highlights**
- **Sandboxes — AWS Lambda MicroVMs** (#13663): declarative Firecracker-isolated VMs with `deploy`/`invoke`/`logs`/`dev`, lifecycle hooks, observability, and IAM roles generated for you.
- **`serverless agent` commands** (#13673): `agent skills install` (bundled Agent Skills) and `agent inspect` (deterministic AWS resource inventory) for AI coding agents.
- Sandbox config summary in the analysis event (#13692), packaging on `archiver` 8 (#13690), and dependency hardening/bumps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the release version to **4.39.0** across the published package metadata.
  * Updated the installer’s pinned package version to keep installs aligned with the new release.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->