### PR TITLE
chore(deps): replace lodash.uniqby with lodash uniqBy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10311,12 +10311,6 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "license": "MIT"
     },
-    "node_modules/lodash.uniqby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
-      "license": "MIT"
-    },
     "node_modules/log": {
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/log/-/log-6.3.2.tgz",
@@ -14642,7 +14636,6 @@
         "json-cycle": "^1.5.0",
         "jszip": "^3.10.1",
         "lodash": "^4.18.1",
-        "lodash.uniqby": "^4.7.0",
         "luxon": "^3.7.2",
         "memoizee": "^0.4.17",
         "micromatch": "^4.0.8",
@@ -14713,7 +14706,7 @@
         "@aws-sdk/client-cloudformation": "3.1087.0",
         "@aws-sdk/client-s3": "3.1087.0",
         "@aws-sdk/client-ssm": "3.1087.0",
-        "@aws-sdk/client-sso-oidc": "^3.1087.0",
+        "@aws-sdk/client-sso-oidc": "3.1087.0",
         "@aws-sdk/client-sts": "3.1087.0",
         "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/credential-providers": "3.1087.0",

--- a/packages/serverless/lib/plugins/python/lib/zip.js
+++ b/packages/serverless/lib/plugins/python/lib/zip.js
@@ -1,6 +1,6 @@
 import fse from 'fs-extra'
 import path from 'path'
-import uniqBy from 'lodash.uniqby'
+import uniqBy from 'lodash/uniqBy.js'
 import JSZip from 'jszip'
 import { addTree, writeZip } from './zipTree.js'
 import { fileURLToPath } from 'url'

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -83,7 +83,6 @@
     "json-cycle": "^1.5.0",
     "jszip": "^3.10.1",
     "lodash": "^4.18.1",
-    "lodash.uniqby": "^4.7.0",
     "luxon": "^3.7.2",
     "memoizee": "^0.4.17",
     "micromatch": "^4.0.8",

--- a/packages/serverless/test/unit/lib/plugins/python/lib/zip.test.js
+++ b/packages/serverless/test/unit/lib/plugins/python/lib/zip.test.js
@@ -1,0 +1,96 @@
+import { jest, describe, beforeEach, it, expect } from '@jest/globals'
+import path from 'path'
+
+jest.unstable_mockModule('fs-extra', () => ({
+  default: {
+    copy: jest.fn(async () => {}),
+    remove: jest.fn(async () => {}),
+  },
+}))
+
+jest.unstable_mockModule(
+  '../../../../../../lib/plugins/python/lib/zipTree.js',
+  () => ({
+    addTree: jest.fn(async (zip) => zip),
+    writeZip: jest.fn(async () => {}),
+  }),
+)
+
+const { default: fse } = await import('fs-extra')
+const { addTree, writeZip } =
+  await import('../../../../../../lib/plugins/python/lib/zipTree.js')
+const { addVendorHelper, removeVendorHelper, packRequirements } =
+  await import('../../../../../../lib/plugins/python/lib/zip.js')
+
+describe('python zip helpers', () => {
+  let context
+
+  const createFunc = (module) => ({
+    module,
+    runtime: 'python3.12',
+    package: { individually: true, patterns: [] },
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    context = {
+      options: { zip: true, cleanupZipHelper: true },
+      servicePath: path.join('/', 'service'),
+      targetFuncs: [
+        createFunc('module1'),
+        createFunc('module1'),
+        createFunc('module2'),
+      ],
+      serverless: {
+        service: {
+          provider: { runtime: 'python3.12' },
+          package: {},
+        },
+      },
+      log: { info: jest.fn() },
+      progress: {
+        get: jest.fn(() => ({ update: jest.fn(), remove: jest.fn() })),
+      },
+    }
+  })
+
+  describe('addVendorHelper', () => {
+    it('copies the helper once per unique module', async () => {
+      await addVendorHelper.call(context)
+
+      expect(fse.copy).toHaveBeenCalledTimes(2)
+      const destinations = fse.copy.mock.calls.map(([, dest]) => dest)
+      expect(destinations).toEqual([
+        path.join('/', 'service', 'module1', 'unzip_requirements.py'),
+        path.join('/', 'service', 'module2', 'unzip_requirements.py'),
+      ])
+    })
+  })
+
+  describe('removeVendorHelper', () => {
+    it('removes the helper once per unique module', async () => {
+      await removeVendorHelper.call(context)
+
+      expect(fse.remove).toHaveBeenCalledTimes(2)
+      const removed = fse.remove.mock.calls.map(([target]) => target)
+      expect(removed).toEqual([
+        path.join('/', 'service', 'module1', 'unzip_requirements.py'),
+        path.join('/', 'service', 'module2', 'unzip_requirements.py'),
+      ])
+    })
+  })
+
+  describe('packRequirements', () => {
+    it('zips requirements once per unique module', async () => {
+      await packRequirements.call(context)
+
+      expect(addTree).toHaveBeenCalledTimes(2)
+      expect(writeZip).toHaveBeenCalledTimes(2)
+      const written = writeZip.mock.calls.map(([, dest]) => dest)
+      expect(written).toEqual([
+        path.join('/', 'service', 'module1', '.requirements.zip'),
+        path.join('/', 'service', 'module2', '.requirements.zip'),
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Replace the `lodash.uniqby` dependency with a subpath import of `uniqBy` from the main `lodash` package (already a dependency of `packages/serverless`)
- `lodash.uniqby` is the per-method lodash distribution, unmaintained since 2016, while the main `lodash` package ships the same `uniqBy` with identical semantics
- Sole importer is `packages/serverless/lib/plugins/python/lib/zip.js`; all three call sites are unchanged
- Remove `lodash.uniqby` from `packages/serverless/package.json` and the lockfile
- Add a unit test covering the de-duplication-by-module behavior of the python plugin zip helpers (`addVendorHelper`, `removeVendorHelper`, `packRequirements`)

## Test plan

- [x] New unit test `packages/serverless/test/unit/lib/plugins/python/lib/zip.test.js` passes against both the old and the new import (run before and after the swap)
- [x] Full `packages/serverless` unit suite passes (164 suites, 2919 tests)
- [x] Differential check: `lodash.uniqby@4.7.0` vs `lodash@4.18.1` `uniqBy` compared on 5,000+ inputs (including `NaN`/`-0`/symbol/object keys, the ≥200-element Set fast path, nullish and sparse inputs, and all iteratee shorthands) — identical results, including element identity; the underlying `baseUniq`, `createSet`, and `baseIteratee` implementations are byte-for-byte identical between the two packages
- [x] Import verified under real Node ESM (not only jest's resolver)
- [x] `packages/sf-core` esbuild bundle builds successfully with no remaining `lodash.uniqby` references
- [x] `npm run lint` and `npm run prettier` pass
- [x] Lockfile updated with npm 12; `npm ci` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python dependency packaging by ensuring duplicate modules are processed only once.
  * Updated the packaging workflow to use the supported Lodash import path.

* **Tests**
  * Added coverage for vendor copying, cleanup, and requirements archive creation.
  * Verified that duplicate module entries do not trigger repeated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->