### PR TITLE
test(package): raise timeout for npm-spawning zip-service tests

### DIFF
--- a/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
+++ b/packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js
@@ -154,6 +154,10 @@ describe('zipService', () => {
   })
 
   describe('#excludeDevDependencies() - node dependency resolution', () => {
+    // Each test spawns real `npm ls` processes; on Windows CI a single npm
+    // spawn can take seconds, so the default 5s per-test timeout is too tight.
+    jest.setTimeout(60_000)
+
     // Separator-agnostic so assertions hold on both POSIX ("node_modules/x/**")
     // and Windows ("node_modules\\x\\**") glob output.
     const isExcluded = (globs, name) =>


### PR DESCRIPTION
## Summary

- Add `jest.setTimeout(60_000)` to the `#excludeDevDependencies() - node dependency resolution` describe block in `packages/serverless/test/unit/lib/plugins/package/lib/zip-service.test.js`
- Fixes intermittent Windows CI failures where these tests exceed jest's default 5s per-test timeout (e.g. [this run](https://github.com/serverless/serverless/actions/runs/30536278400/job/90850263106))

## Root cause

Each of these tests spawns two real `npm ls` child processes in a scaffolded temp project. On Windows a single npm spawn (cmd → npm.cmd → node) takes several seconds, so the tests normally complete at 3–4s — right at the 5s default. On slower runner days they tip over the limit and time out, while the same tests pass comfortably on Linux/macOS. Passing Windows runs show the whole suite at ~13–14s versus ~21s in the failing runs, confirming a runner-speed effect rather than a code regression.

Spawn-heavy suites in this repo already set explicit timeouts for the same reason (`test/unit/lib/plugins/aws/invoke-local/out-extension.test.js` uses 60s; the esbuild suites use 30s); this block was missed when the tests were added.

## Test plan

- [x] `npm run test:unit -- test/unit/lib/plugins/package/lib/zip-service.test.js` — 19/19 pass
- [x] `prettier` and `eslint` clean on the changed file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for dependency-resolution tests to improve reliability in slower or Windows-based CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->