### PR TITLE
test(esbuild): fix invoke-local outExtension test on Windows

### DIFF
--- a/packages/serverless/test/unit/lib/plugins/aws/invoke-local/out-extension.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/invoke-local/out-extension.test.js
@@ -17,7 +17,7 @@ import { execFile } from 'child_process'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 import { promisify } from 'util'
 
 const execFileAsync = promisify(execFile)
@@ -26,13 +26,17 @@ const pluginPath = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../../../../../../lib/plugins/aws/invoke-local/index.js',
 )
+// A `file://` URL, not a bare path: Node's ESM loader rejects a raw
+// drive-letter path (e.g. C:\...) as an import specifier on Windows.
+const pluginUrl = pathToFileURL(pluginPath).href
 
-// Driver executed by the child process: builds the minimal plugin context
-// invokeLocalNodeJs touches and invokes the handler at argv[2]/argv[3].
+// Driver executed by the child process. It receives the plugin URL and the
+// service dir + handler path as argv, builds the minimal plugin context
+// invokeLocalNodeJs touches, and invokes the handler. The dynamic import runs
+// inside the try so any startup failure prints a diagnostic instead of exiting
+// with empty stdout.
 const driverSource = `
-import AwsInvokeLocal from ${JSON.stringify(pluginPath)}
-
-const [serviceDir, handlerPath] = process.argv.slice(2)
+const [pluginUrl, serviceDir, handlerPath] = process.argv.slice(2)
 
 const context = {
   serverless: { serviceDir, service: { provider: {} } },
@@ -45,6 +49,7 @@ const context = {
 }
 
 try {
+  const { default: AwsInvokeLocal } = await import(pluginUrl)
   await AwsInvokeLocal.prototype.invokeLocalNodeJs.call(
     context,
     handlerPath,
@@ -74,7 +79,7 @@ async function invoke(serviceDir, handlerPath) {
   try {
     const { stdout } = await execFileAsync(
       process.execPath,
-      [path.join(serviceDir, 'driver.mjs'), serviceDir, handlerPath],
+      [path.join(serviceDir, 'driver.mjs'), pluginUrl, serviceDir, handlerPath],
       { env: { ...process.env, NODE_NO_WARNINGS: '1' } },
     )
     return stdout.trim()


### PR DESCRIPTION
## Summary

- Fix the `invoke local` `outExtension` unit test on Windows, where all four assertions failed with empty output

## Root cause

The test spawns a Node child process whose driver script imported the plugin through a raw filesystem path. On Windows a drive-letter path (`C:\...`) is not a valid ESM import specifier — Node's loader throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` at module evaluation, before the driver prints anything, so the child produced empty stdout and every assertion saw `""`. On POSIX the absolute path was accepted as a specifier, so the test passed on Linux and macOS.

## Fix

- Import the plugin through a `file://` URL (`pathToFileURL(...).href`), which is a valid specifier on all platforms
- Import inside the driver's `try` block and print a diagnostic on failure, so a future startup error surfaces a code instead of silently exiting with empty output

## Test plan

- [x] `test/unit/lib/plugins/aws/invoke-local/out-extension.test.js` passes (4/4); lint and prettier clean
- [x] Verified a raw drive-letter specifier throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` (reproducing the Windows failure) while the `file://` URL loads correctly

No production code changes; test-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local invocation handling for extensionless handlers across `.mjs`, `.cjs`, and JavaScript module formats.
  * Ensured missing handlers continue to report a clear initialization error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->