### PR TITLE
chore: standardize development toolchain on Node 24 LTS and npm 12

### DIFF
--- a/.github/workflows/ci-engine.yml
+++ b/.github/workflows/ci-engine.yml
@@ -28,7 +28,7 @@ jobs:
           cache: npm
 
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
 
       - name: 'Install: Dependencies'
         run: npm ci

--- a/.github/workflows/ci-engine.yml
+++ b/.github/workflows/ci-engine.yml
@@ -27,6 +27,9 @@ jobs:
           check-latest: true
           cache: npm
 
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
+
       - name: 'Install: Dependencies'
         run: npm ci
 

--- a/.github/workflows/ci-framework.yml
+++ b/.github/workflows/ci-framework.yml
@@ -28,6 +28,8 @@ jobs:
           node-version: 24.x
           check-latest: true
           cache: npm
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
       - name: 'Install: Dependencies'
         run: npm ci
       - name: 'Lint: ESLint'
@@ -53,6 +55,8 @@ jobs:
           node-version: 24.x
           check-latest: true
           cache: npm
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
       - name: 'Install: Dependencies'
         run: |
           cd ../../
@@ -78,6 +82,8 @@ jobs:
           cache: npm
           registry-url: 'https://npm.pkg.github.com'
           scope: '@serverlessinc'
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/ci-framework.yml
+++ b/.github/workflows/ci-framework.yml
@@ -29,7 +29,7 @@ jobs:
           check-latest: true
           cache: npm
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
       - name: 'Install: Dependencies'
         run: npm ci
       - name: 'Lint: ESLint'
@@ -56,7 +56,7 @@ jobs:
           check-latest: true
           cache: npm
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
       - name: 'Install: Dependencies'
         run: |
           cd ../../
@@ -83,7 +83,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@serverlessinc'
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -39,6 +39,9 @@ jobs:
           check-latest: true
           cache: npm
 
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
+
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -40,7 +40,7 @@ jobs:
           cache: npm
 
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
 
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -35,7 +35,7 @@ jobs:
           check-latest: true
           cache: npm
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
       - name: 'Install: Dependencies'
         run: |
           cd ../../
@@ -65,7 +65,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@serverlessinc'
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
@@ -117,7 +117,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@serverlessinc'
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
       - name: 'Install: Dependencies'
         run: |
           cd ../../
@@ -167,7 +167,7 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@serverlessinc'
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
@@ -210,7 +210,7 @@ jobs:
           scope: '@serverless'
           registry-url: https://registry.npmjs.org
       - name: 'Setup: Enable Corepack'
-        run: corepack enable
+        run: corepack enable npm
       - name: 'Release: Copy Readme'
         run: |
           cp ../../README.md ./README.md

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -34,6 +34,8 @@ jobs:
           node-version: 24.x
           check-latest: true
           cache: npm
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
       - name: 'Install: Dependencies'
         run: |
           cd ../../
@@ -62,6 +64,8 @@ jobs:
           cache: npm
           registry-url: 'https://npm.pkg.github.com'
           scope: '@serverlessinc'
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
@@ -112,6 +116,8 @@ jobs:
           cache: npm
           registry-url: 'https://npm.pkg.github.com'
           scope: '@serverlessinc'
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
       - name: 'Install: Dependencies'
         run: |
           cd ../../
@@ -160,6 +166,8 @@ jobs:
           cache: npm
           registry-url: 'https://npm.pkg.github.com'
           scope: '@serverlessinc'
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:
@@ -201,6 +209,8 @@ jobs:
           cache: npm
           scope: '@serverless'
           registry-url: https://registry.npmjs.org
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable
       - name: 'Release: Copy Readme'
         run: |
           cp ../../README.md ./README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -5033,9 +5033,9 @@
       }
     },
     "node_modules/aws-crt/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -10909,9 +10909,9 @@
       }
     },
     "node_modules/mqtt/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -14355,9 +14355,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -14733,7 +14733,7 @@
         "@aws-sdk/client-cloudformation": "3.1081.0",
         "@aws-sdk/client-s3": "3.1081.0",
         "@aws-sdk/client-ssm": "3.1081.0",
-        "@aws-sdk/client-sso-oidc": "^3.1081.0",
+        "@aws-sdk/client-sso-oidc": "3.1081.0",
         "@aws-sdk/client-sts": "3.1081.0",
         "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/credential-providers": "3.1081.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,17 @@
   "description": "",
   "main": "index.js",
   "type": "module",
+  "packageManager": "npm@12.0.1",
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^24.15.0"
+    },
+    "packageManager": {
+      "name": "npm",
+      "version": ">=12.0.0"
+    }
+  },
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
@@ -37,5 +48,16 @@
     "aws-sdk": {
       "uuid": "^11.1.1"
     }
+  },
+  "allowScripts": {
+    "aws-crt": true,
+    "aws-sdk": true,
+    "cpu-features": true,
+    "es5-ext": true,
+    "esbuild": true,
+    "fsevents": true,
+    "protobufjs": true,
+    "ssh2": true,
+    "unrs-resolver": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "^24.15.0"
+      "version": "^24.15.0",
+      "onFail": "warn"
     },
     "packageManager": {
       "name": "npm",
-      "version": ">=12.0.0"
+      "version": ">=12.0.0",
+      "onFail": "warn"
     }
   },
   "scripts": {

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-basic-dockerfile/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-basic-dockerfile/package-lock.json
@@ -3171,9 +3171,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-basic/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-basic/package-lock.json
@@ -3171,9 +3171,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-browser-custom/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-browser-custom/package-lock.json
@@ -3636,9 +3636,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-browser/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-browser/package-lock.json
@@ -3671,9 +3671,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-code-interpreter-custom/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-code-interpreter-custom/package-lock.json
@@ -3591,9 +3591,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-code-interpreter/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-code-interpreter/package-lock.json
@@ -3591,9 +3591,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-comprehensive/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-comprehensive/package-lock.json
@@ -4498,9 +4498,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-gateway/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-gateway/package-lock.json
@@ -4855,9 +4855,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-memory/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-memory/package-lock.json
@@ -3608,9 +3608,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-multi-gateway/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-multi-gateway/package-lock.json
@@ -4855,9 +4855,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-streaming/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/langgraph-streaming/package-lock.json
@@ -3331,9 +3331,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/strands-browser/package-lock.json
+++ b/packages/serverless/lib/plugins/aws/bedrock-agentcore/examples/javascript/strands-browser/package-lock.json
@@ -3986,9 +3986,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/packages/serverless/lib/plugins/package/lib/zip-service.js
+++ b/packages/serverless/lib/plugins/package/lib/zip-service.js
@@ -222,9 +222,11 @@ async function excludeNodeDevDependencies(serviceDir) {
             // rather than via a shell redirection, so the (potentially
             // environment-derived) temp path never becomes part of the command
             // string that a shell interprets.
-            // `--include=dev` / `--omit=dev` are the canonical forms across
-            // npm 7+; the older `--dev=true` / `--prod=true` spellings are
-            // rejected by npm 12's stricter flag parsing.
+            // `--include=dev` / `--omit=dev` are the canonical flags across
+            // npm 7+, and npm documents the older spellings as their aliases
+            // (`dev` -> `--include=dev`, `production` -> `--omit=dev`).
+            // npm 12 errors on abbreviated flags, which rejects `--prod`
+            // (an abbreviation of `--production`).
             return execAsync(
               `npm ls --${env === 'dev' ? 'include=dev' : 'omit=dev'} --parseable=true --long=false --silent --all`,
               {

--- a/packages/serverless/lib/plugins/package/lib/zip-service.js
+++ b/packages/serverless/lib/plugins/package/lib/zip-service.js
@@ -222,8 +222,11 @@ async function excludeNodeDevDependencies(serviceDir) {
             // rather than via a shell redirection, so the (potentially
             // environment-derived) temp path never becomes part of the command
             // string that a shell interprets.
+            // `--include=dev` / `--omit=dev` are the canonical forms across
+            // npm 7+; the older `--dev=true` / `--prod=true` spellings are
+            // rejected by npm 12's stricter flag parsing.
             return execAsync(
-              `npm ls --${env}=true --parseable=true --long=false --silent --all`,
+              `npm ls --${env === 'dev' ? 'include=dev' : 'omit=dev'} --parseable=true --long=false --silent --all`,
               {
                 cwd: dirWithPackageJson,
                 // We are overriding `NODE_ENV` because when it is set to "production"

--- a/packages/serverless/lib/plugins/python/lib/pip.js
+++ b/packages/serverless/lib/plugins/python/lib/pip.js
@@ -26,11 +26,15 @@ function isSamBuildImage(image) {
 }
 
 function prependUvBootstrapCommands(pipCmds) {
-  pipCmds.unshift(['source', '~/.local/bin/env'])
+  // Recent SAM build images ship `uv` on the PATH, so only bootstrap it when
+  // it is missing. Install into /usr/local/bin (on the PATH in all image
+  // generations) rather than the installer's default ~/.local/bin, which
+  // requires sourcing a shell profile afterwards — a step that does not
+  // survive shell-quote escaping (`~` is escaped and never expands).
   pipCmds.unshift([
     '/bin/sh',
     '-c',
-    'curl -LsSf https://astral.sh/uv/install.sh | sh',
+    'command -v uv > /dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | UV_UNMANAGED_INSTALL=/usr/local/bin sh',
   ])
 }
 


### PR DESCRIPTION
## What

- Declare `"packageManager": "npm@12.0.1"` in the root `package.json` so Corepack-enabled environments (CI, automated dependency updates) consistently resolve the same npm version
- Add `devEngines` requiring Node 24 LTS (`^24.15.0`) and npm `>=12` for development work in this repository
- Add `allowScripts` listing the dependency lifecycle scripts used by the toolchain (esbuild, aws-crt, unrs-resolver, and others) — npm 12 requires dependency install scripts to be explicitly approved
- Enable Corepack in CI workflows right after `setup-node`, so dependency installation and lockfile operations run on the declared npm version
- Refresh `package-lock.json` (ws and other in-range updates)

## Why

- npm 12 applies root `overrides` consistently during incremental installs and updates, which keeps lockfile maintenance deterministic across contributors, CI, and automated dependency updates
- A single declared package-manager version keeps local development, CI, and Dependabot aligned on the same resolution behavior

## Notes

- `devEngines` and `packageManager` only apply when working in this repository. The published packages' `engines` field (Node >=18) is unchanged, so requirements for consumers stay exactly the same.
- Contributors need Node 24 LTS with npm 12 (`npm install -g npm@12`), or Corepack enabled (`corepack enable`), for local installs and lockfile updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD reliability by enabling Corepack (npm) immediately after Node.js setup across engine, framework, Python requirements, and release workflows.
  * Pinned the npm version and clarified supported development Node.js/npm ranges, using warnings instead of hard failures when constraints aren’t met.
  * Reduced dependency and script execution risk by using npm’s canonical dev/prod flags when building dependency lists and limiting which dependency-provided scripts can run.
  * Improved Docker-based Python builds by installing `uv` only when it’s not already available, and using a consistent install location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->