### PR TITLE
feat(aws): support Lambda self-managed code storage (reference mode)

### DIFF
--- a/docs/sf/guides/deployment-bucket.md
+++ b/docs/sf/guides/deployment-bucket.md
@@ -119,6 +119,140 @@ This simplifies management and reduces the number of buckets needed for deployme
 and reduces the complexity of managing multiple deployment artifacts across different services and environments.
 To learn more about Compose, refer to the [Compose documentation](./compose).
 
+## Code Storage Mode (Self-Managed Lambda Code Storage)
+
+By default, Lambda copies your deployment package into Lambda-managed storage
+(`copy` mode). With self-managed S3 code storage, Lambda runs your functions
+and layers directly from the deployment bucket instead — your code no longer
+counts against the Lambda code storage quota, and deployments activate
+faster. See the
+[AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/configuration-self-managed-storage.html)
+for platform details.
+
+Enable it with a single setting:
+
+```yaml
+provider:
+  deploymentBucket:
+    codeStorageMode: reference # default: copy
+```
+
+The Framework handles the AWS requirements automatically:
+
+- Each deployment pins every function and layer to the exact S3 object
+  version that was uploaded, so later uploads to the same keys never
+  affect what runs.
+- On the Framework-managed deployment bucket, the required bucket policy
+  (Lambda service read access, scoped to your account) is added
+  automatically. The bucket is already versioned.
+- If your service uses the in-stack deployment bucket (see [Deploying an
+  Existing Service Without Compose](#2-deploying-an-existing-service-without-compose)
+  above), enable `deploymentBucket.versioning: true` — reference mode
+  requires a versioned bucket, and packaging reports an error if versioning
+  is not enabled. The Framework adds the required Lambda read access to the
+  bucket policy it already manages in your stack (with `skipPolicySetup`,
+  managing that statement is up to you).
+- If you bring your own bucket (`deploymentBucket.name`), versioning must be
+  enabled or the deployment stops with an error. The bucket policy is also
+  checked: if the bucket has no policy at all, the deployment stops with an
+  error that includes the exact statement to add; if a policy exists but
+  does not appear to grant the Lambda service read access, a warning with
+  that statement is printed instead. Either way, your bucket configuration
+  is never modified.
+- Rollbacks are reference-aware: `serverless rollback` and
+  `serverless rollback function` restore functions from their pinned S3
+  objects. `serverless deploy function` is a development-cycle command that
+  bypasses CloudFormation; it updates the function with Lambda-managed
+  storage, and the function returns to reference mode on the next
+  `serverless deploy` (see the note about out-of-band code updates below).
+
+### Artifact retention in reference mode
+
+In reference mode, deployment artifacts back your live Lambda versions, so
+the automatic post-deploy cleanup of old deployments is disabled —
+deployments are retained until you retire the versions that use them. With
+the default `versionFunctions: true`, each deployment publishes a new
+function version that keeps its artifact in use, so the deployment bucket
+listing and `serverless deploy list` grow over time until those versions are
+pruned. `prune` is the retention lever in reference mode.
+
+Retirement is handled by the `prune` command: it deletes old function and
+layer versions, and with `--includeArtifacts` it also marks deployment
+artifacts that no longer back any surviving version. Artifacts that still
+back a version — including versions kept for aliases or older versions still
+in use — are always retained. Use `--dryRun` to preview. The sweep is not
+limited to reference mode; it also runs in the default copy mode, which is
+useful for retiring artifact directories left behind by earlier reference-mode
+deployments after switching back.
+
+If you publish function versions or layers and have confirmed that versions
+beyond a certain age are no longer used (no aliases point at them, and no
+consumers invoke them by qualified ARN), you can automate retention:
+
+```yaml
+custom:
+  prune:
+    automatic: true
+    number: 10
+    includeLayers: true
+    includeArtifacts: true
+```
+
+On a versioned bucket — which the Framework-managed bucket always is, and
+which reference mode requires — the `--includeArtifacts` sweep only writes S3
+delete markers: it hides the matched artifacts and destroys nothing. (On an
+unversioned custom bucket, where the sweep can also run in copy mode, those
+deletions are permanent, matching how the automatic post-deploy cleanup
+behaves there.) Actual storage is reclaimed by an S3
+lifecycle rule that expires noncurrent object versions (for example,
+`NoncurrentVersionExpiration`, optionally with `ExpiredObjectDeleteMarker` to
+clean up the leftover markers afterward). This pairs safely with the sweep:
+a pinned artifact stays the current version of its key, so a
+noncurrent-version rule never touches an artifact that still backs a live
+version. See the
+[S3 lifecycle documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+for rule syntax.
+
+When reclaiming storage yourself, delete markers (what the sweep writes) are
+the safe operation; avoid hard-deleting individual object versions or
+overwriting existing objects under the deployment prefix. Removing the specific object version that a live function
+is pinned to does not fail right away — invocations can keep succeeding for a
+while, and the function still reports `Active` — but the function stops
+working, with no advance signal, once Lambda next refreshes the code from its
+source. Let the lifecycle rule reclaim noncurrent versions instead.
+
+### Switching back to copy mode
+
+If you remove `codeStorageMode: reference` (or set it to `copy`), new
+deployments return to Lambda-managed storage — but function versions
+published while reference mode was active continue to run their code
+directly from the deployment bucket, and the regular artifact cleanup
+becomes active again. Before switching back, retire old reference-mode
+versions with `serverless prune`, or keep them in mind when managing the
+bucket. The Framework prints a reminder on the next deploy after switching
+back — it reads the previous deployment's recorded storage mode to decide
+whether to show it. Because that reminder is produced during change
+detection, `serverless deploy --force` skips it.
+
+### Notes
+
+- Reference mode applies to zip-packaged functions and layers. Container
+  image functions continue to use Amazon ECR.
+- The Lambda console code editor is not available for reference-mode
+  functions (AWS limitation).
+- `serverless package` output is finalized during `serverless deploy`, when
+  the uploaded artifacts' S3 object versions are known.
+- `serverless deploy` always restates the storage mode. If a function's code
+  is updated without specifying the storage mode — for example
+  `aws lambda update-function-code`, a console upload, or
+  `serverless deploy function` — that function returns to Lambda-managed
+  storage, and the next `serverless deploy` restores reference mode. A deploy
+  that reports no changes does not run, so the mode switch persists until a
+  deploy actually runs (`serverless deploy --force` deploys unconditionally).
+- Service rollbacks are more dependable in reference mode: each deployment
+  pins its functions and layers to exact S3 object versions, so rolling back
+  to an earlier deployment restores exactly the code that deployment ran.
+
 ## Cleanup and Maintenance
 
 When a service is removed using the `serverless remove` command, the deployment artifacts stored in the Deployment Bucket are also cleaned up.

--- a/docs/sf/providers/aws/cli-reference/deploy-function.md
+++ b/docs/sf/providers/aws/cli-reference/deploy-function.md
@@ -33,7 +33,9 @@ serverless deploy function -f functionName
 **Note:** This command **now** deploys both function configuration and code by
 default. Just as before, this puts your function in an inconsistent state that
 is out of sync with your CloudFormation stack. Use this for faster development
-cycles and not production deployments
+cycles and not production deployments. With `codeStorageMode: reference`, this
+command updates the function using Lambda-managed storage; the next
+`serverless deploy` restores reference mode.
 
 ## Options
 

--- a/docs/sf/providers/aws/cli-reference/prune.md
+++ b/docs/sf/providers/aws/cli-reference/prune.md
@@ -27,8 +27,13 @@ serverless prune -n <number>
 - `--function` or `-f` Limit pruning to a specific function.
 - `--layer` or `-l` Limit pruning to a specific layer.
 - `--includeLayers` or `-i` Include layers in pruning.
+- `--includeArtifacts` or `-a` Also mark deployment artifacts that no longer back any function or layer version. Skipped on `--function`/`--layer` scoped runs.
 - `--dryRun` or `-d` Preview what would be deleted without deleting.
 - `--verbose` Enable detailed output.
+
+## Layer Version Protection
+
+When pruning layers, a layer version that is still attached to an existing version of one of this service's own functions is retained, even if it falls outside the retained `--number`. This is derived from your local service configuration. Attachments from other services or accounts cannot be detected and remain your responsibility to manage.
 
 ## Provided lifecycle events
 
@@ -65,3 +70,11 @@ serverless prune -n 3 --includeLayers
 ```bash
 serverless prune -n 3 -l myLayer
 ```
+
+### Also mark unreferenced deployment artifacts
+
+```bash
+serverless prune -n 3 --includeArtifacts
+```
+
+See [Artifact retention in reference mode](../../../guides/deployment-bucket#artifact-retention-in-reference-mode) for how this interacts with self-managed code storage.

--- a/docs/sf/providers/aws/guide/prune.md
+++ b/docs/sf/providers/aws/guide/prune.md
@@ -36,15 +36,21 @@ custom:
     automatic: true # Prune after each deploy
     number: 3 # Keep 3 most recent versions
     includeLayers: true # Also prune layer versions
+    includeArtifacts: true # Also mark deployment artifacts no longer backed by any version
 ```
 
 ### Configuration Options
 
-| Option          | Type    | Default | Description                                         |
-| --------------- | ------- | ------- | --------------------------------------------------- |
-| `automatic`     | boolean | `false` | Enable automatic pruning after deploy               |
-| `number`        | integer | -       | Number of versions to keep (required for automatic) |
-| `includeLayers` | boolean | `false` | Include Lambda layers in pruning                    |
+| Option             | Type    | Default | Description                                                    |
+| ------------------ | ------- | ------- | -------------------------------------------------------------- |
+| `automatic`        | boolean | `false` | Enable automatic pruning after deploy                          |
+| `number`           | integer | -       | Number of versions to keep (required for automatic)            |
+| `includeLayers`    | boolean | `false` | Include Lambda layers in pruning                               |
+| `includeArtifacts` | boolean | `false` | Also mark deployment artifacts no longer backed by any version |
+
+`includeArtifacts` is most useful when using self-managed code storage, where deployment artifacts back live Lambda versions and are retained until pruned. The sweep works in any storage mode. In the default copy mode the automatic post-deploy cleanup already enforces the `maxPreviousDeploymentArtifacts` retention window, so a steady-state sweep usually finds nothing new; there it is mainly useful for retiring artifact directories left over from earlier reference-mode deployments after switching back to copy mode. See [Artifact retention in reference mode](../../../guides/deployment-bucket#artifact-retention-in-reference-mode) for the full retention story.
+
+The artifact sweep learns which functions and layers to protect from your local service configuration, so run `prune --includeArtifacts` with the same service configuration that produced those deployments. The sweep also honors `provider.deploymentBucket.maxPreviousDeploymentArtifacts` (default `5`) as an unconditional retention window: the newest N deployments are always kept, whether or not their artifacts are still pinned. In reference mode the deploy-time artifact cleanup does not run, so this retention window applies only during the sweep.
 
 ## Manual Pruning
 
@@ -65,11 +71,20 @@ serverless prune -n 3 -l myLayer
 
 # Prune functions and layers
 serverless prune -n 3 --includeLayers
+
+# Also mark unreferenced deployment artifacts (most useful in reference mode)
+serverless prune -n 3 --includeArtifacts
 ```
 
 ## Alias Protection
 
 Versions that are referenced by Lambda aliases will **never** be deleted, regardless of the `number` setting. This ensures stable deployments and traffic shifting configurations remain intact.
+
+## Layer Version Protection
+
+When pruning layers (`--includeLayers` or `-l`), a layer version that is still attached to an existing version of one of this service's own functions is retained even if it falls outside the `number` window. This protection is derived from your local service configuration, which is another reason to run `prune` with the same configuration that produced the deployments.
+
+Attachments from other services or accounts cannot be detected, so layer versions consumed only by functions outside this service remain your responsibility to manage.
 
 ## Dry Run Mode
 

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -319,6 +319,9 @@ provider:
     skipPolicySetup: true
     # Enable bucket versioning (default: false)
     versioning: true
+    # Use Lambda's self-managed S3 code storage instead of Lambda-managed storage (default: copy)
+    # See: https://www.serverless.com/framework/docs/guides/deployment-bucket#code-storage-mode-self-managed-lambda-code-storage
+    codeStorageMode: reference
     # Server-side encryption method
     serverSideEncryption: AES256
     # For server-side encryption

--- a/packages/serverless/lib/cli/commands-schema.js
+++ b/packages/serverless/lib/cli/commands-schema.js
@@ -610,6 +610,13 @@ commands.set('prune', {
       required: false,
       type: 'boolean',
     },
+    includeArtifacts: {
+      usage:
+        'Boolean flag. Also mark deployment artifacts that no longer back any function or layer version.',
+      shortcut: 'a',
+      required: false,
+      type: 'boolean',
+    },
     dryRun: {
       usage:
         'Simulate pruning without executing delete actions. Deletion candidates are logged when used in conjunction with --verbose',

--- a/packages/serverless/lib/plugins/aws/deploy/index.js
+++ b/packages/serverless/lib/plugins/aws/deploy/index.js
@@ -16,9 +16,11 @@ import uploadZipFile from '../lib/upload-zip-file.js'
 import createStack from './lib/create-stack.js'
 import cleanupS3Bucket from './lib/cleanup-s3-bucket.js'
 import uploadArtifacts from './lib/upload-artifacts.js'
+import patchReferenceObjectVersions from './lib/patch-reference-object-versions.js'
 import validateTemplate from './lib/validate-template.js'
 import updateStack from '../lib/update-stack.js'
 import ensureValidBucketExists from './lib/ensure-valid-bucket-exists.js'
+import ensureReferenceCodeStorage from './lib/ensure-reference-code-storage.js'
 import path from 'path'
 import { log, progress, style } from '@serverless/util'
 import memoize from 'memoizee'
@@ -45,7 +47,9 @@ class AwsDeploy {
       checkForChanges,
       cleanupS3Bucket,
       ensureValidBucketExists,
+      ensureReferenceCodeStorage,
       uploadArtifacts,
+      patchReferenceObjectVersions,
       validateTemplate,
       updateStack,
       monitorStack,
@@ -178,6 +182,7 @@ class AwsDeploy {
 
       'aws:deploy:deploy:checkForChanges': async () => {
         await this.ensureValidBucketExists()
+        await this.ensureReferenceCodeStoragePrereqs()
         await this.checkForChanges()
         if (this.serverless.service.provider.shouldNotDeploy) return
 

--- a/packages/serverless/lib/plugins/aws/deploy/lib/check-for-changes.js
+++ b/packages/serverless/lib/plugins/aws/deploy/lib/check-for-changes.js
@@ -33,9 +33,10 @@ export default {
           this.getFunctionsEarliestLastModifiedDate(),
         ])
       })
-      .then(([objMetadata, lastModifiedDate]) =>
-        this.checkIfDeploymentIsNecessary(objMetadata, lastModifiedDate),
-      )
+      .then(([objMetadata, lastModifiedDate]) => {
+        this.warnOnReferenceModeSwitchBack()
+        return this.checkIfDeploymentIsNecessary(objMetadata, lastModifiedDate)
+      })
       .then(() => {
         if (this.serverless.service.provider.shouldNotDeploy) {
           return Promise.resolve()
@@ -128,6 +129,33 @@ export default {
     return Promise.all(
       objects.map(async (obj) => {
         try {
+          const isStateFile = obj.Key.endsWith(
+            `/${this.provider.naming.getServiceStateFileName()}`,
+          )
+          if (isStateFile) {
+            const result = await this.provider.request('S3', 'getObject', {
+              Bucket: this.bucketName,
+              Key: obj.Key,
+            })
+            try {
+              // AWS Node SDK v3 S3 GetObject returns a stream-like body
+              // exposing `transformToString()`; AWS Node SDK v2 (used by
+              // this request path today) returns a Buffer/string directly.
+              // Normalize to string before JSON.parse to support both.
+              const body = result.Body
+              const text =
+                body && typeof body.transformToString === 'function'
+                  ? await body.transformToString()
+                  : Buffer.isBuffer(body)
+                    ? body.toString()
+                    : String(body)
+              this.previousDeploymentState = JSON.parse(text)
+            } catch {
+              this.previousDeploymentState = null
+            }
+            result.Key = obj.Key
+            return result
+          }
           const result = await this.provider.request('S3', 'headObject', {
             Bucket: this.bucketName,
             Key: obj.Key,
@@ -147,6 +175,21 @@ export default {
           throw err
         }
       }),
+    )
+  },
+
+  warnOnReferenceModeSwitchBack() {
+    if (this.provider.isReferenceCodeStorageMode()) return
+    const previousMode =
+      this.previousDeploymentState?.service?.provider?.deploymentBucketObject
+        ?.codeStorageMode
+    if (previousMode !== 'reference') return
+    log.warning(
+      'This service previously deployed with "codeStorageMode: reference". ' +
+        'Older function versions may still run code directly from the deployment bucket, ' +
+        'and regular artifact cleanup is now active again. ' +
+        'Run "serverless prune" to retire old reference-mode versions, or restore "codeStorageMode: reference". ' +
+        'See the deployment bucket documentation for details.',
     )
   },
 
@@ -234,6 +277,34 @@ export default {
         }),
       ),
     )
+
+    // In reference mode a reused layer's zip is uploaded only once (to the
+    // deployment directory of the deploy that first produced it) and is never
+    // re-uploaded on subsequent deploys. Once the newest remote directory is one
+    // of those later, reuse-only deploys, it does not contain the layer zip — yet
+    // the local `.serverless/**.zip` glob still picks it up, so the local set
+    // carries one extra hash with no remote counterpart and the sorted-array
+    // comparison below can never match, permanently preventing no-change skips.
+    // Drop each reused layer's artifact (`artifactAlreadyUploaded === true`) from
+    // the local set, but only when its hash is genuinely absent from the remote
+    // set — when the newest remote directory still carries the layer zip (e.g. the
+    // baseline is the fresh-layer deploy), keeping it preserves a valid match.
+    // This only ever removes local-side entries whose reused byte-identical code
+    // is already deployed, so it can never cause a false skip: the remaining
+    // artifacts (template, state, service zips) still must hash-equal.
+    const remoteHashValues = new Set(remoteHashesMap.values())
+    for (const layerName of this.serverless.service.getAllLayers()) {
+      if (!this.serverless.service.getLayer(layerName).artifactAlreadyUploaded)
+        continue
+      const layerArtifactPath = path.resolve(
+        this.serverless.serviceDir,
+        this.provider.resolveLayerArtifactName(layerName),
+      )
+      const layerHash = localHashesMap.get(layerArtifactPath)
+      if (layerHash !== undefined && !remoteHashValues.has(layerHash)) {
+        localHashesMap.delete(layerArtifactPath)
+      }
+    }
 
     // If any objects were changed after the last time the function was updated
     // there could have been a failed deploy.

--- a/packages/serverless/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js
+++ b/packages/serverless/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js
@@ -49,11 +49,19 @@ export default {
     if (this.serverless.service.provider.deploymentWithEmptyChangeSet) {
       log.info('Removing unnecessary service artifacts from S3')
       await this.cleanupArtifactsForEmptyChangeSet()
-    } else {
-      log.info('Removing old service artifacts from S3')
-      const objectsToRemove = await this.getObjectsToRemove()
-      await this.removeObjects(objectsToRemove)
+      return
     }
+    if (this.provider.isReferenceCodeStorageMode()) {
+      // Reference mode: deployment artifacts back live Lambda versions.
+      // Retirement is handled by "serverless prune --includeArtifacts".
+      log.info(
+        'Skipping deployment artifact cleanup (codeStorageMode: reference). Use "serverless prune --includeArtifacts" to retire old versions and their artifacts.',
+      )
+      return
+    }
+    log.info('Removing old service artifacts from S3')
+    const objectsToRemove = await this.getObjectsToRemove()
+    await this.removeObjects(objectsToRemove)
   },
 
   async cleanupArtifactsForEmptyChangeSet() {

--- a/packages/serverless/lib/plugins/aws/deploy/lib/ensure-reference-code-storage.js
+++ b/packages/serverless/lib/plugins/aws/deploy/lib/ensure-reference-code-storage.js
@@ -1,0 +1,146 @@
+import ServerlessError from '../../../../serverless-error.js'
+import { log } from '@serverless/util'
+
+const POLICY_SID = 'ServerlessLambdaSelfManagedCodeAccess'
+
+export default {
+  /**
+   * Reference code storage prerequisites, run after setBucketName():
+   * - framework-owned global bucket: ensure the Lambda-read bucket policy
+   *   statement exists (merge by Sid, never clobbers other statements)
+   * - custom user bucket: hands-off — hard-fail if unversioned, best-effort
+   *   warn if the policy is readable and lacks the Lambda grant
+   * - legacy in-stack bucket: handled in the compiled template
+   *   (generate-core-template.js), nothing to do at deploy time
+   */
+  async ensureReferenceCodeStoragePrereqs() {
+    if (!this.provider.isReferenceCodeStorageMode()) return
+
+    if (this.serverless.service.provider.deploymentBucket) {
+      await this.validateCustomBucketForReferenceMode()
+      return
+    }
+    if (this.globalDeploymentBucketUsed) {
+      await this.ensureGlobalBucketReferencePolicy()
+    }
+  },
+
+  buildReferencePolicyStatement(accountId) {
+    return {
+      Sid: POLICY_SID,
+      Effect: 'Allow',
+      Principal: { Service: 'lambda.amazonaws.com' },
+      Action: ['s3:GetObject', 's3:GetObjectVersion'],
+      Resource: `arn:aws:s3:::${this.bucketName}/*`,
+      Condition: { StringEquals: { 'aws:SourceAccount': accountId } },
+    }
+  },
+
+  async ensureGlobalBucketReferencePolicy() {
+    let policy = { Version: '2012-10-17', Statement: [] }
+    try {
+      const result = await this.provider.request('S3', 'getBucketPolicy', {
+        Bucket: this.bucketName,
+      })
+      policy = JSON.parse(result.Policy)
+    } catch (error) {
+      const isNoSuchBucketPolicy =
+        error.providerError?.code === 'NoSuchBucketPolicy' ||
+        error.code === 'AWS_S3_GET_BUCKET_POLICY_NO_SUCH_BUCKET_POLICY'
+      if (!isNoSuchBucketPolicy) throw error
+    }
+    if (!Array.isArray(policy.Statement)) {
+      policy.Statement = policy.Statement ? [policy.Statement] : []
+    }
+    if (policy.Statement.some((statement) => statement.Sid === POLICY_SID)) {
+      return
+    }
+    policy.Statement.push(
+      this.buildReferencePolicyStatement(await this.provider.getAccountId()),
+    )
+    await this.provider.request('S3', 'putBucketPolicy', {
+      Bucket: this.bucketName,
+      Policy: JSON.stringify(policy),
+    })
+    log.info(
+      `Granted the Lambda service read access to deployment bucket "${this.bucketName}" (self-managed code storage)`,
+    )
+  },
+
+  async validateCustomBucketForReferenceMode() {
+    const versioning = await this.provider.request(
+      'S3',
+      'getBucketVersioning',
+      { Bucket: this.bucketName },
+    )
+    if (versioning.Status !== 'Enabled') {
+      throw new ServerlessError(
+        `Deployment bucket "${this.bucketName}" must have versioning enabled to use "codeStorageMode: reference". ` +
+          'Enable versioning on the bucket, or remove the codeStorageMode setting.',
+        'REFERENCE_MODE_BUCKET_NOT_VERSIONED',
+      )
+    }
+
+    // Best-effort policy check — the framework never mutates user-owned buckets
+    let result
+    try {
+      result = await this.provider.request('S3', 'getBucketPolicy', {
+        Bucket: this.bucketName,
+      })
+    } catch (error) {
+      const isNoSuchBucketPolicy =
+        error.providerError?.code === 'NoSuchBucketPolicy' ||
+        error.code === 'AWS_S3_GET_BUCKET_POLICY_NO_SUCH_BUCKET_POLICY'
+      if (!isNoSuchBucketPolicy) {
+        // Cannot read the policy for some other reason (e.g. AccessDenied) —
+        // skip silently (best effort).
+        return
+      }
+      const statementJson = JSON.stringify(
+        this.buildReferencePolicyStatement(await this.provider.getAccountId()),
+        null,
+        2,
+      )
+      throw new ServerlessError(
+        `Deployment bucket "${this.bucketName}" has no bucket policy. "codeStorageMode: reference" requires ` +
+          'the Lambda service to be able to read artifacts directly from this bucket. Add a bucket policy ' +
+          `statement granting it read access, for example:\n${statementJson}`,
+        'REFERENCE_MODE_BUCKET_POLICY_MISSING',
+      )
+    }
+
+    const policy = JSON.parse(result.Policy)
+    const statements = Array.isArray(policy.Statement)
+      ? policy.Statement
+      : [policy.Statement]
+    const grantsLambdaRead = statements.some((statement) => {
+      if (statement?.Effect !== 'Allow') return false
+      const principals = [statement.Principal?.Service ?? []].flat()
+      // Exact principal match (not a substring check): each entry is an IAM
+      // service principal identifier, compared in full.
+      if (
+        !principals.some((principal) => principal === 'lambda.amazonaws.com')
+      ) {
+        return false
+      }
+      const actions = [statement.Action ?? []].flat()
+      return (
+        actions.includes('s3:GetObject') ||
+        actions.includes('s3:Get*') ||
+        actions.includes('s3:*')
+      )
+    })
+    if (!grantsLambdaRead) {
+      const statementJson = JSON.stringify(
+        this.buildReferencePolicyStatement(await this.provider.getAccountId()),
+        null,
+        2,
+      )
+      log.warning(
+        `Deployment bucket "${this.bucketName}" policy does not appear to grant the Lambda service read access, ` +
+          'which "codeStorageMode: reference" requires. Add a statement like:\n' +
+          statementJson,
+      )
+    }
+  },
+}

--- a/packages/serverless/lib/plugins/aws/deploy/lib/patch-reference-object-versions.js
+++ b/packages/serverless/lib/plugins/aws/deploy/lib/patch-reference-object-versions.js
@@ -1,0 +1,80 @@
+import path from 'path'
+import ServerlessError from '../../../../serverless-error.js'
+
+export default {
+  /**
+   * After artifact uploads, pin every REFERENCE-mode function/layer resource
+   * in the compiled template to the exact S3 object version that was just
+   * uploaded. Must run BEFORE the compiled template is uploaded to S3 —
+   * CloudFormation consumes the template via TemplateURL.
+   */
+  patchReferenceObjectVersions(artifactVersionIds) {
+    const template =
+      this.serverless.service.provider.compiledCloudFormationTemplate
+
+    const resolveVersionId = (s3Key, resourceLogicalId) => {
+      const versionId = artifactVersionIds[path.basename(s3Key)]
+      if (!versionId) {
+        throw new ServerlessError(
+          `Could not resolve the S3 object version for "${s3Key}" (resource "${resourceLogicalId}"). ` +
+            'Reference code storage mode requires a versioned deployment bucket. ' +
+            'Verify that versioning is enabled on the deployment bucket.',
+          'REFERENCE_MODE_MISSING_S3_OBJECT_VERSION',
+        )
+      }
+      return versionId
+    }
+
+    // Functions
+    Object.entries(template.Resources).forEach(([logicalId, resource]) => {
+      if (
+        resource.Type === 'AWS::Lambda::Function' &&
+        resource.Properties?.Code?.S3ObjectStorageMode === 'REFERENCE' &&
+        resource.Properties.Code.S3Key
+      ) {
+        resource.Properties.Code.S3ObjectVersion = resolveVersionId(
+          resource.Properties.Code.S3Key,
+          logicalId,
+        )
+      }
+    })
+
+    // Layers (via service layer registry — resource logical ids may carry a
+    // retain-hash suffix, and each layer has a matching S3ObjectVersion output)
+    this.serverless.service.getAllLayers().forEach((layerName) => {
+      const layerObject = this.serverless.service.getLayer(layerName)
+      // Reused, unchanged layers already carry the previous deployment's
+      // pinned version (set by compareWithLastLayer) — leave them alone.
+      if (layerObject.artifactAlreadyUploaded) return
+
+      const layerLogicalId =
+        this.provider.naming.getLambdaLayerLogicalId(layerName)
+      const [resolvedLogicalId, layerResource] =
+        Object.entries(template.Resources).find(
+          ([logicalId, resource]) =>
+            resource.Type === 'AWS::Lambda::LayerVersion' &&
+            logicalId.startsWith(layerLogicalId),
+        ) || []
+      if (
+        !layerResource ||
+        layerResource.Properties?.Content?.S3ObjectStorageMode !== 'REFERENCE'
+      ) {
+        return
+      }
+
+      const versionId = resolveVersionId(
+        layerResource.Properties.Content.S3Key,
+        resolvedLogicalId,
+      )
+      layerResource.Properties.Content.S3ObjectVersion = versionId
+
+      const outputLogicalId =
+        this.provider.naming.getLambdaLayerS3ObjectVersionOutputLogicalId(
+          layerName,
+        )
+      if (template.Outputs?.[outputLogicalId]) {
+        template.Outputs[outputLogicalId].Value = versionId
+      }
+    })
+  },
+}

--- a/packages/serverless/lib/plugins/aws/deploy/lib/upload-artifacts.js
+++ b/packages/serverless/lib/plugins/aws/deploy/lib/upload-artifacts.js
@@ -39,6 +39,18 @@ export default {
       progress.get('main').notice(`Uploading (0/${artifactFilePaths.length})`)
     }
 
+    if (this.provider.isReferenceCodeStorageMode()) {
+      // Reference mode: the compiled template must contain the uploaded
+      // artifacts' S3 object versions, so zips go first and the template
+      // (consumed by CloudFormation via TemplateURL) goes last.
+      const artifactVersionIds = await this.uploadFunctionsAndLayers()
+      await this.uploadCustomResources()
+      this.patchReferenceObjectVersions(artifactVersionIds)
+      await this.uploadCloudFormationFile()
+      await this.uploadStateFile()
+      return
+    }
+
     await this.uploadCloudFormationFile()
     await this.uploadStateFile()
     await this.uploadFunctionsAndLayers()
@@ -259,13 +271,17 @@ export default {
         return result
       },
     )
-    const uploadPromises = artifactFilePaths.map((filename) =>
-      limitedUpload({
+    const uploadPromises = artifactFilePaths.map(async (filename) => {
+      const result = await limitedUpload({
         filename,
         s3KeyDirname: this.serverless.service.package.artifactDirectoryName,
-      }),
+      })
+      return [path.basename(filename), result && result.VersionId]
+    })
+    const uploaded = await Promise.all(uploadPromises)
+    return Object.fromEntries(
+      uploaded.filter(([, versionId]) => versionId != null),
     )
-    await Promise.all(uploadPromises)
   },
 
   async uploadCustomResources() {

--- a/packages/serverless/lib/plugins/aws/lib/naming.js
+++ b/packages/serverless/lib/plugins/aws/lib/naming.js
@@ -279,6 +279,9 @@ export default {
   getLambdaLayerS3KeyOutputLogicalId(layerName) {
     return `${this.getLambdaLayerLogicalId(layerName)}S3Key`
   },
+  getLambdaLayerS3ObjectVersionOutputLogicalId(layerName) {
+    return `${this.getLambdaLayerLogicalId(layerName)}S3ObjectVersion`
+  },
 
   // Websockets API
   getWebsocketsApiName() {

--- a/packages/serverless/lib/plugins/aws/lib/normalize-files.js
+++ b/packages/serverless/lib/plugins/aws/lib/normalize-files.js
@@ -33,6 +33,7 @@ export default {
       ) {
         const newVal = value
         newVal.Properties.Code.S3Key = ''
+        delete newVal.Properties.Code.S3ObjectVersion
       }
       if (
         value.Type &&
@@ -41,6 +42,7 @@ export default {
       ) {
         const newVal = value
         newVal.Properties.Content.S3Key = ''
+        delete newVal.Properties.Content.S3ObjectVersion
       }
     })
 

--- a/packages/serverless/lib/plugins/aws/package/compile/functions.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/functions.js
@@ -519,6 +519,9 @@ class AwsCompileFunctions {
       functionResource.Properties.Code.S3Key = `${
         this.serverless.service.package.artifactDirectoryName
       }/${path.basename(artifactFilePath)}`
+      if (this.provider.isReferenceCodeStorageMode()) {
+        functionResource.Properties.Code.S3ObjectStorageMode = 'REFERENCE'
+      }
       functionResource.Properties.Runtime = functionObject.runtime
     } else {
       functionResource.Properties.Code.ImageUri = functionImageUri
@@ -902,6 +905,14 @@ class AwsCompileFunctions {
       // Include function and layer configuration details in the version id hash
       for (const layerConfig of layerConfigurations) {
         delete layerConfig.properties.Content.S3Key
+        // In reference mode the layer-reuse path (compareWithLastLayer) pins
+        // `Content.S3ObjectVersion` on the layer resource at compile time. That
+        // property is absent on the first deploy (fresh layer) and present on
+        // later deploys (reused layer) for identical code, which would otherwise
+        // churn the Lambda Version logical id and defeat no-change skips. Exclude
+        // it from the digest. `S3ObjectStorageMode` is intentionally NOT excluded
+        // so a genuine storage-mode change still rotates versions.
+        delete layerConfig.properties.Content.S3ObjectVersion
       }
 
       const functionProperties = _.cloneDeep(functionResource.Properties)

--- a/packages/serverless/lib/plugins/aws/package/compile/layers.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/layers.js
@@ -40,6 +40,10 @@ class AwsCompileLayers {
     const s3FileName = path.basename(artifactFilePath)
     newLayer.Properties.Content.S3Key = `${s3Folder}/${s3FileName}`
 
+    if (this.provider.isReferenceCodeStorageMode()) {
+      newLayer.Properties.Content.S3ObjectStorageMode = 'REFERENCE'
+    }
+
     newLayer.Properties.LayerName = layerObject.name || layerName
     if (layerObject.description) {
       newLayer.Properties.Description = layerObject.description
@@ -119,13 +123,28 @@ class AwsCompileLayers {
       const newLayerS3KeyOutput = this.cfOutputLayerS3KeyTemplate()
       newLayerS3KeyOutput.Value = newLayer.Properties.Content.S3Key
 
+      const layerOutputs = {
+        [layerOutputLogicalId]: newLayerOutput,
+        [layerHashOutputLogicalId]: newLayerHashOutput,
+        [layerS3KeyOutputLogicalId]: newLayerS3KeyOutput,
+      }
+
+      if (this.provider.isReferenceCodeStorageMode()) {
+        const layerS3ObjectVersionOutputLogicalId =
+          this.provider.naming.getLambdaLayerS3ObjectVersionOutputLogicalId(
+            layerName,
+          )
+        layerOutputs[layerS3ObjectVersionOutputLogicalId] = {
+          Description: 'Current Lambda layer S3ObjectVersion',
+          // Placeholder — the real S3 object version is patched in during
+          // deploy, after the artifact upload returns its VersionId.
+          Value: 'S3ObjectVersion',
+        }
+      }
+
       _.merge(
         this.serverless.service.provider.compiledCloudFormationTemplate.Outputs,
-        {
-          [layerOutputLogicalId]: newLayerOutput,
-          [layerHashOutputLogicalId]: newLayerHashOutput,
-          [layerS3KeyOutputLogicalId]: newLayerS3KeyOutput,
-        },
+        layerOutputs,
       )
     })
   }
@@ -151,6 +170,21 @@ class AwsCompileLayers {
             return
           }
 
+          let lastS3ObjectVersion
+          if (this.provider.isReferenceCodeStorageMode()) {
+            const layerS3ObjectVersionOutputLogicalId =
+              this.provider.naming.getLambdaLayerS3ObjectVersionOutputLogicalId(
+                layerName,
+              )
+            lastS3ObjectVersion = data.Stacks[0].Outputs.find(
+              (output) =>
+                output.OutputKey === layerS3ObjectVersionOutputLogicalId,
+            )
+            // Previous deployment has no pinned object version (it predates
+            // reference mode) — re-upload instead of reusing.
+            if (!lastS3ObjectVersion) return
+          }
+
           const layerS3keyOutputLogicalId =
             this.provider.naming.getLambdaLayerS3KeyOutputLogicalId(layerName)
           const lastS3Key = data.Stacks[0].Outputs.find(
@@ -167,6 +201,19 @@ class AwsCompileLayers {
               `${layerLogicalId}${lastHash.OutputValue}`
             ]
           layerResource.Properties.Content.S3Key = lastS3Key.OutputValue
+
+          if (lastS3ObjectVersion) {
+            const layerS3ObjectVersionOutputLogicalId =
+              this.provider.naming.getLambdaLayerS3ObjectVersionOutputLogicalId(
+                layerName,
+              )
+            compiledCloudFormationTemplate.Outputs[
+              layerS3ObjectVersionOutputLogicalId
+            ].Value = lastS3ObjectVersion.OutputValue
+            layerResource.Properties.Content.S3ObjectVersion =
+              lastS3ObjectVersion.OutputValue
+          }
+
           const layerObject = this.serverless.service.getLayer(layerName)
           layerObject.artifactAlreadyUploaded = true
           log.info(`Layer ${layerName} is already uploaded.`)

--- a/packages/serverless/lib/plugins/aws/package/lib/generate-core-template.js
+++ b/packages/serverless/lib/plugins/aws/package/lib/generate-core-template.js
@@ -1,5 +1,6 @@
 import path from 'path'
 import _ from 'lodash'
+import { log } from '@serverless/util'
 import ServerlessError from '../../../../serverless-error.js'
 
 export default {
@@ -128,6 +129,52 @@ export default {
       }
 
       return
+    }
+
+    // Reference code storage with the legacy in-stack bucket: the bucket must
+    // be versioned (Lambda pins exact object versions), and the Lambda
+    // service principal needs read access via the bucket policy.
+    if (this.provider.isReferenceCodeStorageMode()) {
+      if (
+        !deploymentBucketObject ||
+        deploymentBucketObject.versioning !== true
+      ) {
+        throw new ServerlessError(
+          '"codeStorageMode: reference" with the in-stack deployment bucket requires "deploymentBucket.versioning: true".',
+          'REFERENCE_MODE_LEGACY_BUCKET_VERSIONING_REQUIRED',
+        )
+      }
+      const deploymentBucketPolicyLogicalId =
+        this.provider.naming.getDeploymentBucketPolicyLogicalId()
+      const policyResource =
+        this.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources[deploymentBucketPolicyLogicalId]
+      if (policyResource) {
+        policyResource.Properties.PolicyDocument.Statement.push({
+          Sid: 'ServerlessLambdaSelfManagedCodeAccess',
+          Effect: 'Allow',
+          Principal: { Service: 'lambda.amazonaws.com' },
+          Action: ['s3:GetObject', 's3:GetObjectVersion'],
+          Resource: {
+            'Fn::Join': [
+              '',
+              [
+                'arn:aws:s3:::',
+                { Ref: this.provider.naming.getDeploymentBucketLogicalId() },
+                '/*',
+              ],
+            ],
+          },
+          Condition: {
+            StringEquals: { 'aws:SourceAccount': { Ref: 'AWS::AccountId' } },
+          },
+        })
+      } else {
+        // skipPolicySetup removed the policy resource — the user owns it
+        log.warning(
+          '"codeStorageMode: reference" with "skipPolicySetup: true": make sure your deployment bucket policy grants the Lambda service principal s3:GetObject and s3:GetObjectVersion.',
+        )
+      }
     }
 
     if (isS3TransferAccelerationEnabled && isS3TransferAccelerationSupported) {

--- a/packages/serverless/lib/plugins/aws/package/lib/get-hash-for-file-path.js
+++ b/packages/serverless/lib/plugins/aws/package/lib/get-hash-for-file-path.js
@@ -1,9 +1,12 @@
 import memoize from 'memoizee'
 import crypto from 'crypto'
 import fs from 'fs'
+import fsp from 'fs/promises'
 
-const getHashForFilePath = memoize(
-  async (filePath) => {
+const hashFileContents = memoize(
+  // cacheKey embeds the file's mtime and size so a rewritten artifact at the
+  // same path (e.g. repeated in-process deploys) never reuses a stale hash.
+  async (cacheKey, filePath) => {
     const fileHash = crypto.createHash('sha256')
     fileHash.setEncoding('base64')
     return new Promise((resolve, reject) => {
@@ -25,7 +28,15 @@ const getHashForFilePath = memoize(
         })
     })
   },
-  { promise: true },
+  { promise: true, length: 1 },
 )
+
+const getHashForFilePath = async (filePath) => {
+  const stats = await fsp.stat(filePath)
+  return hashFileContents(
+    `${filePath}:${stats.mtimeMs}:${stats.size}`,
+    filePath,
+  )
+}
 
 export default getHashForFilePath

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -1696,6 +1696,13 @@ deploymentBucket:
 @default false`,
                       type: 'boolean',
                     },
+                    codeStorageMode: {
+                      description: `Lambda code storage mode for functions and layers deployed from this bucket.
+'copy' (default) uploads a copy of your code to Lambda-managed storage. 'reference' configures Lambda to run your code directly from the deployment bucket (self-managed S3 code storage): code no longer counts against the Lambda storage quota and deploys activate faster, but deployment artifacts become live infrastructure managed via the prune command.
+@default 'copy'
+@see https://docs.aws.amazon.com/lambda/latest/dg/configuration-self-managed-storage.html`,
+                      enum: ['copy', 'reference'],
+                    },
                     skipPolicySetup: {
                       description: `Skip automatic deployment bucket policy setup.`,
                       type: 'boolean',
@@ -3440,6 +3447,13 @@ destinations:
 
   getProfile() {
     return this.getProfileSourceValue()
+  }
+
+  isReferenceCodeStorageMode() {
+    return (
+      this.serverless.service.provider.deploymentBucketObject
+        ?.codeStorageMode === 'reference'
+    )
   }
 
   async getServerlessDeploymentBucketName() {

--- a/packages/serverless/lib/plugins/aws/rollback-function.js
+++ b/packages/serverless/lib/plugins/aws/rollback-function.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import ServerlessError from '../../serverless-error.js'
 import validate from './lib/validate.js'
 import { log, progress, style } from '@serverless/util'
@@ -13,12 +14,16 @@ class AwsRollbackFunction {
     Object.assign(this, validate)
 
     this.hooks = {
-      'rollback:function:rollback': async () =>
-        Promise.resolve(this)
-          .then(() => this.validate())
-          .then(() => this.getFunctionToBeRestored())
-          .then(() => this.fetchFunctionCode())
-          .then(() => this.restoreFunction()),
+      'rollback:function:rollback': async () => {
+        await this.validate()
+        const func = await this.getFunctionToBeRestored()
+        if (func.Code && func.Code.ResolvedS3Object) {
+          await this.restoreReferenceFunction(func.Code.ResolvedS3Object)
+          return
+        }
+        const zipBuffer = await this.fetchFunctionCode(func)
+        await this.restoreFunction(zipBuffer)
+      },
     }
   }
 
@@ -42,24 +47,34 @@ class AwsRollbackFunction {
       Qualifier: funcVersion,
     }
 
-    return this.provider
-      .request('Lambda', 'getFunction', params)
-      .then((func) => func)
-      .catch((error) => {
-        if (error.message.match(/not found/)) {
-          const errorMessage = [
-            `Function "${funcName}" with version "${funcVersion}" not found.`,
-            ` Please check if you've deployed "${funcName}"`,
-            ` and version "${funcVersion}" is available for this function.`,
-            ' Please check the docs for more info.',
-          ].join('')
-          throw new ServerlessError(errorMessage, 'AWS_FUNCTION_NOT_FOUND')
-        }
-        throw new ServerlessError(
-          `Cannot resolve function "${funcName}": ${error.message}`,
-          'AWS_FUNCTION_NOT_ACCESIBLE',
-        )
-      })
+    return (
+      this.provider
+        // The response's Code.ResolvedS3Object field (used to detect
+        // reference-mode functions below) is unknown to the frozen v2
+        // `aws-sdk` Lambda API model, which silently drops it. Mode must be
+        // detected FROM the response, so this call always uses the v3 SDK
+        // path, regardless of which mode the target function is actually in.
+        .request('Lambda', 'getFunction', params, { sdkVersion: 3 })
+        .then((func) => func)
+        .catch((error) => {
+          if (
+            error.message.match(/not found/) ||
+            _.get(error, 'providerError.code') === 'ResourceNotFoundException'
+          ) {
+            const errorMessage = [
+              `Function "${funcName}" with version "${funcVersion}" not found.`,
+              ` Please check if you've deployed "${funcName}"`,
+              ` and version "${funcVersion}" is available for this function.`,
+              ' Please check the docs for more info.',
+            ].join('')
+            throw new ServerlessError(errorMessage, 'AWS_FUNCTION_NOT_FOUND')
+          }
+          throw new ServerlessError(
+            `Cannot resolve function "${funcName}": ${error.message}`,
+            'AWS_FUNCTION_NOT_ACCESIBLE',
+          )
+        })
+    )
   }
 
   async fetchFunctionCode(func) {
@@ -84,7 +99,7 @@ class AwsRollbackFunction {
       .request('Lambda', 'updateFunctionCode', params)
       .then(() => {
         log.notice()
-        log.notice.success(
+        log.success(
           `Successfully rolled back function ${funcName} to version "${
             this.options['function-version']
           }" ${style.aside(
@@ -95,6 +110,37 @@ class AwsRollbackFunction {
           )}`,
         )
       })
+  }
+
+  async restoreReferenceFunction(resolvedS3Object) {
+    const funcName = this.options.function
+    const funcObj = this.serverless.service.getFunction(funcName)
+
+    const params = {
+      FunctionName: funcObj.name,
+      S3Bucket: resolvedS3Object.S3Bucket,
+      S3Key: resolvedS3Object.S3Key,
+      S3ObjectVersion: resolvedS3Object.S3ObjectVersion,
+      S3ObjectStorageMode: 'REFERENCE',
+    }
+
+    // S3ObjectStorageMode is unknown to the frozen v2 `aws-sdk` Lambda API
+    // model and is rejected client-side, so this call must use the v3 SDK
+    // path.
+    await this.provider.request('Lambda', 'updateFunctionCode', params, {
+      sdkVersion: 3,
+    })
+    log.notice()
+    log.success(
+      `Successfully rolled back function ${funcName} to version "${
+        this.options['function-version']
+      }" ${style.aside(
+        `(${Math.floor(
+          (Date.now() - this.serverless.pluginManager.commandRunStartTime) /
+            1000,
+        )}s)`,
+      )}`,
+    )
   }
 }
 

--- a/packages/serverless/lib/plugins/prune/artifact-sweep.js
+++ b/packages/serverless/lib/plugins/prune/artifact-sweep.js
@@ -1,0 +1,161 @@
+import path from 'path'
+import findAndGroupDeployments from '../aws/utils/find-and-group-deployments.js'
+
+export const buildPinnedShaSet = (functionVersionLists) => {
+  const set = new Set()
+  for (const versions of functionVersionLists) {
+    for (const version of versions) {
+      if (version.CodeSha256) set.add(version.CodeSha256)
+    }
+  }
+  return set
+}
+
+export const collectLayerArns = (functionVersionLists, layerVersionLists) => {
+  const arns = new Set()
+  for (const versions of functionVersionLists) {
+    for (const version of versions) {
+      for (const layer of version.Layers || []) {
+        if (layer.Arn) arns.add(layer.Arn)
+      }
+    }
+  }
+  for (const layerVersions of layerVersionLists) {
+    for (const layerVersion of layerVersions) {
+      if (layerVersion.LayerVersionArn) arns.add(layerVersion.LayerVersionArn)
+    }
+  }
+  return arns
+}
+
+export const layerBasenameFromArn = (arn) => {
+  // arn:aws:lambda:<region>:<account>:layer:<name>:<version>
+  const parts = arn.split(':')
+  return `${parts[6]}.zip`
+}
+
+const listAllObjects = async (ctx) => {
+  const contents = []
+  let continuationToken
+  do {
+    const result = await ctx.provider.request('S3', 'listObjectsV2', {
+      Bucket: ctx.bucketName,
+      Prefix: `${ctx.deploymentPrefix}/${ctx.service}/${ctx.stage}`,
+      ...(continuationToken && { ContinuationToken: continuationToken }),
+    })
+    contents.push(...(result.Contents || []))
+    continuationToken = result.IsTruncated
+      ? result.NextContinuationToken
+      : undefined
+  } while (continuationToken)
+  return { Contents: contents }
+}
+
+/**
+ * Marker-only sweep: applies plain deleteObjects (delete markers on a
+ * versioned bucket — never hard-deletes, and never targets a specific
+ * VersionId) to deployment directories that are beyond the retention window
+ * AND provably unpinned. Any uncertainty (missing metadata, unreadable
+ * object) keeps the directory.
+ */
+export const sweepArtifacts = async (ctx) => {
+  const listing = await listAllObjects(ctx)
+  const groups = findAndGroupDeployments(
+    listing,
+    ctx.deploymentPrefix,
+    ctx.service,
+    ctx.stage,
+  )
+  // groups follow S3 listing order (real listObjectsV2 returns keys in
+  // lexicographic ascending order, so for timestamped deployment
+  // directories that means oldest first, newest last — see
+  // lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js for the same
+  // slice(0, -keepCount) precedent); the last keepCount groups are the
+  // retention window and are never inspected or swept.
+  const candidates =
+    ctx.keepCount > 0 ? groups.slice(0, -ctx.keepCount) : groups
+
+  const markedDirs = []
+  const keptDirs = []
+  const keysToMark = []
+
+  for (const group of candidates) {
+    const dir = group[0].directory
+    const dirPrefix = `${ctx.deploymentPrefix}/${ctx.service}/${ctx.stage}/${dir}`
+    const zipEntries = group.filter((entry) => entry.file.endsWith('.zip'))
+    const reasons = []
+
+    if (zipEntries.length === 0) {
+      // no artifact to prove unpinned against — uncertainty keeps the dir
+      reasons.push('no artifact files found in directory (fail-safe pin)')
+    }
+
+    for (const entry of zipEntries) {
+      const key = `${dirPrefix}/${entry.file}`
+      const basename = path.basename(entry.file)
+
+      if (ctx.layerBasenameFailSafePins.has(basename)) {
+        reasons.push(`layer artifact "${basename}" (fail-safe pin)`)
+        continue
+      }
+
+      let head
+      try {
+        head = await ctx.provider.request('S3', 'headObject', {
+          Bucket: ctx.bucketName,
+          Key: key,
+        })
+      } catch {
+        reasons.push(`could not read "${basename}" — kept (fail-safe)`)
+        continue
+      }
+
+      const sha = head && head.Metadata && head.Metadata.filesha256
+      if (!sha) {
+        reasons.push(`"${basename}" has no filesha256 metadata (fail-safe pin)`)
+        continue
+      }
+      if (ctx.pinnedShas.has(sha)) {
+        reasons.push(`"${basename}" backs a surviving function version`)
+        continue
+      }
+      if (ctx.layerPins.has(key)) {
+        const pinnedVersionId = ctx.layerPins.get(key)
+        if (pinnedVersionId === null || pinnedVersionId === head.VersionId) {
+          reasons.push(`"${basename}" backs a surviving layer version`)
+          continue
+        }
+      }
+    }
+
+    if (reasons.length > 0) {
+      keptDirs.push({ dir, reasons })
+      continue
+    }
+
+    markedDirs.push(dir)
+    for (const entry of group) {
+      keysToMark.push({ Key: `${dirPrefix}/${entry.file}` })
+    }
+  }
+
+  if (!ctx.dryRun && keysToMark.length > 0) {
+    // marker-only: plain deleteObjects, never a VersionId — this creates
+    // delete markers on the versioned bucket rather than hard-deleting.
+    // Batches of up to 1000 keys (the S3 deleteObjects limit). Never calls
+    // deleteObjects with an empty Objects array — that's an S3 API error.
+    const batchSize = 1000
+    const batches = []
+    for (let i = 0; i < keysToMark.length; i += batchSize) {
+      batches.push(keysToMark.slice(i, i + batchSize))
+    }
+    for (const batch of batches) {
+      await ctx.provider.request('S3', 'deleteObjects', {
+        Bucket: ctx.bucketName,
+        Delete: { Objects: batch },
+      })
+    }
+  }
+
+  return { markedDirs, keptDirs }
+}

--- a/packages/serverless/lib/plugins/prune/index.js
+++ b/packages/serverless/lib/plugins/prune/index.js
@@ -9,8 +9,15 @@
  * See THIRD_PARTY_LICENSES in the repository root for the full license text.
  */
 
+import path from 'path'
 import cliCommandsSchema from '../../cli/commands-schema.js'
 import { log } from '@serverless/util'
+import {
+  buildPinnedShaSet,
+  collectLayerArns,
+  layerBasenameFromArn,
+  sweepArtifacts,
+} from './artifact-sweep.js'
 
 class Prune {
   constructor(serverless, options, { log: pluginLog, progress } = {}) {
@@ -38,6 +45,9 @@ class Prune {
             includeLayers: {
               type: 'boolean',
             },
+            includeArtifacts: {
+              type: 'boolean',
+            },
           },
           additionalProperties: false,
         },
@@ -54,6 +64,55 @@ class Prune {
       'prune:prune': this.cliPrune.bind(this),
       'after:deploy:deploy': this.postDeploy.bind(this),
     }
+
+    // What THIS run deleted — or, under --dryRun, would have deleted —
+    // keyed by function/layer name. Used by sweepDeploymentArtifacts() to
+    // discount those versions so the sweep previews the post-prune world:
+    // on a real run that's discounting versions Lambda's eventually-
+    // consistent list APIs may still return moments after deletion; under
+    // --dryRun (where nothing is actually deleted and nothing is recorded
+    // by the delete methods) it's discounting the versions that WOULD be
+    // gone, so `--dryRun --includeArtifacts` previews the sweep against
+    // planned deletions instead of reporting every still-alive directory as
+    // pinned. Reset at the start of every cliPrune()/postDeploy() run so
+    // dryRun and repeated runs never leak state across runs (see
+    // resetPrunedVersionTracking()).
+    this.resetPrunedVersionTracking()
+  }
+
+  resetPrunedVersionTracking() {
+    this.prunedFunctionVersions = new Map()
+    this.prunedLayerVersions = new Map()
+    // Per-run memo backing getFunctionVersionLists(). Reset here (same
+    // place as the pruned-version maps above) so dryRun and repeated
+    // cliPrune()/postDeploy() runs never reuse a stale listVersionsByFunction
+    // fetch from a previous run.
+    this._functionVersionListsPromise = null
+  }
+
+  // Lazily fetches, and memoizes for the lifetime of this run, the version
+  // listing for every function in the service. pruneFunctions() (when not
+  // scoped to a single --function) and pruneLayers()'s attached-layer-set
+  // builder both need this same "every function's versions" listing, and
+  // cliPrune()/postDeploy() run pruneFunctions() and pruneLayers()
+  // concurrently via Promise.all under --includeLayers — without sharing
+  // this fetch, a combined run would call listVersionsByFunction twice per
+  // function. The cache is reset at the start of every
+  // cliPrune()/postDeploy() run, see resetPrunedVersionTracking().
+  //
+  // CRITICAL: sweepDeploymentArtifacts() must NOT use this cache. It
+  // intentionally re-lists functions fresh, after deletions, because it
+  // needs the post-prune view — see the comment at the top of that method.
+  getFunctionVersionLists() {
+    if (!this._functionVersionListsPromise) {
+      const functionNames = this.serverless.service
+        .getAllFunctions()
+        .map((key) => this.serverless.service.getFunction(key).name)
+      this._functionVersionListsPromise = Promise.all(
+        functionNames.map((name) => this.listVersionForFunction(name)),
+      ).then((versionLists) => ({ functionNames, versionLists }))
+    }
+    return this._functionVersionListsPromise
   }
 
   getNumber() {
@@ -75,29 +134,37 @@ class Prune {
       if (typeof custom.prune.includeLayers === 'boolean') {
         pluginCustom.includeLayers = custom.prune.includeLayers
       }
+
+      if (typeof custom.prune.includeArtifacts === 'boolean') {
+        pluginCustom.includeArtifacts = custom.prune.includeArtifacts
+      }
     }
 
     return pluginCustom
   }
 
   async cliPrune() {
+    this.resetPrunedVersionTracking()
+
     if (this.options.dryRun) {
       this.logNotice('Dry-run enabled, no pruning actions will be performed.')
     }
 
     if (this.options.includeLayers) {
       await Promise.all([this.pruneFunctions(), this.pruneLayers()])
-      return
-    }
-
-    if (this.options.layer && !this.options.function) {
+    } else if (this.options.layer && !this.options.function) {
       await this.pruneLayers()
     } else {
       await this.pruneFunctions()
     }
+
+    if (this.shouldSweepArtifacts()) {
+      await this.sweepDeploymentArtifacts()
+    }
   }
 
   async postDeploy() {
+    this.resetPrunedVersionTracking()
     this.pluginCustom = this.loadCustom(this.serverless.service.custom)
 
     if (this.options.noDeploy === true) {
@@ -111,11 +178,174 @@ class Prune {
     ) {
       if (this.pluginCustom.includeLayers) {
         await Promise.all([this.pruneFunctions(), this.pruneLayers()])
-        return
+      } else {
+        await this.pruneFunctions()
       }
 
-      await this.pruneFunctions()
+      if (this.shouldSweepArtifacts()) {
+        await this.sweepDeploymentArtifacts()
+      }
     }
+  }
+
+  shouldSweepArtifacts() {
+    const requested =
+      this.options.includeArtifacts || this.pluginCustom.includeArtifacts
+    if (!requested) return false
+    if (this.options.function || this.options.layer) {
+      this.logNotice(
+        'Skipping deployment artifact sweep: it is not available on function/layer-scoped prune runs.',
+      )
+      return false
+    }
+    return true
+  }
+
+  async sweepDeploymentArtifacts() {
+    this.createProgress(
+      'prune-plugin-sweep-artifacts',
+      'Sweeping deployment artifacts',
+    )
+
+    // Surviving function versions (post-prune) — fresh lists. Lambda's list
+    // APIs are eventually consistent, so a version this same run just
+    // deleted can still show up here moments later; discount those using
+    // the ground-truth record from deleteVersionsForFunction() rather than
+    // trusting the fresh listing alone.
+    //
+    // Deliberately NOT using the getFunctionVersionLists() memo here: that
+    // cache may hold a pre-prune snapshot (populated by pruneFunctions()
+    // earlier in this same run), while this sweep needs a fresh, post-prune
+    // listing to correctly discount just-deleted versions above.
+    const functionNames = this.serverless.service
+      .getAllFunctions()
+      .map((key) => this.serverless.service.getFunction(key).name)
+    const rawFunctionVersionLists = await Promise.all(
+      functionNames.map((name) => this.listVersionForFunction(name)),
+    )
+    const functionVersionLists = rawFunctionVersionLists.map((versions, i) =>
+      this.excludePrunedVersions(
+        versions,
+        this.prunedFunctionVersions.get(functionNames[i]),
+      ),
+    )
+
+    // Surviving layer versions (post-prune) — fresh lists. Same eventual
+    // consistency caveat as above applies to listLayerVersions.
+    const layerNames = this.serverless.service
+      .getAllLayers()
+      .map((key) => this.serverless.service.getLayer(key).name || key)
+    const rawLayerVersionLists = await Promise.all(
+      layerNames.map((name) => this.listVersionsForLayer(name)),
+    )
+    const layerVersionLists = rawLayerVersionLists.map((versions, i) =>
+      this.excludePrunedVersions(
+        versions,
+        this.prunedLayerVersions.get(layerNames[i]),
+      ),
+    )
+
+    const pinnedShas = buildPinnedShaSet(functionVersionLists)
+    const layerArns = collectLayerArns(functionVersionLists, layerVersionLists)
+
+    // Lazily built (only if a deleted-but-attached ARN is actually
+    // encountered below), memoized map from published Lambda layer name ->
+    // deployment artifact basename, built from this service's layer config.
+    // Needed because deployment artifacts are named after the CONFIG KEY
+    // (see provider.resolveLayerArtifactName / naming.getLayerArtifactName),
+    // not the published layer name — the two only coincide when
+    // `layers.<key>` has no `name:` override. The basename fail-safe
+    // fallback below (an attached ARN whose getLayerVersion call throws,
+    // e.g. deleted-but-still-attached) previously only ever pinned
+    // `<ARN-name>.zip`, which protects nothing when a custom `name:` was
+    // configured. Unknown/unconfigured layer names are simply absent from
+    // this map and fall through to the old ARN-name-only behavior.
+    let layerArtifactBasenameByPublishedName
+    const getLayerArtifactBasenameByPublishedName = () => {
+      if (!layerArtifactBasenameByPublishedName) {
+        layerArtifactBasenameByPublishedName = new Map()
+        for (const key of this.serverless.service.getAllLayers()) {
+          const layerObject = this.serverless.service.getLayer(key)
+          const publishedName = layerObject.name || key
+          const basename = path.basename(
+            this.provider.resolveLayerArtifactName(key),
+          )
+          layerArtifactBasenameByPublishedName.set(publishedName, basename)
+        }
+      }
+      return layerArtifactBasenameByPublishedName
+    }
+
+    // Resolve each surviving/attached layer version to an exact artifact pin;
+    // unresolvable (deleted-but-attached) versions fall back to basename pins.
+    const layerPins = new Map()
+    const layerBasenameFailSafePins = new Set()
+    for (const arn of layerArns) {
+      const parts = arn.split(':')
+      try {
+        // Content.ResolvedS3Object (used for the exact-pin path below) is
+        // unknown to the frozen v2 `aws-sdk` Lambda API model, which
+        // silently drops it and would degrade this to the less precise sha
+        // fallback. Use the v3 SDK path so the exact pin is available.
+        const layerVersion = await this.provider.request(
+          'Lambda',
+          'getLayerVersion',
+          { LayerName: parts[6], VersionNumber: Number(parts[7]) },
+          { sdkVersion: 3 },
+        )
+        const resolved = layerVersion.Content?.ResolvedS3Object
+        if (resolved?.S3Key) {
+          layerPins.set(resolved.S3Key, resolved.S3ObjectVersion ?? null)
+        } else if (layerVersion.Content?.CodeSha256) {
+          pinnedShas.add(layerVersion.Content.CodeSha256)
+        } else {
+          layerBasenameFailSafePins.add(layerBasenameFromArn(arn))
+        }
+      } catch {
+        // Raw ARN-name-derived basename — kept as a belt-and-braces pin
+        // even when the config-key mapping below also applies. Over-pinning
+        // an artifact that isn't actually there is harmless.
+        layerBasenameFailSafePins.add(layerBasenameFromArn(arn))
+        const layerNameFromArn = parts[6]
+        const mappedBasename =
+          getLayerArtifactBasenameByPublishedName().get(layerNameFromArn)
+        if (mappedBasename) {
+          layerBasenameFailSafePins.add(mappedBasename)
+        }
+      }
+    }
+
+    const bucketName = await this.provider.getServerlessDeploymentBucketName()
+    const keepCount =
+      this.serverless.service.provider.deploymentBucketObject
+        ?.maxPreviousDeploymentArtifacts ?? 5
+
+    const { markedDirs, keptDirs } = await sweepArtifacts({
+      provider: this.provider,
+      bucketName,
+      deploymentPrefix: this.provider.getDeploymentPrefix(),
+      service: this.serverless.service.service,
+      stage: this.provider.getStage(),
+      keepCount,
+      pinnedShas,
+      layerPins,
+      layerBasenameFailSafePins,
+      dryRun: Boolean(this.options.dryRun),
+    })
+
+    for (const { dir, reasons } of keptDirs) {
+      this.logInfo(`Keeping deployment ${dir}: ${reasons.join('; ')}`)
+    }
+    for (const dir of markedDirs) {
+      this.logInfo(
+        this.options.dryRun
+          ? `Deployment ${dir} selected for deletion (dry-run).`
+          : `Marked deployment ${dir} for deletion.`,
+      )
+    }
+
+    this.clearProgress('prune-plugin-sweep-artifacts')
+    this.logSuccess('Deployment artifact sweep complete')
   }
 
   async pruneLayers() {
@@ -128,6 +358,37 @@ class Prune {
 
     this.createProgress('prune-plugin-prune-layers', 'Pruning layer versions')
 
+    // Build the set of layer version ARNs currently attached to any
+    // existing version of THIS service's functions (always computed from
+    // ALL service functions, never scoped down to a --layer selection,
+    // since any function can reference any layer). A layer version in this
+    // set must never be deleted, even if it falls outside the retention
+    // window.
+    //
+    // Deliberate superset semantics: cliPrune() runs pruneFunctions() and
+    // pruneLayers() concurrently via Promise.all, so ordering between the
+    // two is undefined. A function version that pruneFunctions() is
+    // deleting in parallel may still show up here as "attached" — that's
+    // fine. Over-protecting a layer version for one prune cycle is safe;
+    // the next prune run converges once the function version is actually
+    // gone.
+    //
+    // Skip this fetch entirely when there is nothing selected to prune —
+    // building the attached set would otherwise cost one
+    // listVersionsByFunction call per service function for zero benefit.
+    let attachedLayerArns = new Set()
+    if (layerNames.length > 0) {
+      const { versionLists: attachedFunctionVersionLists } =
+        await this.getFunctionVersionLists()
+      for (const versions of attachedFunctionVersionLists) {
+        for (const version of versions) {
+          for (const layer of version.Layers || []) {
+            if (layer.Arn) attachedLayerArns.add(layer.Arn)
+          }
+        }
+      }
+    }
+
     const layersData = []
     for (const layerName of layerNames) {
       const versions = await this.listVersionsForLayer(layerName)
@@ -139,7 +400,11 @@ class Prune {
         continue
       }
 
-      const deletionCandidates = this.selectPruneVersionsForLayer(versions)
+      const deletionCandidates = this.selectPruneVersionsForLayer(
+        versions,
+        attachedLayerArns,
+        name,
+      )
       if (deletionCandidates.length > 0) {
         this.updateProgress(
           'prune-plugin-prune-layers',
@@ -149,6 +414,15 @@ class Prune {
 
       if (this.options.dryRun) {
         this.printPruningCandidates(name, deletionCandidates)
+        // Record the planned deletions so a chained --includeArtifacts
+        // sweep previews the post-prune world instead of finding every
+        // still-alive version and reporting the directory as pinned — see
+        // the comment on this.prunedLayerVersions in the constructor.
+        this.recordPlannedPruneVersions(
+          this.prunedLayerVersions,
+          name,
+          deletionCandidates,
+        )
       } else {
         await this.deleteVersionsForLayer(name, deletionCandidates)
       }
@@ -159,7 +433,8 @@ class Prune {
   }
 
   async pruneFunctions() {
-    const selectedFunctions = this.options.function
+    const scopedToOneFunction = Boolean(this.options.function)
+    const selectedFunctions = scopedToOneFunction
       ? [this.options.function]
       : this.serverless.service.getAllFunctions()
     const functionNames = selectedFunctions.map(
@@ -171,10 +446,28 @@ class Prune {
       'Pruning function versions',
     )
 
+    // Unscoped runs (the common case, and the only case that can run
+    // concurrently alongside pruneLayers()'s attached-set builder under
+    // --includeLayers) share the memoized listVersionsByFunction fetch via
+    // getFunctionVersionLists(), so a combined run makes exactly one pass
+    // over the service's functions instead of two. A --function-scoped run
+    // bypasses the memo: it only needs that one function's versions, and
+    // the memo always covers every service function.
+    let versionsByFunctionName
+    if (!scopedToOneFunction) {
+      const { functionNames: allFunctionNames, versionLists } =
+        await this.getFunctionVersionLists()
+      versionsByFunctionName = new Map(
+        allFunctionNames.map((name, i) => [name, versionLists[i]]),
+      )
+    }
+
     const functionsData = []
     for (const functionName of functionNames) {
       const [versions, aliases] = await Promise.all([
-        this.listVersionForFunction(functionName),
+        versionsByFunctionName
+          ? Promise.resolve(versionsByFunctionName.get(functionName))
+          : this.listVersionForFunction(functionName),
         this.listAliasesForFunction(functionName),
       ])
       functionsData.push({ name: functionName, versions, aliases })
@@ -198,6 +491,15 @@ class Prune {
 
       if (this.options.dryRun) {
         this.printPruningCandidates(name, deletionCandidates)
+        // Record the planned deletions so a chained --includeArtifacts
+        // sweep previews the post-prune world instead of finding every
+        // still-alive version and reporting the directory as pinned — see
+        // the comment on this.prunedFunctionVersions in the constructor.
+        this.recordPlannedPruneVersions(
+          this.prunedFunctionVersions,
+          name,
+          deletionCandidates,
+        )
       } else {
         await this.deleteVersionsForFunction(name, deletionCandidates)
       }
@@ -217,6 +519,7 @@ class Prune {
       }
 
       await this.provider.request('Lambda', 'deleteLayerVersion', params)
+      this.recordPrunedVersion(this.prunedLayerVersions, layerName, version)
     }
   }
 
@@ -231,6 +534,11 @@ class Prune {
 
       try {
         await this.provider.request('Lambda', 'deleteFunction', params)
+        this.recordPrunedVersion(
+          this.prunedFunctionVersions,
+          functionName,
+          version,
+        )
       } catch (e) {
         // Ignore if trying to delete replicated lambda edge function
         if (
@@ -249,6 +557,39 @@ class Prune {
         }
       }
     }
+  }
+
+  // Records a qualifier/version so sweepDeploymentArtifacts() can discount
+  // it from the "still alive" listing. On a real run this is called only
+  // after a delete call has NOT thrown (ground truth for what was actually
+  // deleted, discounting Lambda's eventually-consistent list APIs). Under
+  // --dryRun it is called instead by recordPlannedPruneVersions() with the
+  // versions that WOULD be deleted, so the map always reflects "gone in the
+  // post-prune world", real or planned.
+  recordPrunedVersion(map, name, version) {
+    if (!map.has(name)) {
+      map.set(name, new Set())
+    }
+    map.get(name).add(String(version))
+  }
+
+  // dryRun counterpart to deleteVersionsForFunction()/deleteVersionsForLayer():
+  // records planned-but-not-executed deletions into the same map/shape those
+  // methods use, so sweepDeploymentArtifacts()'s excludePrunedVersions() sees
+  // an identical post-prune view whether this was a real or a dry run.
+  recordPlannedPruneVersions(map, name, versions) {
+    for (const version of versions) {
+      this.recordPrunedVersion(map, name, version)
+    }
+  }
+
+  // Filters a fresh version listing down to versions this run did not just
+  // delete. `prunedSet` is undefined when nothing was pruned for this
+  // name (e.g. dryRun, or a function/layer scoped run that never touched
+  // it) — in that case the listing passes through unchanged.
+  excludePrunedVersions(versions, prunedSet) {
+    if (!prunedSet || prunedSet.size === 0) return versions
+    return versions.filter((v) => !prunedSet.has(String(v.Version)))
   }
 
   async listAliasesForFunction(functionName) {
@@ -335,13 +676,36 @@ class Prune {
       .slice(this.getNumber())
   }
 
-  selectPruneVersionsForLayer(versions) {
-    return versions
-      .map((f) => f.Version)
+  selectPruneVersionsForLayer(versions, attachedLayerArns = new Set(), name) {
+    const beyondKeepWindow = versions
+      .slice()
       .sort((a, b) =>
-        parseInt(a) === parseInt(b) ? 0 : parseInt(a) > parseInt(b) ? -1 : 1,
+        parseInt(a.Version) === parseInt(b.Version)
+          ? 0
+          : parseInt(a.Version) > parseInt(b.Version)
+            ? -1
+            : 1,
       )
       .slice(this.getNumber())
+
+    const deletionCandidates = []
+    for (const version of beyondKeepWindow) {
+      if (
+        version.LayerVersionArn &&
+        attachedLayerArns.has(version.LayerVersionArn)
+      ) {
+        // Never delete a layer version still attached to an existing
+        // version of one of this service's functions — see the superset
+        // comment in pruneLayers() for why an over-inclusive attached set
+        // is safe here.
+        this.logInfo(
+          `Retaining layer version ${name}:${version.Version} — attached to existing function versions.`,
+        )
+        continue
+      }
+      deletionCandidates.push(version.Version)
+    }
+    return deletionCandidates
   }
 
   printPruningCandidates(name, deletionCandidates) {

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy-function.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy-function.test.js
@@ -73,6 +73,9 @@ describe('AwsDeployFunction', () => {
         return null
       }),
       getAccountInfo: jest.fn(),
+      isReferenceCodeStorageMode: jest.fn().mockReturnValue(false),
+      getServerlessDeploymentBucketName: jest.fn(),
+      getDeploymentPrefix: jest.fn(),
     })
 
     options = {
@@ -254,6 +257,8 @@ describe('AwsDeployFunction', () => {
           ZipFile: Buffer.from('zip file content'),
         },
       )
+      // Copy mode keeps the default v2 SDK path: no 4th options argument.
+      expect(updateFunctionCodeStub.mock.calls[0]).toHaveLength(3)
     })
 
     it('should deploy the function if the hashes are same but the "force" option is used', async () => {
@@ -273,6 +278,40 @@ describe('AwsDeployFunction', () => {
 
       expect(updateFunctionCodeStub).toHaveBeenCalledTimes(0)
       expect(readFileSyncStub).toHaveBeenCalledTimes(1)
+    })
+
+    describe('reference code storage mode', () => {
+      beforeEach(() => {
+        serverless.service.service = 'my-service'
+        awsDeployFunction.provider.isReferenceCodeStorageMode = jest
+          .fn()
+          .mockReturnValue(true)
+      })
+
+      it('updates the function inline like copy mode, without an S3 upload', async () => {
+        setLocalHash('local-hash-zip-file')
+
+        const requestSpy = awsDeployFunction.provider.request
+
+        await awsDeployFunction.deployFunction()
+
+        const uploadCall = requestSpy.mock.calls.find(
+          ([svc, m]) => svc === 'S3' && m === 'upload',
+        )
+        expect(uploadCall).toBeUndefined()
+
+        const updateCall = requestSpy.mock.calls.find(
+          ([svc, m]) => svc === 'Lambda' && m === 'updateFunctionCode',
+        )
+        expect(updateCall).toBeDefined()
+        expect(updateCall[2]).toEqual({
+          FunctionName: 'first',
+          ZipFile: Buffer.from('zip file content'),
+        })
+        expect(updateCall[2].S3ObjectStorageMode).toBeUndefined()
+        // No 4th options argument: the update stays on the default SDK path.
+        expect(updateCall).toHaveLength(3)
+      })
     })
   })
 

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-object-metadata.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-object-metadata.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, jest } from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: {
+    warning: jest.fn(),
+    get: jest.fn(() => ({ debug: jest.fn() })),
+  },
+}))
+
+const checkForChangesMixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/check-for-changes.js')
+).default
+
+describe('getObjectMetadata', () => {
+  const buildCtx = (requestImpl) => ({
+    ...checkForChangesMixin,
+    bucketName: 'my-bucket',
+    provider: {
+      request: requestImpl,
+      naming: { getServiceStateFileName: () => 'serverless-state.json' },
+    },
+  })
+
+  it('fetches non-state objects via headObject and preserves Key/Metadata', async () => {
+    const request = jest.fn(async (service, method, params) => {
+      expect(service).toBe('S3')
+      expect(method).toBe('headObject')
+      expect(params).toEqual({
+        Bucket: 'my-bucket',
+        Key: 'some/path/my-function.zip',
+      })
+      return { Metadata: { filesha256: 'abc123' } }
+    })
+    const ctx = buildCtx(request)
+
+    const result = await ctx.getObjectMetadata([
+      { Key: 'some/path/my-function.zip' },
+    ])
+
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(result[0].Key).toBe('some/path/my-function.zip')
+    expect(result[0].Metadata.filesha256).toBe('abc123')
+  })
+
+  it('fetches the state-file object via getObject, preserves Key/Metadata, and populates previousDeploymentState from a Buffer body', async () => {
+    const previousState = { service: { provider: { foo: 'bar' } } }
+    const request = jest.fn(async (service, method, params) => {
+      if (params.Key.endsWith('serverless-state.json')) {
+        expect(method).toBe('getObject')
+        return {
+          Metadata: { filesha256: 'state-hash' },
+          Body: Buffer.from(JSON.stringify(previousState)),
+        }
+      }
+      expect(method).toBe('headObject')
+      return { Metadata: { filesha256: 'zip-hash' } }
+    })
+    const ctx = buildCtx(request)
+
+    const result = await ctx.getObjectMetadata([
+      { Key: 'some/path/my-function.zip' },
+      { Key: 'some/path/serverless-state.json' },
+    ])
+
+    const stateEntry = result.find((entry) =>
+      entry.Key.endsWith('serverless-state.json'),
+    )
+    expect(stateEntry.Key).toBe('some/path/serverless-state.json')
+    expect(stateEntry.Metadata.filesha256).toBe('state-hash')
+    expect(ctx.previousDeploymentState).toEqual(previousState)
+  })
+
+  it('populates previousDeploymentState from a v3-style body exposing transformToString', async () => {
+    const previousState = { service: { provider: { baz: 'qux' } } }
+    const request = jest.fn(async () => ({
+      Metadata: { filesha256: 'state-hash' },
+      Body: {
+        transformToString: async () => JSON.stringify(previousState),
+      },
+    }))
+    const ctx = buildCtx(request)
+
+    const result = await ctx.getObjectMetadata([
+      { Key: 'some/path/serverless-state.json' },
+    ])
+
+    expect(result[0].Key).toBe('some/path/serverless-state.json')
+    expect(ctx.previousDeploymentState).toEqual(previousState)
+  })
+
+  it('sets previousDeploymentState to null and does not throw when the body is unparseable', async () => {
+    const request = jest.fn(async () => ({
+      Metadata: { filesha256: 'state-hash' },
+      Body: Buffer.from('not-json'),
+    }))
+    const ctx = buildCtx(request)
+
+    let result
+    await expect(
+      (async () => {
+        result = await ctx.getObjectMetadata([
+          { Key: 'some/path/serverless-state.json' },
+        ])
+      })(),
+    ).resolves.not.toThrow()
+
+    expect(ctx.previousDeploymentState).toBeNull()
+    expect(result[0].Key).toBe('some/path/serverless-state.json')
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-reused-layer.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-reused-layer.test.js
@@ -1,0 +1,149 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: {
+    warning: jest.fn(),
+    get: jest.fn(() => ({ debug: jest.fn() })),
+  },
+}))
+
+const checkForChangesMixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/check-for-changes.js')
+).default
+const normalizeFiles = (
+  await import('../../../../../../../lib/plugins/aws/lib/normalize-files.js')
+).default
+
+const sha256 = (buffer) =>
+  crypto.createHash('sha256').update(buffer).digest('base64')
+
+describe('checkIfDeploymentIsNecessary reused-layer zip exclusion', () => {
+  let tempDir
+  let serverlessDir
+  let template
+  let stateObject
+  let serviceZipPath
+  let commonZipPath
+  // remoteReuseDir: newest remote dir is a reuse-only deploy (lacks the layer zip)
+  // remoteFreshDir: newest remote dir is the fresh-layer deploy (has the layer zip)
+  let remoteReuseDir
+  let remoteFreshDir
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'check-for-changes-reused-layer-'),
+    )
+    serverlessDir = path.join(tempDir, '.serverless')
+    fs.mkdirSync(serverlessDir)
+
+    serviceZipPath = path.join(serverlessDir, 'service.zip')
+    commonZipPath = path.join(serverlessDir, 'common.zip')
+    fs.writeFileSync(serviceZipPath, 'service artifact bytes')
+    fs.writeFileSync(commonZipPath, 'layer artifact bytes')
+
+    template = { Resources: { Foo: { Type: 'AWS::Lambda::Function' } } }
+    stateObject = {
+      service: { service: 'my-service', provider: {} },
+      package: {},
+    }
+    fs.writeFileSync(
+      path.join(serverlessDir, 'serverless-state.json'),
+      JSON.stringify(stateObject),
+    )
+
+    const templateHash = sha256(
+      JSON.stringify(normalizeFiles.normalizeCloudFormationTemplate(template)),
+    )
+    const stateHash = sha256(
+      JSON.stringify(normalizeFiles.normalizeState(stateObject)),
+    )
+    const serviceZipHash = sha256(fs.readFileSync(serviceZipPath))
+    const commonZipHash = sha256(fs.readFileSync(commonZipPath))
+
+    // A reuse-only deployment dir does NOT contain the layer zip.
+    remoteReuseDir = [
+      {
+        Key: 'prefix/compiled-cloudformation-template.json',
+        Metadata: { filesha256: templateHash },
+      },
+      {
+        Key: 'prefix/serverless-state.json',
+        Metadata: { filesha256: stateHash },
+      },
+      {
+        Key: 'prefix/service.zip',
+        Metadata: { filesha256: serviceZipHash },
+      },
+    ]
+    // A fresh-layer deployment dir DOES contain the layer zip.
+    remoteFreshDir = [
+      ...remoteReuseDir,
+      {
+        Key: 'prefix/common.zip',
+        Metadata: { filesha256: commonZipHash },
+      },
+    ]
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  const buildCtx = ({ artifactAlreadyUploaded }) => ({
+    ...checkForChangesMixin,
+    provider: {
+      naming: { getServiceStateFileName: () => 'serverless-state.json' },
+      resolveLayerArtifactName: () => commonZipPath,
+    },
+    serverless: {
+      serviceDir: tempDir,
+      service: {
+        package: {},
+        provider: { compiledCloudFormationTemplate: template },
+        getAllLayers: () => ['common'],
+        getLayer: () => ({
+          package: { artifact: commonZipPath },
+          artifactAlreadyUploaded,
+        }),
+      },
+    },
+  })
+
+  it('skips when the newest remote dir is a reuse-only deploy lacking the layer zip (artifactAlreadyUploaded: true)', async () => {
+    const ctx = buildCtx({ artifactAlreadyUploaded: true })
+    ctx.serverless.service.provider.shouldNotDeploy = false
+
+    await ctx.checkIfDeploymentIsNecessary(remoteReuseDir, new Date())
+
+    expect(ctx.serverless.service.provider.shouldNotDeploy).toBe(true)
+  })
+
+  it('still skips when the newest remote dir is the fresh-layer deploy that carries the layer zip', async () => {
+    const ctx = buildCtx({ artifactAlreadyUploaded: true })
+    ctx.serverless.service.provider.shouldNotDeploy = false
+
+    await ctx.checkIfDeploymentIsNecessary(remoteFreshDir, new Date())
+
+    expect(ctx.serverless.service.provider.shouldNotDeploy).toBe(true)
+  })
+
+  it('does not skip when the layer is genuinely new (artifactAlreadyUploaded falsy) and the layer zip is absent remotely', async () => {
+    const ctx = buildCtx({ artifactAlreadyUploaded: false })
+    ctx.serverless.service.provider.shouldNotDeploy = false
+
+    await ctx.checkIfDeploymentIsNecessary(remoteReuseDir, new Date())
+
+    expect(ctx.serverless.service.provider.shouldNotDeploy).toBe(false)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-switch-back.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-switch-back.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: {
+    warning: jest.fn(),
+    get: jest.fn(() => ({ debug: jest.fn() })),
+  },
+}))
+const { log } = await import('@serverless/util')
+
+const checkForChangesMixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/check-for-changes.js')
+).default
+
+describe('warnOnReferenceModeSwitchBack', () => {
+  beforeEach(() => {
+    log.warning.mockClear()
+  })
+
+  const buildCtx = ({ referenceMode, previousState }) => ({
+    ...checkForChangesMixin,
+    provider: { isReferenceCodeStorageMode: () => referenceMode },
+    previousDeploymentState: previousState,
+  })
+
+  it('warns when the previous deployment used reference mode and current does not', () => {
+    const ctx = buildCtx({
+      referenceMode: false,
+      previousState: {
+        service: {
+          provider: {
+            deploymentBucketObject: { codeStorageMode: 'reference' },
+          },
+        },
+      },
+    })
+    ctx.warnOnReferenceModeSwitchBack()
+    expect(log.warning).toHaveBeenCalledWith(
+      expect.stringContaining('reference'),
+    )
+  })
+
+  it('does not warn when still in reference mode', () => {
+    const ctx = buildCtx({
+      referenceMode: true,
+      previousState: {
+        service: {
+          provider: {
+            deploymentBucketObject: { codeStorageMode: 'reference' },
+          },
+        },
+      },
+    })
+    ctx.warnOnReferenceModeSwitchBack()
+    expect(log.warning).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when the previous deployment was copy mode', () => {
+    const ctx = buildCtx({
+      referenceMode: false,
+      previousState: { service: { provider: {} } },
+    })
+    ctx.warnOnReferenceModeSwitchBack()
+    expect(log.warning).not.toHaveBeenCalled()
+  })
+
+  it('tolerates a missing previous state', () => {
+    const ctx = buildCtx({ referenceMode: false, previousState: null })
+    expect(() => ctx.warnOnReferenceModeSwitchBack()).not.toThrow()
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/cleanup-s3-bucket.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, jest } from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: { info: jest.fn() },
+}))
+
+const cleanupMixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/cleanup-s3-bucket.js')
+).default
+
+const buildCtx = ({ referenceMode, emptyChangeSet = false }) => ({
+  ...cleanupMixin,
+  provider: {
+    isReferenceCodeStorageMode: () => referenceMode,
+    getStage: () => 'dev',
+    getDeploymentPrefix: () => 'serverless',
+    request: jest.fn(async () => ({ Contents: [] })),
+  },
+  bucketName: 'bucket',
+  serverless: {
+    service: {
+      service: 'svc',
+      package: { artifactDirectoryName: 'serverless/svc/dev/123' },
+      provider: { deploymentWithEmptyChangeSet: emptyChangeSet },
+    },
+  },
+})
+
+describe('cleanupS3Bucket — reference mode', () => {
+  it('skips cleanup entirely in reference mode', async () => {
+    const ctx = buildCtx({ referenceMode: true })
+    await ctx.cleanupS3Bucket()
+    expect(ctx.provider.request).not.toHaveBeenCalled()
+  })
+
+  it('still cleans the current deploy artifacts on an empty change set', async () => {
+    const ctx = buildCtx({ referenceMode: true, emptyChangeSet: true })
+    const dir = '1690000000000-2026-07-22T10:00:00.000Z'
+    ctx.serverless.service.package.artifactDirectoryName = `serverless/svc/dev/${dir}`
+    ctx.provider.request = jest.fn(async (service, method) => {
+      if (method === 'listObjectsV2') {
+        return {
+          Contents: [
+            { Key: `serverless/svc/dev/${dir}/compiled-template.json` },
+            { Key: `serverless/svc/dev/${dir}/svc.zip` },
+          ],
+        }
+      }
+      return {}
+    })
+
+    await ctx.cleanupS3Bucket()
+
+    // Lists only the current deploy's directory, and deletes exactly its
+    // objects — never anything from other deployments.
+    expect(ctx.provider.request).toHaveBeenCalledWith('S3', 'listObjectsV2', {
+      Bucket: 'bucket',
+      Prefix: `serverless/svc/dev/${dir}`,
+    })
+    expect(ctx.provider.request).toHaveBeenCalledWith('S3', 'deleteObjects', {
+      Bucket: 'bucket',
+      Delete: {
+        Objects: [
+          { Key: `serverless/svc/dev/${dir}/compiled-template.json` },
+          { Key: `serverless/svc/dev/${dir}/svc.zip` },
+        ],
+      },
+    })
+  })
+
+  it('runs today’s cleanup in copy mode', async () => {
+    const ctx = buildCtx({ referenceMode: false })
+    // Six deployment directories, oldest first; the default retention window
+    // (maxPreviousDeploymentArtifacts: 5) must remove only the oldest one.
+    const dirs = [1, 2, 3, 4, 5, 6].map(
+      (n) => `169000000000${n}-2026-07-22T10:00:0${n}.000Z`,
+    )
+    ctx.provider.request = jest.fn(async (service, method) => {
+      if (method === 'listObjectsV2') {
+        return {
+          Contents: dirs.map((dir) => ({
+            Key: `serverless/svc/dev/${dir}/svc.zip`,
+          })),
+        }
+      }
+      return {}
+    })
+
+    await ctx.cleanupS3Bucket()
+
+    expect(ctx.provider.request).toHaveBeenCalledWith('S3', 'listObjectsV2', {
+      Bucket: 'bucket',
+      Prefix: 'serverless/svc/dev',
+    })
+    expect(ctx.provider.request).toHaveBeenCalledWith('S3', 'deleteObjects', {
+      Bucket: 'bucket',
+      Delete: {
+        Objects: [{ Key: `serverless/svc/dev/${dirs[0]}/svc.zip` }],
+      },
+    })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/ensure-reference-code-storage.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/ensure-reference-code-storage.test.js
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: { info: jest.fn(), warning: jest.fn() },
+}))
+const { log } = await import('@serverless/util')
+
+const mixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/ensure-reference-code-storage.js')
+).default
+
+const buildCtx = ({
+  referenceMode = true,
+  customBucketName = undefined,
+  globalBucketUsed = false,
+  requestImpl,
+} = {}) => ({
+  ...mixin,
+  bucketName:
+    customBucketName || 'serverless-framework-deployments-us-east-1-abc',
+  globalDeploymentBucketUsed: globalBucketUsed,
+  provider: {
+    isReferenceCodeStorageMode: () => referenceMode,
+    getAccountId: async () => '111122223333',
+    request: requestImpl,
+  },
+  serverless: {
+    service: { provider: { deploymentBucket: customBucketName } },
+  },
+})
+
+describe('ensureReferenceCodeStoragePrereqs', () => {
+  it('does nothing in copy mode', async () => {
+    const request = jest.fn()
+    const ctx = buildCtx({ referenceMode: false, requestImpl: request })
+    await ctx.ensureReferenceCodeStoragePrereqs()
+    expect(request).not.toHaveBeenCalled()
+  })
+
+  it('adds the policy statement to the global bucket when missing', async () => {
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketPolicy') {
+        const err = new Error('The bucket policy does not exist')
+        err.code = 'AWS_S3_GET_BUCKET_POLICY_NO_SUCH_BUCKET_POLICY'
+        err.providerError = { code: 'NoSuchBucketPolicy' }
+        throw err
+      }
+      return {}
+    })
+    const ctx = buildCtx({ globalBucketUsed: true, requestImpl: request })
+    await ctx.ensureReferenceCodeStoragePrereqs()
+    const putCall = request.mock.calls.find(([, m]) => m === 'putBucketPolicy')
+    expect(putCall).toBeDefined()
+    const policy = JSON.parse(putCall[2].Policy)
+    const stmt = policy.Statement.find(
+      (s) => s.Sid === 'ServerlessLambdaSelfManagedCodeAccess',
+    )
+    expect(stmt.Principal).toEqual({ Service: 'lambda.amazonaws.com' })
+    expect(stmt.Action).toEqual(['s3:GetObject', 's3:GetObjectVersion'])
+    expect(stmt.Condition).toEqual({
+      StringEquals: { 'aws:SourceAccount': '111122223333' },
+    })
+  })
+
+  it('rethrows non-NoSuchBucketPolicy errors from getBucketPolicy on the global bucket', async () => {
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketPolicy') {
+        throw Object.assign(new Error('Access Denied'), {
+          code: 'AWS_S3_GET_BUCKET_POLICY_ACCESS_DENIED',
+          providerError: { code: 'AccessDenied' },
+        })
+      }
+      return {}
+    })
+    const ctx = buildCtx({ globalBucketUsed: true, requestImpl: request })
+    await expect(ctx.ensureReferenceCodeStoragePrereqs()).rejects.toThrow(
+      'Access Denied',
+    )
+    expect(
+      request.mock.calls.find(([, m]) => m === 'putBucketPolicy'),
+    ).toBeUndefined()
+  })
+
+  it('is idempotent — leaves an existing statement (and others) alone', async () => {
+    const existing = {
+      Version: '2012-10-17',
+      Statement: [
+        { Sid: 'SomethingElse', Effect: 'Deny' },
+        { Sid: 'ServerlessLambdaSelfManagedCodeAccess', Effect: 'Allow' },
+      ],
+    }
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketPolicy')
+        return { Policy: JSON.stringify(existing) }
+      return {}
+    })
+    const ctx = buildCtx({ globalBucketUsed: true, requestImpl: request })
+    await ctx.ensureReferenceCodeStoragePrereqs()
+    expect(
+      request.mock.calls.find(([, m]) => m === 'putBucketPolicy'),
+    ).toBeUndefined()
+  })
+
+  it('hard-fails on a custom bucket without versioning', async () => {
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketVersioning') return {}
+      return {}
+    })
+    const ctx = buildCtx({
+      customBucketName: 'my-bucket',
+      requestImpl: request,
+    })
+    await expect(ctx.ensureReferenceCodeStoragePrereqs()).rejects.toThrow(
+      /versioning/,
+    )
+  })
+
+  it('warns (does not fail) on a custom bucket whose policy lacks the Lambda grant', async () => {
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketVersioning') return { Status: 'Enabled' }
+      if (method === 'getBucketPolicy')
+        return {
+          Policy: JSON.stringify({ Version: '2012-10-17', Statement: [] }),
+        }
+      return {}
+    })
+    const ctx = buildCtx({
+      customBucketName: 'my-bucket',
+      requestImpl: request,
+    })
+    await ctx.ensureReferenceCodeStoragePrereqs()
+    expect(log.warning).toHaveBeenCalled()
+    expect(log.warning.mock.calls[0][0]).toContain('111122223333')
+    expect(log.warning.mock.calls[0][0]).not.toContain('<your-account-id>')
+    expect(
+      request.mock.calls.find(([, m]) => m === 'putBucketPolicy'),
+    ).toBeUndefined()
+  })
+
+  it('hard-fails on a custom bucket with no policy at all (NoSuchBucketPolicy)', async () => {
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketVersioning') return { Status: 'Enabled' }
+      if (method === 'getBucketPolicy') {
+        const err = new Error('The bucket policy does not exist')
+        err.code = 'AWS_S3_GET_BUCKET_POLICY_NO_SUCH_BUCKET_POLICY'
+        err.providerError = { code: 'NoSuchBucketPolicy' }
+        throw err
+      }
+      return {}
+    })
+    const ctx = buildCtx({
+      customBucketName: 'my-bucket',
+      requestImpl: request,
+    })
+    let caught
+    try {
+      await ctx.ensureReferenceCodeStoragePrereqs()
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeDefined()
+    expect(caught.code).toBe('REFERENCE_MODE_BUCKET_POLICY_MISSING')
+    expect(caught.message).toContain('my-bucket')
+    expect(caught.message).toContain('lambda.amazonaws.com')
+    expect(
+      request.mock.calls.find(([, m]) => m === 'putBucketPolicy'),
+    ).toBeUndefined()
+  })
+
+  it('does not warn when the custom bucket policy already grants Lambda read access', async () => {
+    log.warning.mockClear()
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketVersioning') return { Status: 'Enabled' }
+      if (method === 'getBucketPolicy')
+        return {
+          Policy: JSON.stringify({
+            Version: '2012-10-17',
+            Statement: [
+              // Denied grant with the right principal/action — must not count.
+              {
+                Effect: 'Deny',
+                Principal: { Service: 'lambda.amazonaws.com' },
+                Action: ['s3:GetObject'],
+              },
+              // The actual grant.
+              {
+                Effect: 'Allow',
+                Principal: { Service: 'lambda.amazonaws.com' },
+                Action: ['s3:GetObject', 's3:GetObjectVersion'],
+              },
+            ],
+          }),
+        }
+      return {}
+    })
+    const ctx = buildCtx({
+      customBucketName: 'my-bucket',
+      requestImpl: request,
+    })
+    await ctx.ensureReferenceCodeStoragePrereqs()
+    expect(log.warning).not.toHaveBeenCalled()
+  })
+
+  it('wraps a non-array Statement into an array before appending, on the global bucket', async () => {
+    const existingSingleStatement = {
+      Version: '2012-10-17',
+      Statement: { Sid: 'SomethingElse', Effect: 'Allow' },
+    }
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketPolicy')
+        return { Policy: JSON.stringify(existingSingleStatement) }
+      return {}
+    })
+    const ctx = buildCtx({ globalBucketUsed: true, requestImpl: request })
+    await ctx.ensureReferenceCodeStoragePrereqs()
+    const putCall = request.mock.calls.find(([, m]) => m === 'putBucketPolicy')
+    expect(putCall).toBeDefined()
+    const policy = JSON.parse(putCall[2].Policy)
+    expect(Array.isArray(policy.Statement)).toBe(true)
+    expect(policy.Statement).toHaveLength(2)
+    expect(policy.Statement[0]).toEqual({
+      Sid: 'SomethingElse',
+      Effect: 'Allow',
+    })
+    expect(
+      policy.Statement.find(
+        (s) => s.Sid === 'ServerlessLambdaSelfManagedCodeAccess',
+      ),
+    ).toBeDefined()
+  })
+
+  it('stays silent when it cannot read the custom bucket policy', async () => {
+    const request = jest.fn(async (service, method) => {
+      if (method === 'getBucketVersioning') return { Status: 'Enabled' }
+      if (method === 'getBucketPolicy') {
+        const err = new Error('Access Denied')
+        err.code = 'AWS_S3_GET_BUCKET_POLICY_ACCESS_DENIED'
+        err.providerError = { code: 'AccessDenied' }
+        throw err
+      }
+      return {}
+    })
+    const ctx = buildCtx({
+      customBucketName: 'my-bucket',
+      requestImpl: request,
+    })
+    await expect(
+      ctx.ensureReferenceCodeStoragePrereqs(),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/patch-reference-object-versions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/patch-reference-object-versions.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from '@jest/globals'
+
+const patchMixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/patch-reference-object-versions.js')
+).default
+
+describe('patchReferenceObjectVersions', () => {
+  let ctx
+
+  beforeEach(() => {
+    ctx = {
+      ...patchMixin,
+      provider: {
+        naming: {
+          getLambdaLayerLogicalId: (name) =>
+            `${name[0].toUpperCase()}${name.slice(1)}LambdaLayer`,
+          getLambdaLayerS3ObjectVersionOutputLogicalId: (name) =>
+            `${name[0].toUpperCase()}${name.slice(1)}LambdaLayerS3ObjectVersion`,
+        },
+      },
+      serverless: {
+        service: {
+          getAllLayers: () => ['common'],
+          getLayer: () => ({}),
+          provider: {
+            compiledCloudFormationTemplate: {
+              Resources: {
+                HelloLambdaFunction: {
+                  Type: 'AWS::Lambda::Function',
+                  Properties: {
+                    Code: {
+                      S3Bucket: 'bucket',
+                      S3Key: 'serverless/svc/dev/123/svc.zip',
+                      S3ObjectStorageMode: 'REFERENCE',
+                    },
+                  },
+                },
+                CopyModeLambdaFunction: {
+                  Type: 'AWS::Lambda::Function',
+                  Properties: {
+                    Code: {
+                      S3Bucket: 'bucket',
+                      S3Key: 'serverless/svc/dev/123/svc.zip',
+                    },
+                  },
+                },
+                CommonLambdaLayer: {
+                  Type: 'AWS::Lambda::LayerVersion',
+                  Properties: {
+                    Content: {
+                      S3Bucket: 'bucket',
+                      S3Key: 'serverless/svc/dev/123/common.zip',
+                      S3ObjectStorageMode: 'REFERENCE',
+                    },
+                  },
+                },
+              },
+              Outputs: {
+                CommonLambdaLayerS3ObjectVersion: { Value: 'S3ObjectVersion' },
+              },
+            },
+          },
+        },
+      },
+    }
+  })
+
+  it('patches function Code and layer Content + output from the version map', () => {
+    ctx.patchReferenceObjectVersions({
+      'svc.zip': 'fnVersion1',
+      'common.zip': 'layerVersion1',
+    })
+    const { Resources, Outputs } =
+      ctx.serverless.service.provider.compiledCloudFormationTemplate
+    expect(Resources.HelloLambdaFunction.Properties.Code.S3ObjectVersion).toBe(
+      'fnVersion1',
+    )
+    expect(
+      Resources.CopyModeLambdaFunction.Properties.Code.S3ObjectVersion,
+    ).toBeUndefined()
+    expect(Resources.CommonLambdaLayer.Properties.Content.S3ObjectVersion).toBe(
+      'layerVersion1',
+    )
+    expect(Outputs.CommonLambdaLayerS3ObjectVersion.Value).toBe('layerVersion1')
+  })
+
+  it('skips layers whose artifact was reused from a previous deployment', () => {
+    ctx.serverless.service.getLayer = () => ({ artifactAlreadyUploaded: true })
+    ctx.serverless.service.provider.compiledCloudFormationTemplate.Resources.CommonLambdaLayer.Properties.Content.S3ObjectVersion =
+      'reusedVersion'
+    ctx.patchReferenceObjectVersions({ 'svc.zip': 'fnVersion1' })
+    expect(
+      ctx.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        .CommonLambdaLayer.Properties.Content.S3ObjectVersion,
+    ).toBe('reusedVersion')
+  })
+
+  it('skips a layer resource that is not in REFERENCE storage mode (copy-mode layer)', () => {
+    // Copy-mode layer: no S3ObjectStorageMode on Content at all, and no
+    // versionId provided for its artifact — must not throw and must not be
+    // touched, even though the layer is still registered in the service.
+    delete ctx.serverless.service.provider.compiledCloudFormationTemplate
+      .Resources.CommonLambdaLayer.Properties.Content.S3ObjectStorageMode
+    expect(() =>
+      ctx.patchReferenceObjectVersions({ 'svc.zip': 'fnVersion1' }),
+    ).not.toThrow()
+    const { Resources, Outputs } =
+      ctx.serverless.service.provider.compiledCloudFormationTemplate
+    expect(
+      Resources.CommonLambdaLayer.Properties.Content.S3ObjectVersion,
+    ).toBeUndefined()
+    expect(Outputs.CommonLambdaLayerS3ObjectVersion.Value).toBe(
+      'S3ObjectVersion',
+    )
+  })
+
+  it('throws when a REFERENCE resource has no VersionId (unversioned bucket)', () => {
+    expect(() =>
+      ctx.patchReferenceObjectVersions({ 'common.zip': 'layerVersion1' }),
+    ).toThrow(/S3 object version/)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/upload-artifacts-order.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/upload-artifacts-order.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+
+const uploadArtifactsMixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/upload-artifacts.js')
+).default
+
+const buildCtx = ({ referenceMode }) => {
+  const calls = []
+  return {
+    ctx: {
+      ...uploadArtifactsMixin,
+      provider: { isReferenceCodeStorageMode: () => referenceMode },
+      serverless: {
+        service: {
+          package: { artifactDirectoryName: 'serverless/svc/dev/123' },
+          provider: {},
+        },
+        utils: { fileExistsSync: () => false },
+      },
+      getFunctionArtifactFilePaths: async () => ['/tmp/svc.zip'],
+      getLayerArtifactFilePaths: () => [],
+      getFileStats: async () => ({ size: 10 }),
+      uploadCloudFormationFile: jest.fn(async () => calls.push('template')),
+      uploadStateFile: jest.fn(async () => calls.push('state')),
+      uploadFunctionsAndLayers: jest.fn(async () => {
+        calls.push('zips')
+        return { 'svc.zip': 'v1' }
+      }),
+      uploadCustomResources: jest.fn(async () => calls.push('custom')),
+      patchReferenceObjectVersions: jest.fn(() => calls.push('patch')),
+    },
+    calls,
+  }
+}
+
+describe('uploadArtifacts ordering', () => {
+  it('keeps today’s order in copy mode and never patches', async () => {
+    const { ctx, calls } = buildCtx({ referenceMode: false })
+    await ctx.uploadArtifacts()
+    expect(calls).toEqual(['template', 'state', 'zips', 'custom'])
+    expect(ctx.patchReferenceObjectVersions).not.toHaveBeenCalled()
+  })
+
+  it('uploads zips first, patches, then uploads the template in reference mode', async () => {
+    const { ctx, calls } = buildCtx({ referenceMode: true })
+    await ctx.uploadArtifacts()
+    expect(calls).toEqual(['zips', 'custom', 'patch', 'template', 'state'])
+    expect(ctx.patchReferenceObjectVersions).toHaveBeenCalledWith({
+      'svc.zip': 'v1',
+    })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/upload-artifacts.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/upload-artifacts.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import path from 'path'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: { info: jest.fn() },
+  progress: { get: jest.fn(() => ({ notice: jest.fn(), remove: jest.fn() })) },
+}))
+
+const uploadArtifactsMixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/upload-artifacts.js')
+).default
+
+describe('uploadFunctionsAndLayers', () => {
+  // This is the mechanism reference code storage mode depends on end-to-end:
+  // uploadArtifacts() feeds this method's returned map straight into
+  // patchReferenceObjectVersions(artifactVersionIds), which throws if a
+  // REFERENCE resource's basename is missing from the map. A bug here (wrong
+  // key, dropped entry, wrong VersionId) would silently break every
+  // reference-mode deploy's version pinning.
+  it('builds the artifactVersionIds map keyed by basename, from functions, layers, and agent artifacts', async () => {
+    const uploadedFilenames = []
+    const ctx = {
+      ...uploadArtifactsMixin,
+      serverless: {
+        service: {
+          package: { artifactDirectoryName: 'serverless/svc/dev/123' },
+        },
+      },
+      getFunctionArtifactFilePaths: async () => [
+        '/tmp/hello.zip',
+        '/tmp/world.zip',
+      ],
+      getLayerArtifactFilePaths: () => ['/tmp/common.zip'],
+      getAgentArtifactFilePaths: () => ['/tmp/agent.zip'],
+      getFileStats: async () => ({ size: 10 }),
+      uploadZipFile: jest.fn(async ({ filename }) => {
+        uploadedFilenames.push(filename)
+        return { VersionId: `v-${path.basename(filename)}` }
+      }),
+    }
+
+    const result = await ctx.uploadFunctionsAndLayers()
+
+    expect(result).toEqual({
+      'hello.zip': 'v-hello.zip',
+      'world.zip': 'v-world.zip',
+      'common.zip': 'v-common.zip',
+      'agent.zip': 'v-agent.zip',
+    })
+    expect(uploadedFilenames.sort()).toEqual(
+      [
+        '/tmp/hello.zip',
+        '/tmp/world.zip',
+        '/tmp/common.zip',
+        '/tmp/agent.zip',
+      ].sort(),
+    )
+    // Every upload is keyed under the service's artifact directory.
+    expect(ctx.uploadZipFile).toHaveBeenCalledWith(
+      expect.objectContaining({ s3KeyDirname: 'serverless/svc/dev/123' }),
+    )
+  })
+
+  it('drops entries whose upload returned no VersionId (unversioned bucket)', async () => {
+    const ctx = {
+      ...uploadArtifactsMixin,
+      serverless: {
+        service: {
+          package: { artifactDirectoryName: 'serverless/svc/dev/123' },
+        },
+      },
+      getFunctionArtifactFilePaths: async () => [
+        '/tmp/hello.zip',
+        '/tmp/unversioned.zip',
+      ],
+      getLayerArtifactFilePaths: () => [],
+      getAgentArtifactFilePaths: () => [],
+      getFileStats: async () => ({ size: 10 }),
+      uploadZipFile: jest.fn(async ({ filename }) => {
+        if (filename === '/tmp/unversioned.zip') return {}
+        return { VersionId: 'v-hello.zip' }
+      }),
+    }
+
+    const result = await ctx.uploadFunctionsAndLayers()
+
+    expect(result).toEqual({ 'hello.zip': 'v-hello.zip' })
+    expect(result['unversioned.zip']).toBeUndefined()
+  })
+})
+
+describe('getFileStats', () => {
+  it('wraps an unreadable artifact path in a ServerlessError', async () => {
+    await expect(
+      uploadArtifactsMixin.getFileStats('/does/not/exist.zip'),
+    ).rejects.toMatchObject({
+      code: 'INACCESSIBLE_FILE_ARTIFACT',
+      message: expect.stringContaining('/does/not/exist.zip'),
+    })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/lib/naming.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/lib/naming.test.js
@@ -100,4 +100,12 @@ describe('aws naming', () => {
       expect(standardOfFnLogGroupIa).not.toBe(iaOfFn)
     })
   })
+
+  describe('#getLambdaLayerS3ObjectVersionOutputLogicalId()', () => {
+    it('should normalize the layer name and add the S3ObjectVersion suffix', () => {
+      expect(
+        naming.getLambdaLayerS3ObjectVersionOutputLogicalId('test'),
+      ).toEqual('TestLambdaLayerS3ObjectVersion')
+    })
+  })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/lib/normalize-files.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/lib/normalize-files.test.js
@@ -1,0 +1,142 @@
+import { describe, it, expect } from '@jest/globals'
+
+const normalizeFiles = (
+  await import('../../../../../../lib/plugins/aws/lib/normalize-files.js')
+).default
+
+describe('normalizeCloudFormationTemplate', () => {
+  it('blanks S3Key and removes S3ObjectVersion on function Code', () => {
+    const template = {
+      Resources: {
+        FooLambdaFunction: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Code: {
+              S3Bucket: 'bucket',
+              S3Key: 'serverless/svc/dev/123/svc.zip',
+              S3ObjectVersion: 'abc123',
+              S3ObjectStorageMode: 'REFERENCE',
+            },
+          },
+        },
+      },
+    }
+    const result = normalizeFiles.normalizeCloudFormationTemplate(template)
+    const code = result.Resources.FooLambdaFunction.Properties.Code
+    expect(code.S3Key).toBe('')
+    expect('S3ObjectVersion' in code).toBe(false)
+    expect(code.S3ObjectStorageMode).toBe('REFERENCE')
+  })
+
+  it('removes S3ObjectVersion on layer Content', () => {
+    const template = {
+      Resources: {
+        MyLambdaLayer: {
+          Type: 'AWS::Lambda::LayerVersion',
+          Properties: {
+            Content: {
+              S3Bucket: 'bucket',
+              S3Key: 'serverless/svc/dev/123/layer.zip',
+              S3ObjectVersion: 'def456',
+            },
+          },
+        },
+      },
+    }
+    const result = normalizeFiles.normalizeCloudFormationTemplate(template)
+    const content = result.Resources.MyLambdaLayer.Properties.Content
+    expect(content.S3Key).toBe('')
+    expect('S3ObjectVersion' in content).toBe(false)
+  })
+
+  it('produces identical output for templates without S3ObjectVersion (hash stability)', () => {
+    const template = {
+      Resources: {
+        FooLambdaFunction: {
+          Type: 'AWS::Lambda::Function',
+          Properties: { Code: { S3Bucket: 'b', S3Key: 'k' } },
+        },
+      },
+    }
+    const a = JSON.stringify(
+      normalizeFiles.normalizeCloudFormationTemplate(template),
+    )
+    const b = JSON.stringify(
+      normalizeFiles.normalizeCloudFormationTemplate(template),
+    )
+    expect(a).toBe(b)
+    expect(a).not.toContain('S3ObjectVersion')
+  })
+
+  it('normalizes a template that HAS Code/Content.S3ObjectVersion to the exact same JSON as a template that never had those fields (no-op-deploy-detection guarantee)', () => {
+    // This is the guarantee the whole reference-code-storage no-op-deploy
+    // detection depends on: the local pre-patch template (built before any
+    // S3ObjectVersion is known) and the remote post-patch template (which
+    // patch-reference-object-versions.js has stamped with the real
+    // S3ObjectVersion values) must normalize identically, or every deploy
+    // would be seen as a diff even when nothing changed.
+    const withVersions = {
+      Resources: {
+        FooLambdaFunction: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Code: {
+              S3Bucket: 'bucket',
+              S3Key: 'serverless/svc/dev/123/svc.zip',
+              S3ObjectVersion: 'abc123',
+              S3ObjectStorageMode: 'REFERENCE',
+            },
+          },
+        },
+        MyLambdaLayer: {
+          Type: 'AWS::Lambda::LayerVersion',
+          Properties: {
+            Content: {
+              S3Bucket: 'bucket',
+              S3Key: 'serverless/svc/dev/123/layer.zip',
+              S3ObjectVersion: 'def456',
+              S3ObjectStorageMode: 'REFERENCE',
+            },
+          },
+        },
+      },
+    }
+    // Same template, but as if it never went through patch-reference-object-versions.js:
+    // no S3ObjectVersion field at all, and a different (pre-patch) S3Key —
+    // S3Key gets blanked either way, so it must not affect the comparison.
+    const withoutVersions = {
+      Resources: {
+        FooLambdaFunction: {
+          Type: 'AWS::Lambda::Function',
+          Properties: {
+            Code: {
+              S3Bucket: 'bucket',
+              S3Key: 'serverless/svc/dev/456/svc.zip',
+              S3ObjectStorageMode: 'REFERENCE',
+            },
+          },
+        },
+        MyLambdaLayer: {
+          Type: 'AWS::Lambda::LayerVersion',
+          Properties: {
+            Content: {
+              S3Bucket: 'bucket',
+              S3Key: 'serverless/svc/dev/456/layer.zip',
+              S3ObjectStorageMode: 'REFERENCE',
+            },
+          },
+        },
+      },
+    }
+
+    const normalizedWithVersions = JSON.stringify(
+      normalizeFiles.normalizeCloudFormationTemplate(withVersions),
+    )
+    const normalizedWithoutVersions = JSON.stringify(
+      normalizeFiles.normalizeCloudFormationTemplate(withoutVersions),
+    )
+
+    expect(normalizedWithVersions).toBe(normalizedWithoutVersions)
+    expect(normalizedWithVersions).not.toContain('S3ObjectVersion')
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions-code-storage-mode.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions-code-storage-mode.test.js
@@ -1,0 +1,236 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import AwsCompileFunctions from '../../../../../../../lib/plugins/aws/package/compile/functions.js'
+import Serverless from '../../../../../../../lib/serverless.js'
+import AwsProvider from '../../../../../../../lib/plugins/aws/provider.js'
+import { jest } from '@jest/globals'
+
+describe('AwsCompileFunctions', () => {
+  let serverless
+  let awsCompileFunctions
+  let tempDir
+
+  beforeEach(() => {
+    const options = {}
+    tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'functions-code-storage-mode-test-'),
+    )
+    fs.writeFileSync(path.join(tempDir, 'service.zip'), 'dummy content')
+
+    serverless = new Serverless({ commands: [], options: {} })
+    serverless.serviceDir = tempDir
+    serverless.credentialProviders = {
+      aws: {
+        getCredentials: jest.fn(),
+      },
+    }
+    serverless.service.provider.compiledCloudFormationTemplate = {
+      Resources: {},
+      Outputs: {},
+    }
+    serverless.service.package.artifact = 'service.zip'
+    serverless.setProvider('aws', new AwsProvider(serverless, options))
+    awsCompileFunctions = new AwsCompileFunctions(serverless, options)
+
+    serverless.service.functions = {
+      hello: {
+        handler: 'index.handler',
+      },
+    }
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  describe('code storage mode', () => {
+    it('sets Code.S3ObjectStorageMode REFERENCE on zip functions in reference mode', async () => {
+      serverless.service.provider.deploymentBucketObject = {
+        codeStorageMode: 'reference',
+      }
+      await awsCompileFunctions.compileFunctions()
+      const resource =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.HelloLambdaFunction
+      expect(resource.Properties.Code.S3ObjectStorageMode).toBe('REFERENCE')
+      expect(resource.Properties.Code.S3Bucket).toBeDefined()
+      expect(resource.Properties.Code.S3Key).toBeDefined()
+    })
+
+    it('does not set Code.S3ObjectStorageMode in copy mode', async () => {
+      serverless.service.provider.deploymentBucketObject = {
+        codeStorageMode: 'copy',
+      }
+      await awsCompileFunctions.compileFunctions()
+      const resource =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.HelloLambdaFunction
+      expect(resource.Properties.Code.S3ObjectStorageMode).toBeUndefined()
+    })
+
+    it('does not set Code.S3ObjectStorageMode when option absent', async () => {
+      await awsCompileFunctions.compileFunctions()
+      const resource =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.HelloLambdaFunction
+      expect(resource.Properties.Code.S3ObjectStorageMode).toBeUndefined()
+    })
+
+    it('does not set Code.S3ObjectStorageMode on image functions', async () => {
+      serverless.service.provider.deploymentBucketObject = {
+        codeStorageMode: 'reference',
+      }
+      serverless.service.functions.hello = {
+        image: '000000000000.dkr.ecr.us-east-1.amazonaws.com/repo@sha256:abc',
+      }
+      await awsCompileFunctions.compileFunctions()
+      const resource =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.HelloLambdaFunction
+      expect(resource.Properties.Code.S3ObjectStorageMode).toBeUndefined()
+      expect(resource.Properties.Code.ImageUri).toBeDefined()
+    })
+  })
+
+  describe('reused-layer version digest stability', () => {
+    // In reference mode the layer-reuse path pins `Content.S3ObjectVersion` on
+    // the layer resource at compile time. The published Lambda Version logical
+    // id (which embeds a digest of the function + layer configuration) must be
+    // identical whether or not that property is present, otherwise an unchanged
+    // redeploy churns the version id and never skips.
+    const compileWithLayer = async ({
+      withS3ObjectVersion,
+      withS3ObjectStorageMode = false,
+    }) => {
+      const localTempDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'functions-layer-digest-test-'),
+      )
+      fs.writeFileSync(path.join(localTempDir, 'service.zip'), 'dummy content')
+      const layerArtifactPath = path.join(localTempDir, 'layer.zip')
+      fs.writeFileSync(layerArtifactPath, 'layer content')
+
+      const options = {}
+      const localServerless = new Serverless({ commands: [], options: {} })
+      localServerless.serviceDir = localTempDir
+      localServerless.credentialProviders = {
+        aws: { getCredentials: jest.fn() },
+      }
+      const layerContent = { S3Bucket: 'bucket', S3Key: 'layer-key' }
+      if (withS3ObjectVersion) layerContent.S3ObjectVersion = 'abc123version'
+      if (withS3ObjectStorageMode)
+        layerContent.S3ObjectStorageMode = 'REFERENCE'
+      localServerless.service.provider.compiledCloudFormationTemplate = {
+        Resources: {
+          TestLayerLambdaLayer: {
+            Type: 'AWS::Lambda::LayerVersion',
+            _serverlessLayerName: 'testLayer',
+            Properties: { Content: layerContent },
+          },
+        },
+        Outputs: {},
+      }
+      localServerless.service.package.artifact = 'service.zip'
+      localServerless.service.provider.deploymentBucketObject = {
+        codeStorageMode: 'reference',
+      }
+      localServerless.service.provider.versionFunctions = true
+      localServerless.setProvider(
+        'aws',
+        new AwsProvider(localServerless, options),
+      )
+      localServerless.service.layers = {
+        testLayer: { package: { artifact: layerArtifactPath } },
+      }
+      localServerless.service.functions = {
+        hello: {
+          handler: 'index.handler',
+          layers: [{ Ref: 'TestLayerLambdaLayer' }],
+        },
+      }
+
+      const compiler = new AwsCompileFunctions(localServerless, options)
+      await compiler.compileFunctions()
+      const resources =
+        compiler.serverless.service.provider.compiledCloudFormationTemplate
+          .Resources
+      const versionLogicalId = Object.keys(resources).find((key) =>
+        key.startsWith('HelloLambdaVersion'),
+      )
+      fs.rmSync(localTempDir, { recursive: true, force: true })
+      return versionLogicalId
+    }
+
+    it('produces an identical Version logical id whether or not the reused layer pins Content.S3ObjectVersion', async () => {
+      const withoutVersion = await compileWithLayer({
+        withS3ObjectVersion: false,
+      })
+      const withVersion = await compileWithLayer({ withS3ObjectVersion: true })
+      expect(withoutVersion).toBeDefined()
+      expect(withVersion).toBeDefined()
+      expect(withVersion).toBe(withoutVersion)
+    })
+
+    // Negative control for the test above: unlike `S3ObjectVersion`,
+    // `Content.S3ObjectStorageMode` must NOT be excluded from the digest — a
+    // genuine storage-mode change has to rotate the version so a future
+    // refactor can't blindly widen the exclusion and silently swallow it.
+    it('rotates the Version logical id when the reused layer pins Content.S3ObjectStorageMode', async () => {
+      const withoutStorageMode = await compileWithLayer({
+        withS3ObjectVersion: false,
+        withS3ObjectStorageMode: false,
+      })
+      const withStorageMode = await compileWithLayer({
+        withS3ObjectVersion: false,
+        withS3ObjectStorageMode: true,
+      })
+      expect(withoutStorageMode).toBeDefined()
+      expect(withStorageMode).toBeDefined()
+      expect(withStorageMode).not.toBe(withoutStorageMode)
+    })
+  })
+
+  describe('published version CodeSha256 guard', () => {
+    const findVersionResource = () => {
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      return Object.values(resources).find(
+        (resource) => resource.Type === 'AWS::Lambda::Version',
+      )
+    }
+
+    it('sets a real CodeSha256 on the published Version resource in reference mode', async () => {
+      serverless.service.provider.deploymentBucketObject = {
+        codeStorageMode: 'reference',
+      }
+      serverless.service.provider.versionFunctions = true
+      await awsCompileFunctions.compileFunctions()
+      const versionResource = findVersionResource()
+      expect(versionResource).toBeDefined()
+      expect(typeof versionResource.Properties.CodeSha256).toBe('string')
+      expect(versionResource.Properties.CodeSha256).not.toBe('CodeSha256')
+    })
+
+    it('sets a real CodeSha256 on the published Version resource in copy mode', async () => {
+      serverless.service.provider.deploymentBucketObject = {
+        codeStorageMode: 'copy',
+      }
+      serverless.service.provider.versionFunctions = true
+      await awsCompileFunctions.compileFunctions()
+      const versionResource = findVersionResource()
+      expect(versionResource).toBeDefined()
+      expect(typeof versionResource.Properties.CodeSha256).toBe('string')
+      expect(versionResource.Properties.CodeSha256).not.toBe('CodeSha256')
+    })
+
+    it('sets a real CodeSha256 on the published Version resource when option absent', async () => {
+      serverless.service.provider.versionFunctions = true
+      await awsCompileFunctions.compileFunctions()
+      const versionResource = findVersionResource()
+      expect(versionResource).toBeDefined()
+      expect(typeof versionResource.Properties.CodeSha256).toBe('string')
+      expect(versionResource.Properties.CodeSha256).not.toBe('CodeSha256')
+    })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -293,6 +293,46 @@ describe('AwsCompileFunctions', () => {
     })
   })
 
+  describe('code storage mode', () => {
+    it('sets Code.S3ObjectStorageMode to REFERENCE in reference mode', async () => {
+      awsCompileFunctions.provider.isReferenceCodeStorageMode = () => true
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      expect(
+        resources.FuncLambdaFunction.Properties.Code.S3ObjectStorageMode,
+      ).toBe('REFERENCE')
+    })
+
+    it('does not set Code.S3ObjectStorageMode in copy mode', async () => {
+      awsCompileFunctions.provider.isReferenceCodeStorageMode = () => false
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'func.function.handler',
+          name: 'new-service-dev-func',
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      expect(
+        resources.FuncLambdaFunction.Properties.Code.S3ObjectStorageMode,
+      ).toBeUndefined()
+    })
+  })
+
   describe('Managed Instances (Capacity Provider)', () => {
     it('should set CapacityProviderConfig when configured', async () => {
       awsCompileFunctions.serverless.service.functions = {

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/layers.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/layers.test.js
@@ -90,11 +90,16 @@ describe('AwsCompileLayers', () => {
           (name) =>
             `${name.charAt(0).toUpperCase() + name.slice(1)}LambdaLayerS3Key`,
         ),
+        getLambdaLayerS3ObjectVersionOutputLogicalId: jest.fn(
+          (name) =>
+            `${name.charAt(0).toUpperCase() + name.slice(1)}LambdaLayerS3ObjectVersion`,
+        ),
         getStackName: jest.fn(() => 'my-service-dev'),
       },
       serverless,
       resolveLayerArtifactName: jest.fn((name) => `${name}.zip`),
       request: jest.fn(),
+      isReferenceCodeStorageMode: jest.fn(() => false),
     }
 
     serverless.getProvider = jest.fn(() => awsProvider)
@@ -557,6 +562,110 @@ describe('AwsCompileLayers', () => {
       const resources =
         serverless.service.provider.compiledCloudFormationTemplate.Resources
       expect(Object.keys(resources).length).toBe(0)
+    })
+  })
+
+  describe('code storage mode', () => {
+    beforeEach(() => {
+      fsAsync.readFile.mockResolvedValue(Buffer.from('mock-layer-content'))
+      serverless.service.layers = {
+        test: {
+          path: 'layer',
+        },
+      }
+    })
+
+    it('sets Content.S3ObjectStorageMode and the S3ObjectVersion output in reference mode', async () => {
+      awsCompileLayers.provider.isReferenceCodeStorageMode = () => true
+      await awsCompileLayers.compileLayer('test')
+      const template =
+        awsCompileLayers.serverless.service.provider
+          .compiledCloudFormationTemplate
+      expect(
+        template.Resources.TestLambdaLayer.Properties.Content
+          .S3ObjectStorageMode,
+      ).toBe('REFERENCE')
+      expect(template.Outputs.TestLambdaLayerS3ObjectVersion).toBeDefined()
+    })
+
+    it('sets neither mode nor output in copy mode', async () => {
+      awsCompileLayers.provider.isReferenceCodeStorageMode = () => false
+      await awsCompileLayers.compileLayer('test')
+      const template =
+        awsCompileLayers.serverless.service.provider
+          .compiledCloudFormationTemplate
+      expect(
+        template.Resources.TestLambdaLayer.Properties.Content
+          .S3ObjectStorageMode,
+      ).toBeUndefined()
+      expect(template.Outputs.TestLambdaLayerS3ObjectVersion).toBeUndefined()
+    })
+
+    it('carries the previous S3ObjectVersion when reusing an unchanged layer', async () => {
+      awsCompileLayers.provider.isReferenceCodeStorageMode = () => true
+      await awsCompileLayers.compileLayer('test')
+      const template =
+        awsCompileLayers.serverless.service.provider
+          .compiledCloudFormationTemplate
+      const sha = template.Outputs.TestLambdaLayerHash.Value
+      awsCompileLayers.provider.request = jest.fn(async () => ({
+        Stacks: [
+          {
+            Outputs: [
+              { OutputKey: 'TestLambdaLayerHash', OutputValue: sha },
+              {
+                OutputKey: 'TestLambdaLayerS3Key',
+                OutputValue: 'old/dir/test.zip',
+              },
+              {
+                OutputKey: 'TestLambdaLayerS3ObjectVersion',
+                OutputValue: 'oldVersionId123',
+              },
+            ],
+          },
+        ],
+      }))
+      await awsCompileLayers.compareWithLastLayer('test')
+      expect(template.Resources.TestLambdaLayer.Properties.Content.S3Key).toBe(
+        'old/dir/test.zip',
+      )
+      expect(
+        template.Resources.TestLambdaLayer.Properties.Content.S3ObjectVersion,
+      ).toBe('oldVersionId123')
+      expect(template.Outputs.TestLambdaLayerS3ObjectVersion.Value).toBe(
+        'oldVersionId123',
+      )
+      expect(
+        awsCompileLayers.serverless.service.getLayer('test')
+          .artifactAlreadyUploaded,
+      ).toBe(true)
+    })
+
+    it('skips reuse when the previous deployment has no S3ObjectVersion output', async () => {
+      awsCompileLayers.provider.isReferenceCodeStorageMode = () => true
+      await awsCompileLayers.compileLayer('test')
+      const template =
+        awsCompileLayers.serverless.service.provider
+          .compiledCloudFormationTemplate
+      const sha = template.Outputs.TestLambdaLayerHash.Value
+      awsCompileLayers.provider.request = jest.fn(async () => ({
+        Stacks: [
+          {
+            Outputs: [
+              { OutputKey: 'TestLambdaLayerHash', OutputValue: sha },
+              {
+                OutputKey: 'TestLambdaLayerS3Key',
+                OutputValue: 'old/dir/test.zip',
+              },
+            ],
+          },
+        ],
+      }))
+      await awsCompileLayers.compareWithLastLayer('test')
+      expect(
+        awsCompileLayers.serverless.service.getLayer('test')
+          .artifactAlreadyUploaded,
+      ).toBeUndefined()
     })
   })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/package/lib/generate-core-template.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/lib/generate-core-template.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: { warning: jest.fn(), info: jest.fn() },
+}))
+const { log } = await import('@serverless/util')
+
+const mixin = (
+  await import('../../../../../../../lib/plugins/aws/package/lib/generate-core-template.js')
+).default
+
+const coreTemplate = () => ({
+  Resources: {
+    ServerlessDeploymentBucket: { Type: 'AWS::S3::Bucket', Properties: {} },
+    ServerlessDeploymentBucketPolicy: {
+      Type: 'AWS::S3::BucketPolicy',
+      Properties: { PolicyDocument: { Statement: [{ Sid: 'DenyInsecure' }] } },
+    },
+  },
+  Outputs: { ServerlessDeploymentBucketName: { Value: '' } },
+})
+
+const buildCtx = ({ referenceMode, deploymentBucketObject }) => ({
+  ...mixin,
+  provider: {
+    isReferenceCodeStorageMode: () => referenceMode,
+    naming: {
+      getDeploymentBucketLogicalId: () => 'ServerlessDeploymentBucket',
+      getDeploymentBucketPolicyLogicalId: () =>
+        'ServerlessDeploymentBucketPolicy',
+      getCoreTemplateFileName: () => 'core-cloudformation-template.json',
+    },
+    isS3TransferAccelerationSupported: () => false,
+    isS3TransferAccelerationEnabled: () => false,
+    isS3TransferAccelerationDisabled: () => false,
+  },
+  serverless: {
+    config: { serverlessPath: '/x' },
+    serviceDir: '/tmp/svc',
+    utils: {
+      readFileSync: () => coreTemplate(),
+      writeFileSync: jest.fn(),
+    },
+    service: {
+      provider: { deploymentBucketObject },
+      package: {},
+    },
+  },
+})
+
+describe('generateCoreTemplate — reference mode, legacy in-stack bucket', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('requires versioning: true', () => {
+    const ctx = buildCtx({
+      referenceMode: true,
+      deploymentBucketObject: { codeStorageMode: 'reference' },
+    })
+    expect(() => ctx.generateCoreTemplate()).toThrow(/versioning/)
+  })
+
+  it('appends the Lambda-read statement to the bucket policy', () => {
+    const ctx = buildCtx({
+      referenceMode: true,
+      deploymentBucketObject: {
+        codeStorageMode: 'reference',
+        versioning: true,
+      },
+    })
+    ctx.generateCoreTemplate()
+    const statements =
+      ctx.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        .ServerlessDeploymentBucketPolicy.Properties.PolicyDocument.Statement
+    const stmt = statements.find(
+      (s) => s.Sid === 'ServerlessLambdaSelfManagedCodeAccess',
+    )
+    expect(stmt).toBeDefined()
+    expect(stmt.Principal).toEqual({ Service: 'lambda.amazonaws.com' })
+    expect(stmt.Condition.StringEquals['aws:SourceAccount']).toEqual({
+      Ref: 'AWS::AccountId',
+    })
+    // Exact action set: read-only access to the current object AND every
+    // specific version (Lambda pins exact S3ObjectVersions in reference mode).
+    expect(stmt.Action).toEqual(['s3:GetObject', 's3:GetObjectVersion'])
+    // Exact resource shape: join('', ['arn:aws:s3:::', {Ref: <bucket logical
+    // id>}, '/*']) — a wildcard over every object in the deployment bucket,
+    // built from the actual bucket logical id rather than a literal string.
+    expect(stmt.Resource).toEqual({
+      'Fn::Join': [
+        '',
+        ['arn:aws:s3:::', { Ref: 'ServerlessDeploymentBucket' }, '/*'],
+      ],
+    })
+    expect(statements.find((s) => s.Sid === 'DenyInsecure')).toBeDefined()
+  })
+
+  it('warns instead of adding the statement when skipPolicySetup is set', () => {
+    const ctx = buildCtx({
+      referenceMode: true,
+      deploymentBucketObject: {
+        codeStorageMode: 'reference',
+        versioning: true,
+        skipPolicySetup: true,
+      },
+    })
+    ctx.generateCoreTemplate()
+    expect(log.warning).toHaveBeenCalled()
+    expect(
+      ctx.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        .ServerlessDeploymentBucketPolicy,
+    ).toBeUndefined()
+  })
+
+  it('does not touch the policy in copy mode', () => {
+    const ctx = buildCtx({ referenceMode: false, deploymentBucketObject: {} })
+    ctx.generateCoreTemplate()
+    const statements =
+      ctx.serverless.service.provider.compiledCloudFormationTemplate.Resources
+        .ServerlessDeploymentBucketPolicy.Properties.PolicyDocument.Statement
+    expect(statements).toHaveLength(1)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/package/lib/get-hash-for-file-path.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/lib/get-hash-for-file-path.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, afterAll } from '@jest/globals'
+import fsp from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+
+const getHashForFilePath = (
+  await import('../../../../../../../lib/plugins/aws/package/lib/get-hash-for-file-path.js')
+).default
+
+const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'sls-hash-test-'))
+
+afterAll(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true })
+})
+
+const sha256Base64 = (content) =>
+  crypto.createHash('sha256').update(content).digest('base64')
+
+describe('getHashForFilePath', () => {
+  it('returns the sha256 base64 hash of the file contents', async () => {
+    const filePath = path.join(tmpDir, 'artifact-a.zip')
+    await fsp.writeFile(filePath, 'content-a')
+    expect(await getHashForFilePath(filePath)).toBe(sha256Base64('content-a'))
+  })
+
+  it('returns a fresh hash after the file at the same path is rewritten', async () => {
+    // Regression: the memoized hash used to be keyed on path alone, so a
+    // rewritten artifact at the same path (repeated in-process deploys)
+    // reused the previous deploy's hash — breaking Lambda version publishing.
+    const filePath = path.join(tmpDir, 'artifact-b.zip')
+    await fsp.writeFile(filePath, 'first-code')
+    const firstHash = await getHashForFilePath(filePath)
+
+    // ensure a different mtime even on coarse-grained filesystems
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    await fsp.writeFile(filePath, 'second-code')
+
+    const secondHash = await getHashForFilePath(filePath)
+    expect(secondHash).toBe(sha256Base64('second-code'))
+    expect(secondHash).not.toBe(firstHash)
+  })
+
+  it('memoizes for an unchanged file (same result, no error)', async () => {
+    const filePath = path.join(tmpDir, 'artifact-c.zip')
+    await fsp.writeFile(filePath, 'stable-content')
+    const first = await getHashForFilePath(filePath)
+    const second = await getHashForFilePath(filePath)
+    expect(second).toBe(first)
+    expect(first).toBe(sha256Base64('stable-content'))
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/provider-code-storage-mode.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/provider-code-storage-mode.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from '@jest/globals'
+
+const AwsProvider = (await import('../../../../../lib/plugins/aws/provider.js'))
+  .default
+
+describe('AwsProvider#isReferenceCodeStorageMode()', () => {
+  let serverlessStub
+
+  beforeEach(() => {
+    serverlessStub = {
+      version: '4.0.0',
+      cli: {},
+      config: {},
+      configurationInput: {},
+      processedInput: { commands: [], options: {} },
+      service: {
+        provider: { name: 'aws' },
+        defaults: {},
+      },
+      setProvider() {},
+      configSchemaHandler: {
+        defineProvider() {},
+        defineFunctionProperties() {},
+        defineCustomProperties() {},
+      },
+      utils: {},
+      classes: {},
+      getProvider() {},
+      credentialProviders: {
+        aws: {
+          getCredentials() {},
+        },
+      },
+    }
+  })
+
+  const buildProvider = (deploymentBucketObject) => {
+    const provider = new AwsProvider(serverlessStub, {})
+    provider.serverless.service.provider.deploymentBucketObject =
+      deploymentBucketObject
+    return provider
+  }
+
+  it('returns true when codeStorageMode is "reference"', () => {
+    expect(
+      buildProvider({
+        codeStorageMode: 'reference',
+      }).isReferenceCodeStorageMode(),
+    ).toBe(true)
+  })
+
+  it('returns false when codeStorageMode is "copy"', () => {
+    expect(
+      buildProvider({ codeStorageMode: 'copy' }).isReferenceCodeStorageMode(),
+    ).toBe(false)
+  })
+
+  it('returns false when codeStorageMode is absent', () => {
+    expect(buildProvider({}).isReferenceCodeStorageMode()).toBe(false)
+  })
+
+  it('returns false when deploymentBucketObject is absent', () => {
+    expect(buildProvider(undefined).isReferenceCodeStorageMode()).toBe(false)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/provider.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/provider.test.js
@@ -681,4 +681,45 @@ describe('AwsProvider', () => {
       expect(messages[0]).toContain('INFREQUENT_ACCESS')
     })
   })
+
+  describe('deploymentBucket.codeStorageMode schema', () => {
+    let schemaServerless
+
+    beforeEach(() => {
+      schemaServerless = new Serverless({ commands: [], options: {} })
+      schemaServerless.credentialProviders = {
+        aws: { getCredentials: jest.fn() },
+      }
+      schemaServerless.service.provider.name = 'aws'
+      new AwsProvider(schemaServerless, options)
+    })
+
+    const getCodeStorageModeSchema = () => {
+      const deploymentBucketSchema =
+        schemaServerless.configSchemaHandler.schema.properties.provider
+          .properties.deploymentBucket
+      const objectVariant = deploymentBucketSchema.anyOf.find(
+        (variant) => variant.properties && variant.properties.codeStorageMode,
+      )
+      expect(objectVariant).toBeDefined()
+      return objectVariant.properties.codeStorageMode
+    }
+
+    it('accepts "copy" and "reference"', async () => {
+      const Ajv = (await import('ajv')).default
+      const ajv = new Ajv({ allErrors: true, strict: false })
+      const validate = ajv.compile(getCodeStorageModeSchema())
+
+      expect(validate('copy')).toBe(true)
+      expect(validate('reference')).toBe(true)
+    })
+
+    it('rejects a value outside the enum', async () => {
+      const Ajv = (await import('ajv')).default
+      const ajv = new Ajv({ allErrors: true, strict: false })
+      const validate = ajv.compile(getCodeStorageModeSchema())
+
+      expect(validate('banana')).toBe(false)
+    })
+  })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/rollback-function.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/rollback-function.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: Object.assign(jest.fn(), {
+    notice: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+  }),
+  progress: { get: () => ({ notice: jest.fn() }) },
+  style: { aside: (s) => s },
+}))
+
+const { log } = await import('@serverless/util')
+const AwsRollbackFunction = (
+  await import('../../../../../lib/plugins/aws/rollback-function.js')
+).default
+
+describe('AwsRollbackFunction', () => {
+  let plugin
+  let requestMock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const buildPlugin = (getFunctionResponse) => {
+    requestMock = jest.fn(async (service, method) => {
+      if (method === 'getFunction') return getFunctionResponse
+      return {}
+    })
+    const serverless = {
+      getProvider: () => ({ request: requestMock }),
+      service: {
+        getFunction: () => ({ name: 'svc-dev-hello' }),
+      },
+      pluginManager: { commandRunStartTime: Date.now() },
+    }
+    plugin = new AwsRollbackFunction(serverless, {
+      function: 'hello',
+      'function-version': '3',
+    })
+    plugin.validate = jest.fn()
+    return plugin
+  }
+
+  it('rolls back a reference-mode version by repointing S3 coordinates', async () => {
+    buildPlugin({
+      Code: {
+        ResolvedS3Object: {
+          S3Bucket: 'bucket',
+          S3Key: 'serverless/svc/dev/123/svc.zip',
+          S3ObjectVersion: 'pinnedVersion',
+        },
+      },
+    })
+    await plugin.hooks['rollback:function:rollback']()
+
+    // getFunction always goes through the v3 SDK path (mode is detected
+    // from the response, and v2 silently drops Code.ResolvedS3Object).
+    const getFunctionCall = requestMock.mock.calls.find(
+      ([, m]) => m === 'getFunction',
+    )
+    expect(getFunctionCall[3]).toEqual({ sdkVersion: 3 })
+
+    const updateCall = requestMock.mock.calls.find(
+      ([, m]) => m === 'updateFunctionCode',
+    )
+    expect(updateCall[2]).toMatchObject({
+      FunctionName: 'svc-dev-hello',
+      S3Bucket: 'bucket',
+      S3Key: 'serverless/svc/dev/123/svc.zip',
+      S3ObjectVersion: 'pinnedVersion',
+      S3ObjectStorageMode: 'REFERENCE',
+    })
+    expect(updateCall[2].ZipFile).toBeUndefined()
+    // Reference mode's params are unknown to the v2 SDK's Lambda model, so
+    // this call must also opt into the v3 SDK path.
+    expect(updateCall[3]).toEqual({ sdkVersion: 3 })
+
+    expect(log.success).toHaveBeenCalledWith(
+      expect.stringContaining('Successfully rolled back function hello'),
+    )
+  })
+
+  it('rolls back a copy-mode version via download and ZipFile', async () => {
+    global.fetch = jest.fn(async () => ({
+      arrayBuffer: async () => new ArrayBuffer(8),
+    }))
+    buildPlugin({ Code: { Location: 'https://presigned.example/code' } })
+    await plugin.hooks['rollback:function:rollback']()
+    expect(global.fetch).toHaveBeenCalledWith('https://presigned.example/code')
+
+    // getFunction always goes through the v3 SDK path, even for functions
+    // that turn out to be in copy mode (mode is only known after the call).
+    const getFunctionCall = requestMock.mock.calls.find(
+      ([, m]) => m === 'getFunction',
+    )
+    expect(getFunctionCall[3]).toEqual({ sdkVersion: 3 })
+
+    const updateCall = requestMock.mock.calls.find(
+      ([, m]) => m === 'updateFunctionCode',
+    )
+    expect(updateCall[2].ZipFile).toBeInstanceOf(Buffer)
+    expect(updateCall[2].S3ObjectStorageMode).toBeUndefined()
+    // Copy mode keeps the default v2 SDK path: no 4th options argument.
+    expect(updateCall[3]).toBeUndefined()
+
+    expect(log.success).toHaveBeenCalledWith(
+      expect.stringContaining('Successfully rolled back function hello'),
+    )
+  })
+
+  it('raises AWS_FUNCTION_NOT_FOUND when the target version does not exist, regardless of mode', async () => {
+    requestMock = jest.fn(async (service, method) => {
+      if (method === 'getFunction') {
+        // Message deliberately avoids the "not found" phrase so this test
+        // exercises the providerError.code fallback, not the message match.
+        const err = new Error('The resource you requested does not exist.')
+        err.providerError = { code: 'ResourceNotFoundException' }
+        throw err
+      }
+      return {}
+    })
+    const serverless = {
+      getProvider: () => ({ request: requestMock }),
+      service: { getFunction: () => ({ name: 'svc-dev-hello' }) },
+      pluginManager: { commandRunStartTime: Date.now() },
+    }
+    plugin = new AwsRollbackFunction(serverless, {
+      function: 'hello',
+      'function-version': '3',
+    })
+    plugin.validate = jest.fn()
+
+    await expect(
+      plugin.hooks['rollback:function:rollback'](),
+    ).rejects.toMatchObject({ code: 'AWS_FUNCTION_NOT_FOUND' })
+  })
+
+  it('wraps any other getFunction failure as AWS_FUNCTION_NOT_ACCESIBLE', async () => {
+    requestMock = jest.fn(async (service, method) => {
+      if (method === 'getFunction') {
+        throw new Error('Access Denied')
+      }
+      return {}
+    })
+    const serverless = {
+      getProvider: () => ({ request: requestMock }),
+      service: { getFunction: () => ({ name: 'svc-dev-hello' }) },
+      pluginManager: { commandRunStartTime: Date.now() },
+    }
+    plugin = new AwsRollbackFunction(serverless, {
+      function: 'hello',
+      'function-version': '3',
+    })
+    plugin.validate = jest.fn()
+
+    await expect(
+      plugin.hooks['rollback:function:rollback'](),
+    ).rejects.toMatchObject({ code: 'AWS_FUNCTION_NOT_ACCESIBLE' })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/prune/artifact-sweep.test.js
+++ b/packages/serverless/test/unit/lib/plugins/prune/artifact-sweep.test.js
@@ -1,0 +1,330 @@
+import { describe, it, expect, jest } from '@jest/globals'
+
+const {
+  buildPinnedShaSet,
+  collectLayerArns,
+  layerBasenameFromArn,
+  sweepArtifacts,
+} = await import('../../../../../lib/plugins/prune/artifact-sweep.js')
+
+describe('pin set helpers', () => {
+  it('buildPinnedShaSet unions CodeSha256 across functions', () => {
+    const set = buildPinnedShaSet([
+      [{ CodeSha256: 'aaa' }, { CodeSha256: 'bbb' }],
+      [{ CodeSha256: 'ccc' }],
+    ])
+    expect([...set].sort()).toEqual(['aaa', 'bbb', 'ccc'])
+  })
+
+  it('collectLayerArns unions attached and surviving layer version arns', () => {
+    const arns = collectLayerArns(
+      [[{ Layers: [{ Arn: 'arn:aws:lambda:r:a:layer:shared:3' }] }]],
+      [[{ LayerVersionArn: 'arn:aws:lambda:r:a:layer:common:1' }]],
+    )
+    expect([...arns].sort()).toEqual([
+      'arn:aws:lambda:r:a:layer:common:1',
+      'arn:aws:lambda:r:a:layer:shared:3',
+    ])
+  })
+
+  it('layerBasenameFromArn extracts the layer artifact basename', () => {
+    expect(
+      layerBasenameFromArn('arn:aws:lambda:us-east-1:111:layer:common:7'),
+    ).toBe('common.zip')
+  })
+})
+
+// Real S3 listObjectsV2 returns keys in lexicographic ASCENDING order, so
+// for timestamped deployment directories that means oldest first, newest
+// last (see cleanup-s3-bucket.js's slice(0, -keepCount) precedent).
+const listing = {
+  Contents: [
+    // candidates (oldest, outside the keepCount:2 retention window)
+    { Key: 'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip' },
+    { Key: 'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip' },
+    {
+      Key: 'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/compiled-cloudformation-template.json',
+    },
+    // newest 2 dirs (within keepCount window)
+    { Key: 'serverless/svc/dev/200-2026-07-16T00:00:00.000Z/svc.zip' },
+    { Key: 'serverless/svc/dev/300-2026-07-17T00:00:00.000Z/svc.zip' },
+  ],
+}
+
+const buildProvider = ({ shaByKey }) => ({
+  request: jest.fn(async (service, method, params) => {
+    if (method === 'listObjectsV2') return listing
+    if (method === 'headObject')
+      return {
+        Metadata: { filesha256: shaByKey[params.Key] },
+        VersionId: `vid-${params.Key}`,
+      }
+    if (method === 'deleteObjects') return {}
+    throw new Error(`unexpected ${method}`)
+  }),
+})
+
+const baseCtx = (provider, overrides = {}) => ({
+  provider,
+  bucketName: 'bucket',
+  deploymentPrefix: 'serverless',
+  service: 'svc',
+  stage: 'dev',
+  keepCount: 2,
+  pinnedShas: new Set(),
+  layerPins: new Map(),
+  layerBasenameFailSafePins: new Set(),
+  dryRun: false,
+  ...overrides,
+})
+
+describe('sweepArtifacts', () => {
+  it('marks unpinned candidate dirs and keeps pinned ones', async () => {
+    const provider = buildProvider({
+      shaByKey: {
+        'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip': 'PINNED',
+        'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip': 'garbage',
+      },
+    })
+    const result = await sweepArtifacts(
+      baseCtx(provider, { pinnedShas: new Set(['PINNED']) }),
+    )
+    expect(result.markedDirs).toEqual(['050-2026-07-14T00:00:00.000Z'])
+    expect(result.keptDirs.map((d) => d.dir)).toEqual([
+      '100-2026-07-15T00:00:00.000Z',
+    ])
+    const deleteCall = provider.request.mock.calls.find(
+      ([, m]) => m === 'deleteObjects',
+    )
+    expect(deleteCall[2].Delete.Objects).toEqual([
+      { Key: 'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip' },
+    ])
+    // marker-only: no VersionId in any delete object
+    expect(
+      deleteCall[2].Delete.Objects.every((o) => o.VersionId === undefined),
+    ).toBe(true)
+  })
+
+  it('never touches dirs within the keep window', async () => {
+    // With the empty shaByKey fixture, every candidate dir has zip entries
+    // with no filesha256 metadata, so all candidates are fail-safe pinned
+    // (kept) — nothing is ever marked, so no deleteObjects call is made at
+    // all under (3)'s "only call when there's something to mark" gate.
+    const provider = buildProvider({ shaByKey: {} })
+    await sweepArtifacts(baseCtx(provider))
+    expect(
+      provider.request.mock.calls.find(([, m]) => m === 'deleteObjects'),
+    ).toBeUndefined()
+  })
+
+  it('selects the oldest dirs outside the keep window (ordering semantics)', async () => {
+    // Ascending listing order (real S3 semantics), keepCount: 2, and no
+    // pins — every candidate's sha is present but garbage. This locks in
+    // that candidates are the OLDEST dirs (groups.slice(0, -keepCount)),
+    // never the newest.
+    const provider = buildProvider({
+      shaByKey: {
+        'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip': 'garbage',
+        'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip': 'garbage',
+      },
+    })
+    const result = await sweepArtifacts(baseCtx(provider))
+    expect([...result.markedDirs].sort()).toEqual([
+      '050-2026-07-14T00:00:00.000Z',
+      '100-2026-07-15T00:00:00.000Z',
+    ])
+    const deleteCall = provider.request.mock.calls.find(
+      ([, m]) => m === 'deleteObjects',
+    )
+    const keys = deleteCall[2].Delete.Objects.map((o) => o.Key)
+    expect(keys.some((k) => k.includes('200-'))).toBe(false)
+    expect(keys.some((k) => k.includes('300-'))).toBe(false)
+  })
+
+  it('treats missing filesha256 metadata as pinned', async () => {
+    const provider = buildProvider({ shaByKey: {} }) // no metadata for anything
+    const result = await sweepArtifacts(baseCtx(provider))
+    // dirs containing zips without metadata are kept…
+    expect(result.markedDirs).not.toContain('100-2026-07-15T00:00:00.000Z')
+  })
+
+  it('pins by exact layer key/version', async () => {
+    const provider = buildProvider({
+      shaByKey: {
+        'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip': 'garbage',
+        'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip': 'garbage',
+      },
+    })
+    const layerPins = new Map([
+      [
+        'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip',
+        'vid-serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip',
+      ],
+    ])
+    const result = await sweepArtifacts(baseCtx(provider, { layerPins }))
+    expect(result.markedDirs).toEqual(['050-2026-07-14T00:00:00.000Z'])
+  })
+
+  it('pins by layer basename fail-safe', async () => {
+    const provider = buildProvider({
+      shaByKey: {
+        'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip': 'garbage',
+        'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip': 'garbage',
+      },
+    })
+    const result = await sweepArtifacts(
+      baseCtx(provider, { layerBasenameFailSafePins: new Set(['svc.zip']) }),
+    )
+    expect(result.markedDirs).toEqual([])
+  })
+
+  it('reports without deleting on dryRun', async () => {
+    const provider = buildProvider({
+      shaByKey: {
+        'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip': 'garbage',
+        'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip': 'garbage',
+      },
+    })
+    const result = await sweepArtifacts(baseCtx(provider, { dryRun: true }))
+    expect(result.markedDirs.length).toBe(2)
+    expect(
+      provider.request.mock.calls.find(([, m]) => m === 'deleteObjects'),
+    ).toBeUndefined()
+  })
+
+  it('aggregates paginated listObjectsV2 results before selecting candidates', async () => {
+    // First page only covers the 050 and 100 dirs and is truncated; the
+    // second page (fetched with the returned ContinuationToken) covers the
+    // 200 and 300 dirs. This locks that a truncated first page can never
+    // shift the keep-window boundary — candidates must be computed from the
+    // FULL aggregated listing, not from whichever page happened to be seen
+    // first.
+    const page1Contents = [
+      { Key: 'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip' },
+      { Key: 'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip' },
+      {
+        Key: 'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/compiled-cloudformation-template.json',
+      },
+    ]
+    const page2Contents = [
+      { Key: 'serverless/svc/dev/200-2026-07-16T00:00:00.000Z/svc.zip' },
+      { Key: 'serverless/svc/dev/300-2026-07-17T00:00:00.000Z/svc.zip' },
+    ]
+    const shaByKey = {
+      'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip': 'garbage',
+      'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip': 'garbage',
+    }
+    const provider = {
+      request: jest.fn(async (service, method, params) => {
+        if (method === 'listObjectsV2') {
+          if (!params.ContinuationToken) {
+            return {
+              Contents: page1Contents,
+              IsTruncated: true,
+              NextContinuationToken: 'page2',
+            }
+          }
+          expect(params.ContinuationToken).toBe('page2')
+          return { Contents: page2Contents, IsTruncated: false }
+        }
+        if (method === 'headObject')
+          return {
+            Metadata: { filesha256: shaByKey[params.Key] },
+            VersionId: `vid-${params.Key}`,
+          }
+        if (method === 'deleteObjects') return {}
+        throw new Error(`unexpected ${method}`)
+      }),
+    }
+
+    const result = await sweepArtifacts(baseCtx(provider))
+
+    const listCalls = provider.request.mock.calls.filter(
+      ([, m]) => m === 'listObjectsV2',
+    )
+    expect(listCalls.length).toBe(2)
+    expect([...result.markedDirs].sort()).toEqual([
+      '050-2026-07-14T00:00:00.000Z',
+      '100-2026-07-15T00:00:00.000Z',
+    ])
+    const deleteCall = provider.request.mock.calls.find(
+      ([, m]) => m === 'deleteObjects',
+    )
+    const keys = deleteCall[2].Delete.Objects.map((o) => o.Key)
+    expect(keys.some((k) => k.includes('200-'))).toBe(false)
+    expect(keys.some((k) => k.includes('300-'))).toBe(false)
+  })
+
+  it("layer pin with null version pins the key regardless of the object's current version", async () => {
+    const provider = buildProvider({
+      shaByKey: {
+        'serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip': 'garbage',
+        'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/svc.zip': 'garbage',
+      },
+    })
+    const layerPins = new Map([
+      ['serverless/svc/dev/100-2026-07-15T00:00:00.000Z/svc.zip', null],
+    ])
+    const result = await sweepArtifacts(baseCtx(provider, { layerPins }))
+    expect(result.keptDirs.map((d) => d.dir)).toContain(
+      '100-2026-07-15T00:00:00.000Z',
+    )
+    expect(result.markedDirs).not.toContain('100-2026-07-15T00:00:00.000Z')
+  })
+
+  it('keeps a candidate dir with no .zip artifacts at all (fail-safe pin)', async () => {
+    // Oldest candidate dir has ONLY a non-artifact file (e.g. the compiled
+    // template) — nothing to prove unpinned against, so uncertainty keeps it.
+    const listingNoZip = {
+      Contents: [
+        {
+          Key: 'serverless/svc/dev/050-2026-07-14T00:00:00.000Z/compiled-cloudformation-template.json',
+        },
+        { Key: 'serverless/svc/dev/200-2026-07-16T00:00:00.000Z/svc.zip' },
+        { Key: 'serverless/svc/dev/300-2026-07-17T00:00:00.000Z/svc.zip' },
+      ],
+    }
+    const provider = {
+      request: jest.fn(async (service, method) => {
+        if (method === 'listObjectsV2') return listingNoZip
+        throw new Error(`unexpected ${method}`)
+      }),
+    }
+    const result = await sweepArtifacts(baseCtx(provider))
+    expect(result.markedDirs).toEqual([])
+    const kept = result.keptDirs.find(
+      (d) => d.dir === '050-2026-07-14T00:00:00.000Z',
+    )
+    expect(kept).toBeDefined()
+    expect(kept.reasons).toEqual([
+      'no artifact files found in directory (fail-safe pin)',
+    ])
+    // Never even attempts to read an object that isn't there.
+    expect(
+      provider.request.mock.calls.some(([, m]) => m === 'headObject'),
+    ).toBe(false)
+  })
+
+  it('keeps a candidate dir when headObject throws (fail-safe pin)', async () => {
+    const provider = {
+      request: jest.fn(async (service, method, params) => {
+        if (method === 'listObjectsV2') return listing
+        if (method === 'headObject') {
+          if (params.Key.includes('050-')) {
+            throw new Error('access denied')
+          }
+          return { Metadata: { filesha256: 'garbage' }, VersionId: 'vid' }
+        }
+        if (method === 'deleteObjects') return {}
+        throw new Error(`unexpected ${method}`)
+      }),
+    }
+    const result = await sweepArtifacts(baseCtx(provider))
+    const kept = result.keptDirs.find(
+      (d) => d.dir === '050-2026-07-14T00:00:00.000Z',
+    )
+    expect(kept).toBeDefined()
+    expect(kept.reasons[0]).toMatch(/could not read .* kept \(fail-safe\)/)
+    expect(result.markedDirs).not.toContain('050-2026-07-14T00:00:00.000Z')
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/prune/index.test.js
+++ b/packages/serverless/test/unit/lib/plugins/prune/index.test.js
@@ -12,9 +12,17 @@ describe('Prune', () => {
     const serverlessMock = {
       getProvider: jest.fn().mockReturnValue({
         request: providerRequest,
+        isReferenceCodeStorageMode: jest.fn().mockReturnValue(false),
+        getServerlessDeploymentBucketName: jest
+          .fn()
+          .mockResolvedValue('test-deployment-bucket'),
+        getDeploymentPrefix: jest.fn().mockReturnValue('serverless'),
+        getStage: jest.fn().mockReturnValue('dev'),
       }),
       cli: { log: jest.fn() },
       service: {
+        service: 'test-service',
+        provider: {},
         getAllFunctions: jest.fn().mockReturnValue(functions),
         getFunction: jest.fn().mockImplementation((key) => ({
           name: `service-${key}`,
@@ -163,11 +171,22 @@ describe('Prune', () => {
       serverless = createMockServerless(['FuncA', 'FuncB'])
       plugin = new Prune(serverless, { number: 2 })
 
-      providerRequest
-        .mockResolvedValueOnce(createVersionsResponse([1, 2, 3, 4, 5])) // FuncA
-        .mockResolvedValueOnce(createAliasResponse([])) // FuncA aliases
-        .mockResolvedValueOnce(createVersionsResponse([1, 2, 3])) // FuncB
-        .mockResolvedValueOnce(createAliasResponse([])) // FuncB aliases
+      // Dispatch on method/params rather than call order: unscoped
+      // pruneFunctions() now fetches every function's versions via the
+      // shared getFunctionVersionLists() memo (all versions calls fire
+      // together, ahead of any alias calls) rather than interleaving
+      // versions/aliases per function as before.
+      providerRequest.mockImplementation((service, action, params) => {
+        if (action === 'listVersionsByFunction') {
+          if (params.FunctionName === 'service-FuncA')
+            return Promise.resolve(createVersionsResponse([1, 2, 3, 4, 5]))
+          if (params.FunctionName === 'service-FuncB')
+            return Promise.resolve(createVersionsResponse([1, 2, 3]))
+        }
+        if (action === 'listAliases')
+          return Promise.resolve(createAliasResponse([]))
+        return Promise.resolve({})
+      })
 
       await plugin.pruneFunctions()
 
@@ -378,6 +397,15 @@ describe('Prune', () => {
 
       await plugin.pruneFunctions()
       expect(deleteSpy).not.toHaveBeenCalled()
+
+      // Nothing was actually deleted, but the version that WOULD have been
+      // deleted (version 1, since number:1 keeps only the newest version 2)
+      // is still recorded as planned-pruned — so a chained
+      // sweepDeploymentArtifacts() previews the post-prune world instead of
+      // treating every still-alive version as pinned.
+      expect(plugin.prunedFunctionVersions.get('service-FuncA')).toEqual(
+        new Set(['1']),
+      )
     })
   })
 
@@ -497,6 +525,197 @@ describe('Prune', () => {
       await plugin.pruneLayers()
       expect(deleteSpy).not.toHaveBeenCalled()
     })
+
+    describe('usage-aware protection', () => {
+      const LAYER_ARN_V1 =
+        'arn:aws:lambda:us-east-1:111111111111:layer:layer-LayerA:1'
+      const LAYER_ARN_V2 =
+        'arn:aws:lambda:us-east-1:111111111111:layer:layer-LayerA:2'
+
+      const createLayerVersionsResponseWithArn = (entries) => ({
+        LayerVersions: entries.map(({ version, arn }) => ({
+          Version: `${version}`,
+          LayerVersionArn: arn,
+        })),
+      })
+
+      it('does not delete a layer version beyond the keep window when it is still attached to an existing function version', async () => {
+        serverless = createMockServerlessWithLayers(['LayerA'])
+        serverless.service.getAllFunctions = jest
+          .fn()
+          .mockReturnValue(['FuncA'])
+        plugin = new Prune(serverless, { number: 1, includeLayers: true })
+
+        providerRequest.mockImplementation((service, action, params) => {
+          if (action === 'listVersionsByFunction') {
+            return Promise.resolve({
+              Versions: [
+                // Old function version 1 still references old layer
+                // version 1 — layer version 1 must be protected even
+                // though it falls outside the retention window (number:1
+                // keeps only the newest layer version).
+                { Version: '1', Layers: [{ Arn: LAYER_ARN_V1 }] },
+              ],
+            })
+          }
+          if (action === 'listLayerVersions') {
+            return Promise.resolve(
+              createLayerVersionsResponseWithArn([
+                { version: 1, arn: LAYER_ARN_V1 },
+                { version: 2, arn: LAYER_ARN_V2 },
+              ]),
+            )
+          }
+          return Promise.resolve({})
+        })
+
+        await plugin.pruneLayers()
+
+        expect(providerRequest).not.toHaveBeenCalledWith(
+          'Lambda',
+          'deleteLayerVersion',
+          expect.objectContaining({ VersionNumber: '1' }),
+        )
+      })
+
+      it('deletes an old layer version beyond the keep window when it is not attached to any existing function version', async () => {
+        serverless = createMockServerlessWithLayers(['LayerA'])
+        serverless.service.getAllFunctions = jest
+          .fn()
+          .mockReturnValue(['FuncA'])
+        plugin = new Prune(serverless, { number: 1, includeLayers: true })
+
+        providerRequest.mockImplementation((service, action, params) => {
+          if (action === 'listVersionsByFunction') {
+            return Promise.resolve({
+              // Only ever attached to layer version 2 — version 1 is
+              // unused and safe to delete.
+              Versions: [{ Version: '1', Layers: [{ Arn: LAYER_ARN_V2 }] }],
+            })
+          }
+          if (action === 'listLayerVersions') {
+            return Promise.resolve(
+              createLayerVersionsResponseWithArn([
+                { version: 1, arn: LAYER_ARN_V1 },
+                { version: 2, arn: LAYER_ARN_V2 },
+              ]),
+            )
+          }
+          return Promise.resolve({})
+        })
+
+        await plugin.pruneLayers()
+
+        expect(providerRequest).toHaveBeenCalledWith(
+          'Lambda',
+          'deleteLayerVersion',
+          expect.objectContaining({
+            LayerName: 'layer-LayerA',
+            VersionNumber: '1',
+          }),
+        )
+      })
+
+      it('protects attached layer versions on scoped --layer runs too', async () => {
+        serverless = createMockServerlessWithLayers(['LayerA', 'LayerB'])
+        serverless.service.getAllFunctions = jest
+          .fn()
+          .mockReturnValue(['FuncA'])
+        plugin = new Prune(serverless, {
+          number: 1,
+          includeLayers: true,
+          layer: 'LayerA',
+        })
+
+        providerRequest.mockImplementation((service, action, params) => {
+          if (action === 'listVersionsByFunction') {
+            return Promise.resolve({
+              Versions: [{ Version: '1', Layers: [{ Arn: LAYER_ARN_V1 }] }],
+            })
+          }
+          if (action === 'listLayerVersions') {
+            if (params.LayerName === 'layer-LayerA') {
+              return Promise.resolve(
+                createLayerVersionsResponseWithArn([
+                  { version: 1, arn: LAYER_ARN_V1 },
+                  { version: 2, arn: LAYER_ARN_V2 },
+                ]),
+              )
+            }
+            return Promise.resolve({ LayerVersions: [] })
+          }
+          return Promise.resolve({})
+        })
+
+        await plugin.pruneLayers()
+
+        // Scoped run only ever touches LayerA (LayerB's listLayerVersions
+        // is never even called), and within LayerA the attached version 1
+        // is protected exactly as in the unscoped case.
+        expect(providerRequest).not.toHaveBeenCalledWith(
+          'Lambda',
+          'deleteLayerVersion',
+          expect.objectContaining({
+            LayerName: 'layer-LayerA',
+            VersionNumber: '1',
+          }),
+        )
+        expect(providerRequest).not.toHaveBeenCalledWith(
+          'Lambda',
+          'deleteLayerVersion',
+          expect.objectContaining({ LayerName: 'layer-LayerB' }),
+        )
+      })
+
+      it('reflects usage-aware selection in dryRun output', async () => {
+        serverless = createMockServerlessWithLayers(['LayerA'])
+        serverless.service.getAllFunctions = jest
+          .fn()
+          .mockReturnValue(['FuncA'])
+        const logMock = {
+          info: jest.fn(),
+          notice: jest.fn(),
+          warning: jest.fn(),
+          success: jest.fn(),
+        }
+        plugin = new Prune(
+          serverless,
+          { number: 1, includeLayers: true, dryRun: true },
+          { log: logMock },
+        )
+
+        providerRequest.mockImplementation((service, action) => {
+          if (action === 'listVersionsByFunction') {
+            return Promise.resolve({
+              Versions: [{ Version: '1', Layers: [{ Arn: LAYER_ARN_V1 }] }],
+            })
+          }
+          if (action === 'listLayerVersions') {
+            return Promise.resolve(
+              createLayerVersionsResponseWithArn([
+                { version: 1, arn: LAYER_ARN_V1 },
+                { version: 2, arn: LAYER_ARN_V2 },
+              ]),
+            )
+          }
+          return Promise.resolve({})
+        })
+
+        await plugin.pruneLayers()
+
+        // Attached version 1 must never be printed as a deletion
+        // candidate in dry-run mode.
+        expect(logMock.info).not.toHaveBeenCalledWith(
+          expect.stringContaining('layer-LayerA:1 selected for deletion'),
+        )
+        // And the retention reason must be logged instead.
+        expect(logMock.info).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Retaining layer version layer-LayerA:1 — attached to existing function versions.',
+          ),
+        )
+      })
+    })
   })
 
   describe('postDeploy', () => {
@@ -599,6 +818,229 @@ describe('Prune', () => {
     })
   })
 
+  describe('shared function version listings (getFunctionVersionLists)', () => {
+    it('issues exactly N listVersionsByFunction calls for a combined cliPrune run under --includeLayers, not 2N', async () => {
+      const functionKeys = ['FuncA', 'FuncB', 'FuncC']
+      serverless = createMockServerlessWithLayers(['LayerA'])
+      serverless.service.getAllFunctions = jest
+        .fn()
+        .mockReturnValue(functionKeys)
+      plugin = new Prune(serverless, { number: 1, includeLayers: true })
+
+      providerRequest.mockImplementation((service, action) => {
+        if (action === 'listVersionsByFunction') {
+          return Promise.resolve(createVersionsResponse([1, 2]))
+        }
+        if (action === 'listAliases') {
+          return Promise.resolve(createAliasResponse([]))
+        }
+        if (action === 'listLayerVersions') {
+          return Promise.resolve(createLayerVersionsResponse([1, 2]))
+        }
+        return Promise.resolve({})
+      })
+
+      await plugin.cliPrune()
+
+      // pruneFunctions() lists every function's versions once, and
+      // pruneLayers()'s attached-set builder reuses that same fetch via the
+      // getFunctionVersionLists() memo instead of listing again — so a
+      // combined run costs exactly N calls, not 2N.
+      const listVersionsByFunctionCalls = providerRequest.mock.calls.filter(
+        ([, action]) => action === 'listVersionsByFunction',
+      )
+      expect(listVersionsByFunctionCalls).toHaveLength(functionKeys.length)
+    })
+
+    it('issues zero listVersionsByFunction calls from the layer path when the service has zero layers', async () => {
+      serverless = createMockServerless(['FuncA', 'FuncB'])
+      plugin = new Prune(serverless, { number: 1 })
+
+      await plugin.pruneLayers()
+
+      // No layers selected means nothing to prune, so the attached-set
+      // fetch must be skipped entirely — zero Lambda API calls, even
+      // though the service has functions.
+      expect(providerRequest).not.toHaveBeenCalled()
+    })
+
+    it('issues exactly 2N listVersionsByFunction calls for a full includeLayers + includeArtifacts cliPrune run — N from the shared prune-phase memo, N fresh from the sweep', async () => {
+      const functionKeys = ['FuncA', 'FuncB', 'FuncC']
+      serverless = createMockServerlessWithLayers(['LayerA'])
+      serverless.service.getAllFunctions = jest
+        .fn()
+        .mockReturnValue(functionKeys)
+      plugin = new Prune(serverless, {
+        number: 1,
+        includeLayers: true,
+        includeArtifacts: true,
+      })
+      // Enable the sweep prerequisite gated by shouldSweepArtifacts().
+      plugin.provider.isReferenceCodeStorageMode = () => true
+
+      providerRequest.mockImplementation((service, action) => {
+        if (action === 'listVersionsByFunction') {
+          return Promise.resolve(createVersionsResponse([1, 2]))
+        }
+        if (action === 'listAliases') {
+          return Promise.resolve(createAliasResponse([]))
+        }
+        if (action === 'listLayerVersions') {
+          return Promise.resolve(createLayerVersionsResponse([1, 2]))
+        }
+        if (action === 'listObjectsV2') {
+          return Promise.resolve({ Contents: [] })
+        }
+        // deleteFunction / deleteLayerVersion / deleteObjects: succeed with
+        // an empty response, nothing under test here.
+        return Promise.resolve({})
+      })
+
+      await plugin.cliPrune()
+
+      const listVersionsByFunctionCalls = providerRequest.mock.calls.filter(
+        ([, action]) => action === 'listVersionsByFunction',
+      )
+      // N calls from the prune phase: pruneFunctions() and pruneLayers()'s
+      // attached-set builder run concurrently via Promise.all but share the
+      // SAME fetch through the getFunctionVersionLists() memo, so the prune
+      // phase costs exactly N — not 2N — even though both methods need it.
+      // Then sweepDeploymentArtifacts() deliberately does its OWN fresh,
+      // post-prune listing (it must never reuse the pre-prune memo, or it
+      // would miss versions this very run just deleted — see the "discounts
+      // a version this same run just deleted" test above), adding N more.
+      // Total across the whole cliPrune() run: 2N, never 3N or N.
+      expect(listVersionsByFunctionCalls).toHaveLength(functionKeys.length * 2)
+    })
+  })
+
+  describe('includeArtifacts', () => {
+    beforeEach(() => {
+      serverless = createMockServerless(['FuncA'])
+      plugin = new Prune(serverless, { number: 5 })
+    })
+
+    it('accepts custom.prune.includeArtifacts in config', () => {
+      const pluginCustom = plugin.loadCustom({
+        prune: { automatic: true, number: 5, includeArtifacts: true },
+      })
+      expect(pluginCustom.includeArtifacts).toBe(true)
+    })
+
+    it('runs the sweep for a copy-mode service (no codeStorageMode configured)', async () => {
+      // Copy mode is the default: createMockServerless wires
+      // isReferenceCodeStorageMode() to return false. The sweep engine is
+      // storage-mode-blind — it pins from surviving versions either way — so
+      // an unscoped run still lists versions, computes pins, and drives the
+      // S3 sweep. Here the real sweepDeploymentArtifacts()/sweepArtifacts()
+      // path runs end to end; only provider.request is mocked.
+      const DIR_OLD = '050-2026-07-14T00:00:00.000Z'
+      const DIR_NEW = '300-2026-07-17T00:00:00.000Z'
+      const deleteObjectsCalls = []
+      const listObjectsV2Calls = []
+
+      serverless = createMockServerless(['FuncA'])
+      // keepCount 0 disables the retention-window shortcut so both dirs are
+      // actually inspected against the pin set below.
+      serverless.service.provider.deploymentBucketObject = {
+        maxPreviousDeploymentArtifacts: 0,
+      }
+      providerRequest.mockImplementation(async (service, method, params) => {
+        switch (method) {
+          case 'listVersionsByFunction':
+            return { Versions: [{ Version: '2', CodeSha256: 'LIVESHA' }] }
+          case 'listAliases':
+            return { Aliases: [] }
+          case 'listObjectsV2':
+            listObjectsV2Calls.push(params)
+            return {
+              Contents: [
+                {
+                  Key: `serverless/test-service/dev/${DIR_OLD}/test-service.zip`,
+                },
+                {
+                  Key: `serverless/test-service/dev/${DIR_NEW}/test-service.zip`,
+                },
+              ],
+            }
+          case 'headObject':
+            if (params.Key.includes(DIR_NEW)) {
+              return { Metadata: { filesha256: 'LIVESHA' } }
+            }
+            return { Metadata: { filesha256: 'STALESHA' } }
+          case 'deleteObjects':
+            deleteObjectsCalls.push(params)
+            return {}
+          case 'deleteFunction':
+            return {}
+          default:
+            throw new Error(`unexpected request ${service} ${method}`)
+        }
+      })
+
+      plugin = new Prune(serverless, { number: 5, includeArtifacts: true })
+      const warnSpy = jest.spyOn(plugin, 'logWarning')
+
+      await plugin.cliPrune()
+
+      // Copy mode never warns about a missing codeStorageMode — the gate is
+      // gone.
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('codeStorageMode'),
+      )
+      // The sweep actually ran: it listed the artifact directories...
+      expect(listObjectsV2Calls.length).toBeGreaterThan(0)
+      // ...and marked only the stale, unpinned dir (delete marker only), while
+      // the dir backing the surviving version stayed pinned.
+      expect(deleteObjectsCalls).toHaveLength(1)
+      expect(deleteObjectsCalls[0].Delete.Objects).toEqual([
+        { Key: `serverless/test-service/dev/${DIR_OLD}/test-service.zip` },
+      ])
+    })
+
+    it('skips the sweep with a notice on scoped runs', async () => {
+      plugin.options = { number: 5, includeArtifacts: true, function: 'hello' }
+      plugin.provider.isReferenceCodeStorageMode = () => true
+      plugin.pruneFunctions = jest.fn()
+      plugin.sweepDeploymentArtifacts = jest.fn()
+      const noticeSpy = jest.spyOn(plugin, 'logNotice')
+
+      await plugin.cliPrune()
+
+      expect(plugin.sweepDeploymentArtifacts).not.toHaveBeenCalled()
+      expect(noticeSpy).toHaveBeenCalled()
+    })
+
+    it('runs the sweep after pruning on unscoped runs in reference mode', async () => {
+      plugin.options = { number: 5, includeArtifacts: true }
+      plugin.provider.isReferenceCodeStorageMode = () => true
+      plugin.pruneFunctions = jest.fn()
+      plugin.sweepDeploymentArtifacts = jest.fn()
+
+      await plugin.cliPrune()
+
+      expect(plugin.sweepDeploymentArtifacts).toHaveBeenCalled()
+    })
+
+    it('runs the sweep from automatic post-deploy pruning when configured', async () => {
+      plugin.pluginCustom = {
+        automatic: true,
+        number: 5,
+        includeArtifacts: true,
+      }
+      plugin.serverless.service.custom = {
+        prune: { automatic: true, number: 5, includeArtifacts: true },
+      }
+      plugin.provider.isReferenceCodeStorageMode = () => true
+      plugin.pruneFunctions = jest.fn()
+      plugin.sweepDeploymentArtifacts = jest.fn()
+
+      await plugin.postDeploy()
+
+      expect(plugin.sweepDeploymentArtifacts).toHaveBeenCalled()
+    })
+  })
+
   describe('logging helpers', () => {
     let logMock
     beforeEach(() => {
@@ -652,6 +1094,640 @@ describe('Prune', () => {
           FunctionName: 'MyFunc',
           Marker: 'marker1',
         },
+      )
+    })
+  })
+
+  describe('sweepDeploymentArtifacts', () => {
+    // End-to-end coverage of the real sweepDeploymentArtifacts method driving
+    // the real artifact-sweep engine (sweepArtifacts is NOT stubbed). Only
+    // provider.request and the provider getters are mocked.
+    const FUNCTION_NAME = 'svc-dev-hello'
+    const DIR_050 = '050-2026-07-14T00:00:00.000Z'
+    const DIR_100 = '100-2026-07-15T00:00:00.000Z'
+    const DIR_300 = '300-2026-07-17T00:00:00.000Z'
+    const REF_LAYER_ARN = 'arn:aws:lambda:us-east-1:111:layer:refLayer:3'
+    const DEAD_LAYER_ARN = 'arn:aws:lambda:us-east-1:111:layer:deadLayer:1'
+    const REF_LAYER_KEY = `serverless/svc/dev/${DIR_100}/refLayer.zip`
+
+    const s3Listing = {
+      Contents: [
+        { Key: `serverless/svc/dev/${DIR_050}/deadLayer.zip` },
+        { Key: `serverless/svc/dev/${DIR_050}/svc.zip` },
+        { Key: `serverless/svc/dev/${DIR_100}/refLayer.zip` },
+        { Key: `serverless/svc/dev/${DIR_100}/svc.zip` },
+        { Key: `serverless/svc/dev/${DIR_300}/svc.zip` },
+      ],
+    }
+
+    // Builds a fully-wired Prune instance whose only mocked seams are
+    // provider.request and the provider getters listed in the task spec.
+    const buildPlugin = (functionVersions) => {
+      const deleteObjectsCalls = []
+      const getLayerVersionCalls = []
+      const getLayerVersionRequestOptions = []
+
+      const request = jest.fn(async (service, method, params, options) => {
+        switch (method) {
+          case 'listVersionsByFunction':
+            return { Versions: functionVersions }
+          case 'listLayerVersions':
+            if (params.LayerName === 'refLayer') {
+              return { LayerVersions: [{ LayerVersionArn: REF_LAYER_ARN }] }
+            }
+            return { LayerVersions: [] }
+          case 'getLayerVersion':
+            getLayerVersionCalls.push(params)
+            getLayerVersionRequestOptions.push(options)
+            if (params.LayerName === 'refLayer' && params.VersionNumber === 3) {
+              return {
+                Content: {
+                  ResolvedS3Object: {
+                    S3Bucket: 'deployment-bucket',
+                    S3Key: REF_LAYER_KEY,
+                    S3ObjectVersion: 'layerVid',
+                  },
+                },
+              }
+            }
+            if (
+              params.LayerName === 'deadLayer' &&
+              params.VersionNumber === 1
+            ) {
+              throw new Error('layer version not found')
+            }
+            throw new Error(
+              `unexpected getLayerVersion params ${JSON.stringify(params)}`,
+            )
+          case 'listObjectsV2':
+            return s3Listing
+          case 'headObject':
+            if (params.Key.endsWith('svc.zip')) {
+              return { Metadata: { filesha256: 'PINNEDSHA' } }
+            }
+            if (params.Key === REF_LAYER_KEY) {
+              return {
+                Metadata: { filesha256: 'garbage' },
+                VersionId: 'layerVid',
+              }
+            }
+            if (params.Key.endsWith('deadLayer.zip')) {
+              return { Metadata: { filesha256: 'unrelatedsha' } }
+            }
+            throw new Error(`unexpected headObject key ${params.Key}`)
+          case 'deleteObjects':
+            deleteObjectsCalls.push(params)
+            return {}
+          default:
+            throw new Error(`unexpected request ${service} ${method}`)
+        }
+      })
+
+      const mockServerless = {
+        getProvider: jest.fn().mockReturnValue({
+          request,
+          isReferenceCodeStorageMode: () => true,
+          getServerlessDeploymentBucketName: async () => 'deployment-bucket',
+          getDeploymentPrefix: () => 'serverless',
+          getStage: () => 'dev',
+          // Mirrors the real provider.resolveLayerArtifactName: artifact
+          // basename is derived from the CONFIG KEY (naming.getLayerArtifactName),
+          // not the published layer name — only the basename matters here
+          // since sweepDeploymentArtifacts() only calls path.basename() on it.
+          resolveLayerArtifactName: (layerName) => `${layerName}.zip`,
+        }),
+        service: {
+          service: 'svc',
+          provider: {
+            deploymentBucketObject: { maxPreviousDeploymentArtifacts: 1 },
+          },
+          getAllFunctions: jest.fn().mockReturnValue(['hello']),
+          getFunction: jest.fn().mockReturnValue({ name: FUNCTION_NAME }),
+          getAllLayers: jest.fn().mockReturnValue(['refLayer', 'deadLayer']),
+          getLayer: jest.fn().mockImplementation((key) => ({ name: key })),
+          custom: {},
+        },
+        configSchemaHandler: { defineCustomProperties: jest.fn() },
+      }
+
+      const sweepPlugin = new Prune(
+        mockServerless,
+        {},
+        {
+          log: {
+            info: jest.fn(),
+            notice: jest.fn(),
+            warning: jest.fn(),
+            success: jest.fn(),
+          },
+        },
+      )
+
+      return {
+        sweepPlugin,
+        request,
+        deleteObjectsCalls,
+        getLayerVersionCalls,
+        getLayerVersionRequestOptions,
+        mockServerless,
+      }
+    }
+
+    it('keeps every candidate dir when pinned by sha, exact layer version, and basename fail-safe', async () => {
+      const {
+        sweepPlugin,
+        request,
+        deleteObjectsCalls,
+        getLayerVersionCalls,
+        getLayerVersionRequestOptions,
+      } = buildPlugin([
+        {
+          Version: '5',
+          CodeSha256: 'PINNEDSHA',
+          Layers: [{ Arn: REF_LAYER_ARN }, { Arn: DEAD_LAYER_ARN }],
+        },
+      ])
+
+      await sweepPlugin.sweepDeploymentArtifacts()
+
+      // Nothing is provably unpinned, so no deletion marker is ever issued.
+      expect(deleteObjectsCalls).toHaveLength(0)
+
+      // ARN parsing feeds getLayerVersion correctly for both the resolvable
+      // and the deleted-layer-version (thrown) case.
+      expect(getLayerVersionCalls).toEqual(
+        expect.arrayContaining([
+          { LayerName: 'refLayer', VersionNumber: 3 },
+          { LayerName: 'deadLayer', VersionNumber: 1 },
+        ]),
+      )
+
+      // getLayerVersion must go through the v3 SDK path so
+      // Content.ResolvedS3Object reaches the exact-pin logic above (v2
+      // silently drops that field).
+      expect(getLayerVersionRequestOptions).toHaveLength(2)
+      for (const options of getLayerVersionRequestOptions) {
+        expect(options).toEqual({ sdkVersion: 3 })
+      }
+
+      // keepCount:1 (from deploymentBucketObject) protects the newest dir —
+      // it must never even be inspected.
+      expect(request).not.toHaveBeenCalledWith(
+        'S3',
+        'headObject',
+        expect.objectContaining({ Key: expect.stringContaining(DIR_300) }),
+      )
+    })
+
+    it('pins a layer via Content.CodeSha256 when getLayerVersion returns no ResolvedS3Object', async () => {
+      // Fallback path (index.js): when getLayerVersion has no
+      // Content.ResolvedS3Object to exact-pin against, its Content.CodeSha256
+      // is added to the pinned-sha set instead. That sha then protects any
+      // artifact whose filesha256 metadata matches, regardless of storage
+      // mode. Here the surviving function version attaches a layer ARN whose
+      // getLayerVersion response carries only CodeSha256; the old dir holds a
+      // layer artifact stamped with that same sha and must be kept.
+      const ATTACHED_ARN = 'arn:aws:lambda:us-east-1:111:layer:util:4'
+      const DIR_OLD = '050-2026-07-14T00:00:00.000Z'
+      const DIR_NEW = '300-2026-07-17T00:00:00.000Z'
+      const deleteObjectsCalls = []
+
+      const request = jest.fn(async (service, method, params, options) => {
+        switch (method) {
+          case 'listVersionsByFunction':
+            return {
+              Versions: [
+                {
+                  Version: '5',
+                  CodeSha256: 'FUNCSHA',
+                  Layers: [{ Arn: ATTACHED_ARN }],
+                },
+              ],
+            }
+          case 'listLayerVersions':
+            return { LayerVersions: [{ LayerVersionArn: ATTACHED_ARN }] }
+          case 'getLayerVersion':
+            expect(options).toEqual({ sdkVersion: 3 })
+            // No Content.ResolvedS3Object — only a CodeSha256 to fall back to.
+            return { Content: { CodeSha256: 'LAYERSHA' } }
+          case 'listObjectsV2':
+            return {
+              Contents: [
+                { Key: `serverless/svc/dev/${DIR_OLD}/util.zip` },
+                { Key: `serverless/svc/dev/${DIR_NEW}/svc.zip` },
+              ],
+            }
+          case 'headObject':
+            // The old dir's layer artifact is stamped with the layer's
+            // CodeSha256 — the only thing that can keep it is the fallback pin.
+            if (params.Key === `serverless/svc/dev/${DIR_OLD}/util.zip`) {
+              return { Metadata: { filesha256: 'LAYERSHA' } }
+            }
+            throw new Error(`unexpected headObject key ${params.Key}`)
+          case 'deleteObjects':
+            deleteObjectsCalls.push(params)
+            return {}
+          default:
+            throw new Error(`unexpected request ${service} ${method}`)
+        }
+      })
+
+      const mockServerless = {
+        getProvider: jest.fn().mockReturnValue({
+          request,
+          // Copy mode (default) — the fallback pin must work here too.
+          isReferenceCodeStorageMode: () => false,
+          getServerlessDeploymentBucketName: async () => 'deployment-bucket',
+          getDeploymentPrefix: () => 'serverless',
+          getStage: () => 'dev',
+          resolveLayerArtifactName: (layerName) => `${layerName}.zip`,
+        }),
+        service: {
+          service: 'svc',
+          provider: {
+            // keepCount 1 protects DIR_NEW; DIR_OLD is the only candidate.
+            deploymentBucketObject: { maxPreviousDeploymentArtifacts: 1 },
+          },
+          getAllFunctions: jest.fn().mockReturnValue(['hello']),
+          getFunction: jest.fn().mockReturnValue({ name: FUNCTION_NAME }),
+          getAllLayers: jest.fn().mockReturnValue(['util']),
+          getLayer: jest.fn().mockReturnValue({ name: 'util' }),
+          custom: {},
+        },
+        configSchemaHandler: { defineCustomProperties: jest.fn() },
+      }
+
+      const sweepPlugin = new Prune(
+        mockServerless,
+        {},
+        {
+          log: {
+            info: jest.fn(),
+            notice: jest.fn(),
+            warning: jest.fn(),
+            success: jest.fn(),
+          },
+        },
+      )
+
+      await sweepPlugin.sweepDeploymentArtifacts()
+
+      // DIR_OLD's layer artifact matched the fallback CodeSha256 pin, so
+      // nothing is marked for deletion.
+      expect(deleteObjectsCalls).toHaveLength(0)
+    })
+
+    it('marks only the provably-unpinned dir when the function sha no longer matches and the dead layer is unreferenced', async () => {
+      const { sweepPlugin, deleteObjectsCalls } = buildPlugin([
+        {
+          Version: '5',
+          CodeSha256: 'OTHER',
+          // deadLayer is no longer attached to any surviving function version
+          // and no longer appears in listLayerVersions, so it is never
+          // resolved via getLayerVersion and gets no basename fail-safe pin.
+          Layers: [{ Arn: REF_LAYER_ARN }],
+        },
+      ])
+
+      await sweepPlugin.sweepDeploymentArtifacts()
+
+      // Only dir 050 is provably unpinned: dir 100 is kept because refLayer
+      // is still pinned to its exact resolved artifact/version.
+      expect(deleteObjectsCalls).toHaveLength(1)
+      expect(deleteObjectsCalls[0].Bucket).toBe('deployment-bucket')
+      expect(deleteObjectsCalls[0].Delete.Objects).toEqual([
+        { Key: `serverless/svc/dev/${DIR_050}/deadLayer.zip` },
+        { Key: `serverless/svc/dev/${DIR_050}/svc.zip` },
+      ])
+    })
+
+    it('discounts a version this same run just deleted even though the fresh listVersionsByFunction call still (eventual consistency) returns it', async () => {
+      const deleteObjectsCalls = []
+
+      const request = jest.fn(async (service, method, params) => {
+        switch (method) {
+          case 'deleteFunction':
+            return {}
+          case 'listVersionsByFunction':
+            // Simulates Lambda's eventual consistency: version 2, deleted
+            // moments ago below via deleteVersionsForFunction, still shows
+            // up in this "fresh" listing alongside surviving version 3.
+            return {
+              Versions: [
+                { Version: '2', CodeSha256: 'V2SHA' },
+                { Version: '3', CodeSha256: 'V3SHA' },
+              ],
+            }
+          case 'listLayerVersions':
+            return { LayerVersions: [] }
+          case 'listObjectsV2':
+            return {
+              Contents: [
+                { Key: `serverless/svc/dev/${DIR_050}/svc.zip` },
+                { Key: `serverless/svc/dev/${DIR_100}/svc.zip` },
+                { Key: `serverless/svc/dev/${DIR_300}/svc.zip` },
+              ],
+            }
+          case 'headObject':
+            if (params.Key === `serverless/svc/dev/${DIR_050}/svc.zip`) {
+              // Backs the just-pruned (and still, per eventual consistency,
+              // listed) version 2.
+              return { Metadata: { filesha256: 'V2SHA' } }
+            }
+            if (params.Key === `serverless/svc/dev/${DIR_100}/svc.zip`) {
+              // Backs the real surviving version 3.
+              return { Metadata: { filesha256: 'V3SHA' } }
+            }
+            throw new Error(`unexpected headObject key ${params.Key}`)
+          case 'deleteObjects':
+            deleteObjectsCalls.push(params)
+            return {}
+          default:
+            throw new Error(`unexpected request ${service} ${method}`)
+        }
+      })
+
+      const mockServerless = {
+        getProvider: jest.fn().mockReturnValue({
+          request,
+          isReferenceCodeStorageMode: () => true,
+          getServerlessDeploymentBucketName: async () => 'deployment-bucket',
+          getDeploymentPrefix: () => 'serverless',
+          getStage: () => 'dev',
+        }),
+        service: {
+          service: 'svc',
+          provider: {
+            deploymentBucketObject: { maxPreviousDeploymentArtifacts: 1 },
+          },
+          getAllFunctions: jest.fn().mockReturnValue(['hello']),
+          getFunction: jest.fn().mockReturnValue({ name: FUNCTION_NAME }),
+          getAllLayers: jest.fn().mockReturnValue([]),
+          getLayer: jest.fn(),
+          custom: {},
+        },
+        configSchemaHandler: { defineCustomProperties: jest.fn() },
+      }
+
+      const sweepPlugin = new Prune(
+        mockServerless,
+        {},
+        {
+          log: {
+            info: jest.fn(),
+            notice: jest.fn(),
+            warning: jest.fn(),
+            success: jest.fn(),
+          },
+        },
+      )
+
+      // Real recording path: pruneFunctions()/cliPrune() would have called
+      // this moments before sweepDeploymentArtifacts() runs, and it must
+      // have succeeded (not thrown) for the version to be recorded.
+      await sweepPlugin.deleteVersionsForFunction(FUNCTION_NAME, ['2'])
+      expect(sweepPlugin.prunedFunctionVersions.get(FUNCTION_NAME)).toEqual(
+        new Set(['2']),
+      )
+
+      await sweepPlugin.sweepDeploymentArtifacts()
+
+      // DIR_050 backs the just-deleted version 2. Without discounting the
+      // recorded deletion, the stale listVersionsByFunction entry would
+      // still pin V2SHA and this dir would incorrectly survive forever —
+      // exactly the live `prune -n 1 --includeArtifacts` symptom this test
+      // guards against.
+      expect(deleteObjectsCalls).toHaveLength(1)
+      expect(deleteObjectsCalls[0].Delete.Objects).toEqual([
+        { Key: `serverless/svc/dev/${DIR_050}/svc.zip` },
+      ])
+      // DIR_100 backs the real surviving version 3 and must remain pinned.
+      expect(deleteObjectsCalls[0].Delete.Objects).not.toContainEqual({
+        Key: `serverless/svc/dev/${DIR_100}/svc.zip`,
+      })
+    })
+
+    it('protects the config-key artifact basename (not just the ARN-derived name) when a custom-named layer is deleted-but-attached', async () => {
+      // layers: { common: { name: 'acme-prod-utils', ... } } — the config
+      // key ("common") and the published Lambda layer name
+      // ("acme-prod-utils") differ. The deployment artifact is named after
+      // the CONFIG KEY (common.zip), while the attached ARN carries the
+      // PUBLISHED name. Before the fix, the deleted-but-attached fail-safe
+      // only ever pinned "acme-prod-utils.zip" — protecting nothing, since
+      // that file never existed in the bucket.
+      const CONFIG_KEY = 'common'
+      const PUBLISHED_NAME = 'acme-prod-utils'
+      const ATTACHED_ARN = `arn:aws:lambda:us-east-1:111:layer:${PUBLISHED_NAME}:7`
+      const DIR_OLD = '050-2026-07-14T00:00:00.000Z'
+      const DIR_NEW = '300-2026-07-17T00:00:00.000Z'
+
+      const deleteObjectsCalls = []
+      const request = jest.fn(async (service, method, params) => {
+        switch (method) {
+          case 'listVersionsByFunction':
+            return {
+              Versions: [
+                {
+                  Version: '5',
+                  CodeSha256: 'UNRELATEDSHA',
+                  Layers: [{ Arn: ATTACHED_ARN }],
+                },
+              ],
+            }
+          case 'listLayerVersions':
+            // The layer version is gone from listLayerVersions too — fully
+            // deleted-but-still-attached to the surviving function version.
+            return { LayerVersions: [] }
+          case 'getLayerVersion':
+            throw new Error('layer version not found')
+          case 'listObjectsV2':
+            return {
+              Contents: [
+                { Key: `serverless/svc/dev/${DIR_OLD}/${CONFIG_KEY}.zip` },
+                { Key: `serverless/svc/dev/${DIR_NEW}/${CONFIG_KEY}.zip` },
+              ],
+            }
+          case 'headObject':
+            // Not sha-pinned — the only thing that can save DIR_OLD is the
+            // basename fail-safe pin.
+            return { Metadata: { filesha256: 'someothersha' } }
+          case 'deleteObjects':
+            deleteObjectsCalls.push(params)
+            return {}
+          default:
+            throw new Error(`unexpected request ${service} ${method}`)
+        }
+      })
+
+      const mockServerless = {
+        getProvider: jest.fn().mockReturnValue({
+          request,
+          isReferenceCodeStorageMode: () => true,
+          getServerlessDeploymentBucketName: async () => 'deployment-bucket',
+          getDeploymentPrefix: () => 'serverless',
+          getStage: () => 'dev',
+          resolveLayerArtifactName: (layerName) => `${layerName}.zip`,
+        }),
+        service: {
+          service: 'svc',
+          provider: {
+            deploymentBucketObject: { maxPreviousDeploymentArtifacts: 1 },
+          },
+          getAllFunctions: jest.fn().mockReturnValue(['hello']),
+          getFunction: jest.fn().mockReturnValue({ name: FUNCTION_NAME }),
+          getAllLayers: jest.fn().mockReturnValue([CONFIG_KEY]),
+          getLayer: jest.fn().mockReturnValue({ name: PUBLISHED_NAME }),
+          custom: {},
+        },
+        configSchemaHandler: { defineCustomProperties: jest.fn() },
+      }
+
+      const sweepPlugin = new Prune(
+        mockServerless,
+        {},
+        {
+          log: {
+            info: jest.fn(),
+            notice: jest.fn(),
+            warning: jest.fn(),
+            success: jest.fn(),
+          },
+        },
+      )
+
+      await sweepPlugin.sweepDeploymentArtifacts()
+
+      // keepCount:1 protects DIR_NEW automatically (never inspected); DIR_OLD
+      // is the only candidate. It must be kept via the mapped basename
+      // fail-safe pin ("common.zip"), not swept because the raw ARN-name
+      // pin ("acme-prod-utils.zip") doesn't match anything real.
+      expect(deleteObjectsCalls).toHaveLength(0)
+    })
+
+    it('previews the sweep against planned deletions on a combined --dryRun --includeLayers --includeArtifacts cliPrune run', async () => {
+      // Regression: `prune -n 1 --includeLayers
+      // --includeArtifacts --dryRun` under-previewed the sweep because
+      // dryRun pruneFunctions()/pruneLayers() computed deletion candidates
+      // but never recorded them, so the sweep's fresh listing still saw
+      // every version "alive" and reported the directory backing the
+      // would-be-deleted version as pinned/kept. DIR_OLD here is pinned
+      // ONLY by version '1' (V1SHA), which number:1 would delete (keeping
+      // only the newest version '2', V2SHA) — a correctly-fixed dryRun
+      // preview must report DIR_OLD as selected for deletion, exactly as a
+      // real run would produce.
+      const deleteFunctionCalls = []
+      const deleteLayerVersionCalls = []
+      const deleteObjectsCalls = []
+
+      const request = jest.fn(async (service, method, params) => {
+        switch (method) {
+          case 'listVersionsByFunction':
+            return {
+              Versions: [
+                { Version: '1', CodeSha256: 'V1SHA' },
+                { Version: '2', CodeSha256: 'V2SHA' },
+              ],
+            }
+          case 'listAliases':
+            return { Aliases: [] }
+          case 'listLayerVersions':
+            return { LayerVersions: [] }
+          case 'listObjectsV2':
+            return {
+              Contents: [
+                { Key: `serverless/svc/dev/${DIR_050}/svc.zip` },
+                { Key: `serverless/svc/dev/${DIR_300}/svc.zip` },
+              ],
+            }
+          case 'headObject':
+            if (params.Key === `serverless/svc/dev/${DIR_050}/svc.zip`) {
+              return { Metadata: { filesha256: 'V1SHA' } }
+            }
+            if (params.Key === `serverless/svc/dev/${DIR_300}/svc.zip`) {
+              return { Metadata: { filesha256: 'V2SHA' } }
+            }
+            throw new Error(`unexpected headObject key ${params.Key}`)
+          case 'deleteFunction':
+            deleteFunctionCalls.push(params)
+            return {}
+          case 'deleteLayerVersion':
+            deleteLayerVersionCalls.push(params)
+            return {}
+          case 'deleteObjects':
+            deleteObjectsCalls.push(params)
+            return {}
+          default:
+            throw new Error(`unexpected request ${service} ${method}`)
+        }
+      })
+
+      const logMock = {
+        info: jest.fn(),
+        notice: jest.fn(),
+        warning: jest.fn(),
+        success: jest.fn(),
+      }
+
+      const mockServerless = {
+        getProvider: jest.fn().mockReturnValue({
+          request,
+          isReferenceCodeStorageMode: () => true,
+          getServerlessDeploymentBucketName: async () => 'deployment-bucket',
+          getDeploymentPrefix: () => 'serverless',
+          getStage: () => 'dev',
+          resolveLayerArtifactName: (layerName) => `${layerName}.zip`,
+        }),
+        service: {
+          service: 'svc',
+          provider: {
+            // 0 disables the automatic keep-window protection, so both
+            // dirs are actually inspected against the pin sets below.
+            deploymentBucketObject: { maxPreviousDeploymentArtifacts: 0 },
+          },
+          getAllFunctions: jest.fn().mockReturnValue(['hello']),
+          getFunction: jest.fn().mockReturnValue({ name: FUNCTION_NAME }),
+          getAllLayers: jest.fn().mockReturnValue([]),
+          getLayer: jest.fn(),
+          custom: {},
+        },
+        configSchemaHandler: { defineCustomProperties: jest.fn() },
+      }
+
+      const dryRunPlugin = new Prune(
+        mockServerless,
+        {
+          number: 1,
+          includeLayers: true,
+          includeArtifacts: true,
+          dryRun: true,
+        },
+        { log: logMock },
+      )
+
+      await dryRunPlugin.cliPrune()
+
+      // The planned deletion (version '1') was recorded even though dryRun
+      // never actually deletes anything.
+      expect(dryRunPlugin.prunedFunctionVersions.get(FUNCTION_NAME)).toEqual(
+        new Set(['1']),
+      )
+
+      // Nothing was actually deleted anywhere — dryRun end to end.
+      expect(deleteFunctionCalls).toHaveLength(0)
+      expect(deleteLayerVersionCalls).toHaveLength(0)
+      expect(deleteObjectsCalls).toHaveLength(0)
+
+      // DIR_050 (backing only the would-be-pruned version 1) is reported as
+      // selected for deletion — the sweep preview reflects the post-prune
+      // world, not the still-alive-today world.
+      expect(logMock.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `Deployment ${DIR_050} selected for deletion (dry-run).`,
+        ),
+      )
+      // DIR_300 (backing the surviving version 2) must remain kept.
+      expect(logMock.info).not.toHaveBeenCalledWith(
+        expect.stringContaining(`Deployment ${DIR_300} selected for deletion`),
       )
     })
   })

--- a/packages/sf-core/tests/integration/self-managed-storage/reference-mode/fixture/.gitignore
+++ b/packages/sf-core/tests/integration/self-managed-storage/reference-mode/fixture/.gitignore
@@ -1,0 +1,6 @@
+# package directories
+node_modules
+jspm_packages
+
+# Serverless directories
+.serverless

--- a/packages/sf-core/tests/integration/self-managed-storage/reference-mode/fixture/handler.js
+++ b/packages/sf-core/tests/integration/self-managed-storage/reference-mode/fixture/handler.js
@@ -1,0 +1,1 @@
+exports.hello = async () => ({ statusCode: 200, body: 'v1' })

--- a/packages/sf-core/tests/integration/self-managed-storage/reference-mode/fixture/layer/nodejs/util.js
+++ b/packages/sf-core/tests/integration/self-managed-storage/reference-mode/fixture/layer/nodejs/util.js
@@ -1,0 +1,1 @@
+module.exports.marker = 'layer-v1'

--- a/packages/sf-core/tests/integration/self-managed-storage/reference-mode/fixture/serverless.yml
+++ b/packages/sf-core/tests/integration/self-managed-storage/reference-mode/fixture/serverless.yml
@@ -1,0 +1,26 @@
+service: smcs-reference-mode
+frameworkVersion: '*'
+
+provider:
+  name: aws
+  region: us-east-1
+  runtime: nodejs20.x
+  deploymentBucket:
+    codeStorageMode: reference
+    # Kept tight on purpose: the integration suite only performs a handful of
+    # deploys, so a small retention window ensures the "prune --includeArtifacts"
+    # test actually exercises the artifact sweep instead of the default window
+    # (5) simply excluding every directory from consideration.
+    maxPreviousDeploymentArtifacts: 1
+
+layers:
+  common:
+    path: layer
+    compatibleRuntimes:
+      - nodejs20.x
+
+functions:
+  hello:
+    handler: handler.hello
+    layers:
+      - { Ref: CommonLambdaLayer }

--- a/packages/sf-core/tests/integration/self-managed-storage/reference-mode/reference-mode.test.js
+++ b/packages/sf-core/tests/integration/self-managed-storage/reference-mode/reference-mode.test.js
@@ -1,0 +1,363 @@
+import fsp from 'fs/promises'
+import path from 'path'
+import url from 'url'
+import readConfig from '@serverless/framework/lib/configuration/read.js'
+import {
+  LambdaClient,
+  GetFunctionCommand,
+  InvokeCommand,
+  ListVersionsByFunctionCommand,
+} from '@aws-sdk/client-lambda'
+import {
+  S3Client,
+  GetBucketPolicyCommand,
+  ListObjectVersionsCommand,
+} from '@aws-sdk/client-s3'
+import { jest } from '@jest/globals'
+import { setGlobalRendererSettings } from '@serverless/util'
+import { getTestStageName, runSfCore } from '../../../utils/runSfCore.js'
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
+describe('Lambda self-managed code storage (reference mode)', () => {
+  const configFileDirPath = path.join(__dirname, 'fixture')
+  const handlerFilePath = path.join(configFileDirPath, 'handler.js')
+  const lambdaClient = new LambdaClient({ region: 'us-east-1' })
+  const s3Client = new S3Client({ region: 'us-east-1' })
+  const originalEnv = process.env
+  const stage = getTestStageName()
+  let service, configFilePath, functionName
+  let originalHandlerContent
+
+  // State threaded through the test sequence below.
+  let v1ResolvedS3Object
+  let v1VersionNumber
+  let v2ResolvedS3Object
+
+  const setHandlerBody = (body) =>
+    fsp.writeFile(
+      handlerFilePath,
+      `exports.hello = async () => ({ statusCode: 200, body: '${body}' })\n`,
+    )
+
+  beforeAll(async () => {
+    setGlobalRendererSettings({
+      isInteractive: false,
+      logLevel: 'info',
+    })
+    configFilePath = path.join(configFileDirPath, 'serverless.yml')
+    service = await readConfig(configFilePath)
+    functionName = `${service.service}-${stage}-hello`
+    originalHandlerContent = await fsp.readFile(handlerFilePath, 'utf8')
+
+    process.env = {
+      ...originalEnv,
+      SERVERLESS_PLATFORM_STAGE: 'dev',
+      SERVERLESS_LICENSE_KEY: process.env.SERVERLESS_LICENSE_KEY_DEV,
+      SERVERLESS_ACCESS_KEY: undefined,
+    }
+  })
+
+  afterAll(async () => {
+    // Restore the fixture handler so the git tree stays clean regardless of
+    // whether the tests above passed or failed.
+    await fsp.writeFile(handlerFilePath, originalHandlerContent)
+    process.env = originalEnv
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('Deploy', async () => {
+    await runSfCore({
+      coreParams: {
+        options: { stage, c: configFilePath },
+        command: ['deploy'],
+      },
+      jest,
+    })
+  })
+
+  test('Function runs in reference mode with a pinned object version', async () => {
+    const fn = await lambdaClient.send(
+      new GetFunctionCommand({ FunctionName: functionName }),
+    )
+
+    expect(fn.Code.ResolvedS3Object).toBeDefined()
+    expect(fn.Code.ResolvedS3Object.S3ObjectVersion).toBeDefined()
+    expect(fn.Code.ResolvedS3Object.S3Bucket).toBeDefined()
+    expect(fn.Code.ResolvedS3Object.S3Key).toBeDefined()
+    expect(fn.Code.Location).toBeUndefined()
+
+    v1ResolvedS3Object = fn.Code.ResolvedS3Object
+
+    const invoke = await lambdaClient.send(
+      new InvokeCommand({ FunctionName: functionName }),
+    )
+    expect(invoke.StatusCode).toBe(200)
+    expect(invoke.FunctionError).toBeUndefined()
+  })
+
+  test('Deployment bucket has the Lambda-read policy statement', async () => {
+    const bucket = v1ResolvedS3Object.S3Bucket
+    const { Policy } = await s3Client.send(
+      new GetBucketPolicyCommand({ Bucket: bucket }),
+    )
+    const policy = JSON.parse(Policy)
+
+    expect(
+      policy.Statement.some(
+        (statement) =>
+          statement.Sid === 'ServerlessLambdaSelfManagedCodeAccess',
+      ),
+    ).toBe(true)
+  })
+
+  test('Redeploy with changed code pins a new version; old published version keeps its pin', async () => {
+    // 1. Capture the currently published version number (versionFunctions
+    // defaults to true, so the initial deploy already published version "1").
+    const before = await lambdaClient.send(
+      new ListVersionsByFunctionCommand({ FunctionName: functionName }),
+    )
+    const publishedBefore = before.Versions.filter(
+      (v) => v.Version !== '$LATEST',
+    )
+    expect(publishedBefore.length).toBe(1)
+    v1VersionNumber = publishedBefore[0].Version
+
+    // 2. Change the handler body and redeploy.
+    await setHandlerBody('v2')
+    await runSfCore({
+      coreParams: {
+        options: { stage, c: configFilePath },
+        command: ['deploy'],
+      },
+      jest,
+    })
+
+    // 3. The unqualified (current) function now resolves to a new S3 object
+    // version.
+    const fnAfter = await lambdaClient.send(
+      new GetFunctionCommand({ FunctionName: functionName }),
+    )
+    expect(fnAfter.Code.ResolvedS3Object).toBeDefined()
+    expect(fnAfter.Code.Location).toBeUndefined()
+    expect(fnAfter.Code.ResolvedS3Object.S3ObjectVersion).not.toBe(
+      v1ResolvedS3Object.S3ObjectVersion,
+    )
+    v2ResolvedS3Object = fnAfter.Code.ResolvedS3Object
+
+    // 4. The old published version's code coordinates are untouched by the
+    // redeploy — it must still resolve to the original pinned object version.
+    const fnAtV1 = await lambdaClient.send(
+      new GetFunctionCommand({
+        FunctionName: functionName,
+        Qualifier: v1VersionNumber,
+      }),
+    )
+    expect(fnAtV1.Code.ResolvedS3Object).toBeDefined()
+    expect(fnAtV1.Code.ResolvedS3Object.S3ObjectVersion).toBe(
+      v1ResolvedS3Object.S3ObjectVersion,
+    )
+  })
+
+  test('deploy function -f updates code with Lambda-managed storage', async () => {
+    // The CloudFormation-bypassing fast path performs a standard inline code
+    // update in every storage mode, which switches the function to
+    // Lambda-managed storage until the next full deploy restates the mode.
+    await setHandlerBody('v3')
+    await runSfCore({
+      coreParams: {
+        options: { stage, c: configFilePath, function: 'hello' },
+        command: ['deploy', 'function'],
+      },
+      jest,
+    })
+
+    const fn = await lambdaClient.send(
+      new GetFunctionCommand({ FunctionName: functionName }),
+    )
+    // $LATEST is now on Lambda-managed storage: no resolved S3 object, and a
+    // presigned Code.Location is available again.
+    expect(fn.Code.ResolvedS3Object).toBeUndefined()
+    expect(fn.Code.Location).toBeDefined()
+
+    // $LATEST runs the updated code.
+    const invoke = await lambdaClient.send(
+      new InvokeCommand({ FunctionName: functionName }),
+    )
+    expect(invoke.StatusCode).toBe(200)
+    expect(invoke.FunctionError).toBeUndefined()
+    const payload = JSON.parse(Buffer.from(invoke.Payload).toString())
+    expect(payload.body).toBe('v3')
+
+    // A previously published reference version keeps running from its pinned
+    // S3 object, unaffected by the inline update to $LATEST.
+    const invokeV1 = await lambdaClient.send(
+      new InvokeCommand({
+        FunctionName: functionName,
+        Qualifier: v1VersionNumber,
+      }),
+    )
+    expect(invokeV1.StatusCode).toBe(200)
+    expect(invokeV1.FunctionError).toBeUndefined()
+    const payloadV1 = JSON.parse(Buffer.from(invokeV1.Payload).toString())
+    expect(payloadV1.body).toBe('v1')
+  })
+
+  test('serverless deploy restores reference mode after deploy function', async () => {
+    // A full deploy always restates the storage mode. The handler on disk
+    // ("v3") differs from the last full deployment ("v2"), so the deploy runs
+    // and republishes the function in reference mode.
+    await runSfCore({
+      coreParams: {
+        options: { stage, c: configFilePath },
+        command: ['deploy'],
+      },
+      jest,
+    })
+
+    const fn = await lambdaClient.send(
+      new GetFunctionCommand({ FunctionName: functionName }),
+    )
+    expect(fn.Code.ResolvedS3Object).toBeDefined()
+    expect(fn.Code.ResolvedS3Object.S3ObjectVersion).toBeDefined()
+    expect(fn.Code.Location).toBeUndefined()
+    // The restored pin points at an artifact inside a deployment directory,
+    // not the fast-path location the earlier code update used.
+    expect(fn.Code.ResolvedS3Object.S3Key).toEqual(
+      expect.stringContaining(`/${service.service}/${stage}/`),
+    )
+    expect(fn.Code.ResolvedS3Object.S3Key).not.toContain('/code-artifacts/')
+  })
+
+  test('rollback function restores a previous version by coordinates', async () => {
+    await runSfCore({
+      coreParams: {
+        options: {
+          stage,
+          c: configFilePath,
+          function: 'hello',
+          'function-version': v1VersionNumber,
+        },
+        command: ['rollback', 'function'],
+      },
+      jest,
+    })
+
+    const fn = await lambdaClient.send(
+      new GetFunctionCommand({ FunctionName: functionName }),
+    )
+    expect(fn.Code.ResolvedS3Object).toBeDefined()
+    expect(fn.Code.ResolvedS3Object.S3ObjectVersion).toBe(
+      v1ResolvedS3Object.S3ObjectVersion,
+    )
+  })
+
+  test('prune --includeArtifacts marks only unpinned deployments', async () => {
+    // Set the stage for what "unpinned" means at this point: the rollback
+    // above put $LATEST back on the very first deployment's artifact. Three
+    // deployment directories now hold live artifacts (the initial deploy, the
+    // "v2" redeploy, and the deploy that restored reference mode), and three
+    // published versions exist (v1, v2, and v3), all alive.
+    //
+    // Redeploy once more here so a fresh deployment directory exists and
+    // becomes the new "top" pin (via both $LATEST and its published version).
+    // Then "prune -n 1" (keep only the newest published version) prunes the
+    // published versions behind the earlier directories. The very first
+    // directory survives regardless because it also holds the "common" layer's
+    // only published version (layers are never re-uploaded once unchanged, so
+    // the layer artifact permanently lives in the very first deployment
+    // directory). The "v2" directory, by contrast, is left unpinned by
+    // anything once its published version is pruned and $LATEST has moved on --
+    // exactly the case "includeArtifacts" is meant to sweep.
+    await setHandlerBody('v4')
+    await runSfCore({
+      coreParams: {
+        options: { stage, c: configFilePath },
+        command: ['deploy'],
+      },
+      jest,
+    })
+
+    const fnAtV4 = await lambdaClient.send(
+      new GetFunctionCommand({ FunctionName: functionName }),
+    )
+    const v4ResolvedS3Object = fnAtV4.Code.ResolvedS3Object
+    expect(v4ResolvedS3Object).toBeDefined()
+
+    await runSfCore({
+      coreParams: {
+        options: {
+          stage,
+          c: configFilePath,
+          number: '1',
+          includeLayers: true,
+          includeArtifacts: true,
+        },
+        command: ['prune'],
+      },
+      jest,
+    })
+
+    const bucket = v1ResolvedS3Object.S3Bucket
+
+    const readVersionsAndMarkers = async (key) => {
+      const result = await s3Client.send(
+        new ListObjectVersionsCommand({ Bucket: bucket, Prefix: key }),
+      )
+      return {
+        versions: (result.Versions || []).filter((v) => v.Key === key),
+        deleteMarkers: (result.DeleteMarkers || []).filter(
+          (m) => m.Key === key,
+        ),
+      }
+    }
+
+    // The very first deployment directory: kept (it backs the surviving
+    // layer version, and it also happens to be what $LATEST currently
+    // resolves to after the rollback). No delete marker should appear on it,
+    // and its original object version must remain intact.
+    const v1State = await readVersionsAndMarkers(v1ResolvedS3Object.S3Key)
+    expect(v1State.deleteMarkers.length).toBe(0)
+    expect(
+      v1State.versions.some(
+        (v) => v.VersionId === v1ResolvedS3Object.S3ObjectVersion,
+      ),
+    ).toBe(true)
+
+    // The "v2" deployment directory: unpinned once "-n 1" prunes its
+    // published version away, so it's the one genuinely swept. It should
+    // carry a delete marker, but the real object version underneath must
+    // still be there -- a delete marker hides the object, it does not
+    // destroy any version (no data loss).
+    const v2State = await readVersionsAndMarkers(v2ResolvedS3Object.S3Key)
+    expect(v2State.deleteMarkers.length).toBeGreaterThan(0)
+    expect(
+      v2State.versions.some(
+        (v) => v.VersionId === v2ResolvedS3Object.S3ObjectVersion,
+      ),
+    ).toBe(true)
+
+    // The newest ("v4") deployment directory: kept, since it backs both the
+    // surviving published version and the current $LATEST.
+    const v4State = await readVersionsAndMarkers(v4ResolvedS3Object.S3Key)
+    expect(v4State.deleteMarkers.length).toBe(0)
+    expect(
+      v4State.versions.some(
+        (v) => v.VersionId === v4ResolvedS3Object.S3ObjectVersion,
+      ),
+    ).toBe(true)
+  })
+
+  test('Remove', async () => {
+    await runSfCore({
+      coreParams: {
+        options: { stage, c: configFilePath },
+        command: ['remove'],
+      },
+      jest,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `provider.deploymentBucket.codeStorageMode: reference | copy` (default: `copy`). With `reference`, Lambda runs function and layer code directly from the deployment bucket (self-managed code storage, `S3ObjectStorageMode: REFERENCE`), so code no longer counts against the Lambda code storage quota.
- Each deployment pins every function and layer to the exact uploaded S3 object version (`S3ObjectVersion`), so later uploads to the same keys never affect what runs. Layer stacks expose the pinned object version as an additional CloudFormation output so unchanged layers keep their pin across deployments.
- Bucket prerequisites are handled automatically:
  - The Framework-managed deployment bucket (already versioned) gets the required Lambda read policy statement, scoped to the account via `aws:SourceAccount`.
  - Services using the legacy in-stack deployment bucket require `deploymentBucket.versioning: true`; the required policy statement is added to the in-stack bucket policy (skipped with `skipPolicySetup`).
  - Custom buckets (`deploymentBucket.name`) are validated but never modified: deployment stops with a clear error when versioning is off or when the bucket has no policy (the error includes the exact statement to add), and prints a warning when a policy exists without an apparent Lambda read grant.
- In reference mode, deployment artifacts back live Lambda versions, so the automatic post-deploy artifact cleanup is disabled and artifact retirement moves to `prune`:
  - New `--includeArtifacts` (`-a`) flag and `custom.prune.includeArtifacts` option: after version pruning, deployment artifacts that no longer back any surviving function or layer version are marked for deletion.
  - The sweep writes S3 delete markers only, always keeps the newest `maxPreviousDeploymentArtifacts` deployments, supports `--dryRun`, and runs in any storage mode.
- `prune --includeLayers` now retains layer versions that are still attached to existing versions of the service's functions, even when they fall outside the retention window.
- `rollback function` is reference-aware: it restores the exact code a version runs via its resolved S3 coordinates (reference-mode versions have no downloadable code archive, so rollback works from the pinned S3 object directly). `deploy function` keeps its usual inline code update in every storage mode; in reference mode the function uses Lambda-managed storage until the next `serverless deploy` restores the configured mode, consistent with the command's development-cycle contract.
- Change detection works in reference mode (unchanged services skip the deploy), and switching back to `copy` prints a reminder that previously published versions still run code from the deployment bucket.
- Docs: new "Code Storage Mode" section in the deployment bucket guide (including artifact retention and S3 lifecycle-rule guidance) and updated prune guide and CLI reference.

Also includes a few adjacent improvements surfaced while building this:

- The artifact hash memoization is now keyed on file mtime/size, so an artifact rewritten at the same path within one process gets a fresh hash.
- `rollback function` completion logging now uses the correct logger method.
- Lambda API calls that rely on the new storage fields are routed through AWS SDK v3, which knows them.

## Test plan

- [x] Unit tests across packaging, deploy, prune, `deploy function`, and `rollback function` (full suite green)
- [x] New live-AWS integration suite (`packages/sf-core/tests/integration/self-managed-storage/reference-mode`): deploy → pinned invoke → bucket policy verification → redeploy pin retention → `deploy function` → `rollback function` → prune artifact sweep → remove
- [x] Manual verification against a live account: no-op deploy skip, custom-bucket validation paths, copy-mode artifact sweep, switch-back flow, delete-marker-only sweep behavior, and qualified invokes of retained versions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Lambda self-managed code storage “reference mode” to pin functions and layers to exact S3 object versions.
  * Added reference-mode–aware deployment updates, rollback support, and safer behavior around switching back to copy mode.
  * Added pruning enhancements: `--includeArtifacts` for `prune`, plus artifact retention that respects reference-mode workflows.
  * Added layer-version protection during pruning when layers remain attached to existing functions.
* **Documentation**
  * Updated deployment-bucket, provider, deploy-function, and prune guides with configuration, examples, limitations, and retention/rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->