### PR TITLE
test(mcp): resolve module-path expectations portably

### DIFF
--- a/packages/serverless/test/unit/lib/plugins/aws/mcp/entry/compose.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/mcp/entry/compose.test.js
@@ -164,15 +164,21 @@ describe('mcp entry composition', () => {
 
   describe('resolveServerModulePath', () => {
     const exists = (present) => (candidate) => present.includes(candidate)
+    // Both the stubbed filesystem and the expectations are built with the
+    // same `path.resolve` the resolver uses, so the assertions hold on every
+    // runner: on Windows, resolving against '/var/task' yields a
+    // drive-qualified backslash path, and a POSIX string literal would never
+    // match it.
+    const at = (relative) => path.resolve('/var/task', relative)
 
     it('resolves against the task root', () => {
       expect(
         resolveServerModulePath({
           modulePath: 'src/crm.mjs',
           taskRoot: '/var/task',
-          exists: exists(['/var/task/src/crm.mjs']),
+          exists: exists([at('src/crm.mjs')]),
         }),
-      ).toBe('/var/task/src/crm.mjs')
+      ).toBe(at('src/crm.mjs'))
     })
 
     it('finds the built JavaScript sibling of a TypeScript source path', () => {
@@ -182,9 +188,9 @@ describe('mcp entry composition', () => {
         resolveServerModulePath({
           modulePath: 'src/crm.ts',
           taskRoot: '/var/task',
-          exists: exists(['/var/task/src/crm.js']),
+          exists: exists([at('src/crm.js')]),
         }),
-      ).toBe('/var/task/src/crm.js')
+      ).toBe(at('src/crm.js'))
     })
 
     it('prefers the configured path over a sibling', () => {
@@ -192,9 +198,9 @@ describe('mcp entry composition', () => {
         resolveServerModulePath({
           modulePath: 'src/crm.mjs',
           taskRoot: '/var/task',
-          exists: exists(['/var/task/src/crm.mjs', '/var/task/src/crm.js']),
+          exists: exists([at('src/crm.mjs'), at('src/crm.js')]),
         }),
-      ).toBe('/var/task/src/crm.mjs')
+      ).toBe(at('src/crm.mjs'))
     })
 
     it('skips a TypeScript source that also reached the artifact', () => {
@@ -207,9 +213,9 @@ describe('mcp entry composition', () => {
         resolveServerModulePath({
           modulePath: 'src/crm.ts',
           taskRoot: '/var/task',
-          exists: exists(['/var/task/src/crm.ts', '/var/task/src/crm.js']),
+          exists: exists([at('src/crm.ts'), at('src/crm.js')]),
         }),
-      ).toBe('/var/task/src/crm.js')
+      ).toBe(at('src/crm.js'))
     })
 
     it('probes .mjs ahead of .js', () => {
@@ -217,9 +223,9 @@ describe('mcp entry composition', () => {
         resolveServerModulePath({
           modulePath: 'src/crm.ts',
           taskRoot: '/var/task',
-          exists: exists(['/var/task/src/crm.js', '/var/task/src/crm.mjs']),
+          exists: exists([at('src/crm.js'), at('src/crm.mjs')]),
         }),
-      ).toBe('/var/task/src/crm.mjs')
+      ).toBe(at('src/crm.mjs'))
     })
 
     it('falls back to the working directory with no task root', () => {
@@ -246,8 +252,8 @@ describe('mcp entry composition', () => {
       }
       expect(error).toBeDefined()
       expect(error.message).toContain('src/crm.ts')
-      expect(error.message).toContain('/var/task/src/crm.js')
-      expect(error.message).toContain('/var/task/src/crm.mjs')
+      expect(error.message).toContain(at('src/crm.js'))
+      expect(error.message).toContain(at('src/crm.mjs'))
     })
   })
 


### PR DESCRIPTION
## Summary

The release workflow's Windows leg fails on six `resolveServerModulePath` tests in `compose.test.js`: the tests stub the filesystem with POSIX string literals (`/var/task/src/crm.mjs`), while the resolver builds candidates with `path.resolve` — which on Windows yields drive-qualified backslash paths (`C:\var\task\src\crm.mjs`). No candidate ever matches the stub, so all six tests throw the not-in-package error.

Failing run: https://github.com/serverless/serverless/actions/runs/31014879879/job/92336224583

**Test-only change — product code is untouched.** The MCP entry executes only on Lambda's Linux runtime; the failures are pure test portability. The stub keys and the expectations are now built with the same `path.resolve('/var/task', …)` call the resolver uses, so the assertions hold on every runner by construction.

Why this surfaced only post-merge: the cross-platform matrix (Windows/arm) runs only in `Release: Framework CLI`, which no PR CI exercises — this was the suite's first contact with Windows. The Windows job ran the full 186-suite fleet and this was the only failure.

## Impact

`release-canary` `needs: [test-matrix, test-engine]`, so the failing leg blocked the release cleanly — nothing was published. Merging this unblocks the release train.

## Testing

- `compose.test.js` 57/57 green on POSIX; the win32 resolution shape was probed explicitly to confirm the mismatch mechanism and that the fix keys both sides on the same call.
- The Windows leg itself re-runs on this PR's merge via the release workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved path-resolution test coverage across different operating systems.
  * Updated error-message checks to reflect platform-specific resolved paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->