### PR TITLE
fix: ignore .git folder on template download

### DIFF
--- a/packages/sf-core/src/utils/https/index.js
+++ b/packages/sf-core/src/utils/https/index.js
@@ -391,6 +391,9 @@ export const downloadTemplate = async (inputUrl, newTemplateName) => {
     path.join(newServicePath, 'serverless.template.yml'),
   )
 
+  // Remove .git if it exists
+  await removeFileOrDirectory(path.join(newServicePath, '.git'))
+
   return newServicePath
 }
 


### PR DESCRIPTION
Fixes #11978

When downloading a template via `--template-url`, the `.git` directory from the repository was being copied over, meaning the new project erroneously inherited the remote of the template repository. This fix ensures the `.git` folder is removed upon template download.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloaded service templates no longer retain `.git` metadata from the source template.
  * Generated templates continue to remove unnecessary template configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->