### PR TITLE
chore(deps): ignore graphql v17 upgrades to preserve Node.js 18 support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -98,6 +98,9 @@ updates:
       - dependency-name: 'https-proxy-agent'
         # https-proxy-agent v9 (and agent-base v9) drop support for Node.js 18
         versions: ['>= 9.0.0']
+      - dependency-name: 'graphql'
+        # graphql v17 drops support for Node.js 18 and 20
+        versions: ['>= 17.0.0']
 
   # Maintain Go dependencies
   - package-ecosystem: 'gomod'


### PR DESCRIPTION
## Summary

- Add `graphql` (`>= 17.0.0`) to the Dependabot ignore list in `.github/dependabot.yml`, alongside the existing entries for packages whose new majors drop Node.js 18 support

## Root cause

`graphql@17` declares `engines.node: "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"`, dropping Node.js 18 and 20. `graphql` is a runtime dependency of `packages/serverless` (used by the AppSync plugin in `packages/serverless/lib/plugins/aws/appsync/`), and `packages/serverless` declares `engines.node: ">=18.0"`, so upgrading to v17 would break the CLI for users on Node.js 18/20. This follows the same policy as the existing ignore entries (chokidar, glob, rimraf, undici, etc.).

Dependabot PR #13735 (graphql 16.14.2 → 17.0.1) is being closed with `@dependabot ignore this major version` accordingly.

## Test plan

- [x] YAML validated
- [x] CI green on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to prevent incompatible GraphQL versions from being proposed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
