### PR TITLE
chore(deps): bump brace-expansion from 5.0.8 to 5.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5135,9 +5135,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -13121,7 +13121,7 @@
         "@aws-sdk/client-cloudformation": "3.1094.0",
         "@aws-sdk/client-s3": "3.1094.0",
         "@aws-sdk/client-ssm": "3.1094.0",
-        "@aws-sdk/client-sso-oidc": "^3.1094.0",
+        "@aws-sdk/client-sso-oidc": "3.1094.0",
         "@aws-sdk/client-sts": "3.1094.0",
         "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/credential-providers": "3.1094.0",


### PR DESCRIPTION
## Summary

- Bump `brace-expansion` from 5.0.8 to 5.0.9 in the root `package-lock.json` (transitive dependency via `minimatch`), picking up the latest upstream patch release
- The diff also syncs the lockfile's mirror entry for `packages/sf-core` to the exact `@aws-sdk/client-sso-oidc` pin already declared in `packages/sf-core/package.json` (the lockfile still carried a stale `^` range from a previous update)

## Test plan

- [x] `npm ci` passes and `npm ls brace-expansion` resolves to 5.0.9
- [x] Smoke-tested `brace-expansion@5.0.9` and `minimatch@10.2.5` on Node 18.20.8: package loads, `expand()` and minimatch brace patterns behave as expected (the new `engines` declaration is metadata-only, matching 5.0.8 already in the tree)
- [x] Lockfile diff limited to the intended entries; override placement verified (`grep -c 'mqtt/node_modules/help-me' package-lock.json` → 0)
