### PR TITLE
ci(binary-installer): sign windows binary with Azure Artifact Signing

### DIFF
--- a/.github/workflows/release-binary-installer.yml
+++ b/.github/workflows/release-binary-installer.yml
@@ -28,10 +28,38 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::802587217904:role/GithubActionsPublicServerlessRepoAccessRole
           aws-region: us-east-1
+      - name: 'Setup: Azure Credentials'
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: 'Test: Unit'
         run: make test
       - name: 'Build: Production'
         run: make build-prod
+      # Authenticode-signs the Windows binary via Azure Artifact Signing (jsign
+      # detects the PE format by content, so the missing .exe suffix is fine).
+      # Timestamping is applied automatically for this storetype, keeping
+      # signatures valid after the short-lived certificate expires.
+      - name: 'Sign: Windows Binary'
+        env:
+          SIGNING_ENDPOINT: ${{ vars.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          SIGNING_ACCOUNT: ${{ vars.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+          SIGNING_CERT_PROFILE: ${{ vars.AZURE_TRUSTED_SIGNING_CERT_PROFILE }}
+          JSIGN_VERSION: '7.5'
+          JSIGN_SHA256: 602a51c3545a6dc4fb99bd2ea7152b26d1345916d0c93ddfbd5936cb735af91c
+        run: |
+          curl -sSfL -o /tmp/jsign.jar "https://github.com/ebourg/jsign/releases/download/${JSIGN_VERSION}/jsign-${JSIGN_VERSION}.jar"
+          echo "$JSIGN_SHA256  /tmp/jsign.jar" | sha256sum -c -
+          ACCESS_TOKEN=$(az account get-access-token --resource https://codesigning.azure.net --query accessToken -o tsv)
+          echo "::add-mask::$ACCESS_TOKEN"
+          java -jar /tmp/jsign.jar \
+            --storetype TRUSTEDSIGNING \
+            --keystore "$SIGNING_ENDPOINT" \
+            --storepass "$ACCESS_TOKEN" \
+            --alias "$SIGNING_ACCOUNT/$SIGNING_CERT_PROFILE" \
+            dist/prod/serverless-windows-amd64
       - name: 'Release: Install Script'
         run: |
           aws s3 cp ./install.sh s3://install.serverless.com/install.sh

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -52,7 +52,7 @@ The workflow triggers on pushes to `main` that touch `packages/sf-core/**`, `pac
 - **`release-npm`:**
   Publishes the installer package to npm after the stable release completes.
 
-> **Note:** The Go-based binary installer (the `curl` install script and launcher binaries) has its own, separate release pipeline: `.github/workflows/release-binary-installer.yml`, triggered manually via `workflow_dispatch`.
+> **Note:** The Go-based binary installer (the `curl` install script and launcher binaries) has its own, separate release pipeline: `.github/workflows/release-binary-installer.yml`, triggered manually via `workflow_dispatch`. That pipeline Authenticode-signs the Windows binary via Azure Artifact Signing (GitHub OIDC, no stored credentials) — see `binary-installer/README.md` → "Code Signing" for the required secrets/variables and verification instructions.
 
 ---
 

--- a/binary-installer/Makefile
+++ b/binary-installer/Makefile
@@ -3,6 +3,7 @@ VERSION=$(shell git describe --tags --always --dirty)
 PLATFORMS=darwin linux windows
 ARCHITECTURES=amd64 arm64
 LDFLAGS=-ldflags="-s -w"
+BUILD_FLAGS=-trimpath $(LDFLAGS)
 
 .PHONY: all clean build-all build-prod build-canary test
 
@@ -22,7 +23,7 @@ build-prod:
 			fi; \
 			echo "Building $$platform/$$arch..."; \
 			mkdir -p dist/prod; \
-			CGO_ENABLED=0 GOOS=$$platform GOARCH=$$arch go build $(LDFLAGS) -o dist/prod/$(BINARY_NAME)-$$platform-$$arch .; \
+			CGO_ENABLED=0 GOOS=$$platform GOARCH=$$arch go build $(BUILD_FLAGS) -o dist/prod/$(BINARY_NAME)-$$platform-$$arch .; \
 		done; \
 	done
 
@@ -35,7 +36,7 @@ build-canary:
 			fi; \
 			echo "Building $$platform/$$arch..."; \
 			mkdir -p dist/canary; \
-			CGO_ENABLED=0 GOOS=$$platform GOARCH=$$arch go build $(LDFLAGS) -tags=canary -o dist/canary/$(BINARY_NAME)-$$platform-$$arch .; \
+			CGO_ENABLED=0 GOOS=$$platform GOARCH=$$arch go build $(BUILD_FLAGS) -tags=canary -o dist/canary/$(BINARY_NAME)-$$platform-$$arch .; \
 		done; \
 	done
 

--- a/binary-installer/README.md
+++ b/binary-installer/README.md
@@ -26,11 +26,24 @@ These certificates are added to the system trust store used by the installer’s
 
 ## Code Signing
 
-The Windows binary (`serverless-windows-amd64`) is Authenticode-signed with a `Serverless Inc` certificate issued through Azure Artifact Signing, with an RFC 3161 timestamp. Verify with `Get-AuthenticodeSignature` in PowerShell or `signtool verify /pa`. In managed environments, the signature allows allow-listing by publisher rule (WDAC/AppLocker) instead of by file hash.
+The Windows binary (`serverless-windows-amd64`) is Authenticode-signed with a `Serverless Inc` certificate issued through Azure Artifact Signing, with an RFC 3161 timestamp. In managed environments, the signature allows allow-listing by publisher rule (WDAC/AppLocker) instead of by file hash.
+
+To verify a downloaded binary, in PowerShell:
+
+```powershell
+Get-AuthenticodeSignature .\serverless-windows-amd64 | Format-List Status, SignerCertificate
+# Expected: Status: Valid, Signer: CN=Serverless Inc, ...
+```
+
+or with the Windows SDK:
+
+```
+signtool verify /pa serverless-windows-amd64
+```
 
 Note that the binaries at `installer-builds/` are overwritten in place on each launcher release, so pinned file hashes stop matching after each release. If your antivirus software flags a binary, check its Authenticode signature and report the false positive to your vendor (for Microsoft Defender: https://www.microsoft.com/en-us/wdsi/filesubmission).
 
-The release workflow (`.github/workflows/release-binary-installer.yml`) signs via GitHub OIDC (no stored credentials). It requires the repository secrets `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_SUBSCRIPTION_ID`, and the repository variables `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`, and `AZURE_TRUSTED_SIGNING_CERT_PROFILE`.
+The release workflow (`.github/workflows/release-binary-installer.yml`) signs via GitHub OIDC (no stored credentials): the workflow's `id-token: write` permission lets it obtain an OIDC token, which Azure exchanges for signing access via a federated identity credential configured for this repository. The Azure identity holds only the `Artifact Signing Certificate Profile Signer` role. The workflow requires the repository secrets `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_SUBSCRIPTION_ID`, and the repository variables `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`, and `AZURE_TRUSTED_SIGNING_CERT_PROFILE`.
 
 ## How the Binary Installer Works
 

--- a/binary-installer/README.md
+++ b/binary-installer/README.md
@@ -37,7 +37,7 @@ Get-AuthenticodeSignature .\serverless-windows-amd64 | Format-List Status, Signe
 
 or with the Windows SDK:
 
-```
+```text
 signtool verify /pa serverless-windows-amd64
 ```
 

--- a/binary-installer/README.md
+++ b/binary-installer/README.md
@@ -24,6 +24,14 @@ For environments that use private CAs or TLS-intercepting proxies, the installer
 
 These certificates are added to the system trust store used by the installer’s HTTP client.
 
+## Code Signing
+
+The Windows binary (`serverless-windows-amd64`) is Authenticode-signed with a `Serverless Inc` certificate issued through Azure Artifact Signing, with an RFC 3161 timestamp. Verify with `Get-AuthenticodeSignature` in PowerShell or `signtool verify /pa`. In managed environments, the signature allows allow-listing by publisher rule (WDAC/AppLocker) instead of by file hash.
+
+Note that the binaries at `installer-builds/` are overwritten in place on each launcher release, so pinned file hashes stop matching after each release. If your antivirus software flags a binary, check its Authenticode signature and report the false positive to your vendor (for Microsoft Defender: https://www.microsoft.com/en-us/wdsi/filesubmission).
+
+The release workflow (`.github/workflows/release-binary-installer.yml`) signs via GitHub OIDC (no stored credentials). It requires the repository secrets `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, and `AZURE_SUBSCRIPTION_ID`, and the repository variables `AZURE_TRUSTED_SIGNING_ENDPOINT`, `AZURE_TRUSTED_SIGNING_ACCOUNT`, and `AZURE_TRUSTED_SIGNING_CERT_PROFILE`.
+
 ## How the Binary Installer Works
 
 ### High-level flow


### PR DESCRIPTION
## Summary

- Authenticode-sign the `serverless-windows-amd64` launcher binary in the
  `Release: Binary Installer` workflow, using Azure Artifact Signing with an
  RFC 3161 timestamp. Unsigned Go binaries are a common source of antivirus
  ML false positives, and a signature also lets managed environments
  allow-list by publisher rule (WDAC/AppLocker) instead of by file hash.
- Authentication uses GitHub OIDC via `azure/login` (SHA-pinned) — no stored
  credentials. Signing runs on the Linux runner via jsign, downloaded with a
  pinned version and SHA-256 check.
- Add `-trimpath` to the launcher build flags so binaries are reproducible
  and carry no build-machine paths.
- Document the signing setup and verification steps in
  `binary-installer/README.md` and reference it from `RELEASE_PROCESS.md`.

Requires repository secrets `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
`AZURE_SUBSCRIPTION_ID` and variables `AZURE_TRUSTED_SIGNING_ENDPOINT`,
`AZURE_TRUSTED_SIGNING_ACCOUNT`, `AZURE_TRUSTED_SIGNING_CERT_PROFILE`
(already configured on this repository).

## Test plan

- [x] End-to-end signing exercised against the real signing account with the
      exact jsign invocation from the workflow; signature chain verified with
      `osslsigncode` up to the Microsoft root (CRL check included), timestamp
      countersignature present
- [x] `make test` and `make build-prod` pass with the new build flags
- [x] `actionlint` clean on the workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows binary installers are now digitally signed using Authenticode, helping verify their publisher and integrity.
  * Release signatures include trusted timestamps to support validation after certificates expire.

* **Documentation**
  * Updated release documentation explains installer signing, publisher allow-listing, hash changes when binaries are replaced, and how to report antivirus false positives.
  * Added guidance for the authentication requirements used during release signing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->