### PR TITLE
chore(deps): remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -897,20 +897,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/crt-loader": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crt-loader/-/crt-loader-3.972.63.tgz",
-      "integrity": "sha512-TjUYSV8lO7SM22sU2x0OiOvSFvEyMPBHNJFAm0G1f77rl3ZPbJ7wvDtpWN8RIU10F3oxqLn05PKV8B+2miXurg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.975.3",
-        "aws-crt": "^1.31.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/dynamodb-codec": {
       "version": "3.973.33",
       "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.33.tgz",
@@ -1072,24 +1058,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-crt": {
-      "version": "3.1087.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.1087.0.tgz",
-      "integrity": "sha512-vPL7iLnPfcxHlQwugR5qUp+B1TnMT0eErIsZCfTe9zfOAexZR1eHw4Fvd9lSSGuFZAHfGgxBl51hnTizveCCrQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/crt-loader": "^3.972.62",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.40",
-        "@aws-sdk/types": "^3.974.1",
-        "@smithy/core": "^3.29.3",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.996.41",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
@@ -1159,15 +1127,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.259.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
-      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
@@ -4860,12 +4819,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4880,164 +4833,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/aws-crt": {
-      "version": "1.32.2",
-      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.32.2.tgz",
-      "integrity": "sha512-aBnti9KsPVV9CI57ZJ2J9HqTtcr8ghOnFnjKzangCiOeXiV9EtK/+QyObcpn+AvcGvTxeh3ve12fAV0BWuqcIQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/util-utf8-browser": "^3.259.0",
-        "@httptoolkit/websocket-stream": "^6.0.1",
-        "axios": "^1.12.2",
-        "buffer": "^6.0.3",
-        "crypto-js": "^4.2.0",
-        "mqtt": "^4.3.8",
-        "process": "^0.11.10"
-      }
-    },
-    "node_modules/aws-crt/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/aws-crt/node_modules/duplexify": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
-      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.2"
-      }
-    },
-    "node_modules/aws-crt/node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/aws-crt/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/aws-crt/node_modules/mqtt": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.8.tgz",
-      "integrity": "sha512-2xT75uYa0kiPEF/PE0VPdavmEkoBzMT/UL9moid0rAvlCtV48qBwxD62m7Ld/4j8tSkIO1E/iqRl/S72SEOhOw==",
-      "license": "MIT",
-      "dependencies": {
-        "commist": "^1.0.0",
-        "concat-stream": "^2.0.0",
-        "debug": "^4.1.1",
-        "duplexify": "^4.1.1",
-        "help-me": "^3.0.0",
-        "inherits": "^2.0.3",
-        "lru-cache": "^6.0.0",
-        "minimist": "^1.2.5",
-        "mqtt-packet": "^6.8.0",
-        "number-allocator": "^1.0.9",
-        "pump": "^3.0.0",
-        "readable-stream": "^3.6.0",
-        "reinterval": "^1.1.0",
-        "rfdc": "^1.3.0",
-        "split2": "^3.1.0",
-        "ws": "^7.5.5",
-        "xtend": "^4.0.2"
-      },
-      "bin": {
-        "mqtt": "bin/mqtt.js",
-        "mqtt_pub": "bin/pub.js",
-        "mqtt_sub": "bin/sub.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/aws-crt/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/aws-crt/node_modules/ws": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
-      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/aws-crt/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/aws-iot-device-sdk": {
       "version": "2.2.16",
@@ -5150,43 +4945,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/axios/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/b4a": {
@@ -5984,18 +5742,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commist": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
@@ -6477,15 +6223,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -7744,26 +7481,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7793,43 +7510,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -9916,16 +9596,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-sdsl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
-      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/js-sdsl"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11028,16 +10698,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/number-allocator": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
-      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.1",
-        "js-sdsl": "4.3.0"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -11754,15 +11414,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -12138,6 +11789,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/router": {
@@ -14544,7 +14196,6 @@
         "@aws-sdk/client-ssm": "3.1087.0",
         "@aws-sdk/client-sts": "3.1087.0",
         "@aws-sdk/client-wafv2": "3.1087.0",
-        "@aws-sdk/signature-v4-crt": "3.1087.0",
         "@aws-sdk/signature-v4a": "3.1082.0",
         "@aws-sdk/util-arn-parser": "3.972.28",
         "@serverless/util": "*",
@@ -14564,12 +14215,12 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@serverless/engine": "*",
         "@serverless/framework": "*",
-        "eventsource": "^3.0.7",
         "express": "^5.2.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
         "@aws-sdk/client-cloudwatch-logs": "3.1087.0",
+        "eventsource": "^3.0.7",
         "jest": "^30.4.2"
       }
     },
@@ -14713,7 +14364,7 @@
         "@aws-sdk/client-cloudformation": "3.1087.0",
         "@aws-sdk/client-s3": "3.1087.0",
         "@aws-sdk/client-ssm": "3.1087.0",
-        "@aws-sdk/client-sso-oidc": "^3.1087.0",
+        "@aws-sdk/client-sso-oidc": "3.1087.0",
         "@aws-sdk/client-sts": "3.1087.0",
         "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/credential-providers": "3.1087.0",
@@ -14726,7 +14377,6 @@
         "@serverless/framework": "*",
         "@serverless/mcp": "*",
         "@serverless/util": "*",
-        "@smithy/util-retry": "^4.5.10",
         "adm-zip": "^0.6.0",
         "child-process-ext": "^3.0.2",
         "dotenv": "^17.3.1",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -40,7 +40,6 @@
     "@aws-sdk/client-ssm": "3.1087.0",
     "@aws-sdk/client-sts": "3.1087.0",
     "@aws-sdk/client-wafv2": "3.1087.0",
-    "@aws-sdk/signature-v4-crt": "3.1087.0",
     "@aws-sdk/signature-v4a": "3.1082.0",
     "@aws-sdk/util-arn-parser": "3.972.28",
     "@serverless/util": "*",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -22,12 +22,12 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@serverless/engine": "*",
     "@serverless/framework": "*",
-    "eventsource": "^3.0.7",
     "express": "^5.2.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@aws-sdk/client-cloudwatch-logs": "3.1087.0",
+    "eventsource": "^3.0.7",
     "jest": "^30.4.2"
   }
 }

--- a/packages/sf-core/package.json
+++ b/packages/sf-core/package.json
@@ -69,7 +69,6 @@
     "@serverless/framework": "*",
     "@serverless/mcp": "*",
     "@serverless/util": "*",
-    "@smithy/util-retry": "^4.5.10",
     "adm-zip": "^0.6.0",
     "child-process-ext": "^3.0.2",
     "dotenv": "^17.3.1",


### PR DESCRIPTION
Removes dependencies that are not imported anywhere, shrinking the install and audit surface. The published bundle is unchanged, since none of these are statically imported by shipped code.

- **Remove `@aws-sdk/signature-v4-crt` from `@serverless/engine`** — nothing imports it, so the CRT signer was never registered: `@aws-sdk/signature-v4-multi-region` only uses the CRT signer when an application explicitly imports `@aws-sdk/signature-v4-crt`. CloudFront KeyValueStore SigV4a signing uses the pure-JS `@smithy/signature-v4a` signer (registered via the side-effect import in `cloudfront-kv.js`), which stays in place. Verified at runtime: after loading `cloudfront-kv.js`, the JS signer is registered and the CRT container remains `null` — identical to current behavior. This drops the `aws-crt` native-binding subtree (25 packages, including `axios`, `crypto-js`, and a second `mqtt` copy) from the lockfile.
- **Remove `@smithy/util-retry` from `@serverlessinc/sf-core`** — no imports in sf-core source. The packages that use it (`packages/serverless`, `packages/engine`) keep their own entries.
- **Move `eventsource` in `@serverless/mcp` from `dependencies` to `devDependencies`** — it is only imported by the manual SSE test client (`src/test.js`); the runtime server path doesn't use it, and `@modelcontextprotocol/sdk` declares its own `eventsource` dependency.

Verification:

- `npm run test:unit` in `packages/sf-core`: 569/569 pass
- `npm test` in `packages/engine`: 79/79 pass
- `packages/mcp` unit tests: results identical to `main` baseline
- `npm run build` in `packages/sf-core`: bundle builds and runs (`--version` OK); bundle contents unchanged with respect to signers
- Lockfile regenerated; diff is pure removals plus manifest-sync normalizations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined package dependencies by removing unused runtime dependencies.
  * Reclassified `eventsource` as a development-only dependency.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->