### PR TITLE
fix(package): capture npm ls output in Node instead of shell redirection

### DIFF
--- a/packages/serverless/lib/plugins/package/lib/zip-service.js
+++ b/packages/serverless/lib/plugins/package/lib/zip-service.js
@@ -218,8 +218,12 @@ async function excludeNodeDevDependencies(serviceDir) {
           ['dev', 'prod'],
           (env) => {
             const depFile = env === 'dev' ? nodeDevDepFile : nodeProdDepFile
+            // Capture `npm ls` output and write it to `depFile` from Node
+            // rather than via a shell redirection, so the (potentially
+            // environment-derived) temp path never becomes part of the command
+            // string that a shell interprets.
             return execAsync(
-              `npm ls --${env}=true --parseable=true --long=false --silent --all >> ${depFile}`,
+              `npm ls --${env}=true --parseable=true --long=false --silent --all`,
               {
                 cwd: dirWithPackageJson,
                 // We are overriding `NODE_ENV` because when it is set to "production"
@@ -228,12 +232,23 @@ async function excludeNodeDevDependencies(serviceDir) {
                   ...process.env,
                   NODE_ENV: null,
                 },
+                // Output was previously streamed straight to disk and so was
+                // unbounded; keep a generous limit so large dependency trees
+                // are not truncated (which could drop required dependencies).
+                maxBuffer: 1024 * 1024 * 1024,
               },
-            ).catch((err) => {
-              log.debug(
-                `Failed to run npm ls to retrieve dependencies for exclusion. Error: ${err.message}`,
-              )
-            })
+            )
+              .then(({ stdout }) => fsp.appendFile(depFile, stdout))
+              .catch((err) => {
+                log.debug(
+                  `Failed to run npm ls to retrieve dependencies for exclusion. Error: ${err.message}`,
+                )
+                // `npm ls` exits non-zero on missing/invalid deps but still
+                // prints a partial tree on stdout; preserve it as the previous
+                // shell redirection did. Append unconditionally so the file
+                // exists even when there is no output.
+                return fsp.appendFile(depFile, err.stdout || '').catch(() => {})
+              })
           },
           { concurrency: os.cpus().length },
         )

--- a/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -152,6 +152,107 @@ describe('zipService', () => {
     })
   })
 
+  describe('#excludeDevDependencies() - node dependency resolution', () => {
+    // Separator-agnostic so assertions hold on both POSIX ("node_modules/x/**")
+    // and Windows ("node_modules\\x\\**") glob output.
+    const isExcluded = (globs, name) =>
+      globs.some((glob) =>
+        new RegExp(`node_modules[\\\\/]${name}[\\\\/]`).test(glob),
+      )
+    let serviceDir
+
+    beforeEach(() => {
+      // `npm ls` reports realpaths; on macOS os.tmpdir() lives under the
+      // /var -> /private/var symlink, so resolve the service dir to its real
+      // path to match npm's output (real projects are not under such a link).
+      serviceDir = fs.realpathSync(tmpDirPath)
+      packagePlugin.serverless.serviceDir = serviceDir
+    })
+
+    function writePackageJson(dir, contents) {
+      fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(contents))
+    }
+
+    // Builds a real project whose node_modules contains one prod-only and one
+    // dev-only package so `npm ls` reports a deterministic tree.
+    function scaffoldProject({ declareMissingDep = false } = {}) {
+      writePackageJson(serviceDir, {
+        name: 'exclude-dev-deps-test',
+        version: '1.0.0',
+        dependencies: {
+          'prod-pkg': '1.0.0',
+          // A declared-but-not-installed dependency makes `npm ls` exit 1.
+          ...(declareMissingDep ? { 'missing-pkg': '1.0.0' } : {}),
+        },
+        devDependencies: { 'dev-pkg': '1.0.0' },
+      })
+      writePackageJson(path.join(serviceDir, 'node_modules', 'prod-pkg'), {
+        name: 'prod-pkg',
+        version: '1.0.0',
+      })
+      writePackageJson(path.join(serviceDir, 'node_modules', 'dev-pkg'), {
+        name: 'dev-pkg',
+        version: '1.0.0',
+      })
+    }
+
+    it('excludes dev-only dependencies and keeps prod dependencies', async () => {
+      scaffoldProject()
+
+      const updated = await packagePlugin.excludeDevDependencies(params)
+
+      expect(isExcluded(updated.exclude, 'dev-pkg')).toBe(true)
+      expect(isExcluded(updated.exclude, 'prod-pkg')).toBe(false)
+    })
+
+    it('still excludes dev-only dependencies when npm ls exits non-zero', async () => {
+      // `npm ls` exits 1 on a missing declared dependency but still prints a
+      // partial tree; that partial output must not be lost.
+      scaffoldProject({ declareMissingDep: true })
+
+      const updated = await packagePlugin.excludeDevDependencies(params)
+
+      expect(isExcluded(updated.exclude, 'dev-pkg')).toBe(true)
+      expect(isExcluded(updated.exclude, 'prod-pkg')).toBe(false)
+    })
+
+    it('does not execute shell metacharacters injected via the temp path', async () => {
+      if (os.platform() === 'win32') {
+        // POSIX-shell payload; temp-path handling is exercised on *nix.
+        return
+      }
+      // A project `.env` can set TMPDIR/TMP/TEMP before packaging and
+      // `os.tmpdir()` honors them, so os.tmpdir() may return an
+      // attacker-influenced value. Model that value carrying a shell breakout
+      // and prove the temp path can no longer execute commands.
+      const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+      const realTmp = fs.realpathSync(os.tmpdir())
+      const marker = path.join(realTmp, `sls-pwn-${unique}`)
+      const redirectJunk = path.join(realTmp, `sls-junk-${unique}`)
+      const maliciousTmp = `${redirectJunk}; touch ${marker} #`
+      const tmpdirSpy = jest.spyOn(os, 'tmpdir').mockReturnValue(maliciousTmp)
+
+      // A package.json is enough to reach the `npm ls` invocation.
+      writePackageJson(serviceDir, { name: 'pwn-test', version: '1.0.0' })
+
+      let markerCreated
+      try {
+        const updated = await packagePlugin.excludeDevDependencies(params)
+        // Capture the effect before cleanup so removal can't mask a breakout.
+        markerCreated = fs.existsSync(marker)
+        // Packaging still resolves gracefully.
+        expect(updated.zipFileName).toBe(params.zipFileName)
+      } finally {
+        tmpdirSpy.mockRestore()
+        fs.rmSync(marker, { force: true })
+        fs.rmSync(redirectJunk, { force: true })
+      }
+
+      expect(markerCreated).toBe(false)
+    })
+  })
+
   describe('#zip()', () => {
     const testDirectory = {
       '.': {


### PR DESCRIPTION
## What

During development-dependency pruning, `serverless package` runs `npm ls` and previously appended its output to a temporary file using a shell redirection (`npm ls ... >> <tmpfile>`). This changes the command to capture `npm ls` stdout in Node and write it with `fs.promises.appendFile`.

As a result the command string is static and the temporary path is handled through the filesystem API rather than being interpolated into the shell command. This also makes the temp-file handling more robust for temporary directories whose path contains spaces or other special characters.

## Behavior

No change to packaging behavior:

- Output still accumulates across multiple `package.json` files.
- Partial output from a non-zero `npm ls` exit (e.g. an invalid or missing dependency) is still retained.
- A large `maxBuffer` is set so the dependency tree of large projects is not truncated (the previous shell redirection streamed straight to disk).

## Tests

Adds unit tests to `zip-service.test.js` covering:

- dev-only dependencies are excluded while prod dependencies are kept;
- exclusion still works when `npm ls` exits non-zero with a partial tree;
- temporary-path handling.

All existing package tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaging reliability when dependency listings contain missing or invalid packages.
  * Ensured production dependencies are retained while development-only dependencies are excluded.
  * Prevented shell-related issues from manipulated temporary directory paths.
  * Preserved partial dependency information when dependency resolution reports errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->