### PR TITLE
chore(ci): remove unused GitHub Packages registry config from workflows

### DIFF
--- a/.github/workflows/ci-framework.yml
+++ b/.github/workflows/ci-framework.yml
@@ -80,8 +80,6 @@ jobs:
           node-version: 24.x
           check-latest: true
           cache: npm
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@serverlessinc'
       - name: 'Setup: Enable Corepack'
         run: corepack enable npm
       - name: 'Setup: AWS Credentials'

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -62,8 +62,6 @@ jobs:
           node-version: 24.x
           check-latest: true
           cache: npm
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@serverlessinc'
       - name: 'Setup: Enable Corepack'
         run: corepack enable npm
       - name: 'Setup: AWS Credentials'
@@ -114,8 +112,6 @@ jobs:
           node-version: 24.x
           check-latest: true
           cache: npm
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@serverlessinc'
       - name: 'Setup: Enable Corepack'
         run: corepack enable npm
       - name: 'Install: Dependencies'
@@ -164,8 +160,6 @@ jobs:
           node-version: 24.x
           check-latest: true
           cache: npm
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@serverlessinc'
       - name: 'Setup: Enable Corepack'
         run: corepack enable npm
       - name: 'Setup: AWS Credentials'


### PR DESCRIPTION
## Summary

- Remove `registry-url: 'https://npm.pkg.github.com'` and `scope: '@serverlessinc'` from the `actions/setup-node` steps in `.github/workflows/ci-framework.yml` (Test: Framework job) and `.github/workflows/release-framework.yml` (test-matrix, release-canary, release-stable jobs)
- The `release-npm` job's `registry-url: https://registry.npmjs.org` is left untouched: publish auth itself comes from npm trusted publishing (OIDC), and keeping the input matches the setup recommended by the npm trusted-publishing docs

## Root cause

This registry configuration is unused: every `@serverlessinc` package (`sf-core`, `standards`) is a local npm workspace, and `package-lock.json` contains zero `npm.pkg.github.com` references, so no dependency is ever fetched from GitHub Packages. No workflow sets `NODE_AUTH_TOKEN` either — the config only appeared to work because `actions/setup-node` ≤ v6 exported a placeholder `NODE_AUTH_TOKEN` when `registry-url` was set. setup-node v7 removed that placeholder export, so the generated `.npmrc` now carries an unexpandable `${NODE_AUTH_TOKEN}` reference that npm warns about on every command.

## Test plan

- [x] Verified `package-lock.json` has no `npm.pkg.github.com` entries and all `@serverlessinc/*` packages resolve to local workspace paths
- [x] Verified in a recent successful "Test: Framework" CI run log that the only mention of `npm.pkg.github.com` is setup-node echoing its own input — `npm ci` installs everything from registry.npmjs.org
- [x] Verified in the latest release run's "Release: NPM Installer" log that `npm publish` authenticates via trusted publishing (signed provenance from GitHub Actions), not via the registry-url/.npmrc token wiring
- [x] CI on this PR passes without the registry configuration
