### PR TITLE
fix: prevent crash when frameworkVersion is "*"

### DIFF
--- a/packages/serverless/lib/classes/service.js
+++ b/packages/serverless/lib/classes/service.js
@@ -6,9 +6,6 @@ import { log } from '@serverless/util'
 
 class Service {
   constructor(serverless, data) {
-    // #######################################################################
-    // ## KEEP SYNCHRONIZED WITH EQUIVALENT IN ~/lib/plugins/print/print.js ##
-    // #######################################################################
     this.serverless = serverless
 
     // Default properties
@@ -129,11 +126,17 @@ class Service {
       ymlVersion = null
     }
 
+    // `semver.coerce` returns null for ranges without a concrete version
+    // (e.g. "*"), which cannot mismatch any version
+    const coercedVersion = semver.coerce(version)
+    const coercedYmlVersion = semver.coerce(ymlVersion)
     if (
       ymlVersion &&
       version &&
       version !== ymlVersion &&
-      semver.coerce(version).major !== semver.coerce(ymlVersion).major
+      coercedVersion &&
+      coercedYmlVersion &&
+      coercedVersion.major !== coercedYmlVersion.major
     ) {
       const errorMessage = [
         `The Serverless version (${version}) does not satisfy the`,

--- a/packages/serverless/test/unit/lib/classes/service.test.js
+++ b/packages/serverless/test/unit/lib/classes/service.test.js
@@ -1,0 +1,68 @@
+import { describe, expect, it } from '@jest/globals'
+
+const { default: Service } = await import('../../../../lib/classes/service.js')
+
+const createServerlessStub = ({ version, configurationInput }) => ({
+  configurationFilename: 'serverless.yml',
+  configurationInput: {
+    service: 'test-service',
+    provider: { name: 'aws' },
+    ...configurationInput,
+  },
+  utils: {
+    getVersion: () => version,
+  },
+})
+
+const loadService = ({ version = '4.32.0', ...configurationInput } = {}) => {
+  const service = new Service(
+    createServerlessStub({ version, configurationInput }),
+  )
+  service.loadServiceFileParam()
+  return service
+}
+
+describe('Service', () => {
+  describe('frameworkVersion validation', () => {
+    it('should accept "*" (any version)', () => {
+      expect(() => loadService({ frameworkVersion: '*' })).not.toThrow()
+    })
+
+    it('should accept a caret range covering the current version', () => {
+      expect(() =>
+        loadService({ frameworkVersion: '^4.0.0', version: '4.32.0' }),
+      ).not.toThrow()
+    })
+
+    it('should accept an exact pin equal to the current version', () => {
+      expect(() =>
+        loadService({ frameworkVersion: '4.32.0', version: '4.32.0' }),
+      ).not.toThrow()
+    })
+
+    it('should accept a different version within the same major', () => {
+      expect(() =>
+        loadService({ frameworkVersion: '4.1.0', version: '4.32.0' }),
+      ).not.toThrow()
+    })
+
+    it('should reject a version pin with a different major', () => {
+      expect(() =>
+        loadService({ frameworkVersion: '3.38.0', version: '4.32.0' }),
+      ).toThrow(expect.objectContaining({ code: 'FRAMEWORK_VERSION_MISMATCH' }))
+    })
+
+    it('should skip validation for an invalid version string by default', () => {
+      expect(() => loadService({ frameworkVersion: 'latest' })).not.toThrow()
+    })
+
+    it('should reject an invalid version string when configValidationMode is "error"', () => {
+      expect(() =>
+        loadService({
+          frameworkVersion: 'latest',
+          configValidationMode: 'error',
+        }),
+      ).toThrow(expect.objectContaining({ code: 'INVALID_FRAMEWORK_VERSION' }))
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fix `TypeError: Cannot read properties of null (reading 'major')` thrown on any command when `serverless.yml` sets `frameworkVersion` to a range without a concrete version, such as `'*'`
- Null-guard the `semver.coerce()` results in the framework version mismatch check in `packages/serverless/lib/classes/service.js` — a range that coerces to `null` cannot mismatch any version, so validation is skipped for it
- Remove a stale "KEEP SYNCHRONIZED WITH ~/lib/plugins/print/print.js" banner — that file was rewritten years ago and no longer duplicates any `Service` logic
- Add unit tests for `frameworkVersion` validation (`'*'`, caret range, exact pin, same-major pin, cross-major mismatch, invalid strings under both validation modes)

## Root cause

`'*'` passes the `semver.validRange()` check (it is a valid range), but `semver.coerce('*')` returns `null` because the range contains no concrete version to coerce. The subsequent `.major` access then threw. The existing major-version-only comparison semantics are preserved; only the crash is fixed.

## Test plan

- [x] New unit tests reproduce the crash before the fix and pass after (`packages/serverless/test/unit/lib/classes/service.test.js`)
- [x] Full `packages/serverless` unit suite passes (137 suites, 2571 tests)
- [x] Verified from source against a minimal service with `frameworkVersion: '*'`: crashed before the fix, runs cleanly after


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved framework version validation so wildcard and range-based values are handled correctly.
  * More reliably triggers framework version mismatch errors only when major versions are truly incompatible.
  * Maintains the existing behavior for configurable handling of invalid framework version inputs.
* **Tests**
  * Added unit test coverage for wildcard (`*`), caret ranges, exact pin matches, same-major mismatches, and invalid version handling (including strict validation mode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->