### PR TITLE
fix(esbuild): build shared handler files once to prevent corrupted bundles

### DIFF
--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -65,7 +65,9 @@ build:
       - '!@aws-sdk/client-bedrock-runtime'
 
     # By default Framework will attempt to build and package all functions concurrently.
-    # This property can bet set to a different number if you wish to limit the
+    # Each unique handler file is built only once, so functions that share a handler
+    # file (a module exporting several handlers) do not trigger duplicate builds.
+    # This property can be set to a different number if you wish to limit the
     # concurrency of those operations.
     buildConcurrency: 3
 

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -670,6 +670,11 @@ class Esbuild {
       }
     }
 
+    if (buildGroups.size === 0) {
+      log.debug('No buildable handler files resolved for esbuild')
+      return
+    }
+
     // Determine the concurrency to use for building, by default framework will
     // attempt to build all unique handler files concurrently, but this can be
     // overridden by setting the buildConcurrency property.

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -16,6 +16,19 @@ const nodeRuntimeRe = /nodejs(?<version>\d+).x/
 
 const logger = log.get('esbuild')
 
+// Serverless `handler` strings are `path/to/file.exportName`. Strip only the
+// LAST `.exportName` occurrence (not the first) so that a path segment
+// earlier in the string that happens to collide with the export name (e.g. a
+// directory named after the handler, `items.get/index.get`) doesn't cause the
+// wrong file path to be derived. Mirrors the community serverless-esbuild
+// plugin's deliberate `lastIndexOf` approach: "replace only last instance to
+// allow the same name for file and handler".
+const stripHandlerExportSuffix = (functionHandler) => {
+  const exportName = path.extname(functionHandler) // '.get' for 'src/items.get'
+  if (!exportName) return functionHandler
+  return functionHandler.slice(0, functionHandler.lastIndexOf(exportName))
+}
+
 // Pin every archive entry to a fixed date so that identical content always
 // produces a byte-for-byte identical zip. Without this, archiver stamps each
 // entry with the source file's mtime (esbuild rewrites its output on every
@@ -225,8 +238,7 @@ class Esbuild {
         return true
       }
 
-      const functionName = path.extname(functionHandler).slice(1)
-      const handlerPath = functionHandler.replace(`.${functionName}`, '')
+      const handlerPath = stripHandlerExportSuffix(functionHandler)
       let parsedExtension = undefined
       for (const extension of [
         '.js',
@@ -332,8 +344,7 @@ class Esbuild {
 
   // This is all the possible extensions that the esbuild plugin can build for
   async _extensionForFunction(functionHandler) {
-    const functionName = path.extname(functionHandler).slice(1)
-    const handlerPath = functionHandler.replace(`.${functionName}`, '')
+    const handlerPath = stripHandlerExportSuffix(functionHandler)
     for (const extension of [
       '.js',
       '.ts',
@@ -600,12 +611,8 @@ class Esbuild {
     const buildProperties = await this._buildProperties()
 
     for (const [alias, functionObject] of Object.entries(functionsToBuild)) {
-      const functionName = path
-        .extname(functionObject[handlerPropertyName])
-        .slice(1)
-      const handlerPath = functionObject[handlerPropertyName].replace(
-        `.${functionName}`,
-        '',
+      const handlerPath = stripHandlerExportSuffix(
+        functionObject[handlerPropertyName],
       )
       const runtime =
         functionObject.runtime || this.serverless.service.provider.runtime
@@ -643,12 +650,8 @@ class Esbuild {
         Object.entries(updatedFunctionsToBuild).map(
           ([alias, functionObject]) => {
             return limit(async () => {
-              const functionName = path
-                .extname(functionObject[handlerPropertyName])
-                .slice(1)
-              const handlerPath = functionObject[handlerPropertyName].replace(
-                `.${functionName}`,
-                '',
+              const handlerPath = stripHandlerExportSuffix(
+                functionObject[handlerPropertyName],
               )
               const esbuildProps = {
                 ...buildProperties,
@@ -789,12 +792,8 @@ class Esbuild {
               )
 
               zip.pipe(output)
-              const functionName = path
-                .extname(functionObject[handlerPropertyName])
-                .slice(1)
-              const handlerPath = functionObject[handlerPropertyName].replace(
-                `.${functionName}`,
-                '',
+              const handlerPath = stripHandlerExportSuffix(
+                functionObject[handlerPropertyName],
               )
 
               const packageJsonPath = path.join(
@@ -928,12 +927,8 @@ class Esbuild {
         zip.pipe(output)
 
         for (const [, functionObject] of Object.entries(functions)) {
-          const functionName = path
-            .extname(functionObject[handlerPropertyName])
-            .slice(1)
-          const handlerPath = functionObject[handlerPropertyName].replace(
-            `.${functionName}`,
-            '',
+          const handlerPath = stripHandlerExportSuffix(
+            functionObject[handlerPropertyName],
           )
 
           const packageJsonPath = path.join(

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -29,6 +29,19 @@ const stripHandlerExportSuffix = (functionHandler) => {
   return functionHandler.slice(0, functionHandler.lastIndexOf(exportName))
 }
 
+// Compare two arrays as sets (order- and duplicate-insensitive). Used to
+// detect whether functions sharing a handler file resolved to the same
+// esbuild `external` list.
+const areSameSet = (a, b) => {
+  const setA = new Set(a)
+  const setB = new Set(b)
+  if (setA.size !== setB.size) return false
+  for (const value of setA) {
+    if (!setB.has(value)) return false
+  }
+  return true
+}
+
 // Pin every archive entry to a fixed date so that identical content always
 // produces a byte-for-byte identical zip. Without this, archiver stamps each
 // entry with the source file's mtime (esbuild rewrites its output on every
@@ -606,9 +619,16 @@ class Esbuild {
       return
     }
 
-    const updatedFunctionsToBuild = {}
-
     const buildProperties = await this._buildProperties()
+
+    // Multiple functions can share a single handler file (e.g. one module
+    // exporting several handlers). Building each function separately would
+    // spawn concurrent esbuild.build() calls writing to the same outfile,
+    // racing on truncate+write and corrupting the output (#13716). Instead we
+    // group functions by their resolved absolute entry path and build each
+    // unique file once, applying the per-function side effects to every alias
+    // in the group afterwards.
+    const buildGroups = new Map()
 
     for (const [alias, functionObject] of Object.entries(functionsToBuild)) {
       const handlerPath = stripHandlerExportSuffix(
@@ -622,79 +642,118 @@ class Esbuild {
       const extension = await this._extensionForFunction(
         functionObject[handlerPropertyName],
       )
-      if (extension) {
-        // Enrich the functionObject with additional values we will need for building
-        updatedFunctionsToBuild[alias] = {
-          ...functionObject,
-          handlerPath: path.join(
-            this.serverless.config.serviceDir,
-            handlerPath + extension,
-          ),
-          extension,
-          esbuild: {
-            external,
-          },
-        }
+      if (!extension) {
+        continue
+      }
+
+      // `path.join` normalizes the entry path (e.g. `./src/x` vs `src/x`) so
+      // functions pointing at the same file land in the same group.
+      const entry = path.join(
+        this.serverless.config.serviceDir,
+        handlerPath + extension,
+      )
+
+      const existingGroup = buildGroups.get(entry)
+      if (existingGroup) {
+        existingGroup.aliases.push(alias)
+        existingGroup.externals.push(external)
+      } else {
+        buildGroups.set(entry, {
+          entry,
+          // Relative stripped handler path used to derive the outfile. All
+          // members of a group resolve to the same file, so any member's
+          // relative path is correct once `path.join`-normalized below.
+          handlerPath,
+          aliases: [alias],
+          externals: [external],
+        })
       }
     }
 
-    // Determine the concurrency to use for building functions, by default framework will attempt to build
-    // all functions concurrently, but this can be overridden by setting the buildConcurrency property.
-    const concurrency =
-      buildProperties.buildConcurrency ?? Object.keys(functionsToBuild).length
+    // Determine the concurrency to use for building, by default framework will
+    // attempt to build all unique handler files concurrently, but this can be
+    // overridden by setting the buildConcurrency property.
+    const concurrency = buildProperties.buildConcurrency ?? buildGroups.size
 
     const limit = pLimit(concurrency)
 
     try {
       await Promise.all(
-        Object.entries(updatedFunctionsToBuild).map(
-          ([alias, functionObject]) => {
-            return limit(async () => {
-              const handlerPath = stripHandlerExportSuffix(
-                functionObject[handlerPropertyName],
+        Array.from(buildGroups.values()).map((group) => {
+          return limit(async () => {
+            // Reconcile the group members' external lists. They only diverge
+            // when functions sharing a handler file straddle the node16/18
+            // boundary via per-function `runtime`. This matters solely when
+            // bundling: `bundle !== true` forces `external: []` below, so the
+            // lists are never consulted and no conflict is possible.
+            const externals = group.externals
+            let external = externals[0]
+            if (buildProperties.bundle === true) {
+              const referenceExternal = externals[0]
+              const hasConflict = externals.some(
+                (candidate) => !areSameSet(candidate, referenceExternal),
               )
-              const esbuildProps = {
-                ...buildProperties,
-                platform: 'node',
-                ...(buildProperties.bundle === true
-                  ? { external: functionObject.esbuild.external }
-                  : { external: [] }),
-                entryPoints: [functionObject.handlerPath],
-                outfile: path.join(
+              if (hasConflict) {
+                // Compare as (order-insensitive) sets and use the intersection
+                // so we never bundle a module that any function in the group
+                // needs left external. Filter the first member's array to keep
+                // a deterministic order.
+                external = referenceExternal.filter((dep) =>
+                  externals.every((other) => other.includes(dep)),
+                )
+                logger.warning(
+                  `Functions ${group.aliases.join(', ')} share the handler file "${group.entry}" but resolve to different esbuild "external" lists. ` +
+                    `Building the file once with the intersection of those lists: ${external.length > 0 ? external.join(', ') : '(empty)'}.`,
+                )
+              }
+            }
+
+            const esbuildProps = {
+              ...buildProperties,
+              platform: 'node',
+              ...(buildProperties.bundle === true
+                ? { external }
+                : { external: [] }),
+              entryPoints: [group.entry],
+              outfile: path.join(
+                this.serverless.config.serviceDir,
+                '.serverless',
+                'build',
+                group.handlerPath + '.js',
+              ),
+              logLevel: 'error',
+            }
+
+            // Remove the following properties from the esbuildProps as they are not valid esbuild properties
+            delete esbuildProps.exclude
+            delete esbuildProps.buildConcurrency
+            delete esbuildProps.configFile
+
+            const result = await esbuild.build(esbuildProps)
+
+            /**
+             * If the user has set the esbuild metafile option, we need to write the metafile to the build directory
+             * so that they analyze the build output, just like the esbuild CLI does.
+             */
+            if (result.metafile) {
+              await writeFile(
+                path.join(
                   this.serverless.config.serviceDir,
                   '.serverless',
                   'build',
-                  handlerPath + '.js',
+                  'meta.json',
                 ),
-                logLevel: 'error',
-              }
+                JSON.stringify(result.metafile, null, 2),
+              )
+            }
 
-              // Remove the following properties from the esbuildProps as they are not valid esbuild properties
-              delete esbuildProps.exclude
-              delete esbuildProps.buildConcurrency
-              delete esbuildProps.configFile
+            if (!this.serverless.builtFunctions) {
+              this.serverless.builtFunctions = new Set()
+            }
 
-              const result = await esbuild.build(esbuildProps)
-
-              /**
-               * If the user has set the esbuild metafile option, we need to write the metafile to the build directory
-               * so that they analyze the build output, just like the esbuild CLI does.
-               */
-              if (result.metafile) {
-                await writeFile(
-                  path.join(
-                    this.serverless.config.serviceDir,
-                    '.serverless',
-                    'build',
-                    'meta.json',
-                  ),
-                  JSON.stringify(result.metafile, null, 2),
-                )
-              }
-
-              if (!this.serverless.builtFunctions) {
-                this.serverless.builtFunctions = new Set()
-              }
+            // Apply the per-function side effects to every alias sharing this
+            // handler file, not just the one whose build we ran.
+            for (const alias of group.aliases) {
               this.serverless.builtFunctions.add(alias)
               if (
                 this.serverless.service.build?.esbuild?.sourcemap ===
@@ -715,9 +774,9 @@ class Esbuild {
                     '--enable-source-maps'
                 }
               }
-            })
-          },
-        ),
+            }
+          })
+        }),
       )
     } catch (err) {
       if (this.serverless.devmodeEnabled === true) {

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -132,7 +132,7 @@ class Esbuild {
             // The packages config, this can be set to override the behavior of external
             packages: { type: 'string', enum: ['external'] },
             buildConcurrency: {
-              description: `Number of concurrent unique handler-file builds. Functions sharing a handler file are built once, and by default all unique handler files are built concurrently.`,
+              description: `Number of concurrent unique handler-file builds and per-function packaging operations. Functions sharing a handler file are built once, and by default all unique handler files are built concurrently.`,
               type: 'number',
             },
             // Whether to bundle or not. Default is true

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -132,7 +132,7 @@ class Esbuild {
             // The packages config, this can be set to override the behavior of external
             packages: { type: 'string', enum: ['external'] },
             buildConcurrency: {
-              description: `Number of concurrent function builds. All functions are built concurrently by default.`,
+              description: `Number of concurrent unique handler-file builds. Functions sharing a handler file are built once, and by default all unique handler files are built concurrently.`,
               type: 'number',
             },
             // Whether to bundle or not. Default is true

--- a/packages/serverless/test/unit/lib/plugins/esbuild/build-dedup.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/build-dedup.test.js
@@ -214,6 +214,26 @@ describe('esbuild shared-handler build dedup', () => {
     expect([...plugin.serverless.builtFunctions]).toEqual(['getItems'])
   })
 
+  test('no buildable handler files resolves without throwing and does not build', async () => {
+    // Handler points at a file that doesn't exist on disk (e.g. missing file
+    // or a typo'd path), so `_extensionForFunction` returns undefined for
+    // every candidate and `buildGroups` ends up empty. Pre-fix, falling
+    // through to `pLimit(buildProperties.buildConcurrency ?? buildGroups.size)`
+    // with `buildConcurrency` unset computed `pLimit(0)`, which throws
+    // `TypeError: Expected concurrency to be a number from 1 and up` outside
+    // the try/catch (bypassing both ESBULD_BUILD_ERROR wrapping and the
+    // dev-mode swallow). This should be a clean no-op instead.
+    const serviceDir = makeServiceDir({})
+    const functions = {
+      missing: { handler: 'does/not/exist.handler' },
+    }
+    const plugin = makePlugin(serviceDir, functions)
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect(buildMock).not.toHaveBeenCalled()
+  })
+
   test('real esbuild: one shared .ts handler across 4 functions yields a single valid bundle', async () => {
     // Delegate the spy to the real bundler so we exercise the actual build.
     buildMock.mockImplementation((props) => realBuild(props))

--- a/packages/serverless/test/unit/lib/plugins/esbuild/build-dedup.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/build-dedup.test.js
@@ -1,0 +1,255 @@
+/**
+ * Multiple Framework functions can point at the same handler file (one module
+ * exporting several handlers). Before the fix, `_build` ran one
+ * `esbuild.build()` per function; functions sharing a handler file therefore
+ * spawned concurrent builds writing to the SAME outfile, racing on
+ * truncate+write and corrupting the bundle (#13716).
+ *
+ * The fix groups functions by their resolved absolute entry path and builds
+ * each unique file exactly once, then replays the per-function side effects
+ * (`builtFunctions` membership, the `--enable-source-maps` NODE_OPTIONS
+ * mutation) for every alias in the group. When functions sharing a file
+ * resolve to different esbuild `external` lists (only possible when their
+ * per-function runtimes straddle the node16/18 boundary while bundling), the
+ * plugin builds once with the intersection and logs a warning.
+ *
+ * These tests pin that behavior. `esbuild` is mocked with a spy so we can count
+ * and inspect `build()` calls; the final test swaps the spy to delegate to the
+ * REAL esbuild to prove the single-build path produces a valid bundle.
+ *
+ * Pre-fix, the call-count assertions would have failed: the 4-functions case
+ * called `build()` 4 times (not 1) and the shared-runtime-conflict case 2 times
+ * (not 1), with no intersection reconciliation and no warning.
+ */
+
+import { jest } from '@jest/globals'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { log } from '@serverless/util'
+
+// `build` is a spy. Its default implementation is set per-test in beforeEach;
+// `realBuild` (captured from the actual esbuild via requireActual) lets the
+// final test delegate to the real bundler while still counting the call.
+let realBuild
+const buildMock = jest.fn()
+
+jest.unstable_mockModule('esbuild', () => {
+  realBuild = jest.requireActual('esbuild').build
+  return { build: buildMock }
+})
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+// The plugin logs conflicts via `log.get('esbuild')`, a memoized singleton, so
+// this is the same instance the plugin holds — spying here intercepts its call.
+const esbuildLogger = log.get('esbuild')
+
+const createdServiceDirs = []
+
+function makeServiceDir(files) {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+  createdServiceDirs.push(serviceDir)
+  for (const [name, contents] of Object.entries(files)) {
+    const filePath = path.join(serviceDir, name)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+  return serviceDir
+}
+
+function makePlugin(serviceDir, functions, { runtime = 'nodejs18.x' } = {}) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      provider: { runtime },
+      functions,
+      getFunction: (alias) => functions[alias],
+    },
+  }
+  const plugin = new Esbuild(serverless, {})
+  // Target `_build` directly: bypass the introspection in `functions()` so the
+  // grouping/build logic is what's under test.
+  plugin.functions = async () => functions
+  return plugin
+}
+
+describe('esbuild shared-handler build dedup', () => {
+  jest.setTimeout(30_000)
+
+  beforeEach(() => {
+    buildMock.mockReset()
+    buildMock.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    while (createdServiceDirs.length > 0) {
+      fs.rmSync(createdServiceDirs.pop(), { recursive: true, force: true })
+    }
+  })
+
+  test('4 functions sharing one handler file build the file once', async () => {
+    const serviceDir = makeServiceDir({
+      'handler.ts':
+        'export const a = async () => ({})\n' +
+        'export const b = async () => ({})\n' +
+        'export const c = async () => ({})\n' +
+        'export const d = async () => ({})\n',
+    })
+    const functions = {
+      a: { handler: 'handler.a' },
+      b: { handler: 'handler.b' },
+      c: { handler: 'handler.c' },
+      d: { handler: 'handler.d' },
+    }
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    // Pre-fix: called 4 times (one per function), racing on the same outfile.
+    expect(buildMock).toHaveBeenCalledTimes(1)
+
+    expect([...plugin.serverless.builtFunctions].sort()).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+    ])
+    for (const alias of ['a', 'b', 'c', 'd']) {
+      expect(functions[alias].environment.NODE_OPTIONS).toBe(
+        '--enable-source-maps',
+      )
+    }
+  })
+
+  test('2 functions with distinct handler files build twice', async () => {
+    const serviceDir = makeServiceDir({
+      'alpha.ts': 'export const a = async () => ({})\n',
+      'beta.ts': 'export const b = async () => ({})\n',
+    })
+    const functions = {
+      a: { handler: 'alpha.a' },
+      b: { handler: 'beta.b' },
+    }
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(2)
+    expect([...plugin.serverless.builtFunctions].sort()).toEqual(['a', 'b'])
+  })
+
+  test('shared handler with node16/node18 runtimes builds once with the intersection and warns', async () => {
+    const serviceDir = makeServiceDir({
+      'shared.ts':
+        'export const a = async () => ({})\nexport const b = async () => ({})\n',
+    })
+    // Per-function runtimes straddle the node16/18 boundary: `a` resolves to
+    // external ['aws-sdk'], `b` to ['@aws-sdk/*']. Their intersection is empty.
+    const functions = {
+      a: { handler: 'shared.a', runtime: 'nodejs16.x' },
+      b: { handler: 'shared.b', runtime: 'nodejs18.x' },
+    }
+    const plugin = makePlugin(serviceDir, functions)
+
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+
+    try {
+      await plugin._build()
+
+      // Pre-fix: called twice (one per function) with no reconciliation.
+      expect(buildMock).toHaveBeenCalledTimes(1)
+
+      // The captured `external` is the intersection of the two lists (empty).
+      const props = buildMock.mock.calls[0][0]
+      expect(props.external).toEqual([])
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toMatch(
+        /share the handler file .* different esbuild "external" lists/,
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  test('suffix stripping derives the correct entry/outfile when a path segment collides with the export name', async () => {
+    // The directory name mirrors the export name (`items.get`), so `.get`
+    // occurs TWICE in the handler string. First-occurrence stripping (the old
+    // bug) removes the `.get` in the directory segment, deriving the
+    // nonexistent entry `handlers/items/index.get.ts` — the function is then
+    // silently skipped (0 builds, no captured props). Last-occurrence
+    // stripping derives the real file.
+    const serviceDir = makeServiceDir({
+      'handlers/items.get/index.ts':
+        'export const get = async () => ({ statusCode: 200 })\n',
+    })
+    const functions = {
+      getItems: { handler: 'handlers/items.get/index.get' },
+    }
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(1)
+    const props = buildMock.mock.calls[0][0]
+    expect(props.entryPoints).toEqual([
+      path.join(serviceDir, 'handlers', 'items.get', 'index.ts'),
+    ])
+    expect(props.outfile).toBe(
+      path.join(
+        serviceDir,
+        '.serverless',
+        'build',
+        'handlers',
+        'items.get',
+        'index.js',
+      ),
+    )
+    expect([...plugin.serverless.builtFunctions]).toEqual(['getItems'])
+  })
+
+  test('real esbuild: one shared .ts handler across 4 functions yields a single valid bundle', async () => {
+    // Delegate the spy to the real bundler so we exercise the actual build.
+    buildMock.mockImplementation((props) => realBuild(props))
+
+    const serviceDir = makeServiceDir({
+      'handler.ts':
+        'export const a = async () => ({ statusCode: 200 })\n' +
+        'export const b = async () => ({ statusCode: 201 })\n' +
+        'export const c = async () => ({ statusCode: 202 })\n' +
+        'export const d = async () => ({ statusCode: 203 })\n',
+    })
+    const functions = {
+      a: { handler: 'handler.a' },
+      b: { handler: 'handler.b' },
+      c: { handler: 'handler.c' },
+      d: { handler: 'handler.d' },
+    }
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(1)
+
+    const outfile = path.join(serviceDir, '.serverless', 'build', 'handler.js')
+    expect(fs.existsSync(outfile)).toBe(true)
+
+    // A corrupted (concurrently-truncated) bundle would have zero or multiple
+    // trailing sourcemap comments; a clean single build has exactly one.
+    const contents = fs.readFileSync(outfile, 'utf-8')
+    expect((contents.match(/sourceMappingURL/g) || []).length).toBe(1)
+
+    expect([...plugin.serverless.builtFunctions].sort()).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+    ])
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/handler-path.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/handler-path.test.js
@@ -26,8 +26,11 @@ import path from 'path'
 const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
   .default
 
+const createdServiceDirs = []
+
 function makeServiceDir() {
   const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+  createdServiceDirs.push(serviceDir)
   // Directory name mirrors the export name ("items.get"), so the buggy
   // first-occurrence replace strips the wrong ".get" from the handler string.
   const nestedDir = path.join(serviceDir, 'handlers', 'items.get')
@@ -52,6 +55,12 @@ const HANDLER = 'handlers/items.get/index.get'
 
 describe('esbuild handler export-suffix stripping', () => {
   jest.setTimeout(30_000)
+
+  afterEach(() => {
+    while (createdServiceDirs.length > 0) {
+      fs.rmSync(createdServiceDirs.pop(), { recursive: true, force: true })
+    }
+  })
 
   test('_extensionForFunction finds the file when a path segment collides with the export name', async () => {
     const serviceDir = makeServiceDir()

--- a/packages/serverless/test/unit/lib/plugins/esbuild/handler-path.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/handler-path.test.js
@@ -1,0 +1,77 @@
+/**
+ * Serverless `handler` strings are `path/to/file.exportName` — the file lives
+ * at `path/to/file.{ts,js,...}` and exports a function named `exportName`.
+ *
+ * The buggy derivation stripped the FIRST occurrence of `.{exportName}`
+ * anywhere in the handler string (`handler.replace(`.${functionName}`, '')`).
+ * When a directory or file segment earlier in the path happens to contain
+ * the literal substring `.{exportName}` (e.g. a folder mirroring the handler
+ * name, `items.get/index.get`), the first occurrence is not the real suffix,
+ * so the derived path is wrong and the plugin looks for a file that doesn't
+ * exist. It must strip the LAST occurrence instead (mirrors the community
+ * serverless-esbuild plugin's deliberate `lastIndexOf` fix).
+ *
+ * Note: a handler like `handler.handler` (file and export sharing a name)
+ * does NOT reproduce the bug — with only one occurrence of `.handler` in the
+ * string, first-occurrence and last-occurrence replacement coincide. The
+ * divergence only appears when the pattern occurs twice with unrelated
+ * content between the two occurrences, as constructed below.
+ */
+
+import { jest } from '@jest/globals'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+function makeServiceDir() {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+  // Directory name mirrors the export name ("items.get"), so the buggy
+  // first-occurrence replace strips the wrong ".get" from the handler string.
+  const nestedDir = path.join(serviceDir, 'handlers', 'items.get')
+  fs.mkdirSync(nestedDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(nestedDir, 'index.ts'),
+    'export const get = async () => ({ statusCode: 200 })\n',
+  )
+  return serviceDir
+}
+
+function makePlugin(serviceDir) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: { service: 'my-service' },
+  }
+  return new Esbuild(serverless, {})
+}
+
+const HANDLER = 'handlers/items.get/index.get'
+
+describe('esbuild handler export-suffix stripping', () => {
+  jest.setTimeout(30_000)
+
+  test('_extensionForFunction finds the file when a path segment collides with the export name', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+
+    const extension = await plugin._extensionForFunction(HANDLER)
+
+    expect(extension).toBe('.ts')
+  })
+
+  test('WillEsBuildRun detects the typescript handler when a path segment collides with the export name', () => {
+    const serviceDir = makeServiceDir()
+
+    const configFile = {
+      provider: { runtime: 'nodejs18.x' },
+      functions: {
+        hello: { handler: HANDLER },
+      },
+    }
+
+    expect(Esbuild.WillEsBuildRun(configFile, serviceDir, 'handler')).toBe(true)
+  })
+})


### PR DESCRIPTION
Resolves #13716

### Problem

The native esbuild builder runs one `esbuild.build()` per **function**, deriving the output path from the handler **file** path. When multiple functions reference exports from the same handler file, all of their builds run concurrently and write the same `.serverless/build/<handler>.js` (and `.js.map`). Concurrent truncate+write on one file can leave a corrupted bundle — a complete module followed by a partial duplicate fragment — which fails at Lambda INIT with `Runtime.UserCodeSyntaxError: SyntaxError: Unexpected token ')'`. The corruption is timing-dependent, so it can appear and disappear across deploys of the same commit. Even when the output happens to be clean, shared handler files are built N times redundantly.

### Changes

- **Build each unique handler file once.** `_build()` now groups functions by their resolved entry file and runs a single build per group, then applies the per-function effects (`builtFunctions` registration, `NODE_OPTIONS=--enable-source-maps`) to every function sharing the file. With a single writer per outfile the race no longer exists, and shared handlers stop being rebuilt per function. (Same approach as `serverless-esbuild`'s "only build unique entry files".)
- **Reconcile per-function `external` lists.** Functions sharing a handler can resolve different esbuild `external` lists only when their runtimes straddle the Node 16/18 boundary. In that case the file is built once with the intersection of the lists (bundling more, which is valid for every runtime in the group) and a warning is logged.
- **Strip the handler export suffix at its last occurrence.** The previous derivation removed the *first* occurrence of `.{exportName}` from the handler string, which resolved the wrong file when an earlier path segment contained the same substring (e.g. `handlers/items.get/index.get`). All derivation sites now share one helper that strips the final suffix, matching the entry-resolution behavior of `serverless-esbuild`.
- **No-op instead of crash when nothing is buildable.** If no handler file resolves to a known extension, `_build()` now returns cleanly instead of reaching `pLimit(0)`.
- Docs: `buildConcurrency` description updated — it bounds concurrent **unique handler-file** builds (unchanged behavior for services where every function has its own handler file); fixed an adjacent typo.

### Testing

- New unit suites: build-count dedup (shared vs distinct handlers), external-list intersection + warning, suffix-stripping through the build path, empty-build no-op, and a real-esbuild test asserting the shared-handler bundle is valid with exactly one `sourceMappingURL`.
- Verified end-to-end with a 4-functions / 1-handler service (the issue's reproduction shape): the handler file is built once, `serverless package` produces a valid bundle, `NODE_OPTIONS` is set on all four functions in the generated template, and `package.individually` still yields one artifact per function containing the bundle.

### Notes

- Two deploy processes sharing one working directory can still race on `.serverless/build`; that is outside the scope of this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build shared handler files only once to improve deployment build efficiency.
  * Added concurrency control across unique handler-file builds.
  * Generates build metadata (for example, `meta.json`) when an esbuild metafile is available.
* **Bug Fixes**
  * More accurate handler path resolution by stripping only the final handler export suffix (fixing overlap with directory names).
  * Preserves correct per-alias sourcemap output and runtime settings for shared handlers.
  * Avoids errors when no buildable handler files are found; warns on conflicting bundling settings.
* **Documentation**
  * Clarified esbuild build concurrency behavior and handler deduplication.
* **Tests**
  * Added Jest coverage for handler deduplication, suffix collisions, conflicts, and “no build” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- The corrected handler-path derivation matches AWS Lambda's own handler resolution. Configs whose handler strings only resolved under the old first-occurrence stripping could not have produced a runnable function (the packaged file path never matched what Lambda loads); such configs may now surface an explicit build/packaging error instead of deploying a non-functional artifact.
