### PR TITLE
fix(esbuild): pin zip entry dates so unchanged code is not redeployed

### DIFF
--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -16,6 +16,13 @@ const nodeRuntimeRe = /nodejs(?<version>\d+).x/
 
 const logger = log.get('esbuild')
 
+// Pin every archive entry to a fixed date so that identical content always
+// produces a byte-for-byte identical zip. Without this, archiver stamps each
+// entry with the source file's mtime (esbuild rewrites its output on every
+// build), so the artifact hash changes on every deploy and check-for-changes
+// forces a needless redeploy of every function (issue #4240).
+const PINNED_ARTIFACT_DATE = new Date(0)
+
 class Esbuild {
   constructor(serverless, options) {
     this.serverless = serverless
@@ -798,7 +805,10 @@ class Esbuild {
               )
 
               if (existsSync(packageJsonPath)) {
-                zip.file(packageJsonPath, { name: `package.json` })
+                zip.file(packageJsonPath, {
+                  name: `package.json`,
+                  date: PINNED_ARTIFACT_DATE,
+                })
               }
 
               // Add lockfiles if they exist
@@ -816,7 +826,10 @@ class Esbuild {
                   lockFile,
                 )
                 if (existsSync(lockFilePath)) {
-                  zip.file(lockFilePath, { name: destName })
+                  zip.file(lockFilePath, {
+                    name: destName,
+                    date: PINNED_ARTIFACT_DATE,
+                  })
                 }
               }
 
@@ -827,11 +840,15 @@ class Esbuild {
                 handlerPath + '.js',
               )
 
-              zip.file(handlerZipPath, { name: `${handlerPath}.js` })
+              zip.file(handlerZipPath, {
+                name: `${handlerPath}.js`,
+                date: PINNED_ARTIFACT_DATE,
+              })
 
               if (existsSync(`${handlerZipPath}.map`)) {
                 zip.file(`${handlerZipPath}.map`, {
                   name: `${handlerPath}.js.map`,
+                  date: PINNED_ARTIFACT_DATE,
                 })
               }
 
@@ -843,6 +860,7 @@ class Esbuild {
                   'node_modules',
                 ),
                 'node_modules',
+                { date: PINNED_ARTIFACT_DATE },
               )
 
               await Promise.all(
@@ -853,9 +871,14 @@ class Esbuild {
                   )
                   const stats = await stat(absolutePath)
                   if (stats.isDirectory()) {
-                    zip.directory(absolutePath, filePath)
+                    zip.directory(absolutePath, filePath, {
+                      date: PINNED_ARTIFACT_DATE,
+                    })
                   } else {
-                    zip.file(absolutePath, { name: filePath })
+                    zip.file(absolutePath, {
+                      name: filePath,
+                      date: PINNED_ARTIFACT_DATE,
+                    })
                   }
                 }),
               )
@@ -921,7 +944,10 @@ class Esbuild {
           )
 
           if (existsSync(packageJsonPath) && !addedFiles.has(packageJsonPath)) {
-            zip.file(packageJsonPath, { name: `package.json` })
+            zip.file(packageJsonPath, {
+              name: `package.json`,
+              date: PINNED_ARTIFACT_DATE,
+            })
             addedFiles.add(packageJsonPath)
           }
 
@@ -940,7 +966,10 @@ class Esbuild {
               lockFile,
             )
             if (existsSync(lockFilePath) && !addedFiles.has(lockFilePath)) {
-              zip.file(lockFilePath, { name: destName })
+              zip.file(lockFilePath, {
+                name: destName,
+                date: PINNED_ARTIFACT_DATE,
+              })
               addedFiles.add(lockFilePath)
             }
           }
@@ -953,7 +982,10 @@ class Esbuild {
           )
 
           if (!addedFiles.has(handlerZipPath)) {
-            zip.file(handlerZipPath, { name: `${handlerPath}.js` })
+            zip.file(handlerZipPath, {
+              name: `${handlerPath}.js`,
+              date: PINNED_ARTIFACT_DATE,
+            })
             addedFiles.add(handlerZipPath)
           }
 
@@ -963,6 +995,7 @@ class Esbuild {
           ) {
             zip.file(`${handlerZipPath}.map`, {
               name: `${handlerPath}.js.map`,
+              date: PINNED_ARTIFACT_DATE,
             })
 
             addedFiles.add(`${handlerZipPath}.map`)
@@ -977,6 +1010,7 @@ class Esbuild {
             'node_modules',
           ),
           'node_modules',
+          { date: PINNED_ARTIFACT_DATE },
         )
 
         await Promise.all(
@@ -984,9 +1018,14 @@ class Esbuild {
             const absolutePath = path.join(this.serverless.serviceDir, filePath)
             const stats = await stat(absolutePath)
             if (stats.isDirectory()) {
-              zip.directory(absolutePath, filePath)
+              zip.directory(absolutePath, filePath, {
+                date: PINNED_ARTIFACT_DATE,
+              })
             } else if (!addedFiles.has(absolutePath)) {
-              zip.file(absolutePath, { name: filePath })
+              zip.file(absolutePath, {
+                name: filePath,
+                date: PINNED_ARTIFACT_DATE,
+              })
               addedFiles.add(absolutePath)
             }
           }),

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-determinism.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-determinism.test.js
@@ -1,0 +1,104 @@
+/**
+ * The esbuild packaging path must produce byte-for-byte identical zip
+ * artifacts when the source content is unchanged, even though esbuild rewrites
+ * its output on every build (giving the built files a fresh mtime).
+ *
+ * archiver stamps each entry with the source file's mtime unless a `date` is
+ * pinned. Un-pinned dates make the zip bytes — and therefore the sha256 used by
+ * check-for-changes — differ on every deploy, forcing a needless redeploy of
+ * every function. The legacy (non-esbuild) packaging path pins every entry to
+ * `new Date(0)`; the esbuild path must do the same.
+ *
+ * We assert this by reading the produced archive and checking that every
+ * entry's stored timestamp is pinned to the epoch (DOS-clamped to 1980) rather
+ * than the file's mtime. This is robust regardless of the test runner's clock,
+ * unlike comparing artifact hashes across simulated rebuilds.
+ */
+
+import { jest } from '@jest/globals'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import JsZip from 'jszip'
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+const PINNED_EPOCH_YEAR = 1980 // new Date(0) clamped to the DOS date minimum
+
+async function entryYears(artifactPath) {
+  const zip = await JsZip.loadAsync(fs.readFileSync(artifactPath))
+  return Object.values(zip.files).map((entry) => ({
+    name: entry.name,
+    year: entry.date.getFullYear(),
+  }))
+}
+
+function makeServiceDir() {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+  const buildDir = path.join(serviceDir, '.serverless', 'build')
+  fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep'), { recursive: true })
+  // A real file inside node_modules so the zip.directory() path is exercised.
+  fs.writeFileSync(
+    path.join(buildDir, 'node_modules', 'dep', 'index.js'),
+    'module.exports = 1\n',
+  )
+  fs.writeFileSync(
+    path.join(buildDir, 'handler.js'),
+    'export const hello = async () => ({ statusCode: 200 })\n',
+  )
+  return serviceDir
+}
+
+function makePlugin(serviceDir) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      package: { patterns: [] },
+    },
+    pluginManager: { spawn: async () => {} },
+  }
+  return new Esbuild(serverless, {})
+}
+
+const functions = { hello: { handler: 'handler.hello' } }
+
+describe('esbuild packaging determinism', () => {
+  jest.setTimeout(30_000)
+
+  test('_packageAll pins every zip entry date to the epoch', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+
+    await plugin._packageAll(functions)
+
+    const entries = await entryYears(
+      path.join(serviceDir, '.serverless', 'my-service.zip'),
+    )
+    expect(entries.length).toBeGreaterThan(0)
+    for (const entry of entries) {
+      expect(entry.year).toBe(PINNED_EPOCH_YEAR)
+    }
+  })
+
+  test('individual packaging pins every zip entry date to the epoch', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+    plugin.serverless.service.package.individually = true
+    // Bypass build/introspection so the test targets the zipping logic only.
+    plugin.functions = async () => functions
+    plugin._buildProperties = async () => ({})
+
+    await plugin._package()
+
+    const entries = await entryYears(
+      path.join(serviceDir, '.serverless', 'my-service-hello.zip'),
+    )
+    expect(entries.length).toBeGreaterThan(0)
+    for (const entry of entries) {
+      expect(entry.year).toBe(PINNED_EPOCH_YEAR)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Services packaged through the built-in esbuild path (the default for Node.js/TypeScript functions in v4) were redeployed on every `serverless deploy` even when nothing had changed.

Deploy change-detection compares the sha256 of each `.zip` artifact against the copy stored in S3 and skips the deploy when they match. The esbuild packaging code added every file to the archive without a fixed `date`, so archiver stamped each entry with the source file's mtime. esbuild rewrites its output on every build, giving those files a fresh mtime, so the artifact bytes — and therefore the hash — changed on every run. The result was that identical code always looked "changed" and every function was redeployed.

## Fix

Pin every `zip.file()` / `zip.directory()` entry to a fixed epoch date (`new Date(0)`) in both packaging paths (`_package` for `package.individually`, and `_packageAll`). This matches the existing behavior of the legacy (non-esbuild) `zip-service`, which already pins entry dates for exactly this reason.

With entry timestamps pinned, identical content now produces byte-identical artifacts, so change-detection correctly skips redeploying unchanged functions.

## Test

Adds a test that drives the real packaging methods and asserts every entry in the produced artifact carries the pinned date rather than the file mtime. Covered for both packaged-together and packaged-individually modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made esbuild-generated deployment ZIP artifacts deterministic by pinning archive entry timestamps, resulting in stable hashes across repeated builds.
  * Ensured consistent timestamps for packaged outputs, lockfiles, built handlers, source maps, bundled dependencies, and additional included files.

* **Tests**
  * Added a regression test covering both single-zip and per-function packaging modes to verify ZIP entry dates are pinned consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->