### PR TITLE
fix(sandboxes): build dev images for the Docker daemon's architecture

### DIFF
--- a/docs/sf/providers/aws/guide/sandboxes.md
+++ b/docs/sf/providers/aws/guide/sandboxes.md
@@ -630,9 +630,11 @@ customizable with `--port`, so the address your code targets doesn't change betw
 port is already in use, `dev` exits with a clear error so you can pick another; run two sandboxes at
 once by giving each its own `--port`. Press Ctrl-C to stop.
 
-> **Note:** `dev` requires a local Docker daemon and a local `artifact` directory
-> containing a `Dockerfile`. A sandbox whose `artifact` is an `s3://` zip cannot be
-> run with `dev` — use a local directory for the dev loop.
+> **Note:** `dev` requires a Docker daemon and a local `artifact` directory
+> containing a `Dockerfile`. The image is built for the daemon's native CPU
+> architecture, so a daemon whose architecture differs from your machine's
+> (a VM or remote `DOCKER_HOST`) works too. A sandbox whose `artifact` is an
+> `s3://` zip cannot be run with `dev` — use a local directory for the dev loop.
 
 > The dev loop runs under the sandbox's real execution role (see [IAM
 > emulation](#iam-emulation) below). It does not reproduce the production

--- a/packages/serverless/lib/plugins/aws/sandboxes/dev/index.js
+++ b/packages/serverless/lib/plugins/aws/sandboxes/dev/index.js
@@ -92,6 +92,22 @@ class SandboxesDevMode {
     )
   }
 
+  // The sandbox image is built and run by the Docker daemon, whose CPU
+  // architecture may differ from the CLI host's (a Colima VM or remote
+  // DOCKER_HOST of another arch) — so ask the daemon what it runs natively,
+  // falling back to the host arch when it doesn't say. Arch comes back in
+  // GOARCH form ('arm64', 'amd64', …); the images we build are always Linux.
+  async resolveDockerPlatform() {
+    const fallback = process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64'
+    try {
+      const { Arch } =
+        (await this.docker.getDockerodeClient?.().version()) || {}
+      return Arch ? `linux/${Arch}` : fallback
+    } catch {
+      return fallback
+    }
+  }
+
   async run() {
     const name = this.resolveSandboxName()
     const cfg = this.getSandboxesConfig()[name]
@@ -100,13 +116,13 @@ class SandboxesDevMode {
     // default so the endpoint doesn't change between runs (unlike the per-instance proxy ports,
     // which are dynamic); override with --port. Defaults to 9100.
     const controlPlanePort = Number(this.options.port) || 9100
-    const platform = process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64'
     this.ctx = {
       name,
       cfg,
       contextPath,
       controlPlanePort,
-      platform,
+      // Resolved after the daemon check below — asking the daemon needs it up.
+      platform: null,
       imageUri: `serverless-sandbox-dev/${this.serverless.service.service}-${name}:latest`,
       containerName: `sls-sandbox-dev-${this.serverless.service.service}-${name}`,
     }
@@ -126,6 +142,7 @@ class SandboxesDevMode {
         { stack: false },
       )
     }
+    this.ctx.platform = await this.resolveDockerPlatform()
 
     // Header — the same "Dev ϟ Mode" banner functions Dev Mode prints, so the `serverless dev`
     // family reads as one product. A one-line description follows (grey). Optional-chained: test

--- a/packages/serverless/test/unit/lib/plugins/aws/sandboxes/dev/index.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/sandboxes/dev/index.test.js
@@ -560,6 +560,122 @@ test('run() builds the image before starting the control-plane', async () => {
   await p
 })
 
+// ---------------------------------------------------------------------------
+// Build platform: the image is built and run by the Docker daemon, whose CPU
+// architecture may differ from the CLI host's (e.g. an Intel Mac driving an
+// ARM Colima VM via DOCKER_HOST) — so the daemon's arch wins, with the host
+// arch as fallback when the daemon doesn't report one.
+// ---------------------------------------------------------------------------
+
+function makeForPlatform(docker) {
+  const signals = {}
+  const d = new SandboxesDevMode(
+    {
+      service: { service: 'svc', sandboxes: { api: { artifact: './app' } } },
+      serviceDir: '/svc',
+      getProvider: () => ({}),
+    },
+    { sandbox: 'api', 'assume-role': false },
+    {
+      log: { notice() {}, debug() {} },
+      progress: { notice() {}, remove() {} },
+    },
+    {
+      docker,
+      fileExists: () => true,
+      onSignal: (sig, h) => {
+        signals[sig] = h
+      },
+      createWatcher: () => ({ on() {}, close: async () => {} }),
+      startControlPlane: async () => ({
+        url: 'http://127.0.0.1:45020',
+        port: 45020,
+        server: {},
+        shutdown: async () => {},
+      }),
+      makeContainerManager: () => ({}),
+      makeRegistry: () => ({}),
+    },
+  )
+  return { d, signals }
+}
+
+const hostPlatform = process.arch === 'arm64' ? 'linux/arm64' : 'linux/amd64'
+const oppositeOfHost = process.arch === 'arm64' ? 'linux/amd64' : 'linux/arm64'
+
+test("run() builds for the Docker daemon's architecture, not the CLI host's", async () => {
+  const buildImage = jest.fn(async () => {})
+  // Daemon reports the arch OPPOSITE to the host — the daemon must win.
+  const { d, signals } = makeForPlatform({
+    ensureIsRunning: async () => {},
+    buildImage,
+    getDockerodeClient: () => ({
+      version: async () => ({
+        Arch: process.arch === 'arm64' ? 'amd64' : 'arm64',
+      }),
+    }),
+  })
+  const p = d.run()
+  await new Promise((r) => setImmediate(r))
+  expect(buildImage).toHaveBeenCalledWith(
+    expect.objectContaining({ platform: oppositeOfHost }),
+  )
+  await signals.SIGINT()
+  await p
+})
+
+test('run() falls back to the host architecture when the daemon reports none', async () => {
+  const buildImage = jest.fn(async () => {})
+  const { d, signals } = makeForPlatform({
+    ensureIsRunning: async () => {},
+    buildImage,
+    getDockerodeClient: () => ({ version: async () => ({}) }),
+  })
+  const p = d.run()
+  await new Promise((r) => setImmediate(r))
+  expect(buildImage).toHaveBeenCalledWith(
+    expect.objectContaining({ platform: hostPlatform }),
+  )
+  await signals.SIGINT()
+  await p
+})
+
+test('run() falls back to the host architecture when the daemon query fails or is unavailable', async () => {
+  // version() rejects (daemon reachable for ping but version call fails).
+  const buildImage = jest.fn(async () => {})
+  const { d, signals } = makeForPlatform({
+    ensureIsRunning: async () => {},
+    buildImage,
+    getDockerodeClient: () => ({
+      version: async () => {
+        throw new Error('version unavailable')
+      },
+    }),
+  })
+  const p = d.run()
+  await new Promise((r) => setImmediate(r))
+  expect(buildImage).toHaveBeenCalledWith(
+    expect.objectContaining({ platform: hostPlatform }),
+  )
+  await signals.SIGINT()
+  await p
+
+  // Test doubles without getDockerodeClient (the other tests in this file)
+  // must also get the fallback rather than a crash.
+  const buildImage2 = jest.fn(async () => {})
+  const { d: d2, signals: s2 } = makeForPlatform({
+    ensureIsRunning: async () => {},
+    buildImage: buildImage2,
+  })
+  const p2 = d2.run()
+  await new Promise((r) => setImmediate(r))
+  expect(buildImage2).toHaveBeenCalledWith(
+    expect.objectContaining({ platform: hostPlatform }),
+  )
+  await s2.SIGINT()
+  await p2
+})
+
 test('run() injects assumed-role creds into containerManager env by default', async () => {
   let capturedEnv
   const startControlPlane = jest.fn(async () => ({


### PR DESCRIPTION
## Summary

- `serverless dev --sandbox` now asks the Docker daemon for its native architecture (Docker `version` API) and builds the sandbox image for that platform, instead of deriving the platform from the CLI host's CPU (`process.arch`)
- Falls back to the previous host-based heuristic when the daemon doesn't report an architecture or the query fails
- Documents in the sandboxes guide that the dev image is built for the daemon's native architecture

## Root cause

The dev-mode sandbox image is built and run entirely by the Docker daemon, which can have a different CPU architecture than the machine running the CLI — for example an Intel Mac driving an ARM Colima VM via `DOCKER_HOST`, or a remote daemon. Deriving `--platform` from the CLI host's `process.arch` forced a cross-architecture build on such setups, which fails on daemons without emulation support.

## Test plan

- [x] New unit test: a daemon reporting the architecture opposite to the host's wins (fails against the previous implementation)
- [x] New unit tests: fallback to the host architecture when the daemon reports no arch, when the version query fails, and when the Docker client can't be queried
- [x] Full sandboxes unit suite passes (412 tests), lint and prettier clean
- [x] Live check: `serverless dev --sandbox` from source builds with the daemon-reported platform, launches a MicroVM to `RUNNING`, the app responds from inside the container, and teardown removes the container

## Related

Closes #13785


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local sandbox development now supports Docker daemons running on different CPU architectures, including virtual machines and remote Docker hosts.
  * Images are built for the Docker daemon’s native architecture when available.

* **Bug Fixes**
  * Added fallback to the local host architecture when Docker platform information is unavailable or cannot be retrieved.

* **Documentation**
  * Updated sandbox requirements and guidance for cross-architecture Docker setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->