### PR TITLE
fix(aws): accept case-insensitive function url invokeMode values

### DIFF
--- a/packages/serverless/lib/plugins/aws/package/compile/functions.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/functions.js
@@ -1212,8 +1212,8 @@ class AwsCompileFunctions {
       }
     }
 
-    if (url.invokeMode === 'RESPONSE_STREAM') {
-      urlResource.Properties.InvokeMode = url.invokeMode
+    if (url.invokeMode && url.invokeMode.toUpperCase() === 'RESPONSE_STREAM') {
+      urlResource.Properties.InvokeMode = 'RESPONSE_STREAM'
     }
 
     const logicalId =

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -2927,8 +2927,9 @@ destinations:
                     },
                     invokeMode: {
                       description: `Function URL invoke mode.`,
-                      type: 'string',
-                      enum: ['BUFFERED', 'RESPONSE_STREAM'],
+                      anyOf: ['BUFFERED', 'RESPONSE_STREAM'].map(
+                        caseInsensitive,
+                      ),
                     },
                   },
                   additionalProperties: false,

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -1002,6 +1002,48 @@ describe('AwsCompileFunctions', () => {
       // Permission should NOT be created for AWS_IAM
       expect(resources.FuncLambdaFnUrlPermission).toBeUndefined()
     })
+
+    it('should normalize lowercase invokeMode to RESPONSE_STREAM', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          url: {
+            invokeMode: 'response_stream',
+          },
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      expect(resources.FuncLambdaFunctionUrl.Properties.InvokeMode).toBe(
+        'RESPONSE_STREAM',
+      )
+    })
+
+    it('should not set InvokeMode for lowercase buffered (the default)', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          url: {
+            invokeMode: 'buffered',
+          },
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      expect(
+        resources.FuncLambdaFunctionUrl.Properties.InvokeMode,
+      ).toBeUndefined()
+    })
   })
 
   describe('Configuration Properties', () => {

--- a/packages/serverless/test/unit/lib/plugins/aws/provider.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/provider.test.js
@@ -3,6 +3,8 @@ import { createRequire } from 'module'
 import path from 'path'
 import os from 'os'
 import fs from 'fs/promises'
+import Ajv from 'ajv'
+import regexpKeyword from '../../../../../lib/classes/config-schema-handler/regexp-keyword.js'
 
 const require = createRequire(import.meta.url)
 
@@ -104,6 +106,44 @@ describe('AwsProvider', () => {
           newAwsProvider.serverless.service.provider.deploymentBucket,
         ).toBe('my.deployment.bucket')
       })
+    })
+  })
+
+  describe('function url config schema', () => {
+    let validate
+
+    beforeEach(() => {
+      // Schema registration is gated on provider.name === 'aws'
+      serverless.service.provider.name = 'aws'
+      new AwsProvider(serverless, options)
+      const urlSchema =
+        serverless.configSchemaHandler.schema.properties.functions
+          .patternProperties['^[a-zA-Z0-9-_]+$'].properties.url
+      // Mirror the runtime AJV configuration from
+      // lib/classes/config-schema-handler/resolve-ajv-validate.js
+      const ajv = new Ajv({
+        allErrors: true,
+        coerceTypes: 'array',
+        verbose: true,
+        strict: false,
+        strictRequired: false,
+      })
+      ajv.addKeyword(regexpKeyword)
+      validate = ajv.compile(urlSchema)
+    })
+
+    it.each([
+      'BUFFERED',
+      'RESPONSE_STREAM',
+      'buffered',
+      'response_stream',
+      'Response_Stream',
+    ])('accepts invokeMode value %s', (invokeMode) => {
+      expect(validate({ invokeMode })).toBe(true)
+    })
+
+    it('rejects an unknown invokeMode value', () => {
+      expect(validate({ invokeMode: 'STREAMING' })).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Summary

- Accept `functions.*.url.invokeMode` values case-insensitively (`buffered`, `response_stream`, etc.), matching the convention used by other AWS provider schema enums such as the `http` event's `response.transferMode`
- Normalize the value before assigning the CloudFormation `InvokeMode` property, so any casing of `response_stream` deploys a streaming Function URL

## Root cause

The `invokeMode` schema used a case-sensitive `enum`, and compilation compared strictly against `'RESPONSE_STREAM'`. With the default `configValidationMode: warn`, a config like `invokeMode: response_stream` produced only a validation warning and then silently deployed a buffered URL instead of a streaming one.

## Test plan

- [x] Schema unit tests: accepts `BUFFERED`/`RESPONSE_STREAM` in any casing, still rejects unknown values (`packages/serverless/test/unit/lib/plugins/aws/provider.test.js`)
- [x] Compile unit tests: `response_stream` produces `InvokeMode: RESPONSE_STREAM`; `buffered` leaves `InvokeMode` unset, same as `BUFFERED` (`packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js`)
- [x] Full `@serverless/framework` unit suite passes (166 suites, 2939 tests), plus lint and prettier


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lambda Function URLs now accept `invokeMode` values regardless of letter casing.
  * Supported modes are correctly applied when configured as `response_stream` or other casing variants.

* **Bug Fixes**
  * Improved validation and handling of Function URL invocation modes.
  * Preserved buffered mode behavior when no streaming response mode is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->