### PR TITLE
fix(esbuild): honor config file sourcemap setting when adding NODE_OPTIONS

### DIFF
--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -115,6 +115,8 @@ build:
 
 The JavaScript file must export a function that returns an esbuild configuration object. For your convenience, the **serverless** instance is passed to that function.
 
+Options returned by the config file are merged with the `build.esbuild` options in `serverless.yml`, with `serverless.yml` taking precedence when both set the same option. For boolean `sourcemap` values, or when `sourcemap` is omitted from `serverless.yml`, the effective merged setting controls whether the `NODE_OPTIONS=--enable-source-maps` environment variable is added to your functions — for example, returning `sourcemap: false` from the config file disables both sourcemap generation and the environment variable. A `sourcemap` object in `serverless.yml` uses its `setNodeOptions` property instead.
+
 Here's an example of the `esbuild.config.js` file that uses the `esbuild-plugin-env` plugin:
 
 **ESM:**

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -730,6 +730,19 @@ class Esbuild {
 
     const limit = pLimit(concurrency)
 
+    // Whether to inject NODE_OPTIONS=--enable-source-maps. A yml `sourcemap`
+    // value decides when present (the object form via its `setNodeOptions`
+    // flag, false by default); otherwise the decision follows the effective
+    // merged setting so that `sourcemap: false` inside a `configFile`
+    // suppresses the env var just like its yml equivalent (#12997).
+    const ymlSourcemap = this.serverless.service.build?.esbuild?.sourcemap
+    const shouldSetNodeOptions =
+      typeof ymlSourcemap === 'object' && ymlSourcemap !== null
+        ? ymlSourcemap.setNodeOptions === true
+        : ymlSourcemap === undefined
+          ? Boolean(buildProperties.sourcemap)
+          : ymlSourcemap === true
+
     try {
       await Promise.all(
         Array.from(buildGroups.values()).map((group) => {
@@ -810,13 +823,7 @@ class Esbuild {
             // handler file, not just the one whose build we ran.
             for (const alias of group.aliases) {
               this.serverless.builtFunctions.add(alias)
-              if (
-                this.serverless.service.build?.esbuild?.sourcemap ===
-                  undefined ||
-                this.serverless.service.build?.esbuild?.sourcemap === true ||
-                this.serverless.service.build?.esbuild.sourcemap
-                  ?.setNodeOptions === true
-              ) {
+              if (shouldSetNodeOptions) {
                 const functionObject =
                   this.serverless.service.getFunction(alias)
                 if (functionObject.environment?.NODE_OPTIONS) {

--- a/packages/serverless/test/unit/lib/plugins/esbuild/sourcemap-node-options.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/sourcemap-node-options.test.js
@@ -1,0 +1,141 @@
+/**
+ * The decision to inject NODE_OPTIONS=--enable-source-maps must follow the
+ * EFFECTIVE sourcemap setting — the merge of serverless.yml over an esbuild
+ * config file over the defaults — not just the raw serverless.yml value.
+ *
+ * Before the fix (#12997), the env-var decision read only
+ * `service.build.esbuild.sourcemap`: with `sourcemap: false` set solely inside
+ * a `configFile`, the build correctly emitted no source maps, yet every
+ * function still received NODE_OPTIONS=--enable-source-maps.
+ *
+ * These tests run the real esbuild binary over a tiny handler so the emitted
+ * artifacts (presence/absence of .map files) are asserted alongside the env
+ * var, pinning both halves of the behavior to the same effective setting.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+const createdServiceDirs = []
+
+afterAll(() => {
+  for (const dir of createdServiceDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+const HANDLER_SOURCE =
+  'export const hello = async () => ({ statusCode: 200 })\n'
+
+function makeConfigFile(esbuildOptions) {
+  return `module.exports = () => (${JSON.stringify(esbuildOptions)})\n`
+}
+
+async function buildService({ esbuildConfig, configFileContents }) {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-sourcemap-'))
+  createdServiceDirs.push(serviceDir)
+  fs.writeFileSync(path.join(serviceDir, 'handler.js'), HANDLER_SOURCE)
+  fs.writeFileSync(path.join(serviceDir, 'package.json'), '{}')
+  if (configFileContents) {
+    fs.writeFileSync(
+      path.join(serviceDir, 'esbuild.config.js'),
+      configFileContents,
+    )
+  }
+
+  const functions = {
+    hello: { handler: 'handler.hello', runtime: 'nodejs20.x' },
+  }
+
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      provider: { runtime: 'nodejs20.x' },
+      build: { esbuild: esbuildConfig },
+      functions,
+      getFunction: (alias) => functions[alias],
+    },
+  }
+
+  const plugin = new Esbuild(serverless, {})
+  plugin.functions = async () => functions
+
+  await plugin._build()
+
+  const buildDir = path.join(serviceDir, '.serverless', 'build')
+  const emittedFiles = fs.existsSync(buildDir) ? fs.readdirSync(buildDir) : []
+  return {
+    nodeOptions: functions.hello.environment?.NODE_OPTIONS,
+    mapFiles: emittedFiles.filter((file) => file.endsWith('.map')),
+  }
+}
+
+describe('esbuild sourcemap NODE_OPTIONS decision', () => {
+  it('does not set NODE_OPTIONS when the config file sets sourcemap: false', async () => {
+    const { nodeOptions, mapFiles } = await buildService({
+      esbuildConfig: { configFile: './esbuild.config.js' },
+      configFileContents: makeConfigFile({
+        bundle: true,
+        minify: false,
+        sourcemap: false,
+      }),
+    })
+
+    expect(mapFiles).toEqual([])
+    expect(nodeOptions).toBeUndefined()
+  })
+
+  it('sets NODE_OPTIONS when the config file enables sourcemaps', async () => {
+    const { nodeOptions, mapFiles } = await buildService({
+      esbuildConfig: { configFile: './esbuild.config.js' },
+      configFileContents: makeConfigFile({ bundle: true, sourcemap: true }),
+    })
+
+    expect(mapFiles).toEqual(['handler.js.map'])
+    expect(nodeOptions).toBe('--enable-source-maps')
+  })
+
+  it('sets NODE_OPTIONS by default when neither yml nor config file set sourcemap', async () => {
+    const { nodeOptions, mapFiles } = await buildService({
+      esbuildConfig: { configFile: './esbuild.config.js' },
+      configFileContents: makeConfigFile({ bundle: true }),
+    })
+
+    expect(mapFiles).toEqual(['handler.js.map'])
+    expect(nodeOptions).toBe('--enable-source-maps')
+  })
+
+  it('lets yml sourcemap: false win over the config file enabling sourcemaps', async () => {
+    const { nodeOptions, mapFiles } = await buildService({
+      esbuildConfig: { configFile: './esbuild.config.js', sourcemap: false },
+      configFileContents: makeConfigFile({ bundle: true, sourcemap: true }),
+    })
+
+    expect(mapFiles).toEqual([])
+    expect(nodeOptions).toBeUndefined()
+  })
+
+  it('does not set NODE_OPTIONS for yml sourcemap object without setNodeOptions', async () => {
+    const { nodeOptions, mapFiles } = await buildService({
+      esbuildConfig: { sourcemap: { type: 'linked' } },
+    })
+
+    expect(mapFiles).toEqual(['handler.js.map'])
+    expect(nodeOptions).toBeUndefined()
+  })
+
+  it('sets NODE_OPTIONS for yml sourcemap object with setNodeOptions: true', async () => {
+    const { nodeOptions, mapFiles } = await buildService({
+      esbuildConfig: { sourcemap: { type: 'linked', setNodeOptions: true } },
+    })
+
+    expect(mapFiles).toEqual(['handler.js.map'])
+    expect(nodeOptions).toBe('--enable-source-maps')
+  })
+})


### PR DESCRIPTION
## Summary

- Base the `NODE_OPTIONS=--enable-source-maps` decision on the effective sourcemap setting (the merge of `serverless.yml` over the esbuild `configFile` over defaults) instead of only the raw `serverless.yml` value
- Document the merge precedence between `build.esbuild` in `serverless.yml` and the `configFile`, and that the effective `sourcemap` setting also controls the environment variable (`docs/sf/providers/aws/guide/building.md`)
- Add unit tests covering the env-var decision across yml and config-file sourcemap combinations, asserting emitted `.map` artifacts alongside the env var (`packages/serverless/test/unit/lib/plugins/esbuild/sourcemap-node-options.test.js`)

## Root cause

The esbuild build honors the merged options (so `sourcemap: false` returned from a `configFile` correctly emitted no source maps), but the code that injects `NODE_OPTIONS=--enable-source-maps` read only `service.build.esbuild.sourcemap` from `serverless.yml`. When sourcemaps were configured solely inside the config file, that value was `undefined`, which the check treated as "enabled by default" — so every function received the env var even though no source maps existed.

The fix computes the decision once per build: a `serverless.yml` `sourcemap` value keeps its existing semantics (boolean as-is; object form via its `setNodeOptions` flag, false by default), and only when `serverless.yml` is silent does the merged result decide.

## Test plan

- [x] New unit tests fail before the fix (config-file `sourcemap: false` case) and pass after; the remaining cases pin existing yml semantics
- [x] Full `@serverless/framework` unit suite passes (162 suites / 2911 tests), lint and prettier clean
- [x] Live esbuild integration suite passes (5 suites / 22 tests, real deploys including the js-config scenario)
- [x] Exhaustive comparison of the old vs new decision across 83 valid yml × config-file sourcemap combinations shows exactly one behavioral change: the fixed case (yml silent + config file `sourcemap: false` no longer sets the env var)

## Related

Closes #12997


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured `NODE_OPTIONS=--enable-source-maps` and sourcemap emission are controlled by the *effective merged* `sourcemap` setting (with `serverless.yml` taking precedence over esbuild config).
  - Respects advanced sourcemap forms (e.g., linked maps) and only injects `NODE_OPTIONS` when appropriate (e.g., `setNodeOptions: true`).

- **Documentation**
  - Clarified how esbuild config options merge with `serverless.yml`, and how the final `sourcemap` value drives both generated maps and runtime environment variables.

- **Tests**
  - Added Jest unit tests validating the NODE_OPTIONS injection and sourcemap behavior using the real esbuild binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->