### PR TITLE
fix(cli): never enable spinner animations on zero-width terminals

### DIFF
--- a/packages/serverless/test/unit/lib/util/logger-is-interactive.test.js
+++ b/packages/serverless/test/unit/lib/util/logger-is-interactive.test.js
@@ -134,6 +134,17 @@ test('override + zero-width stderr pty is NOT interactive even when stdout is us
   ).toBe(false)
 })
 
+test('override + stderr TTY with undefined columns is NOT interactive even when stdin/stdout are usable', () => {
+  expect(
+    computeIsInteractive({
+      stdin: tty(120),
+      stdout: tty(120),
+      stderr: { isTTY: true },
+      env: { SLS_INTERACTIVE_SETUP_ENABLE: '1' },
+    }),
+  ).toBe(false)
+})
+
 test('override + TTY with undefined columns is NOT interactive', () => {
   expect(
     computeIsInteractive({

--- a/packages/serverless/test/unit/lib/util/logger-is-interactive.test.js
+++ b/packages/serverless/test/unit/lib/util/logger-is-interactive.test.js
@@ -1,21 +1,37 @@
 // Guards the interactivity gate that drives the ora spinner's `isEnabled`. The key regression:
 // a pty with no window size reports `columns: 0`, and ora's `ceil(width / columns)` divides by zero
 // → Infinity lines to clear → an unbounded clear loop that emits gigabytes. computeIsInteractive
-// must treat 0/undefined width as NON-interactive so the spinner never animates there (bounded
-// plain-text path, like a pipe). Pure predicate — no spinner, no I/O, no pty.
+// must treat a zero-width TTY as NON-interactive on EVERY path — including the
+// SLS_INTERACTIVE_SETUP_ENABLE override, which previously bypassed the width guard and re-created
+// the flood on CircleCI's zero-width pty (GitHub issue #13786). Non-TTY streams are not vetoed:
+// the override keeps working for scripted (piped) setups, and ora skips its clear-line path on
+// non-TTY streams, so no flood is possible there. Every case passes stdin/stdout/stderr explicitly
+// so results never depend on the terminal the test runner happens to be attached to. Pure
+// predicate — no spinner, no I/O, no pty.
 import { computeIsInteractive } from '@serverless/util/src/logger/index.js'
 
 const tty = (columns) => ({ isTTY: true, columns })
+const pipe = () => ({ isTTY: false })
 
 test('a real terminal with a usable width is interactive', () => {
   expect(
-    computeIsInteractive({ stdin: { isTTY: true }, stdout: tty(120), env: {} }),
+    computeIsInteractive({
+      stdin: tty(120),
+      stdout: tty(120),
+      stderr: tty(120),
+      env: {},
+    }),
   ).toBe(true)
 })
 
 test('columns:0 (winsize-less pty) is NOT interactive — the GB-blowup guard', () => {
   expect(
-    computeIsInteractive({ stdin: { isTTY: true }, stdout: tty(0), env: {} }),
+    computeIsInteractive({
+      stdin: tty(0),
+      stdout: tty(0),
+      stderr: tty(0),
+      env: {},
+    }),
   ).toBe(false)
 })
 
@@ -24,6 +40,7 @@ test('columns undefined is NOT interactive', () => {
     computeIsInteractive({
       stdin: { isTTY: true },
       stdout: { isTTY: true },
+      stderr: { isTTY: true },
       env: {},
     }),
   ).toBe(false)
@@ -32,8 +49,9 @@ test('columns undefined is NOT interactive', () => {
 test('a non-TTY pipe is NOT interactive (columns irrelevant)', () => {
   expect(
     computeIsInteractive({
-      stdin: { isTTY: false },
-      stdout: { isTTY: false },
+      stdin: pipe(),
+      stdout: pipe(),
+      stderr: pipe(),
       env: {},
     }),
   ).toBe(false)
@@ -42,19 +60,87 @@ test('a non-TTY pipe is NOT interactive (columns irrelevant)', () => {
 test('CI set forces non-interactive even on a good terminal', () => {
   expect(
     computeIsInteractive({
-      stdin: { isTTY: true },
+      stdin: tty(120),
       stdout: tty(120),
+      stderr: tty(120),
       env: { CI: 'true' },
     }),
   ).toBe(false)
 })
 
-test('SLS_INTERACTIVE_SETUP_ENABLE is an explicit override (no TTY needed)', () => {
+test('a zero-width stderr TTY is NOT interactive even when stdout is usable — the spinner renders on stderr', () => {
   expect(
     computeIsInteractive({
-      stdin: { isTTY: false },
-      stdout: { isTTY: false },
-      env: { SLS_INTERACTIVE_SETUP_ENABLE: '1' },
+      stdin: tty(120),
+      stdout: tty(120),
+      stderr: tty(0),
+      env: {},
+    }),
+  ).toBe(false)
+})
+
+test('a non-TTY stderr does not block interactivity (ora skips clear-line on pipes)', () => {
+  expect(
+    computeIsInteractive({
+      stdin: tty(120),
+      stdout: tty(120),
+      stderr: pipe(),
+      env: {},
     }),
   ).toBe(true)
+})
+
+test('SLS_INTERACTIVE_SETUP_ENABLE overrides the CI check on a usable terminal', () => {
+  expect(
+    computeIsInteractive({
+      stdin: tty(120),
+      stdout: tty(120),
+      stderr: tty(120),
+      env: { CI: 'true', SLS_INTERACTIVE_SETUP_ENABLE: '1' },
+    }),
+  ).toBe(true)
+})
+
+test('SLS_INTERACTIVE_SETUP_ENABLE keeps working for scripted non-TTY (piped) setups', () => {
+  expect(
+    computeIsInteractive({
+      stdin: pipe(),
+      stdout: pipe(),
+      stderr: pipe(),
+      env: { CI: 'true', SLS_INTERACTIVE_SETUP_ENABLE: '1' },
+    }),
+  ).toBe(true)
+})
+
+test('override + zero-width stdout pty is NOT interactive — the #13786 flood guard', () => {
+  expect(
+    computeIsInteractive({
+      stdin: tty(0),
+      stdout: tty(0),
+      stderr: tty(0),
+      env: { CI: 'true', SLS_INTERACTIVE_SETUP_ENABLE: '1' },
+    }),
+  ).toBe(false)
+})
+
+test('override + zero-width stderr pty is NOT interactive even when stdout is usable', () => {
+  expect(
+    computeIsInteractive({
+      stdin: tty(120),
+      stdout: tty(120),
+      stderr: tty(0),
+      env: { SLS_INTERACTIVE_SETUP_ENABLE: '1' },
+    }),
+  ).toBe(false)
+})
+
+test('override + TTY with undefined columns is NOT interactive', () => {
+  expect(
+    computeIsInteractive({
+      stdin: { isTTY: true },
+      stdout: { isTTY: true },
+      stderr: { isTTY: true },
+      env: { SLS_INTERACTIVE_SETUP_ENABLE: '1' },
+    }),
+  ).toBe(false)
 })

--- a/packages/serverless/test/unit/lib/util/logger-progress-plain-path.test.js
+++ b/packages/serverless/test/unit/lib/util/logger-progress-plain-path.test.js
@@ -1,0 +1,87 @@
+// Guards the plain (non-animated) progress path. When the spinner cannot render
+// (non-TTY streams — always the case under jest — or a zero-width TTY), progress
+// updates are written as plain stderr lines at the 'info' level. That level is
+// deliberate for compose messages too: Compose's aggregated progress line (re-
+// noticed with a shrinking service list) only makes sense morphing in place
+// inside the spinner — on the plain path it stays filtered (both at the
+// 'compose' level and in error-only runs), and non-animated compose runs report
+// per-service completion lines via writeCompose instead.
+import {
+  progress,
+  setGlobalRendererSettings,
+  getGlobalRendererSettings,
+} from '@serverless/util/src/logger/index.js'
+
+// Pin the renderer to non-interactive: when jest runs in-band from a real
+// terminal, the module-load detection sees genuine TTYs and the animated path
+// would engage instead — failing the synchronous assertions and leaving a live
+// ora interval behind. Restored after the suite.
+let originalIsInteractive
+beforeAll(() => {
+  originalIsInteractive = getGlobalRendererSettings().isInteractive
+  setGlobalRendererSettings({ isInteractive: false })
+})
+afterAll(() => {
+  setGlobalRendererSettings({ isInteractive: originalIsInteractive })
+})
+
+const captureStdErr = (fn) => {
+  const written = []
+  const original = process.stderr.write
+  process.stderr.write = (chunk) => {
+    written.push(String(chunk))
+    return true
+  }
+  try {
+    fn()
+  } finally {
+    process.stderr.write = original
+  }
+  return written.join('')
+}
+
+const withLogLevel = (logLevel, fn) => {
+  const { logLevel: previous } = getGlobalRendererSettings()
+  setGlobalRendererSettings({ logLevel })
+  try {
+    return fn()
+  } finally {
+    setGlobalRendererSettings({ logLevel: previous })
+  }
+}
+
+test('compose progress messages stay off the plain path at the compose log level', () => {
+  const output = withLogLevel('compose', () =>
+    captureStdErr(() =>
+      progress
+        .get('plain-path-compose')
+        .notice('Deploying services', { isComposeMessage: true }),
+    ),
+  )
+  expect(output).not.toContain('Deploying services')
+})
+
+test('compose progress messages stay silent in error-only runs', () => {
+  const output = withLogLevel('error', () =>
+    captureStdErr(() =>
+      progress
+        .get('plain-path-compose-error')
+        .notice('Deploying services', { isComposeMessage: true }),
+    ),
+  )
+  expect(output).not.toContain('Deploying services')
+})
+
+test('regular progress messages print at the info level on the plain path', () => {
+  const output = withLogLevel('info', () =>
+    captureStdErr(() => progress.get('plain-path-info').notice('Packaging')),
+  )
+  expect(output).toContain('Packaging')
+})
+
+test('regular progress messages stay hidden at the default notice level', () => {
+  const output = withLogLevel('notice', () =>
+    captureStdErr(() => progress.get('plain-path-notice').notice('Packaging')),
+  )
+  expect(output).not.toContain('Packaging')
+})

--- a/packages/util/src/logger/index.js
+++ b/packages/util/src/logger/index.js
@@ -36,19 +36,26 @@ renderer.colorSupportLevel =
 // ora's clear-line math `ceil(stringWidth / columns)` then divides by zero → `Infinity` lines to
 // clear → an unbounded clear loop that emits gigabytes of escape sequences. Note `columns ?? 80`
 // in ora does NOT guard this (0 is not nullish). So we treat a 0/undefined width as non-interactive
-// and fall back to the bounded plain-text path — exactly like a pipe. (`SLS_INTERACTIVE_SETUP_ENABLE`
-// remains an explicit override.)
+// and fall back to the bounded plain-text path — exactly like a pipe.
+//
+// A zero-width TTY vetoes interactivity on EVERY path, including the `SLS_INTERACTIVE_SETUP_ENABLE`
+// override: CircleCI allocates a zero-width pty for build steps, and an override that bypassed the
+// width guard force-enabled the spinner there and re-created the unbounded clear loop (GitHub
+// issue #13786). stderr is vetoed too because the spinner renders to stderr. Non-TTY streams are
+// NOT vetoed — the override keeps enabling interactive flows for scripted (piped) setups, and ora
+// skips its clear-line path entirely on non-TTY streams, so no flood is possible there.
 function computeIsInteractive({
   stdin = process.stdin,
   stdout = process.stdout,
+  stderr = process.stderr,
   env = process.env,
 } = {}) {
+  const isZeroWidthTty = (stream) =>
+    Boolean(stream.isTTY) &&
+    !(Number.isInteger(stream.columns) && stream.columns > 0)
+  if (isZeroWidthTty(stdout) || isZeroWidthTty(stderr)) return false
   const hasUsableTty =
-    Boolean(stdin.isTTY) &&
-    Boolean(stdout.isTTY) &&
-    typeof env.CI !== 'string' &&
-    Number.isInteger(stdout.columns) &&
-    stdout.columns > 0
+    Boolean(stdin.isTTY) && Boolean(stdout.isTTY) && typeof env.CI !== 'string'
   return Boolean(hasUsableTty || env.SLS_INTERACTIVE_SETUP_ENABLE)
 }
 renderer.isInteractive = computeIsInteractive()
@@ -131,7 +138,11 @@ renderer.spinner = {
       renderer.spinner._spinner = ora({
         color: 'red',
         text: content,
-        isEnabled: renderer.isInteractive,
+        // Animation additionally requires the stream ora renders to (stderr) to be
+        // a terminal — with stderr redirected (`2> err.log`) the session can stay
+        // interactive for prompts while ora degrades to one plain line per phase
+        // instead of writing a frame line every interval into the file.
+        isEnabled: renderer.isInteractive && Boolean(process.stderr.isTTY),
       }).start()
     }
   },

--- a/packages/util/src/logger/index.js
+++ b/packages/util/src/logger/index.js
@@ -59,6 +59,13 @@ function computeIsInteractive({
   return Boolean(hasUsableTty || env.SLS_INTERACTIVE_SETUP_ENABLE)
 }
 renderer.isInteractive = computeIsInteractive()
+// Whether progress may render as a spinner animation: the session must be interactive AND the
+// stream ora draws on (stderr) must be a terminal. When this is false, progress must take the
+// plain per-message path — a disabled ora instance never renders `.text` updates, so routing
+// progress through it would drop phases (and every spinner restart around a log write would
+// re-print the current one).
+const canAnimateProgress = () =>
+  renderer.isInteractive && Boolean(process.stderr.isTTY)
 // Log levels
 renderer.levels = {
   compose: 0, // This is for compose. It is the lowest log level to have full control over the CLI.
@@ -138,11 +145,7 @@ renderer.spinner = {
       renderer.spinner._spinner = ora({
         color: 'red',
         text: content,
-        // Animation additionally requires the stream ora renders to (stderr) to be
-        // a terminal — with stderr redirected (`2> err.log`) the session can stay
-        // interactive for prompts while ora degrades to one plain line per phase
-        // instead of writing a frame line every interval into the file.
-        isEnabled: renderer.isInteractive && Boolean(process.stderr.isTTY),
+        isEnabled: canAnimateProgress(),
       }).start()
     }
   },
@@ -528,7 +531,12 @@ class Progress {
    * Updates the progress state with a new message.
    */
   notice(message, { isComposeMessage = false } = {}) {
-    if (!renderer.isInteractive) {
+    if (!canAnimateProgress()) {
+      // 'info' is deliberate for compose messages too: Compose's aggregated
+      // progress line (re-noticed with a shrinking service list) only makes
+      // sense morphing in place inside the spinner. On the plain path the
+      // 'compose' log level filters it out, and non-animated compose runs
+      // report per-service completion lines via writeCompose instead.
       writeStdErr({ level: 'info', messageTokens: [message] })
       return
     }
@@ -546,7 +554,7 @@ class Progress {
    * Stops the renderer.spinner if there are no progress states.
    */
   remove() {
-    if (!renderer.isInteractive || renderer.logLevel === 'compose') {
+    if (!canAnimateProgress() || renderer.logLevel === 'compose') {
       return
     }
     if (renderer.state.progressTasks.has(this.namespace) === undefined) {
@@ -562,7 +570,7 @@ class Progress {
    * For example, you may want to save the message, alter it, and then restore it.
    */
   getState() {
-    if (!renderer.isInteractive) {
+    if (!canAnimateProgress()) {
       return
     }
     if (renderer.state.progressTasks.has(this.namespace) === undefined) {


### PR DESCRIPTION
## Summary

- Treat a zero-width TTY (a pty allocated without a window size — as CI systems commonly do for build steps) as non-interactive on every code path, including the `SLS_INTERACTIVE_SETUP_ENABLE` override
- Animate the progress spinner only when the stream it renders to (stderr) is a terminal; with stderr redirected, progress degrades to one plain line per phase instead of a frame line per tick
- Rework the interactivity unit tests to pass explicit stdin/stdout/stderr fakes, so results never depend on the terminal the test runner happens to be attached to

## Root cause

A terminal that reports `columns: 0` breaks the spinner's clear-line math: `Math.ceil(textWidth / columns)` yields `Infinity`, turning a single frame clear into an endless synchronous loop of erase-line/cursor-up escape sequences. The loop floods the terminal at multiple MB/s and blocks the event loop, so the command in progress never proceeds.

v4.39.0 added a terminal-width guard to the default interactivity detection, but `SLS_INTERACTIVE_SETUP_ENABLE` sat outside it. Before v4.39.0 the override happened to produce a non-boolean value that the spinner's `isEnabled` option ignored (falling back to its own CI-aware detection, which kept it quiet in CI); once the detection returned a strict boolean, the override force-enabled the spinner even on zero-width CI ptys — and neither `CI=true`, `TERM=dumb`, `NO_COLOR`, nor `FORCE_COLOR` could switch it off. Reproduced on CircleCI's environment (`cimg` image, `CI=true`, zero-width pty): with the override set, `serverless --version` emitted ~40 MB of escape sequences in 15 seconds on ≥4.39.0 while 4.38.1 ran clean.

The fix makes the zero-width check a veto that applies to every path (stdout and stderr both, since the spinner renders to stderr), while the override keeps its established behavior everywhere animations are safe: it still neutralizes the CI check on real terminals and still enables interactive flows for scripted (piped) setups, where the spinner's clear-line path is skipped entirely.

## Test plan

- [x] Unit: 12 predicate contracts covering usable terminals, zero-width/undefined-width TTYs, pipes, `CI`, and the override on each of those (`packages/serverless/test/unit/lib/util/logger-is-interactive.test.js`)
- [x] Full unit suite green
- [x] Live, zero-width pty + override + `CI=true`: released 4.40.0 floods (~40 MB in 15 s, verified on `cimg/python:3.13.12-node`); patched build runs clean
- [x] Live, fully piped run with the override: completes normally; the log contains one plain line per progress phase and zero escape bytes
- [x] Live, terminal run with `2> err.log`: stdout output unchanged, `err.log` gets one plain line per phase and zero escape bytes

Fixes #13786


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive terminal detection across standard input, output, and error streams.
  * Prevented interactive features when terminal dimensions are unavailable or invalid.
  * Improved behavior for piped output, CI environments, and configuration overrides.
  * Spinner animations now appear only when supported by the error output stream.
  * Ensured non-interactive progress output respects configured logging levels.

* **Tests**
  * Expanded coverage for terminal width, piping, CI overrides, error-stream behavior, and plain progress output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->