### PR TITLE
fix(packaging): stop packaging when the production dependency listing is unavailable

### DIFF
--- a/packages/serverless/lib/plugins/package/lib/zip-service.js
+++ b/packages/serverless/lib/plugins/package/lib/zip-service.js
@@ -168,6 +168,9 @@ async function excludeNodeDevDependencies(serviceDir) {
     exclude: [],
   }
 
+  // `npm ls` invocations that produced no output at all, per listing kind.
+  const listingHardFailures = { dev: [], prod: [] }
+
   // the files where we'll write the dependencies into
   const tmpDir = os.tmpdir()
   const randHash = crypto.randomBytes(8).toString('hex')
@@ -248,6 +251,17 @@ async function excludeNodeDevDependencies(serviceDir) {
                 log.debug(
                   `Failed to run npm ls to retrieve dependencies for exclusion. Error: ${err.message}`,
                 )
+                // A failure without any stdout means no tree was produced at
+                // all (as opposed to the tolerated non-zero exits that still
+                // print a partial tree); record it for the guard below.
+                if (!err.stdout) {
+                  listingHardFailures[env].push(
+                    (err.stderr || err.message || '')
+                      .split(/[\r\n]+/)
+                      .map((l) => l.trim())
+                      .find(Boolean) || 'unknown error',
+                  )
+                }
                 // `npm ls` exits non-zero on missing/invalid deps but still
                 // prints a partial tree on stdout; preserve it as the previous
                 // shell redirection did. Append unconditionally so the file
@@ -277,8 +291,41 @@ async function excludeNodeDevDependencies(serviceDir) {
           }),
         )
         .then(async (devAndProDependencies) => {
-          const devDependencies = devAndProDependencies[0]
-          const prodDependencies = devAndProDependencies[1]
+          const devDependencies = devAndProDependencies[0] || []
+          const prodDependencies = devAndProDependencies[1] || []
+
+          // `npm ls --parseable` prints at least the project root on success
+          // and keeps a partial tree on stdout for ordinary listing errors
+          // (missing or invalid dependencies), so a listing without any
+          // output at all — whether it failed outright or reported success —
+          // means that dependency inventory is unusable. Excluding based on
+          // a dev listing without the matching production listing would
+          // remove production dependencies from the artifact, so stop
+          // packaging instead.
+          if (
+            (listingHardFailures.prod.length || !prodDependencies.length) &&
+            devDependencies.length
+          ) {
+            const reason =
+              listingHardFailures.prod[0] ||
+              'the command reported success but returned no dependency data'
+            throw new ServerlessError(
+              'Unable to determine production dependencies for dev-dependency exclusion' +
+                ` ("npm ls" produced no output: ${reason}).` +
+                ' Packaging was stopped because continuing could exclude production dependencies from the deployment artifact.' +
+                ' To package without dev-dependency exclusion, set "package.excludeDevDependencies: false".',
+              'DEV_DEPENDENCY_EXCLUSION_LISTING_FAILED',
+            )
+          }
+          if (!devDependencies.length) {
+            if (listingHardFailures.dev.length) {
+              log.warning(
+                'Skipping development dependency exclusion: unable to inventory dependencies' +
+                  ` ("npm ls" produced no output: ${listingHardFailures.dev[0]}).`,
+              )
+            }
+            return exAndIn
+          }
 
           // NOTE: the order for _.difference is important
           const dependencies = _.difference(devDependencies, prodDependencies)
@@ -353,13 +400,19 @@ async function excludeNodeDevDependencies(serviceDir) {
 
           return exAndIn
         })
-        .then(() => {
+        .finally(() => {
           // cleanup
-          unlinkSync(nodeDevDepFile)
-          unlinkSync(nodeProdDepFile)
-          return exAndIn
+          try {
+            unlinkSync(nodeDevDepFile)
+            unlinkSync(nodeProdDepFile)
+          } catch {
+            // temp files may not exist if listing failed early
+          }
         })
         .catch((err) => {
+          // Deliberate packaging errors must reach the user; only incidental
+          // bookkeeping failures are swallowed to keep exclusion best-effort.
+          if (err instanceof ServerlessError) throw err
           log.debug(`Failed to exclude dev dependencies. Error: ${err.message}`)
           return exAndIn
         })

--- a/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -43,6 +43,7 @@ const { default: Package } =
   await import('../../../../../../lib/plugins/package/package.js')
 const { default: Serverless } =
   await import('../../../../../../lib/serverless.js')
+const { log: mockedLog } = await import('@serverless/util')
 
 describe('zipService', () => {
   let tmpDirPath
@@ -337,6 +338,30 @@ describe('zipService', () => {
           // Nothing is excluded; the artifact keeps all dependencies.
           expect(isExcluded(updated.exclude, 'dev-pkg')).toBe(false)
           expect(isExcluded(updated.exclude, 'prod-pkg')).toBe(false)
+        } finally {
+          process.env.PATH = originalPath
+        }
+      },
+    )
+
+    itPosix(
+      'warns and skips exclusion when only the development listing is unavailable',
+      async () => {
+        scaffoldProject()
+        const shimDir = shimNpm({ failDev: true, failProd: false })
+        const originalPath = process.env.PATH
+        process.env.PATH = `${shimDir}${path.delimiter}${originalPath}`
+        try {
+          const updated = await packagePlugin.excludeDevDependencies(params)
+          // Without the full listing there are no removal candidates; the
+          // artifact keeps all dependencies and the skip is surfaced.
+          expect(isExcluded(updated.exclude, 'dev-pkg')).toBe(false)
+          expect(isExcluded(updated.exclude, 'prod-pkg')).toBe(false)
+          expect(mockedLog.warning).toHaveBeenCalledWith(
+            expect.stringContaining(
+              'Skipping development dependency exclusion',
+            ),
+          )
         } finally {
           process.env.PATH = originalPath
         }

--- a/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -217,6 +217,25 @@ describe('zipService', () => {
       expect(isExcluded(updated.exclude, 'prod-pkg')).toBe(false)
     })
 
+    it('handles services with only development dependencies', async () => {
+      // A production listing of such a project legitimately contains no
+      // packages (just the project root); this must exclude the dev
+      // dependencies and must not be treated as a listing failure.
+      writePackageJson(serviceDir, {
+        name: 'dev-only-test',
+        version: '1.0.0',
+        devDependencies: { 'dev-pkg': '1.0.0' },
+      })
+      writePackageJson(path.join(serviceDir, 'node_modules', 'dev-pkg'), {
+        name: 'dev-pkg',
+        version: '1.0.0',
+      })
+
+      const updated = await packagePlugin.excludeDevDependencies(params)
+
+      expect(isExcluded(updated.exclude, 'dev-pkg')).toBe(true)
+    })
+
     it('does not execute shell metacharacters injected via the temp path', async () => {
       if (os.platform() === 'win32') {
         // POSIX-shell payload; temp-path handling is exercised on *nix.
@@ -251,6 +270,78 @@ describe('zipService', () => {
 
       expect(markerCreated).toBe(false)
     })
+
+    // Shims `npm` via PATH so the two `npm ls` listings can be made to fail
+    // independently — a hard failure produces no stdout at all, unlike the
+    // tolerated non-zero exits that still print a partial tree.
+    function shimNpm({ failDev, failProd }) {
+      const shimDir = path.join(serviceDir, '.npm-shim')
+      fs.mkdirSync(shimDir, { recursive: true })
+      const tree = [
+        serviceDir,
+        path.join(serviceDir, 'node_modules', 'dev-pkg'),
+        path.join(serviceDir, 'node_modules', 'prod-pkg'),
+      ]
+      const prodTree = [
+        serviceDir,
+        path.join(serviceDir, 'node_modules', 'prod-pkg'),
+      ]
+      const script = [
+        '#!/bin/sh',
+        'case "$*" in',
+        `  *"--omit=dev"*) ${
+          failProd
+            ? 'echo "simulated npm failure" >&2; exit 1'
+            : `printf '%s\\n' ${prodTree.map((p) => `'${p}'`).join(' ')}`
+        } ;;`,
+        `  *) ${
+          failDev
+            ? 'echo "simulated npm failure" >&2; exit 1'
+            : `printf '%s\\n' ${tree.map((p) => `'${p}'`).join(' ')}`
+        } ;;`,
+        'esac',
+      ].join('\n')
+      const shimPath = path.join(shimDir, 'npm')
+      fs.writeFileSync(shimPath, script, { mode: 0o755 })
+      return shimDir
+    }
+
+    const itPosix = os.platform() === 'win32' ? it.skip : it
+
+    itPosix(
+      'stops packaging when the production dependency listing produces no output',
+      async () => {
+        scaffoldProject()
+        const shimDir = shimNpm({ failDev: false, failProd: true })
+        const originalPath = process.env.PATH
+        process.env.PATH = `${shimDir}${path.delimiter}${originalPath}`
+        try {
+          await expect(
+            packagePlugin.excludeDevDependencies(params),
+          ).rejects.toThrow(/production dependencies/)
+        } finally {
+          process.env.PATH = originalPath
+        }
+      },
+    )
+
+    itPosix(
+      'skips exclusion when no dependency listing is available',
+      async () => {
+        scaffoldProject()
+        const shimDir = shimNpm({ failDev: true, failProd: true })
+        const originalPath = process.env.PATH
+        process.env.PATH = `${shimDir}${path.delimiter}${originalPath}`
+        try {
+          const updated = await packagePlugin.excludeDevDependencies(params)
+          // Nothing is excluded; the artifact keeps all dependencies.
+          expect(isExcluded(updated.exclude, 'dev-pkg')).toBe(false)
+          expect(isExcluded(updated.exclude, 'prod-pkg')).toBe(false)
+        } finally {
+          process.env.PATH = originalPath
+        }
+      },
+    )
   })
 
   describe('#zip()', () => {


### PR DESCRIPTION
## What

Hardens the dev-dependency exclusion step in classic (non-bundled) packaging. The exclusion list is computed by subtracting the production `npm ls` listing from the full listing, and the two listings can fail independently. This change makes the outcome of each combination explicit:

- **Production listing unavailable while the full listing has content**: packaging now stops with a clear error (`DEV_DEPENDENCY_EXCLUSION_LISTING_FAILED`) that explains why and points to the `package.excludeDevDependencies: false` opt-out. Proceeding in this state would compute an exclusion list that also covers production dependencies.
- **No listing available at all**: exclusion is skipped with a visible warning and packaging continues — the artifact contains all dependencies and remains fully functional, just unoptimized.
- Ordinary `npm ls` non-zero exits that still produce output (missing or invalid dependencies in the tree) keep today's behavior: the printed tree is used and packaging proceeds.

Also in this change:

- temp-file cleanup moved to `finally` so listing files are removed on all paths
- deliberate packaging errors now propagate to the user instead of being absorbed by the best-effort catch
- unit coverage for the new paths, including a service with only development dependencies and hermetic npm shims that fail each listing independently

## Validation

- 35/35 package-plugin unit tests under npm 11 and npm 12
- Exercised end to end via the CLI across seven scenarios: standard project, dev-dependencies-only project, tree with a missing declared dependency, unavailable production listing, no listings at all, opt-out via `excludeDevDependencies: false`, and runtime execution of the produced artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaging reliability when dependency information from `npm ls` is missing or incomplete.
  * Added safety checks to avoid excluding production dependencies when production inventory can’t be determined; packaging now fails fast in risky cases.
  * Dev-dependency exclusion now safely skips when dev inventory can’t be determined, and emits a warning.
  * More resilient temporary file cleanup during the exclusion flow, tolerating missing temp files.
* **Tests**
  * Expanded unit test coverage for dev-only projects and multiple incomplete-output scenarios using a deterministic `npm` shim.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->