### PR TITLE
chore(deps): bump js-yaml from 3.15.0 to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2604,9 +2604,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Bump the transitive dev dependency `js-yaml` from 3.15.0 to 3.15.1 in `package-lock.json`
- Nested under `@istanbuljs/load-nyc-config` (jest coverage chain); its `^3.13.1` range already allows 3.15.1, so this is a lockfile-only change

## Test plan

- [x] `npm ci` passes
- [x] `npm ls js-yaml` resolves the nested copy to 3.15.1 (root copies unchanged at 4.3.1)
- [x] Lockfile diff limited to the single nested entry; override canary clean
