### PR TITLE
chore(deps): bump jackson to 2.22.1 in java invoke-local runtime wrapper

### DIFF
--- a/packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml
+++ b/packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml
@@ -27,12 +27,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.22.0</version>
+      <version>2.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.22.0</version>
+      <version>2.22.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
-      <version>2.22.0</version>
+      <version>2.22.1</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Bumps the Jackson dependencies in the Java `invoke-local` runtime wrapper (`packages/serverless/lib/plugins/aws/invoke-local/runtime-wrappers/java/pom.xml`) from 2.22.0 to 2.22.1:

- `jackson-core` 2.22.0 → 2.22.1
- `jackson-databind` 2.22.0 → 2.22.1
- `jackson-datatype-joda` 2.22.0 → 2.22.1

`jackson-annotations` is left at 2.22 — there is no 2.22.1 annotations artifact published, and the 2.22.1 Jackson BOM itself pins annotations to 2.22.

Verified locally with `mvn clean package`: BUILD SUCCESS, 21/21 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled library versions to the latest patch release, helping keep local Java runtime support current and more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->