### PR TITLE
fix(binary-installer): bump Go toolchain to 1.26.5

### DIFF
--- a/.github/workflows/ci-binary-installer.yml
+++ b/.github/workflows/ci-binary-installer.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '>=1.26.4'
+          go-version: '>=1.26.5'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Test: Unit'
         run: make test

--- a/.github/workflows/release-binary-installer.yml
+++ b/.github/workflows/release-binary-installer.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: '>=1.26.4'
+          go-version: '>=1.26.5'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1

--- a/binary-installer/go.mod
+++ b/binary-installer/go.mod
@@ -1,6 +1,6 @@
 module sf-core
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
## What

Bumps the Go toolchain used to build the binary installer (`sf-core`) from **1.26.4** to **1.26.5**.

Changes (one line each):

- `binary-installer/go.mod` — `go` directive `1.26.4` → `1.26.5`
- `.github/workflows/ci-binary-installer.yml` — `setup-go` version `>=1.26.4` → `>=1.26.5`
- `.github/workflows/release-binary-installer.yml` — `setup-go` version `>=1.26.4` → `>=1.26.5`

## Why

Security advisories were reported against the Go standard library at 1.26.4 (`crypto/tls` and `os` packages). These are toolchain-level issues in the standard library, not third-party module problems, so the fix is a toolchain bump rather than a dependency change. Raising the `go` directive and the `setup-go` floor ensures builds compile against the patched runtime.

No third-party dependency or `go.sum` changes are required.

## Verification

- `go build` (native + cross-compile `linux/amd64`, and `-tags=canary`) — pass
- `make test` — all packages pass
- `go vet ./...` — clean
- `go mod tidy` — no-op (no dependency changes)
- Built binary reports embedded stdlib `go1.26.5` and runs (`--version`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go version used by CI and release workflows to a newer patch release.
  * Bumped the project’s required Go toolchain version to match the updated environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->