### PR TITLE
chore(deps): bump brace-expansion to 1.1.17, 2.1.3 and 5.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5185,15 +5185,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -7515,9 +7515,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -12309,9 +12309,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13547,7 +13547,7 @@
         "@aws-sdk/client-cloudformation": "3.1092.0",
         "@aws-sdk/client-s3": "3.1092.0",
         "@aws-sdk/client-ssm": "3.1092.0",
-        "@aws-sdk/client-sso-oidc": "^3.1092.0",
+        "@aws-sdk/client-sso-oidc": "3.1092.0",
         "@aws-sdk/client-sts": "3.1092.0",
         "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/credential-providers": "3.1092.0",


### PR DESCRIPTION
Lockfile-only bump of the transitive `brace-expansion` dependency to the newest release on each line present in the tree.

## Summary

- `1.1.16` → `1.1.17` — dev only, via `test-exclude` → `minimatch@3`
- `2.1.2` → `2.1.3` — via `glob@10` → `minimatch@9`
- `5.0.7` → `5.0.8` — via `archiver` → `readdir-glob` → `minimatch@10`
- Also re-syncs the lockfile's cached copy of the `packages/sf-core` manifest, where `@aws-sdk/client-sso-oidc` was recorded as `^3.1092.0` while the manifest pins `3.1092.0` exactly, like its sibling AWS SDK entries.

No manifest changes — each new version already satisfies the range its parent declares.

## Behaviour change worth knowing about

All three lines now default `expand()` to a maximum of 100,000 results and 4,000,000 total characters. The 1.x and 2.x lines previously defaulted to unbounded. Patterns expanding past either limit are silently truncated rather than erroring. Both are overridable via the `max` and `maxLength` options.

Nothing in this repo approaches those limits — the largest brace expansions come from user `package.patterns` and the python plugin's cache globs.

## Node.js v18

`brace-expansion@5.0.8` narrowed its declared `engines.node` from `18 || 20 || >=22` to `20 || >=22`. Node 18 support is maintained:

- The `5.0.7` → `5.0.8` diff is algorithm-only; it introduces no API requiring Node 20.
- `5.0.8` was verified running on Node 18.20.8, both its CommonJS and ESM builds, covering basic expansion, numeric/zero-padded/step ranges, nested groups and glob-style patterns.
- The repo does not set `engine-strict`, so this produces at most an `EBADENGINE` warning on Node 18 installs, not a failure.

The `1.1.17` and `2.1.3` releases declare no `engines` field at all.

## Test plan

- [x] `npm ci` passes
- [x] `npm ls brace-expansion` resolves to `1.1.17`, `2.1.3` and `5.0.8`
- [x] Lockfile diff confined to the `brace-expansion` entries and the manifest re-sync noted above
- [x] `glob@10` output byte-identical on Node 18 before and after, across the four option sets used by the python plugin (`mark`, `dot`, `nodir`, `follow`, `windowsPathsNoEscape`, plus string and array patterns)
