### PR TITLE
fix(binary-installer): validate canary framework version and contain release path

### DIFF
--- a/binary-installer/src/version.go
+++ b/binary-installer/src/version.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -180,6 +181,40 @@ func getVersion(frameworkVersion string, force bool) (*GetVersionResult, error) 
 	}, nil
 }
 
+// canaryVersionPattern matches the accepted pinned-canary version format: the
+// "canary-" prefix followed by one or more alphanumerics, dots, dashes, or
+// underscores.
+var canaryVersionPattern = regexp.MustCompile(`^canary-[A-Za-z0-9._-]+$`)
+
+// validateCanaryVersion returns an error for pinned-canary version strings that
+// are not in the expected format. The pattern confines the value to a single
+// path component (its character class excludes path separators), so a matching
+// value can never traverse. The explicit ".." check is defense-in-depth: it
+// rejects a "canary-.."-style name up front, though containedReleasePath would
+// keep it contained regardless.
+func validateCanaryVersion(version string) error {
+	if !canaryVersionPattern.MatchString(version) || strings.Contains(version, "..") {
+		return fmt.Errorf("invalid framework version %q", version)
+	}
+	return nil
+}
+
+// containedReleasePath joins version into releasesDir and returns the result
+// only when version resolves to a direct child of releasesDir (a single path
+// component). A version that resolves to releasesDir itself, to a parent, or to
+// any nested or outside location yields an error.
+func containedReleasePath(releasesDir, version string) (string, error) {
+	releasePath := filepath.Join(releasesDir, version)
+	rel, err := filepath.Rel(releasesDir, releasePath)
+	if err != nil ||
+		rel == "." ||
+		rel == ".." ||
+		strings.ContainsRune(rel, os.PathSeparator) {
+		return "", fmt.Errorf("invalid release path for version %q", version)
+	}
+	return releasePath, nil
+}
+
 func getMostRecentCanaryVersionWithBaseURL(base string) (string, error) {
 	body, err := fetchURL(fmt.Sprintf("%s/releases.json", base))
 	if err != nil {
@@ -229,6 +264,9 @@ func GetFrameworkVersion(filename string, shouldCheckForUpdates bool) (*Framewor
 				LatestVersion: FrameworkVersion(mostRecentVersion),
 			}
 		} else {
+			if err := validateCanaryVersion(version); err != nil {
+				return nil, err
+			}
 			releaseRecord = &ReleaseRecord{
 				Version:       FrameworkVersion(version),
 				ReleaseDate:   time.Now().Format(time.RFC3339),
@@ -301,7 +339,11 @@ func downloadFrameworkVersion(releaseRecord *ReleaseRecord, shouldCheckForUpdate
 		return "", fmt.Errorf("resolving home dir: %w", err)
 	}
 
-	releasePath := filepath.Join(homeDir, ".serverless", "releases", string(releaseRecord.Version))
+	releasesDir := filepath.Join(homeDir, ".serverless", "releases")
+	releasePath, err := containedReleasePath(releasesDir, string(releaseRecord.Version))
+	if err != nil {
+		return "", err
+	}
 
 	// This may always pull for the latest that matches user's requested version
 	useSpinner := !IsCIEnvironment()

--- a/binary-installer/src/version_test.go
+++ b/binary-installer/src/version_test.go
@@ -348,6 +348,91 @@ func TestGetFrameworkVersion_PinnedCanary_NoNetwork(t *testing.T) {
 	}
 }
 
+func TestValidateCanaryVersion(t *testing.T) {
+	valid := []string{
+		"canary-1.2.3",
+		"canary-4.39.0-rc.1",
+		"canary-abc123def",
+		"canary-a_b.c-d",
+	}
+	for _, v := range valid {
+		if err := validateCanaryVersion(v); err != nil {
+			t.Errorf("expected %q to be accepted, got error: %v", v, err)
+		}
+	}
+
+	invalid := []string{
+		"canary-../../../../sentinel",
+		"canary-/etc",
+		"canary-..",
+		"canary-a/b",
+		`canary-..\..\windows`,
+		"canary-", // empty suffix
+		"canary",  // bare canary is handled elsewhere, not by this validator
+	}
+	for _, v := range invalid {
+		if err := validateCanaryVersion(v); err == nil {
+			t.Errorf("expected %q to be rejected, got nil error", v)
+		}
+	}
+}
+
+func TestGetFrameworkVersion_RejectsTraversingCanary(t *testing.T) {
+	badVersions := []string{
+		"canary-../../../../sentinel",
+		"canary-/etc",
+		"canary-..",
+		"canary-a/b",
+		`canary-..\..\windows`,
+	}
+	for _, v := range badVersions {
+		t.Run(v, func(t *testing.T) {
+			tempHome := t.TempDir()
+			t.Setenv("HOME", tempHome)
+
+			cfg := filepath.Join(tempHome, "serverless.yml")
+			if err := os.WriteFile(cfg, []byte("frameworkVersion: '"+v+"'\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := GetFrameworkVersion(cfg, false); err == nil {
+				t.Fatalf("expected error for version %q, got nil", v)
+			}
+		})
+	}
+}
+
+func TestContainedReleasePath(t *testing.T) {
+	releasesDir := filepath.Join(t.TempDir(), ".serverless", "releases")
+
+	// Valid versions resolve to a path inside releasesDir.
+	for _, v := range []string{"4.1.0", "canary-1.2.3"} {
+		got, err := containedReleasePath(releasesDir, v)
+		if err != nil {
+			t.Errorf("expected %q to be contained, got error: %v", v, err)
+			continue
+		}
+		want := filepath.Join(releasesDir, v)
+		if got != want {
+			t.Errorf("version %q: want path %q, got %q", v, want, got)
+		}
+	}
+
+	// Traversing, nested, or absolute versions are rejected before any path is used.
+	for _, v := range []string{
+		"canary-../../../../sentinel",
+		"..",
+		"../escape",
+		"a/../../escape",
+		"a/b", // nested: only a direct child is allowed
+		"",    // empty resolves to releasesDir itself
+	} {
+		if _, err := containedReleasePath(releasesDir, v); err == nil {
+			t.Errorf("expected %q to be rejected, got nil error", v)
+		}
+	}
+}
+
 func TestGetMostRecentCanaryVersionWithBaseURL_Non200(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)


### PR DESCRIPTION
## Summary

For canary releases, the installer used the raw `frameworkVersion` string directly as a path segment under `~/.serverless/releases/<version>` and, on an incomplete install, removed the resulting path in a deferred cleanup. A value containing path separators or `..` segments could resolve to a location outside the releases directory.

This change adds two layers of input validation:

- **Format check** — pinned-canary versions must match `canary-` followed by alphanumerics, dots, dashes, or underscores. Values containing path separators, `..` segments, or an absolute path are rejected with a clear error before any path is built.
- **Path containment** — before the install/cleanup block runs, the computed release path is verified to be a direct child of the releases directory. This covers every resolution path (bare `canary`, pinned canary, and semver), including the server-provided value used for bare `canary`.

Legitimate `canary` and `canary-<commit-short-sha>` values, and the standard semver resolution path, are unaffected.

## Testing

- `go test ./src/...` — full suite passes.
- Added table-driven tests for the format validator, the containment helper, and end-to-end rejection through `GetFrameworkVersion`.
- Manually compared the built launcher against the released build under an isolated `HOME`: identical output for a pinned installed version and for a valid pinned canary; invalid canary values now fail fast with a clear message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of pinned canary framework versions to reject malformed or traversal-like inputs.
  * Hardened release-directory path construction to ensure downloads stay within the expected releases folder.
* **Tests**
  * Added unit tests covering valid/invalid canary versions and release-path safety, including traversal, nested, absolute-like, and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->