### PR TITLE
fix: include per-function artifacts in change detection

### DIFF
--- a/packages/serverless/lib/plugins/aws/deploy/lib/check-for-changes.js
+++ b/packages/serverless/lib/plugins/aws/deploy/lib/check-for-changes.js
@@ -260,6 +260,21 @@ export default {
         ),
       )
     }
+    // Per-function `package.artifact` overrides may point at pre-built zips
+    // outside `.serverless/` (see #13770). Include them in the hash set so
+    // change detection catches code updates for individually-packaged
+    // services, mirroring the artifact resolution in `upload-artifacts.js`.
+    for (const funName of this.serverless.service.getAllFunctions()) {
+      const functionObject = this.serverless.service.getFunction(funName)
+      if (functionObject.image) continue
+      const functionArtifact =
+        functionObject.package && functionObject.package.artifact
+      if (functionArtifact) {
+        zipFiles.push(
+          path.resolve(this.serverless.serviceDir, functionArtifact),
+        )
+      }
+    }
     // resolve paths and ensure we only hash each unique file once.
     const zipFilePaths = Array.from(
       new Set(

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-per-function-artifact.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-per-function-artifact.test.js
@@ -86,12 +86,15 @@ describe('checkIfDeploymentIsNecessary with per-function artifacts', () => {
     },
   })
 
-  it('deploys when a per-function artifact outside .serverless changed', async () => {
+  it('deploys when a changed per-function artifact is missing from the remote deployment', async () => {
     const ctx = buildCtx({ functionArtifact: 'artifacts/lambda/fn.zip' })
     ctx.serverless.service.provider.shouldNotDeploy = false
 
-    // Remote matches the template/state but carries a *different* function zip
-    // hash, so the per-function artifact must be included to force a deploy.
+    // Remote carries only the template and state hashes — the newest
+    // deployment directory lacks the function zip (e.g. an interrupted
+    // upload). Without the per-function artifact in the local hash set both
+    // sides match and the deploy is silently skipped despite changed code
+    // (#13770).
     const templateHash = sha256(
       JSON.stringify(normalizeFiles.normalizeCloudFormationTemplate(template)),
     )
@@ -106,10 +109,6 @@ describe('checkIfDeploymentIsNecessary with per-function artifacts', () => {
       {
         Key: 'prefix/serverless-state.json',
         Metadata: { filesha256: stateHash },
-      },
-      {
-        Key: 'prefix/fn.zip',
-        Metadata: { filesha256: sha256(Buffer.from('stale function bytes')) },
       },
     ]
 
@@ -149,9 +148,13 @@ describe('checkIfDeploymentIsNecessary with per-function artifacts', () => {
     expect(ctx.serverless.service.provider.shouldNotDeploy).toBe(true)
   })
 
-  it('ignores image-based functions (no zip to hash)', async () => {
+  it('ignores image-based functions even when package.artifact is set', async () => {
+    // The artifact must be ignored because image-function zips are never
+    // uploaded (mirrors getFunctionArtifactFilePaths in upload-artifacts.js);
+    // hashing it locally would leave a hash with no remote counterpart and
+    // permanently prevent no-change skips.
     const ctx = buildCtx({
-      functionArtifact: null,
+      functionArtifact: 'artifacts/lambda/fn.zip',
       hasImageFunction: true,
     })
     ctx.serverless.service.provider.shouldNotDeploy = false

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-per-function-artifact.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-per-function-artifact.test.js
@@ -1,0 +1,180 @@
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import crypto from 'crypto'
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => ({
+  log: {
+    warning: jest.fn(),
+    get: jest.fn(() => ({ debug: jest.fn() })),
+  },
+}))
+
+const checkForChangesMixin = (
+  await import('../../../../../../../lib/plugins/aws/deploy/lib/check-for-changes.js')
+).default
+const normalizeFiles = (
+  await import('../../../../../../../lib/plugins/aws/lib/normalize-files.js')
+).default
+
+const sha256 = (buffer) =>
+  crypto.createHash('sha256').update(buffer).digest('base64')
+
+describe('checkIfDeploymentIsNecessary with per-function artifacts', () => {
+  let tempDir
+  let serverlessDir
+  let template
+  let stateObject
+  let functionZipPath
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'check-for-changes-per-function-'),
+    )
+    serverlessDir = path.join(tempDir, '.serverless')
+    fs.mkdirSync(serverlessDir)
+
+    // Per-function artifact points outside .serverless/ (e.g. a pre-built zip
+    // referenced via `package.artifact` on the function).
+    functionZipPath = path.join(tempDir, 'artifacts', 'lambda', 'fn.zip')
+    fs.mkdirSync(path.dirname(functionZipPath), { recursive: true })
+    fs.writeFileSync(functionZipPath, 'function artifact bytes')
+
+    template = { Resources: { Foo: { Type: 'AWS::Lambda::Function' } } }
+    stateObject = {
+      service: { service: 'my-service', provider: {} },
+      package: {},
+    }
+    fs.writeFileSync(
+      path.join(serverlessDir, 'serverless-state.json'),
+      JSON.stringify(stateObject),
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  const buildCtx = ({ functionArtifact, hasImageFunction = false }) => ({
+    ...checkForChangesMixin,
+    provider: {
+      naming: { getServiceStateFileName: () => 'serverless-state.json' },
+    },
+    serverless: {
+      serviceDir: tempDir,
+      service: {
+        package: {},
+        provider: { compiledCloudFormationTemplate: template },
+        getAllFunctions: () => ['fn'],
+        getAllLayers: () => [],
+        getFunction: (name) =>
+          name === 'fn'
+            ? {
+                package: functionArtifact ? { artifact: functionArtifact } : {},
+                ...(hasImageFunction ? { image: 'image:tag' } : {}),
+              }
+            : {},
+      },
+    },
+  })
+
+  it('deploys when a per-function artifact outside .serverless changed', async () => {
+    const ctx = buildCtx({ functionArtifact: 'artifacts/lambda/fn.zip' })
+    ctx.serverless.service.provider.shouldNotDeploy = false
+
+    // Remote matches the template/state but carries a *different* function zip
+    // hash, so the per-function artifact must be included to force a deploy.
+    const templateHash = sha256(
+      JSON.stringify(normalizeFiles.normalizeCloudFormationTemplate(template)),
+    )
+    const stateHash = sha256(
+      JSON.stringify(normalizeFiles.normalizeState(stateObject)),
+    )
+    const remoteObjects = [
+      {
+        Key: 'prefix/compiled-cloudformation-template.json',
+        Metadata: { filesha256: templateHash },
+      },
+      {
+        Key: 'prefix/serverless-state.json',
+        Metadata: { filesha256: stateHash },
+      },
+      {
+        Key: 'prefix/fn.zip',
+        Metadata: { filesha256: sha256(Buffer.from('stale function bytes')) },
+      },
+    ]
+
+    await ctx.checkIfDeploymentIsNecessary(remoteObjects, new Date())
+
+    expect(ctx.serverless.service.provider.shouldNotDeploy).toBe(false)
+  })
+
+  it('skips when the per-function artifact is unchanged', async () => {
+    const ctx = buildCtx({ functionArtifact: 'artifacts/lambda/fn.zip' })
+    ctx.serverless.service.provider.shouldNotDeploy = false
+
+    const templateHash = sha256(
+      JSON.stringify(normalizeFiles.normalizeCloudFormationTemplate(template)),
+    )
+    const stateHash = sha256(
+      JSON.stringify(normalizeFiles.normalizeState(stateObject)),
+    )
+    const functionZipHash = sha256(fs.readFileSync(functionZipPath))
+    const remoteObjects = [
+      {
+        Key: 'prefix/compiled-cloudformation-template.json',
+        Metadata: { filesha256: templateHash },
+      },
+      {
+        Key: 'prefix/serverless-state.json',
+        Metadata: { filesha256: stateHash },
+      },
+      {
+        Key: 'prefix/fn.zip',
+        Metadata: { filesha256: functionZipHash },
+      },
+    ]
+
+    await ctx.checkIfDeploymentIsNecessary(remoteObjects, new Date())
+
+    expect(ctx.serverless.service.provider.shouldNotDeploy).toBe(true)
+  })
+
+  it('ignores image-based functions (no zip to hash)', async () => {
+    const ctx = buildCtx({
+      functionArtifact: null,
+      hasImageFunction: true,
+    })
+    ctx.serverless.service.provider.shouldNotDeploy = false
+
+    const templateHash = sha256(
+      JSON.stringify(normalizeFiles.normalizeCloudFormationTemplate(template)),
+    )
+    const stateHash = sha256(
+      JSON.stringify(normalizeFiles.normalizeState(stateObject)),
+    )
+    const remoteObjects = [
+      {
+        Key: 'prefix/compiled-cloudformation-template.json',
+        Metadata: { filesha256: templateHash },
+      },
+      {
+        Key: 'prefix/serverless-state.json',
+        Metadata: { filesha256: stateHash },
+      },
+    ]
+
+    await ctx.checkIfDeploymentIsNecessary(remoteObjects, new Date())
+
+    expect(ctx.serverless.service.provider.shouldNotDeploy).toBe(true)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-reused-layer.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/check-for-changes-reused-layer.test.js
@@ -112,6 +112,7 @@ describe('checkIfDeploymentIsNecessary reused-layer zip exclusion', () => {
         package: {},
         provider: { compiledCloudFormationTemplate: template },
         getAllLayers: () => ['common'],
+        getAllFunctions: () => [],
         getLayer: () => ({
           package: { artifact: commonZipPath },
           artifactAlreadyUploaded,


### PR DESCRIPTION
## What does this implement?

Fixes #13770: `checkIfDeploymentIsNecessary()` only added the **service-level** `package.artifact` to the set of local zip files it hashes and compares against the remote S3 `filesha256` metadata. When a service uses `package.individually: true` with **per-function** `package.artifact` overrides pointing at pre-built zips outside `.serverless/`, none of the actual Lambda code participated in the change comparison — so `serverless deploy` could silently skip the CloudFormation update and S3 upload even when code genuinely changed.

The fix mirrors the artifact resolution already used by `upload-artifacts.js` (`getFunctionArtifactFilePaths`): for each function, if it has an explicit `package.artifact` (and is not an image-based function), that path is added to the local hash set. Deduplication via `new Set` already handles overlap with the `.serverless/**.zip` glob.

## Verification

- Added `check-for-changes-per-function-artifact.test.js` with 3 tests:
  - deploys when a per-function artifact outside `.serverless/` changed
  - skips when the per-function artifact is unchanged
  - ignores image-based functions (no zip to hash)
- Updated the existing reused-layer test mock to expose `getAllFunctions` (required by the new loop).
- All 14 `check-for-changes` tests pass; Prettier clean.

Commit is SSH-signed. Let me know if you'd prefer the resolution to also cover `service.artifact` / individually-named zips in `.serverless/` (those are already covered by the glob, so I left the diff minimal).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment change detection for functions using individually configured ZIP artifacts, including artifacts stored outside the standard deployment directory.
  * Prevented unnecessary deployments when artifact contents have not changed.
  * Correctly ignores image-based functions without ZIP artifacts when checking for changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->