### PR TITLE
fix(esbuild): support compose root dependencies with packages external

### DIFF
--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -87,6 +87,8 @@ build:
     metafile: true
 ```
 
+Dependencies that stay out of the bundle — packages listed in `external`, or all packages when `packages: external` is set — are installed into the `node_modules` directory of the deployment archive. Their versions are resolved from the service's `package.json`. In a [Serverless Compose](../../../guides/compose) project, the `package.json` next to `serverless-compose.yml` acts as a fallback, so services can share dependencies declared once at the project root: `external` packages not found in the service's `package.json` are resolved from it, and with `packages: external` it is used when the service declares no dependencies of its own.
+
 You may also configure esbuild with a JavaScript file, which is useful if you want to use esbuild plugins. Here's an example:
 
 ```yml

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -1188,6 +1188,13 @@ class Esbuild {
               composePackageJson.dependencies[key]
           }
         }
+      } else {
+        // packages: 'external' keeps the service's own dependencies; only a
+        // service that declares none (dependencies live at the compose root)
+        // falls back to the compose-root package.json
+        packageJsonNoDevDeps.dependencies = packageJson.dependencies
+          ? { ...packageJson.dependencies }
+          : { ...composePackageJson.dependencies }
       }
 
       for (const key of exclude) {

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -1189,9 +1189,11 @@ class Esbuild {
           }
         }
       } else {
-        // packages: 'external' keeps the service's own dependencies; only a
-        // service that declares none (dependencies live at the compose root)
-        // falls back to the compose-root package.json
+        // packages: 'external' keeps the service's own dependencies — even an
+        // explicitly empty `dependencies: {}` — exactly as declared: configs
+        // that packaged successfully before must keep producing identical
+        // artifacts. The compose-root fallback applies only to a service with
+        // no dependencies declaration at all, which previously crashed here.
         packageJsonNoDevDeps.dependencies = packageJson.dependencies
           ? { ...packageJson.dependencies }
           : { ...composePackageJson.dependencies }

--- a/packages/serverless/test/unit/lib/plugins/esbuild/prepare-package-json.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/prepare-package-json.test.js
@@ -1,0 +1,185 @@
+/**
+ * `_preparePackageJson` writes the trimmed package.json into `.serverless/build`
+ * and installs the external dependencies there. Inside a Compose project the
+ * service may have no package.json of its own, with all dependencies declared
+ * in the compose-root package.json instead.
+ *
+ * Before the fix, combining that layout with `build.esbuild.packages:
+ * 'external'` crashed: the outer dependency branch was entered via the
+ * compose-root dependencies, the `packages !== 'external'` branch that
+ * initializes `packageJsonNoDevDeps.dependencies` was skipped, and the
+ * exclude-deletion loop (exclude always contains the `@aws-sdk/*` default)
+ * dereferenced `undefined` — `TypeError: Cannot convert undefined or null to
+ * object`.
+ *
+ * With the fix, `packages: 'external'` uses the service's own dependencies
+ * when it declares any (exactly as before), and falls back to the compose-root
+ * package.json only when the service declares none — the previously crashing
+ * configuration. Configurations that worked before produce identical output.
+ *
+ * The packager install step is stubbed (spawn mock) — these tests assert on
+ * the package.json written to the build directory, not on a real install.
+ */
+
+import { jest } from '@jest/globals'
+import { EventEmitter } from 'events'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+const spawnMock = jest.fn(() => {
+  const child = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdout = new EventEmitter()
+  const promise = Promise.resolve()
+  promise.child = child
+  process.nextTick(() => child.emit('close', 0))
+  return promise
+})
+
+jest.unstable_mockModule('child-process-ext/spawn.js', () => ({
+  default: spawnMock,
+}))
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+const createdDirs = []
+
+function makeDir(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-pkg-'))
+  createdDirs.push(dir)
+  for (const [name, contents] of Object.entries(files)) {
+    const filePath = path.join(dir, name)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+  return dir
+}
+
+function makePlugin(serviceDir, { esbuild = {}, isWithinCompose = false }) {
+  // _preparePackageJson writes into the build dir the build step normally creates
+  fs.mkdirSync(path.join(serviceDir, '.serverless', 'build'), {
+    recursive: true,
+  })
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      provider: { runtime: 'nodejs20.x' },
+      build: { esbuild },
+    },
+    compose: { isWithinCompose },
+  }
+  return new Esbuild(serverless, {})
+}
+
+function readBuildPackageJson(serviceDir) {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(serviceDir, '.serverless', 'build', 'package.json'),
+      'utf-8',
+    ),
+  )
+}
+
+describe('esbuild _preparePackageJson', () => {
+  beforeEach(() => {
+    spawnMock.mockClear()
+  })
+
+  afterEach(() => {
+    while (createdDirs.length > 0) {
+      fs.rmSync(createdDirs.pop(), { recursive: true, force: true })
+    }
+  })
+
+  test('compose service without its own package.json and packages: "external" resolves dependencies from the compose root', async () => {
+    // Compose root holds the only package.json; the service dir has none.
+    const composeRoot = makeDir({
+      'serverless-compose.yml': 'services:\n  my-service:\n    path: service\n',
+      'package.json': JSON.stringify({
+        dependencies: { zod: '^3.24.1' },
+        devDependencies: { typescript: '^5.0.0' },
+      }),
+      'service/handler.mjs': 'export const hello = async () => ({})\n',
+    })
+    const serviceDir = path.join(composeRoot, 'service')
+    const plugin = makePlugin(serviceDir, {
+      esbuild: { packages: 'external', external: ['zod'] },
+      isWithinCompose: true,
+    })
+
+    // Pre-fix: TypeError: Cannot convert undefined or null to object
+    await expect(plugin._preparePackageJson()).resolves.toBeUndefined()
+
+    const buildPackageJson = readBuildPackageJson(serviceDir)
+    expect(buildPackageJson.dependencies).toEqual({ zod: '^3.24.1' })
+    expect(buildPackageJson.devDependencies).toBeUndefined()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('compose service with its own dependencies keeps exactly those with packages: "external" — the compose root is not merged in', async () => {
+    const composeRoot = makeDir({
+      'serverless-compose.yml': 'services:\n  my-service:\n    path: service\n',
+      'package.json': JSON.stringify({
+        dependencies: { zod: '^3.0.0', lodash: '^4.17.21' },
+      }),
+      'service/package.json': JSON.stringify({
+        dependencies: { zod: '^3.24.1' },
+      }),
+    })
+    const serviceDir = path.join(composeRoot, 'service')
+    const plugin = makePlugin(serviceDir, {
+      esbuild: { packages: 'external' },
+      isWithinCompose: true,
+    })
+
+    await plugin._preparePackageJson()
+
+    // Same output this configuration produced before the fix: the compose
+    // root must not change artifacts of services that declare their own
+    // dependencies.
+    const buildPackageJson = readBuildPackageJson(serviceDir)
+    expect(buildPackageJson.dependencies).toEqual({ zod: '^3.24.1' })
+  })
+
+  test('outside compose, packages: "external" keeps the service dependencies unchanged', async () => {
+    const serviceDir = makeDir({
+      'package.json': JSON.stringify({
+        dependencies: { zod: '^3.24.1' },
+        devDependencies: { typescript: '^5.0.0' },
+      }),
+    })
+    const plugin = makePlugin(serviceDir, {
+      esbuild: { packages: 'external' },
+    })
+
+    await plugin._preparePackageJson()
+
+    const buildPackageJson = readBuildPackageJson(serviceDir)
+    expect(buildPackageJson.dependencies).toEqual({ zod: '^3.24.1' })
+    expect(buildPackageJson.devDependencies).toBeUndefined()
+  })
+
+  test('compose service without its own package.json bundling (no packages: "external") still resolves externals from the compose root', async () => {
+    const composeRoot = makeDir({
+      'serverless-compose.yml': 'services:\n  my-service:\n    path: service\n',
+      'package.json': JSON.stringify({
+        dependencies: { zod: '^3.24.1', lodash: '^4.17.21' },
+      }),
+    })
+    const serviceDir = path.join(composeRoot, 'service')
+    const plugin = makePlugin(serviceDir, {
+      esbuild: { external: ['zod'] },
+      isWithinCompose: true,
+    })
+
+    await plugin._preparePackageJson()
+
+    // Only the externals land in the build package.json, resolved from the compose root.
+    const buildPackageJson = readBuildPackageJson(serviceDir)
+    expect(buildPackageJson.dependencies).toEqual({ zod: '^3.24.1' })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/prepare-package-json.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/prepare-package-json.test.js
@@ -145,6 +145,32 @@ describe('esbuild _preparePackageJson', () => {
     expect(buildPackageJson.dependencies).toEqual({ zod: '^3.24.1' })
   })
 
+  test('compose service with an explicitly empty dependencies object keeps it with packages: "external" — the compose root is not consulted', async () => {
+    // Backward-compatibility contract: `dependencies: {}` packaged
+    // successfully before the compose-root fallback existed (producing empty
+    // node_modules), so it must keep producing an identical artifact. Only a
+    // service with no dependencies declaration at all uses the compose root.
+    const composeRoot = makeDir({
+      'serverless-compose.yml': 'services:\n  my-service:\n    path: service\n',
+      'package.json': JSON.stringify({
+        dependencies: { zod: '^3.24.1', lodash: '^4.17.21' },
+      }),
+      'service/package.json': JSON.stringify({
+        dependencies: {},
+      }),
+    })
+    const serviceDir = path.join(composeRoot, 'service')
+    const plugin = makePlugin(serviceDir, {
+      esbuild: { packages: 'external' },
+      isWithinCompose: true,
+    })
+
+    await plugin._preparePackageJson()
+
+    const buildPackageJson = readBuildPackageJson(serviceDir)
+    expect(buildPackageJson.dependencies).toEqual({})
+  })
+
   test('outside compose, packages: "external" keeps the service dependencies unchanged', async () => {
     const serviceDir = makeDir({
       'package.json': JSON.stringify({


### PR DESCRIPTION
## Summary

- Fix a `TypeError: Cannot convert undefined or null to object` crash in `packages/serverless/lib/plugins/esbuild/index.js` (`_preparePackageJson`) when a service inside a Serverless Compose project has no `package.json` of its own (or none with a `dependencies` field) and sets `build.esbuild.packages: external`
- With `packages: external`, a service that declares its own dependencies keeps exactly those (unchanged behavior); a service that declares none now falls back to the `package.json` next to `serverless-compose.yml`, so the deployment archive gets a working `node_modules` instead of a crash
- Document dependency-version resolution for externals, including the Compose-root fallback, in `docs/sf/providers/aws/guide/building.md`

## Root cause

When packaging inside a Compose project, `_preparePackageJson` enters its dependency-processing branch if either the service or the compose-root `package.json` declares dependencies. The `packages: external` path kept only the service's dependencies and skipped initializing the rewritten `dependencies` object, so with no service dependencies the subsequent exclude-cleanup loop (the `@aws-sdk/*` default is always present) dereferenced `undefined` and crashed the `package`/`deploy` command.

## Backward compatibility

The change is scoped to configurations that previously crashed. Every configuration that packaged successfully before produces identical output: outside Compose nothing changes, and inside Compose a service with its own dependencies never consults the compose root under `packages: external`. This deliberately includes a service declaring an explicitly empty `"dependencies": {}` — that configuration packaged successfully before (producing empty `node_modules`), so it keeps doing exactly that rather than pulling in the compose-root dependencies; a dedicated unit test pins this contract.

## Test plan

- [x] New unit tests in `packages/serverless/test/unit/lib/plugins/esbuild/prepare-package-json.test.js`: crash case (compose + no service `package.json` + `packages: external`), service-declared dependencies remain exactly as before (compose root not merged), non-compose `packages: external` unchanged, bundling-path compose fallback unchanged
- [x] Full `packages/serverless` unit suite passes (160 suites, 2893 tests)
- [x] Live check from source CLI: compose project with root-only `package.json` and `packages: external` — previously crashed, now packages successfully with the root dependencies in `node_modules`; the same project with a service-level `package.json` produces a zip containing only the service's dependencies (root packages absent), matching pre-fix output

## How to test

In a Compose project where only the root (next to `serverless-compose.yml`) has a `package.json`:

```yaml
# service serverless.yml
build:
  esbuild:
    packages: external
```

```bash
serverless <service> package
```

Before: crashes with `TypeError: Cannot convert undefined or null to object`. After: packaging succeeds and the function zip contains `node_modules` with the compose-root dependencies.

## Related

- Follow-up to the Compose externals resolution discussed in #12957 (fixed for the bundling path in v4.26.1; this covers the `packages: external` path)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS Lambda packaging for `esbuild` when using external packages, ensuring dependencies are correctly included in the deployment archive’s `node_modules`.
  * Preserved a service’s own dependency list (including an explicitly empty `dependencies`) when `packages: "external"` is enabled.
  * Added clearer fallback behavior for external dependencies using the Compose root when the service doesn’t declare dependencies.
* **Documentation**
  * Clarified how external dependencies are resolved and included for AWS Lambda builds (including Compose behavior).
* **Tests**
  * Added/updated unit coverage for `packages: "external"` in both Compose and non-Compose scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
