### PR TITLE
chore(deps): bump brace-expansion, minimatch and undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12605,9 +12605,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/packages/sf-core-installer/npm-shrinkwrap.json
+++ b/packages/sf-core-installer/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "rimraf": "5.0.10",
-        "undici": "6.27.0"
+        "undici": "6.28.0"
       },
       "bin": {
         "serverless": "run.js",
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/packages/sf-core-installer/npm-shrinkwrap.json
+++ b/packages/sf-core-installer/npm-shrinkwrap.json
@@ -82,15 +82,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/color-convert": {
@@ -211,12 +211,12 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "rimraf": "5.0.10",
-    "undici": "6.27.0"
+    "undici": "6.28.0"
   },
   "devDependencies": {},
   "overrides": {


### PR DESCRIPTION
## Summary

Dependency bumps across the root lockfile and the published installer package.

**`packages/sf-core-installer`** — its `npm-shrinkwrap.json` ships with the `serverless` npm package, so these pins reach end users:

- `brace-expansion` 5.0.7 → 5.0.8 and `minimatch` 10.2.5 → 10.2.6 — brings the shrinkwrap in line with the root lockfile bump from #13757
- `undici` 6.27.0 → 6.28.0 — an exact pin, so `package.json` moves alongside the shrinkwrap

**Root lockfile** — `undici` 6.27.0 → 6.28.0, already in range for `@serverless/util`'s declared `^6.25.0`.

### Notes on undici 6.28.0

- 6.28.0 is the newest 6.x. undici 7 requires Node `>=20.18.1` and undici 8 requires `>=22.19.0`, so the 6.x line is the only one compatible with the CLI's Node 18 support.
- `engines.node` is unchanged at `>=18.17` between 6.27.0 and 6.28.0, and neither version has runtime dependencies.
- The upstream diff touches four source files: header-value validation in `lib/core/request.js`, blob content-type validation in `lib/dispatcher/client-h1.js`, a partial-response length check in `lib/handler/retry-handler.js` (purely additive), and stricter cookie attribute validation in `lib/web/cookies/util.js`.
- The framework imports only `ProxyAgent` from undici, so the cookie and retry-interceptor paths are unused. The `request.js` change is inert for ordinary header values: string values were already validated in 6.27.0, and the newly validated branch covers only non-string coercions, where numbers and booleans stringify to valid values.

## Test plan

- [x] Root `npm ci` passes; `undici@6.28.0` resolves for both `@serverless/util` and `@serverless-inc/sdk` (deduped)
- [x] Installer: `npm install --ignore-scripts` against the shrinkwrap resolves `undici@6.28.0` and leaves the shrinkwrap byte-identical afterwards (stable resolution)
- [x] Shrinkwrap regenerated from a clean resolve rather than hand-edited; the resulting diff is confined to undici, and the `brace-expansion`/`minimatch` pins from the first commit reproduce exactly
- [x] Override-drift canary (`mqtt/node_modules/help-me`) is 0
- [x] `npm audit` reports no advisories for undici
- [x] `prettier` passes on all changed files
- [x] `brace-expansion@5.0.8` verified to run correctly on Node 18 (its `engines` metadata change is not a code-level incompatibility — same assessment as #13757); `minimatch@10.2.6` keeps Node 18 in `engines`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying package components to newer patch versions, including improvements to network communication and pattern matching.
  * Refreshed package metadata and integrity information to support reliable installations.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->