### PR TITLE
test(sf-core): retry endpoint fetches in SAM integration tests

### DIFF
--- a/.github/workflows/ci-framework.yml
+++ b/.github/workflows/ci-framework.yml
@@ -107,11 +107,11 @@ jobs:
           SERVERLESS_ACCESS_KEY_DEV: ${{ secrets.SERVERLESS_ACCESS_KEY_DEV }}
           TEST_STAGE: pr-${{ github.event.pull_request.user.login }}
           SLS_AWS_SDK: 3
-          AWS_MAX_ATTEMPTS: 5
+          AWS_MAX_ATTEMPTS: 7
       - name: 'Test: Resolvers'
         run: npm run test:resolvers -- --maxWorkers=8
         env:
           SERVERLESS_LICENSE_KEY_DEV: ${{ secrets.SERVERLESS_LICENSE_KEY_DEV }}
           SERVERLESS_ACCESS_KEY_DEV: ${{ secrets.SERVERLESS_ACCESS_KEY_DEV }}
           TEST_STAGE: pr-${{ github.event.pull_request.user.login }}
-          AWS_MAX_ATTEMPTS: 5
+          AWS_MAX_ATTEMPTS: 7

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -90,7 +90,7 @@ jobs:
           SERVERLESS_LICENSE_KEY_DEV: ${{ secrets.SERVERLESS_LICENSE_KEY_DEV }}
           SERVERLESS_ACCESS_KEY_DEV: ${{ secrets.SERVERLESS_ACCESS_KEY_DEV }}
           TEST_STAGE: mr-${{ github.actor }}
-          AWS_MAX_ATTEMPTS: 5
+          AWS_MAX_ATTEMPTS: 7
   release-canary:
     name: 'Release: Canary & Tag'
     needs: [test-matrix, test-engine]

--- a/packages/sf-core/tests/integration/sam/cloudformation-compose/cloudformation-compose.test.js
+++ b/packages/sf-core/tests/integration/sam/cloudformation-compose/cloudformation-compose.test.js
@@ -7,6 +7,7 @@ import {
 } from '@aws-sdk/client-cloudformation'
 import { jest } from '@jest/globals'
 import { getTestStageName, runSfCore } from '../../../utils/runSfCore'
+import { fetchWithRetry } from '../../../utils/testUtils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const randomId = Math.floor(1000 + Math.random() * 9000).toString()
@@ -70,7 +71,7 @@ describe('SAM/CFN - CloudFormation with Compose', () => {
   })
 
   test('Ensure variables resolved correctly', async () => {
-    const getResponse = await fetch(endpoint, {
+    const getResponse = await fetchWithRetry(endpoint, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/sf-core/tests/integration/sam/sam-compose-run-service/sam-compose-run-service.test.js
+++ b/packages/sf-core/tests/integration/sam/sam-compose-run-service/sam-compose-run-service.test.js
@@ -8,6 +8,7 @@ import {
 } from '@aws-sdk/client-cloudformation'
 import { jest } from '@jest/globals'
 import { getTestStageName, runSfCore } from '../../../utils/runSfCore'
+import { fetchWithRetry } from '../../../utils/testUtils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const randomId = Math.floor(1000 + Math.random() * 9000).toString()
@@ -132,14 +133,14 @@ describe('SAM/CFN - Deploy only SAM service inside Compose', () => {
   })
 
   test('Ensure only SAM service was updated', async () => {
-    const samResponse = await await fetch(samEndpoint, {
+    const samResponse = await fetchWithRetry(samEndpoint, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
       },
     })
 
-    const frameworkResponse = await await fetch(frameworkEndpoint, {
+    const frameworkResponse = await fetchWithRetry(frameworkEndpoint, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/sf-core/tests/integration/sam/sam-compose-state/sam-compose-state.test.js
+++ b/packages/sf-core/tests/integration/sam/sam-compose-state/sam-compose-state.test.js
@@ -7,6 +7,7 @@ import {
 } from '@aws-sdk/client-cloudformation'
 import { jest } from '@jest/globals'
 import { getTestStageName, runSfCore } from '../../../utils/runSfCore'
+import { fetchWithRetry } from '../../../utils/testUtils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const randomId = Math.floor(1000 + Math.random() * 9000).toString()
@@ -71,7 +72,7 @@ describe('SAM/CFN - SAM state within a Compose app', () => {
   })
 
   test('Ensure variables resolved correctly', async () => {
-    const getResponse = await fetch(endpoint, {
+    const getResponse = await fetchWithRetry(endpoint, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/sf-core/tests/integration/sam/sam-compose/sam-compose.test.js
+++ b/packages/sf-core/tests/integration/sam/sam-compose/sam-compose.test.js
@@ -7,6 +7,7 @@ import {
 } from '@aws-sdk/client-cloudformation'
 import { jest } from '@jest/globals'
 import { getTestStageName, runSfCore } from '../../../utils/runSfCore'
+import { fetchWithRetry } from '../../../utils/testUtils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const randomId = Math.floor(1000 + Math.random() * 9000).toString()
@@ -70,7 +71,7 @@ describe('SAM/CFN - SAM within a Compose app', () => {
   })
 
   test('Ensure variables resolved correctly', async () => {
-    const getResponse = await fetch(endpoint, {
+    const getResponse = await fetchWithRetry(endpoint, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/sf-core/tests/integration/sam/sam-existing/sam-existing.test.js
+++ b/packages/sf-core/tests/integration/sam/sam-existing/sam-existing.test.js
@@ -8,6 +8,7 @@ import {
 } from '@aws-sdk/client-cloudformation'
 import { jest } from '@jest/globals'
 import { runSfCore } from '../../../utils/runSfCore'
+import { fetchWithRetry } from '../../../utils/testUtils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const randomId = Math.floor(1000 + Math.random() * 9000).toString()
@@ -91,7 +92,7 @@ describe('SAM/CFN Projects - SAM Existing App', () => {
   })
 
   test('Ensure service runs as expected', async () => {
-    const getResponse = await await fetch(endpoint, {
+    const getResponse = await fetchWithRetry(endpoint, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/sf-core/tests/integration/sam/sam-todo/sam-todo.test.js
+++ b/packages/sf-core/tests/integration/sam/sam-todo/sam-todo.test.js
@@ -7,6 +7,7 @@ import {
 } from '@aws-sdk/client-cloudformation'
 import { jest } from '@jest/globals'
 import { runSfCore } from '../../../utils/runSfCore'
+import { fetchWithRetry } from '../../../utils/testUtils'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const randomId = Math.floor(1000 + Math.random() * 9000).toString()
@@ -67,7 +68,7 @@ describe('SAM/CFN Projects - SAM Todo App', () => {
   })
 
   test('Ensure service runs as expected', async () => {
-    const createResponse = await fetch(endpoint, {
+    const createResponse = await fetchWithRetry(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -80,7 +81,7 @@ describe('SAM/CFN Projects - SAM Todo App', () => {
 
     expect(await createResponse.json()).toEqual({ id: 'foo', name: 'bar' })
 
-    const getResponse = await fetch(`${endpoint}/foo`, {
+    const getResponse = await fetchWithRetry(`${endpoint}/foo`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -89,7 +90,7 @@ describe('SAM/CFN Projects - SAM Todo App', () => {
 
     expect(await getResponse.json()).toEqual({ id: 'foo', name: 'bar' })
 
-    const listResponse = await fetch(endpoint, {
+    const listResponse = await fetchWithRetry(endpoint, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/sf-core/tests/utils/testUtils.js
+++ b/packages/sf-core/tests/utils/testUtils.js
@@ -3,3 +3,29 @@ import os from 'os'
 export const isWindows = () => {
   return os.type() === 'Windows_NT'
 }
+
+export const fetchWithRetry = async (
+  endpoint,
+  options,
+  attempts = 5,
+  delayMs = 5000,
+) => {
+  let lastErr
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const response = await fetch(endpoint, options)
+      // A freshly deployed API Gateway can briefly answer 403/404 while routes
+      // propagate — retry on any non-2xx.
+      if (response.ok) {
+        return response
+      }
+      lastErr = new Error(`endpoint returned ${response.status}`)
+    } catch (err) {
+      lastErr = err
+    }
+    if (i < attempts - 1) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+  throw lastErr
+}

--- a/packages/sf-core/tests/utils/testUtils.js
+++ b/packages/sf-core/tests/utils/testUtils.js
@@ -19,6 +19,9 @@ export const fetchWithRetry = async (
       if (response.ok) {
         return response
       }
+      // Consume the body so undici releases the connection back to the pool;
+      // an unread body keeps the socket open until GC.
+      await response.arrayBuffer().catch(() => {})
       lastErr = new Error(`endpoint returned ${response.status}`)
     } catch (err) {
       lastErr = err


### PR DESCRIPTION
## Summary

The SAM/CFN integration tests hit their deployed API Gateway endpoint with a single bare `fetch()` immediately after deploy. A freshly deployed endpoint can briefly answer `404 {"message":"Not Found"}` while routes propagate, so these tests fail intermittently — e.g. the `sam-compose-state` "Ensure variables resolved correctly" test flaked on #13705 CI (job 87323902022) and passed on a same-commit re-run.

## Changes

- Add a shared `fetchWithRetry` helper to `tests/utils/testUtils.js` (5 attempts, 5s delay; retries on any non-2xx response and on network errors), mirroring the pattern already used in `sandboxes.test.js`. Non-2xx response bodies are consumed so undici releases the connection (CodeRabbit feedback).
- Use it for every post-deploy endpoint fetch in the SAM integration tests: `sam-compose-state`, `cloudformation-compose`, `sam-compose`, `sam-todo`, `sam-existing`, `sam-compose-run-service`.
- Fixes two pre-existing `await await fetch(...)` typos in `sam-existing` and `sam-compose-run-service` in passing.
- CI: raise `AWS_MAX_ATTEMPTS` from 5 to 7 on the integration/resolvers test steps (ci-framework.yml, release-framework.yml). Release run 28945515476 (2026-07-08) failed on sustained CloudFormation `DescribeStackEvents` throttling with 5 attempts while concurrent platform jobs shared the account's describe quota; 7 roughly doubles the jittered ride-out window. Interim mitigation — the proper fix (throttling-tolerant polling + pinned retry strategy in the sf-core CFN runner) is tracked separately.

Tests + CI config only — no production code touched.

## Verification

Helper validated unit-style against a local HTTP server (no live AWS): succeeds after transient 404s, retries network errors, and throws `endpoint returned 404` after exhausting all attempts on a persistent failure. Prettier + ESLint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration-test reliability by adding retry-capable HTTP fetching for deployed endpoint checks and runtime verification.
  * Updated SAM Compose/CFN, SAM existing, and SAM Todo integration suites to use the retry helper while preserving the same payload assertions.
* **CI / Workflows**
  * Increased AWS retry configuration (`AWS_MAX_ATTEMPTS`) from 5 to 7 for integration-related framework test steps, including the test-resolvers step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->