### PR TITLE
fix(esbuild): honor outExtension for bundling and packaging

### DIFF
--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -74,6 +74,21 @@ build:
     # Enable or Disable minifying the built code. (Default: false)
     minify: false
 
+    # The file extension of the bundled handler files. (Default: '.js')
+    #
+    # Map '.js' to '.mjs' to emit ES module bundles that Lambda loads with the
+    # ESM loader without a "type": "module" package.json in the artifact, or
+    # to '.cjs' to make CommonJS loading explicit. Emitting '.mjs' requires
+    # `format: esm`; the bundled handler, its sourcemap, and the packaged file
+    # names all use the configured extension. Lambda resolves the handler file
+    # by extension automatically, so function `handler` values stay unchanged.
+    outExtension:
+      '.js': '.mjs'
+
+    # The output format of the bundled code. Defaults to 'cjs', or to 'esm' if
+    # the service's package.json declares "type": "module".
+    format: esm
+
     # Enable or configure sourcemaps, can be set to true or to an object with further configuration.
     sourcemap:
       # The sourcemap type to use, options are (inline, linked, or external)

--- a/packages/serverless/lib/plugins/aws/invoke-local/index.js
+++ b/packages/serverless/lib/plugins/aws/invoke-local/index.js
@@ -1136,17 +1136,25 @@ class AwsInvokeLocal {
           error.code === 'MODULE_NOT_FOUND' ||
           error.code === 'ERR_MODULE_NOT_FOUND'
         ) {
-          // Attempt to import with `.js` extension
-          const pathToHandler = `${modulePath}.js`
-          try {
-            return await import(pathToHandler)
-          } catch (innerError) {
-            // Throw original error if still "MODULE_NOT_FOUND", as not finding module with `.js` might be confusing
-            if (innerError.code !== 'MODULE_NOT_FOUND') {
-              throw innerError
+          // Probe the extensions the Lambda Node.js runtime resolves; `.mjs`
+          // and `.cjs` also cover bundles emitted via esbuild's `outExtension`
+          for (const extension of ['.js', '.mjs', '.cjs']) {
+            try {
+              return await import(`${modulePath}${extension}`)
+            } catch (innerError) {
+              // Keep probing on "not found"; rethrow anything else (e.g. a
+              // handler that throws at initialization)
+              if (
+                innerError.code !== 'MODULE_NOT_FOUND' &&
+                innerError.code !== 'ERR_MODULE_NOT_FOUND'
+              ) {
+                throw innerError
+              }
             }
           }
         }
+        // Throw the original extensionless error, as surfacing a "not found"
+        // for one specific probed extension might be confusing
         throw error
       }
     }

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -137,6 +137,14 @@ class Esbuild {
             },
             // Whether to bundle or not. Default is true
             bundle: { type: 'boolean' },
+            outExtension: {
+              description: `Output file extension for the bundled handlers, e.g. { '.js': '.mjs' } to emit ES module bundles.
+@example { '.js': '.mjs' }`,
+              type: 'object',
+              properties: {
+                '.js': { type: 'string', enum: ['.js', '.cjs', '.mjs'] },
+              },
+            },
             // Whether to minify or not. Default is false
             minify: { type: 'boolean' },
             // If set to a boolean, true, then framework uses external sourcemaps and enables it on functions by default.
@@ -476,6 +484,45 @@ class Esbuild {
   }
 
   /**
+   * The extension of the bundled handler files, derived from esbuild's
+   * `outExtension` option. The plugin builds with `outfile` (not `outdir`),
+   * and esbuild ignores `outExtension` in outfile mode, so the mapping is
+   * applied here — to the outfile passed to esbuild and to the file names the
+   * packaging step zips — instead of by esbuild itself.
+   * @param {object} buildProperties - The merged esbuild build properties
+   * @returns {string} The configured output extension, defaulting to '.js'
+   */
+  _outputExtension(buildProperties) {
+    const extension = buildProperties.outExtension?.['.js'] ?? '.js'
+
+    if (!['.js', '.cjs', '.mjs'].includes(extension)) {
+      throw new ServerlessError(
+        `esbuild's "outExtension" maps ".js" to "${extension}", but only ".js", ".cjs" and ".mjs" are supported because the Lambda Node.js runtime cannot load handler files with other extensions`,
+        'ESBUILD_OUT_EXTENSION_UNSUPPORTED',
+      )
+    }
+
+    // Mirrors esbuild's own coherence rules: Lambda decides between the CJS
+    // and ESM loaders by file extension, so a mismatched pair produces a
+    // bundle that crashes at initialization. Fail at build time instead.
+    const isEsm = buildProperties.format === 'esm'
+    if (isEsm && extension === '.cjs') {
+      throw new ServerlessError(
+        'esbuild format "esm" cannot emit files with the ".cjs" extension. Remove the "outExtension" mapping or set the format to "cjs"',
+        'ESBUILD_OUT_EXTENSION_FORMAT_MISMATCH',
+      )
+    }
+    if (!isEsm && extension === '.mjs') {
+      throw new ServerlessError(
+        'Emitting ".mjs" files requires the esbuild format "esm". Set "format: esm" in the esbuild configuration or remove the "outExtension" mapping',
+        'ESBUILD_OUT_EXTENSION_FORMAT_MISMATCH',
+      )
+    }
+
+    return extension
+  }
+
+  /**
    * Determine which modules to mark as external (i.e. added to the generated package.json) and which modules to be excluded all together
    * @param {string} runtime - The provider.runtime or functionObject.runtime value used to determine which version of the AWS SDK to exclude
    * @returns
@@ -620,6 +667,7 @@ class Esbuild {
     }
 
     const buildProperties = await this._buildProperties()
+    const outputExtension = this._outputExtension(buildProperties)
 
     // Multiple functions can share a single handler file (e.g. one module
     // exporting several handlers). Building each function separately would
@@ -724,7 +772,7 @@ class Esbuild {
                 this.serverless.config.serviceDir,
                 '.serverless',
                 'build',
-                group.handlerPath + '.js',
+                group.handlerPath + outputExtension,
               ),
               logLevel: 'error',
             }
@@ -733,6 +781,8 @@ class Esbuild {
             delete esbuildProps.exclude
             delete esbuildProps.buildConcurrency
             delete esbuildProps.configFile
+            // Applied to the outfile above; esbuild ignores it in outfile mode
+            delete esbuildProps.outExtension
 
             const result = await esbuild.build(esbuildProps)
 
@@ -803,6 +853,7 @@ class Esbuild {
   async _package(handlerPropertyName = 'handler') {
     const functions = await this.functions(handlerPropertyName)
     const buildProperties = await this._buildProperties()
+    const outputExtension = this._outputExtension(buildProperties)
 
     if (Object.keys(functions).length === 0) {
       log.debug('No functions to package')
@@ -900,17 +951,17 @@ class Esbuild {
                 this.serverless.config.serviceDir,
                 '.serverless',
                 'build',
-                handlerPath + '.js',
+                handlerPath + outputExtension,
               )
 
               zip.file(handlerZipPath, {
-                name: `${handlerPath}.js`,
+                name: `${handlerPath}${outputExtension}`,
                 date: PINNED_ARTIFACT_DATE,
               })
 
               if (existsSync(`${handlerZipPath}.map`)) {
                 zip.file(`${handlerZipPath}.map`, {
-                  name: `${handlerPath}.js.map`,
+                  name: `${handlerPath}${outputExtension}.map`,
                   date: PINNED_ARTIFACT_DATE,
                 })
               }
@@ -965,6 +1016,8 @@ class Esbuild {
   }
 
   async _packageAll(functions, handlerPropertyName = 'handler') {
+    const buildProperties = await this._buildProperties()
+    const outputExtension = this._outputExtension(buildProperties)
     const zipName = `${this.serverless.service.service}.zip`
     const zipPath = path.join(
       this.serverless.config.serviceDir,
@@ -1037,12 +1090,12 @@ class Esbuild {
             this.serverless.config.serviceDir,
             '.serverless',
             'build',
-            handlerPath + '.js',
+            handlerPath + outputExtension,
           )
 
           if (!addedFiles.has(handlerZipPath)) {
             zip.file(handlerZipPath, {
-              name: `${handlerPath}.js`,
+              name: `${handlerPath}${outputExtension}`,
               date: PINNED_ARTIFACT_DATE,
             })
             addedFiles.add(handlerZipPath)
@@ -1053,7 +1106,7 @@ class Esbuild {
             !addedFiles.has(`${handlerZipPath}.map`)
           ) {
             zip.file(`${handlerZipPath}.map`, {
-              name: `${handlerPath}.js.map`,
+              name: `${handlerPath}${outputExtension}.map`,
               date: PINNED_ARTIFACT_DATE,
             })
 

--- a/packages/serverless/test/unit/lib/plugins/aws/invoke-local/out-extension.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/invoke-local/out-extension.test.js
@@ -1,0 +1,128 @@
+/**
+ * `invoke local` resolves the handler module by importing the extensionless
+ * handler path and falling back to `<path>.js` when the module is not found.
+ * When esbuild's `outExtension` emits `.mjs`/`.cjs` bundles (or a service
+ * simply uses those extensions directly), that fallback must probe them too —
+ * the Lambda Node.js runtime resolves all three extensions, so local
+ * invocation has to match.
+ *
+ * These tests spawn a real `node` child process instead of calling
+ * `invokeLocalNodeJs` in-process: jest's module resolver resolves
+ * extensionless dynamic imports (node-style), which Node's own ESM loader
+ * does NOT — an in-process test goes green even when the real CLI fails.
+ */
+
+import { jest } from '@jest/globals'
+import { execFile } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+
+const pluginPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../../../../lib/plugins/aws/invoke-local/index.js',
+)
+
+// Driver executed by the child process: builds the minimal plugin context
+// invokeLocalNodeJs touches and invokes the handler at argv[2]/argv[3].
+const driverSource = `
+import AwsInvokeLocal from ${JSON.stringify(pluginPath)}
+
+const [serviceDir, handlerPath] = process.argv.slice(2)
+
+const context = {
+  serverless: { serviceDir, service: { provider: {} } },
+  options: {
+    extraServicePath: '',
+    functionObj: { name: 'hello', timeout: 6 },
+  },
+  provider: { naming: { getLogGroupName: () => '/aws/lambda/hello' } },
+  logger: { blankLine: () => {} },
+}
+
+try {
+  await AwsInvokeLocal.prototype.invokeLocalNodeJs.call(
+    context,
+    handlerPath,
+    'hello',
+    {},
+  )
+  console.log(process.exitCode ? 'HANDLER_ERROR' : 'INVOKED')
+} catch (error) {
+  console.log('LOAD_FAILED ' + error.code)
+  process.exitCode = 1
+}
+`
+
+const createdServiceDirs = []
+
+function makeServiceDir(files) {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-invoke-'))
+  createdServiceDirs.push(serviceDir)
+  fs.writeFileSync(path.join(serviceDir, 'driver.mjs'), driverSource)
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(serviceDir, name), contents)
+  }
+  return serviceDir
+}
+
+async function invoke(serviceDir, handlerPath) {
+  try {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [path.join(serviceDir, 'driver.mjs'), serviceDir, handlerPath],
+      { env: { ...process.env, NODE_NO_WARNINGS: '1' } },
+    )
+    return stdout.trim()
+  } catch (error) {
+    return (error.stdout ?? '').trim()
+  }
+}
+
+describe('invoke local handler extension probing', () => {
+  jest.setTimeout(60_000)
+
+  afterEach(() => {
+    while (createdServiceDirs.length > 0) {
+      fs.rmSync(createdServiceDirs.pop(), { recursive: true, force: true })
+    }
+  })
+
+  test('resolves an .mjs handler from an extensionless handler path', async () => {
+    const serviceDir = makeServiceDir({
+      'handler.mjs': 'export const hello = async () => ({ statusCode: 200 })\n',
+    })
+
+    await expect(invoke(serviceDir, 'handler')).resolves.toContain('INVOKED')
+  })
+
+  test('resolves a .cjs handler from an extensionless handler path', async () => {
+    const serviceDir = makeServiceDir({
+      'handler.cjs':
+        'module.exports.hello = async () => ({ statusCode: 200 })\n',
+    })
+
+    await expect(invoke(serviceDir, 'handler')).resolves.toContain('INVOKED')
+  })
+
+  test('still resolves a .js handler from an extensionless handler path', async () => {
+    const serviceDir = makeServiceDir({
+      'handler.js': 'export const hello = async () => ({ statusCode: 200 })\n',
+      'package.json': '{ "type": "module" }\n',
+    })
+
+    await expect(invoke(serviceDir, 'handler')).resolves.toContain('INVOKED')
+  })
+
+  test('a missing handler still fails with the initialization error', async () => {
+    const serviceDir = makeServiceDir({})
+
+    await expect(invoke(serviceDir, 'handler')).resolves.toContain(
+      'LOAD_FAILED INVOKE_LOCAL_LAMBDA_INITIALIZATION_FAILED',
+    )
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/out-extension.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/out-extension.test.js
@@ -1,0 +1,315 @@
+/**
+ * esbuild's `outExtension` option (https://esbuild.github.io/api/#out-extension)
+ * lets users emit `.mjs`/`.cjs` bundles instead of `.js` — e.g. to force the
+ * ESM loading path on Lambda without shipping a `type: module` package.json in
+ * the artifact.
+ *
+ * The plugin builds with `outfile` (not `outdir`), and esbuild silently
+ * ignores `outExtension` in `outfile` mode. The plugin therefore derives the
+ * output extension from the merged build options itself: the `outfile` it
+ * passes to esbuild carries the configured extension, `outExtension` is
+ * stripped from the esbuild call, and the packaging step zips the matching
+ * file names.
+ *
+ * Invalid configurations fail fast at build time instead of producing a
+ * bundle Lambda cannot load: an ESM-format build cannot emit `.cjs`, a
+ * CJS-format build cannot emit `.mjs`, and values other than
+ * `.js`/`.cjs`/`.mjs` are rejected (Lambda only resolves those handler file
+ * extensions).
+ */
+
+import { jest } from '@jest/globals'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import JsZip from 'jszip'
+
+let realBuild
+const buildMock = jest.fn()
+
+jest.unstable_mockModule('esbuild', () => {
+  realBuild = jest.requireActual('esbuild').build
+  return { build: buildMock }
+})
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+const createdServiceDirs = []
+
+function makeServiceDir(files) {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+  createdServiceDirs.push(serviceDir)
+  for (const [name, contents] of Object.entries(files)) {
+    const filePath = path.join(serviceDir, name)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+  return serviceDir
+}
+
+function makePlugin(serviceDir, functions, { esbuildConfig = {} } = {}) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      provider: { runtime: 'nodejs20.x' },
+      build: { esbuild: esbuildConfig },
+      functions,
+      getFunction: (alias) => functions[alias],
+    },
+  }
+  const plugin = new Esbuild(serverless, {})
+  // Target `_build` directly: bypass the introspection in `functions()` so the
+  // extension/validation logic is what's under test.
+  plugin.functions = async () => functions
+  return plugin
+}
+
+const handlerFiles = {
+  'handler.ts': 'export const hello = async () => ({ statusCode: 200 })\n',
+}
+const functions = { hello: { handler: 'handler.hello' } }
+
+describe('esbuild outExtension support', () => {
+  jest.setTimeout(30_000)
+
+  beforeEach(() => {
+    buildMock.mockReset()
+    buildMock.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    while (createdServiceDirs.length > 0) {
+      fs.rmSync(createdServiceDirs.pop(), { recursive: true, force: true })
+    }
+  })
+
+  test("outExtension { '.js': '.mjs' } produces an .mjs outfile and is not passed to esbuild", async () => {
+    const serviceDir = makeServiceDir(handlerFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { format: 'esm', outExtension: { '.js': '.mjs' } },
+    })
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(1)
+    const props = buildMock.mock.calls[0][0]
+    expect(props.outfile).toBe(
+      path.join(serviceDir, '.serverless', 'build', 'handler.mjs'),
+    )
+    // esbuild ignores outExtension in outfile mode; the plugin applies it
+    // itself and must not forward it.
+    expect(props).not.toHaveProperty('outExtension')
+  })
+
+  test("outExtension { '.js': '.cjs' } produces a .cjs outfile", async () => {
+    const serviceDir = makeServiceDir(handlerFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { outExtension: { '.js': '.cjs' } },
+    })
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(1)
+    expect(buildMock.mock.calls[0][0].outfile).toBe(
+      path.join(serviceDir, '.serverless', 'build', 'handler.cjs'),
+    )
+  })
+
+  test('without outExtension the outfile keeps the .js extension', async () => {
+    const serviceDir = makeServiceDir(handlerFiles)
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(1)
+    expect(buildMock.mock.calls[0][0].outfile).toBe(
+      path.join(serviceDir, '.serverless', 'build', 'handler.js'),
+    )
+  })
+
+  test("an explicit no-op outExtension { '.js': '.js' } keeps the .js extension", async () => {
+    const serviceDir = makeServiceDir(handlerFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { outExtension: { '.js': '.js' } },
+    })
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(1)
+    expect(buildMock.mock.calls[0][0].outfile).toBe(
+      path.join(serviceDir, '.serverless', 'build', 'handler.js'),
+    )
+  })
+
+  test('outExtension from a configFile function is honored', async () => {
+    const serviceDir = makeServiceDir({
+      ...handlerFiles,
+      'esbuild.config.mjs':
+        "export default () => ({ format: 'esm', outExtension: { '.js': '.mjs' } })\n",
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { configFile: './esbuild.config.mjs' },
+    })
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(1)
+    const props = buildMock.mock.calls[0][0]
+    expect(props.outfile).toBe(
+      path.join(serviceDir, '.serverless', 'build', 'handler.mjs'),
+    )
+    expect(props).not.toHaveProperty('outExtension')
+    expect(props).not.toHaveProperty('configFile')
+  })
+
+  test("ESM build emitting '.cjs' fails fast", async () => {
+    const serviceDir = makeServiceDir(handlerFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { format: 'esm', outExtension: { '.js': '.cjs' } },
+    })
+
+    await expect(plugin._build()).rejects.toThrow(
+      /format "esm".*\.cjs|\.cjs.*format "esm"/,
+    )
+    expect(buildMock).not.toHaveBeenCalled()
+  })
+
+  test("non-ESM build emitting '.mjs' fails fast", async () => {
+    const serviceDir = makeServiceDir(handlerFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { outExtension: { '.js': '.mjs' } },
+    })
+
+    await expect(plugin._build()).rejects.toThrow(/\.mjs/)
+    expect(buildMock).not.toHaveBeenCalled()
+  })
+
+  test('an unsupported extension value fails fast', async () => {
+    const serviceDir = makeServiceDir(handlerFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { outExtension: { '.js': '.jsx' } },
+    })
+
+    await expect(plugin._build()).rejects.toThrow(/\.jsx/)
+    expect(buildMock).not.toHaveBeenCalled()
+  })
+
+  test('real esbuild writes the bundle and sourcemap at the .mjs path', async () => {
+    const serviceDir = makeServiceDir(handlerFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { format: 'esm', outExtension: { '.js': '.mjs' } },
+    })
+
+    buildMock.mockImplementation((props) => realBuild(props))
+
+    await plugin._build()
+
+    const bundlePath = path.join(
+      serviceDir,
+      '.serverless',
+      'build',
+      'handler.mjs',
+    )
+    expect(fs.existsSync(bundlePath)).toBe(true)
+    expect(fs.existsSync(`${bundlePath}.map`)).toBe(true)
+    const bundle = fs.readFileSync(bundlePath, 'utf-8')
+    expect(bundle).toContain('hello')
+    // ESM output: exports statements survive, no CJS wrapper.
+    expect(bundle).toMatch(/export\s*\{/)
+  })
+})
+
+describe('esbuild packaging with outExtension', () => {
+  jest.setTimeout(30_000)
+
+  afterEach(() => {
+    while (createdServiceDirs.length > 0) {
+      fs.rmSync(createdServiceDirs.pop(), { recursive: true, force: true })
+    }
+  })
+
+  // Simulates the state after `_build` ran with outExtension: the build dir
+  // holds .mjs output. Packaging must zip those names, not `<handler>.js`.
+  function makeBuiltServiceDir(extension) {
+    const serviceDir = makeServiceDir({
+      [`.serverless/build/handler${extension}`]:
+        'export const hello = async () => ({ statusCode: 200 })\n',
+      [`.serverless/build/handler${extension}.map`]: '{}\n',
+      '.serverless/build/node_modules/dep/index.js': 'module.exports = 1\n',
+    })
+    return serviceDir
+  }
+
+  function makePackagingPlugin(serviceDir, { esbuildConfig, individually }) {
+    const serverless = {
+      serviceDir,
+      config: { serviceDir },
+      service: {
+        service: 'my-service',
+        provider: { runtime: 'nodejs20.x' },
+        build: { esbuild: esbuildConfig },
+        package: { patterns: [], individually },
+        functions,
+        getFunction: (alias) => functions[alias],
+      },
+      pluginManager: { spawn: async () => {} },
+    }
+    const plugin = new Esbuild(serverless, {})
+    plugin.functions = async () => functions
+    return plugin
+  }
+
+  async function zipEntryNames(artifactPath) {
+    const zip = await JsZip.loadAsync(fs.readFileSync(artifactPath))
+    return Object.keys(zip.files)
+  }
+
+  test('_packageAll zips the .mjs bundle and sourcemap', async () => {
+    const serviceDir = makeBuiltServiceDir('.mjs')
+    const plugin = makePackagingPlugin(serviceDir, {
+      esbuildConfig: { format: 'esm', outExtension: { '.js': '.mjs' } },
+    })
+
+    await plugin._packageAll(functions)
+
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service.zip'),
+    )
+    expect(entries).toContain('handler.mjs')
+    expect(entries).toContain('handler.mjs.map')
+    expect(entries).not.toContain('handler.js')
+  })
+
+  test('individual packaging zips the .mjs bundle and sourcemap', async () => {
+    const serviceDir = makeBuiltServiceDir('.mjs')
+    const plugin = makePackagingPlugin(serviceDir, {
+      esbuildConfig: { format: 'esm', outExtension: { '.js': '.mjs' } },
+      individually: true,
+    })
+
+    await plugin._package()
+
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-hello.zip'),
+    )
+    expect(entries).toContain('handler.mjs')
+    expect(entries).toContain('handler.mjs.map')
+    expect(entries).not.toContain('handler.js')
+  })
+
+  test('without outExtension packaging still zips .js names', async () => {
+    const serviceDir = makeBuiltServiceDir('.js')
+    const plugin = makePackagingPlugin(serviceDir, { esbuildConfig: {} })
+
+    await plugin._packageAll(functions)
+
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service.zip'),
+    )
+    expect(entries).toContain('handler.js')
+    expect(entries).toContain('handler.js.map')
+  })
+})


### PR DESCRIPTION
## Summary

- Support esbuild's [`outExtension`](https://esbuild.github.io/api/#out-extension) option (e.g. `{ '.js': '.mjs' }`) from both `build.esbuild` and a `configFile`: the bundled handler, its sourcemap, and the packaged file names now use the configured extension
- Validate the configuration at build time: supported values are `.js`, `.cjs` and `.mjs`; emitting `.mjs` pairs with `format: esm`, and `format: esm` pairs with `.js`/`.mjs`
- Document `outExtension` and `format` in the building guide and config schema
- `invoke local` now resolves `.mjs` and `.cjs` handler files in addition to `.js`

## Details

esbuild applies `outExtension` only when building with `outdir`, while the build integration uses `outfile` — so the option previously had no effect and artifacts were always emitted and packaged with the `.js` extension. The output extension is now derived from the merged build options and applied to the `outfile` and the packaged file names directly.

Emitting `.mjs` makes the Lambda Node.js runtime load the bundle with the ESM loader without shipping a `package.json` with `"type": "module"` inside the deployment artifact. Function `handler` values stay unchanged, as Lambda resolves the handler file extension automatically.

## Test plan

- [x] Unit tests: extension derivation (`build.esbuild`, `configFile`, defaults, no-op mapping), validation, real-esbuild `.mjs` bundle + sourcemap output, zip entries for both packaging modes, and `invoke local` extension resolution exercised in a spawned Node.js process
- [x] Full `@serverless/framework` unit suite, lint, prettier
- [x] Live on AWS: `package` produces `<handler>.mjs` + `<handler>.mjs.map` in the artifact; `deploy`; remote `invoke` returns 200 from the `.mjs` handler; `invoke local`; `remove`
- [x] Default configuration (no `outExtension`) produces identical `.js` artifacts

Closes #12863


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring bundled handler files with `.js`, `.cjs`, or `.mjs` extensions.
  - Added validation for compatible module formats and output extensions.
  - Updated packaging to include handlers and source maps with the configured extension.
  - Improved local invocation to resolve extensionless handlers across supported extensions.

- **Documentation**
  - Added AWS Lambda guidance for using `.mjs` bundles with ESM format and unchanged handler values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->