### PR TITLE
chore: release 4.40.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14728,7 +14728,7 @@
     },
     "packages/sf-core": {
       "name": "@serverlessinc/sf-core",
-      "version": "4.39.0",
+      "version": "4.40.0",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "3.1081.0",
         "@aws-sdk/client-s3": "3.1081.0",

--- a/packages/framework-dist/package.json
+++ b/packages/framework-dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/framework-alpha",
-  "version": "4.39.0",
+  "version": "4.40.0",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/sf-core-installer/npm-shrinkwrap.json
+++ b/packages/sf-core-installer/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless",
-  "version": "4.39.0",
+  "version": "4.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless",
-      "version": "4.39.0",
+      "version": "4.40.0",
       "hasInstallScript": true,
       "dependencies": {
         "rimraf": "5.0.10",

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "4.39.0",
+  "version": "4.40.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/sf-core/package.json
+++ b/packages/sf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/sf-core",
-  "version": "4.39.0",
+  "version": "4.40.0",
   "main": "src/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release 4.40.0.

Version bump across the installer, `sf-core`, `framework-dist`, and lockfiles (`4.39.0` → `4.40.0`), mirroring previous release PRs. Minor bump for the new features landing this cycle.

**Highlights**
- **Lambda self-managed code storage (reference mode)** (#13725): deploy functions whose code artifacts you upload and manage yourself, with the framework referencing them instead of packaging and uploading.
- **Compose `--service` accepts a comma-separated list** (#13705): run commands against an exact subset of services in a Compose project.
- **Serverless Container Framework and Serverless AI Framework removed** (#13698).
- Fixes: shared IAM role scoped to functions without dedicated per-function roles (#13704), shared handler files built once to prevent corrupted bundles (#13717), unchanged code no longer redeployed due to zip timestamps (#13696), no crash on `frameworkVersion: "*"` (#13714), packaging stops safely when the production dependency listing is unavailable (#13724, #13699), stricter canary version validation in the installer (#13700).
- Dependency updates, including the AWS SDK group (#13715) and security bumps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the framework and installer packages to version 4.40.0.
  * Synchronized package metadata and lockfile version information for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->