### PR TITLE
fix(compose): stop package and print from wiping deployed service state

### DIFF
--- a/docs/sf/guides/compose.md
+++ b/docs/sf/guides/compose.md
@@ -134,6 +134,8 @@ Let's break down the example above into 3 steps:
        SERVICE_A_QUEUE_URL: ${param:queueUrl}
    ```
 
+With `serverless package` and `serverless print`, cross-service values are read from the state of the last deployment: `package` requires the referenced services to be deployed, while `print` displays `NOT_AVAILABLE_IN_PRINT_COMMAND` for values that do not exist yet.
+
 Cross-service variables are a great way to share API URLs, queue URLs, database table names, and more, without having to hardcode resource names or use SSM.
 
 ### Explicit dependencies

--- a/packages/sf-core/src/lib/runners/cfn/cfn.js
+++ b/packages/sf-core/src/lib/runners/cfn/cfn.js
@@ -205,7 +205,8 @@ export class CfnRunner extends Runner {
         break
       }
       case 'print':
-        state = await print({
+        // print renders to the terminal; its return value is not service state
+        await print({
           templateFile: this.templateFile,
           format: this.options.format || 'yaml',
         })

--- a/packages/sf-core/src/lib/runners/compose/index.js
+++ b/packages/sf-core/src/lib/runners/compose/index.js
@@ -18,6 +18,17 @@ const { Graph, alg } = graphlib
 const composeParamRegex = /(?<=\$\{)[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+(?=\})/
 
 /**
+ * The only commands whose returned state may be persisted to the state store.
+ * deploy/info gather real stack outputs (via the aws:info flow); remove's `{}`
+ * is an intentional clear. Every other command — package, print, logs, invoke,
+ * dev, deploy function, and anything added later — is read-only by
+ * construction: its returned state is discarded and `localState` falls back to
+ * the store when the service has dependents, so a fabricated empty state can
+ * never wipe deployed outputs.
+ */
+const STATE_WRITER_COMMANDS = ['deploy', 'info', 'remove']
+
+/**
  * @typedef {Object} State
  * @property {Record<string, any>} localState
  * @property {Function} putServiceState
@@ -528,25 +539,29 @@ class Compose {
     } = runnerOutput || {}
 
     const serviceUniqueIdProvided = serviceUniqueId && runnerType
+    const isStateAuthoritative = STATE_WRITER_COMMANDS.includes(
+      command.join(' '),
+    )
+    // get-state's returned state IS a store read: never re-persisted, but it
+    // must still populate localState (it is the warming pass).
+    const isGetState = command[0] === 'get-state'
+    const usableState =
+      isStateAuthoritative || isGetState ? returnedState : undefined
 
-    if (
-      serviceUniqueIdProvided &&
-      returnedState &&
-      command[0] !== 'get-state'
-    ) {
+    if (serviceUniqueIdProvided && isStateAuthoritative && usableState) {
       await state?.putServiceState({
         serviceUniqueId,
         runnerType,
-        value: JSON.stringify(returnedState),
+        value: JSON.stringify(usableState),
       })
     }
 
     if (
       state?.localState &&
-      (returnedState || graph.predecessors(alias)?.length)
+      (usableState || graph.predecessors(alias)?.length)
     ) {
       state.localState[alias] =
-        returnedState ||
+        usableState ||
         (serviceUniqueIdProvided
           ? await state?.getServiceState({
               serviceUniqueId,

--- a/packages/sf-core/src/lib/runners/framework.js
+++ b/packages/sf-core/src/lib/runners/framework.js
@@ -24,6 +24,7 @@ import {
   collectArtifactPaths,
   deriveAnalysisEnrichment,
 } from './framework-analytics.js'
+import { buildCommandState } from './state-utils.js'
 import { buildSandboxesAnalytics } from '@serverless/framework/lib/plugins/aws/sandboxes/analytics.js'
 import { buildMcpAnalytics } from '@serverless/framework/lib/plugins/aws/mcp/analytics.js'
 import { Deployment } from '../platform/deployments.js'
@@ -579,10 +580,10 @@ const runFramework = async ({
 
   await serverless.run()
 
-  state = serverless.stackOutputs ? { outputs: serverless.stackOutputs } : {}
-  if (fullCommand === 'remove') {
-    state = {}
-  }
+  state = buildCommandState({
+    stackOutputs: serverless.stackOutputs,
+    fullCommand,
+  })
 
   const analyticsMetrics = {}
   const lifecycleEventDurations =

--- a/packages/sf-core/src/lib/runners/state-utils.js
+++ b/packages/sf-core/src/lib/runners/state-utils.js
@@ -1,0 +1,21 @@
+/**
+ * Shape a runner command's returned state.
+ *
+ * A command's state is authoritative only when the run actually gathered
+ * stack outputs (the aws:info flow, spawned by deploy and info). Commands
+ * that gathered nothing return undefined — NOT an empty object — so
+ * consumers (compose's updateLocalState) fall back to the persisted state
+ * instead of mistaking "nothing gathered" for "the service has no outputs".
+ * remove is the one intentional clear: an explicit empty state.
+ *
+ * @param {Object} params
+ * @param {Record<string, string>|undefined} params.stackOutputs
+ * @param {string} params.fullCommand - command.join(' ')
+ * @returns {{outputs: Record<string, string>}|Record<string, never>|undefined}
+ */
+export const buildCommandState = ({ stackOutputs, fullCommand }) => {
+  if (fullCommand === 'remove') {
+    return {}
+  }
+  return stackOutputs ? { outputs: stackOutputs } : undefined
+}

--- a/packages/sf-core/tests/unit/lib/runners/compose/state-authority.test.js
+++ b/packages/sf-core/tests/unit/lib/runners/compose/state-authority.test.js
@@ -1,0 +1,483 @@
+import { jest } from '@jest/globals'
+
+jest.unstable_mockModule('@serverless/util', () => {
+  const noopFn = () => ({
+    notice: () => {},
+    remove: () => {},
+    get: () => noopFn(),
+  })
+  return {
+    log: {
+      get: () => ({
+        info: () => {},
+        debug: () => {},
+        writeCompose: () => {},
+        logoCompose: () => {},
+      }),
+    },
+    progress: { get: noopFn },
+    style: {
+      aside: (v) => v,
+      bold: (v) => v,
+      strong: (v) => v,
+      error: (v) => v,
+      warning: (v) => v,
+    },
+    ServerlessError: class ServerlessError extends Error {
+      constructor(message, code, options) {
+        super(message)
+        this.code = code
+        if (options?.stack === false) this.stack = undefined
+      }
+    },
+    ServerlessErrorCodes: {
+      compose: {
+        COMPOSE_COULD_NOT_RESOLVE_PARAM: 'COMPOSE_COULD_NOT_RESOLVE_PARAM',
+        COMPOSE_CONFIGURATION_INVALID: 'COMPOSE_CONFIGURATION_INVALID',
+        COMPOSE_GRAPH_SERVICE_DEPENDENCY_DOES_NOT_EXIST:
+          'COMPOSE_GRAPH_SERVICE_DEPENDENCY_DOES_NOT_EXIST',
+        COMPOSE_GRAPH_CIRCULAR_DEPENDENCY: 'COMPOSE_GRAPH_CIRCULAR_DEPENDENCY',
+      },
+    },
+  }
+})
+jest.unstable_mockModule('../../../../../src/lib/router.js', () => ({
+  getRunner: jest.fn(),
+  route: jest.fn(),
+}))
+jest.unstable_mockModule('../../../../../src/utils/index.js', () => ({
+  getHumanFriendlyTime: jest.fn(),
+}))
+
+const { parseComposeGraph } =
+  await import('../../../../../src/lib/runners/compose/index.js')
+
+const TWO_SERVICES = {
+  services: {
+    producer: { path: './producer' },
+    consumer: {
+      path: './consumer',
+      params: { queueUrl: '${producer.QueueUrl}' },
+    },
+  },
+}
+
+const buildCompose = () =>
+  parseComposeGraph({
+    servicePath: '/tmp/project',
+    configuration: TWO_SERVICES,
+    versions: { serverless_framework: '4.0.0' },
+  })
+
+const mockState = () => ({
+  localState: {},
+  putServiceState: jest.fn(),
+  getServiceState: jest.fn(),
+})
+
+const runnerOutput = (state) => ({
+  state,
+  serviceUniqueId: 'stack-producer',
+  runnerType: 'traditional',
+})
+
+describe('updateLocalState state authority', () => {
+  afterEach(() => {
+    process.exitCode = undefined
+    jest.clearAllMocks()
+  })
+
+  test.each([
+    ['deploy', { outputs: { QueueUrl: 'https://q' } }],
+    ['deploy', { outputs: {} }], // stale-clear on last-output removal
+    ['info', { outputs: { QueueUrl: 'https://q' } }],
+    ['remove', {}], // intentional clear
+  ])('%s persists its returned state %j', async (cmd, returned) => {
+    const compose = await buildCompose()
+    const state = mockState()
+    await compose.updateLocalState({
+      alias: 'producer',
+      runnerOutput: runnerOutput(returned),
+      command: [cmd],
+      state,
+      graph: compose.graph,
+    })
+    expect(state.putServiceState).toHaveBeenCalledWith({
+      serviceUniqueId: 'stack-producer',
+      runnerType: 'traditional',
+      value: JSON.stringify(returned),
+    })
+    expect(state.localState.producer).toEqual(returned)
+  })
+
+  test.each([
+    ['package'],
+    ['print'],
+    ['logs'],
+    ['invoke'],
+    ['deploy function'],
+  ])('%s never persists, even a fabricated {} state', async (cmdString) => {
+    const compose = await buildCompose()
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({
+      outputs: { QueueUrl: 'https://q' },
+    })
+    await compose.updateLocalState({
+      alias: 'producer',
+      runnerOutput: runnerOutput({}), // fabricated empty state (pre-fix producer shape)
+      command: cmdString.split(' '),
+      state,
+      graph: compose.graph,
+    })
+    expect(state.putServiceState).not.toHaveBeenCalled()
+    // The fabricated {} is discarded; localState carries the stored value.
+    expect(state.localState.producer).toEqual({
+      outputs: { QueueUrl: 'https://q' },
+    })
+  })
+
+  test('non-writer falls back to the store when the service has dependents', async () => {
+    const compose = await buildCompose()
+    const state = mockState()
+    const stored = { outputs: { QueueUrl: 'https://q' } }
+    state.getServiceState.mockResolvedValue(stored)
+    await compose.updateLocalState({
+      alias: 'producer', // consumer depends on it → predecessors non-empty
+      runnerOutput: runnerOutput(undefined), // honest post-fix producer shape
+      command: ['package'],
+      state,
+      graph: compose.graph,
+    })
+    expect(state.getServiceState).toHaveBeenCalledWith({
+      serviceUniqueId: 'stack-producer',
+      runnerType: 'traditional',
+    })
+    expect(state.localState.producer).toEqual(stored)
+    expect(state.putServiceState).not.toHaveBeenCalled()
+  })
+
+  test('non-writer skips the store read for a service without dependents', async () => {
+    const compose = await buildCompose()
+    const state = mockState()
+    await compose.updateLocalState({
+      alias: 'consumer', // nothing depends on consumer
+      runnerOutput: runnerOutput(undefined),
+      command: ['package'],
+      state,
+      graph: compose.graph,
+    })
+    expect(state.getServiceState).not.toHaveBeenCalled()
+    expect(state.putServiceState).not.toHaveBeenCalled()
+  })
+
+  test('never-deployed service (no serviceUniqueId) reads nothing, localState null', async () => {
+    const compose = await buildCompose()
+    const state = mockState()
+    await compose.updateLocalState({
+      alias: 'producer',
+      runnerOutput: {
+        state: undefined,
+        serviceUniqueId: null,
+        runnerType: 'traditional',
+      },
+      command: ['package'],
+      state,
+      graph: compose.graph,
+    })
+    expect(state.getServiceState).not.toHaveBeenCalled()
+    expect(state.localState.producer).toBeNull()
+  })
+
+  test('get-state never persists (writer list does not reintroduce it)', async () => {
+    const compose = await buildCompose()
+    const state = mockState()
+    await compose.updateLocalState({
+      alias: 'producer',
+      runnerOutput: runnerOutput({ outputs: { QueueUrl: 'https://q' } }),
+      command: ['get-state'],
+      state,
+      graph: compose.graph,
+    })
+    expect(state.putServiceState).not.toHaveBeenCalled()
+    expect(state.localState.producer).toEqual({
+      outputs: { QueueUrl: 'https://q' },
+    })
+  })
+
+  test('a non-writer returning a garbage string cannot reach the store or localState-as-state', async () => {
+    const compose = await buildCompose()
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({
+      outputs: { QueueUrl: 'https://q' },
+    })
+    await compose.updateLocalState({
+      alias: 'producer',
+      runnerOutput: runnerOutput('service: producer\n...rendered yaml...'),
+      command: ['print'],
+      state,
+      graph: compose.graph,
+    })
+    expect(state.putServiceState).not.toHaveBeenCalled()
+    expect(state.localState.producer).toEqual({
+      outputs: { QueueUrl: 'https://q' },
+    })
+  })
+})
+
+describe('cross-service param resolution by command', () => {
+  afterEach(() => {
+    process.exitCode = undefined
+    jest.clearAllMocks()
+  })
+
+  const capturingRunner =
+    (received) =>
+    async ({ compose: ctx }) => {
+      received[ctx.serviceName] = { ...ctx.params }
+      return {
+        state: undefined,
+        serviceUniqueId: `stack-${ctx.serviceName}`,
+        runnerType: 'traditional',
+      }
+    }
+
+  const neverDeployedRunner =
+    (received) =>
+    async ({ compose: ctx }) => {
+      received[ctx.serviceName] = { ...ctx.params }
+      return {
+        state: undefined,
+        serviceUniqueId: null,
+        runnerType: 'traditional',
+      }
+    }
+
+  // Reporting an empty state object is remove's intentional clear, and the
+  // shape a read-only command must never be able to persist or resolve from.
+  const emptyStateRunner =
+    (received) =>
+    async ({ compose: ctx }) => {
+      received[ctx.serviceName] = { ...ctx.params }
+      return {
+        state: {},
+        serviceUniqueId: `stack-${ctx.serviceName}`,
+        runnerType: 'traditional',
+      }
+    }
+
+  test('package resolves the consumer param from stored outputs', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({
+      outputs: { QueueUrl: 'https://q' },
+    })
+    await compose.executeComponentsGraph({
+      command: ['package'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: capturingRunner(received),
+      state,
+    })
+    expect(received.consumer.queueUrl).toBe('https://q')
+    expect(state.putServiceState).not.toHaveBeenCalled()
+    expect(Object.keys(compose.failedRuns)).toHaveLength(0)
+  })
+
+  test('package with a never-deployed producer fails the consumer with the teaching error', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    // never deployed: no serviceUniqueId → no store read possible
+    await compose.executeComponentsGraph({
+      command: ['package'],
+      options: { stage: 'dev' },
+      resolverProviders: {},
+      params: {},
+      runnerFunction: neverDeployedRunner(received),
+      state,
+    })
+    expect(Object.keys(compose.failedRuns)).toContain('consumer')
+    expect(compose.failedRuns.consumer[0].message).toMatch(
+      /no deployed state found for service 'producer'/,
+    )
+    expect(compose.failedRuns.consumer[0].message).toMatch(/--stage dev/)
+  })
+
+  test('print shows the real stored value when the producer is deployed', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({
+      outputs: { QueueUrl: 'https://q' },
+    })
+    await compose.executeComponentsGraph({
+      command: ['print'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: capturingRunner(received),
+      state,
+    })
+    expect(received.consumer.queueUrl).toBe('https://q')
+  })
+
+  test('print falls back to the sentinel when no state exists, and never fails', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    await compose.executeComponentsGraph({
+      command: ['print'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: neverDeployedRunner(received),
+      state,
+    })
+    expect(received.consumer.queueUrl).toBe('NOT_AVAILABLE_IN_PRINT_COMMAND')
+    expect(Object.keys(compose.failedRuns)).toHaveLength(0)
+  })
+
+  test('an empty-string stored output value passes through (not treated as missing)', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({ outputs: { QueueUrl: '' } })
+    await compose.executeComponentsGraph({
+      command: ['package'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: capturingRunner(received),
+      state,
+    })
+    expect(received.consumer.queueUrl).toBe('')
+    expect(Object.keys(compose.failedRuns)).toHaveLength(0)
+  })
+
+  test('deployed producer whose stack has zero outputs teaches the (none) listing', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({ outputs: {} })
+    await compose.executeComponentsGraph({
+      command: ['package'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: capturingRunner(received),
+      state,
+    })
+    expect(Object.keys(compose.failedRuns)).toContain('consumer')
+    expect(compose.failedRuns.consumer[0].message).toMatch(
+      /has no output 'QueueUrl'/,
+    )
+    expect(compose.failedRuns.consumer[0].message).toMatch(/\(none\)/)
+  })
+
+  test('remove still substitutes empty string for refs', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    await compose.executeComponentsGraph({
+      command: ['remove'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: emptyStateRunner(received),
+      state,
+    })
+    expect(received.consumer.queueUrl).toBe('')
+  })
+
+  test('deploy still fails loudly when the producer run yields no outputs and no store state', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    await compose.executeComponentsGraph({
+      command: ['deploy'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: neverDeployedRunner(received),
+      state,
+    })
+    expect(Object.keys(compose.failedRuns)).toContain('consumer')
+  })
+
+  test('package survives a producer that reports an empty state object', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({
+      outputs: { QueueUrl: 'https://q' },
+    })
+    await compose.executeComponentsGraph({
+      command: ['package'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: emptyStateRunner(received),
+      state,
+    })
+    expect(received.consumer.queueUrl).toBe('https://q')
+    expect(Object.keys(compose.failedRuns)).toHaveLength(0)
+    // The stored outputs of the producer are left untouched.
+    expect(state.putServiceState).not.toHaveBeenCalled()
+  })
+
+  test('print survives a producer that reports an empty state object', async () => {
+    const compose = await buildCompose()
+    const received = {}
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({
+      outputs: { QueueUrl: 'https://q' },
+    })
+    await compose.executeComponentsGraph({
+      command: ['print'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: emptyStateRunner(received),
+      state,
+    })
+    expect(received.consumer.queueUrl).toBe('https://q')
+    expect(state.putServiceState).not.toHaveBeenCalled()
+  })
+
+  test('fan-out: two consumers of one producer both resolve during package', async () => {
+    const compose = await parseComposeGraph({
+      servicePath: '/tmp/project',
+      configuration: {
+        services: {
+          producer: { path: './producer' },
+          consumer: {
+            path: './consumer',
+            params: { queueUrl: '${producer.QueueUrl}' },
+          },
+          consumer2: {
+            path: './consumer2',
+            params: { q2: '${producer.QueueUrl}' },
+          },
+        },
+      },
+      versions: { serverless_framework: '4.0.0' },
+    })
+    const received = {}
+    const state = mockState()
+    state.getServiceState.mockResolvedValue({
+      outputs: { QueueUrl: 'https://q' },
+    })
+    await compose.executeComponentsGraph({
+      command: ['package'],
+      options: {},
+      resolverProviders: {},
+      params: {},
+      runnerFunction: capturingRunner(received),
+      state,
+    })
+    expect(received.consumer.queueUrl).toBe('https://q')
+    expect(received.consumer2.q2).toBe('https://q')
+  })
+})

--- a/packages/sf-core/tests/unit/lib/runners/state-utils.test.js
+++ b/packages/sf-core/tests/unit/lib/runners/state-utils.test.js
@@ -1,0 +1,45 @@
+import { buildCommandState } from '../../../../src/lib/runners/state-utils.js'
+
+describe('buildCommandState', () => {
+  test('returns outputs state when the run gathered stack outputs', () => {
+    expect(
+      buildCommandState({
+        stackOutputs: { QueueUrl: 'https://q' },
+        fullCommand: 'deploy',
+      }),
+    ).toEqual({ outputs: { QueueUrl: 'https://q' } })
+  })
+
+  test('returns empty-outputs state when info gathered a stack with no outputs', () => {
+    expect(
+      buildCommandState({ stackOutputs: {}, fullCommand: 'info' }),
+    ).toStrictEqual({ outputs: {} })
+  })
+
+  test('returns undefined when nothing was gathered (package, print, logs, ...)', () => {
+    expect(
+      buildCommandState({ stackOutputs: undefined, fullCommand: 'package' }),
+    ).toBeUndefined()
+    expect(
+      buildCommandState({ stackOutputs: undefined, fullCommand: 'print' }),
+    ).toBeUndefined()
+    expect(
+      buildCommandState({
+        stackOutputs: undefined,
+        fullCommand: 'deploy function',
+      }),
+    ).toBeUndefined()
+  })
+
+  test('remove returns the explicit clear regardless of gathered outputs', () => {
+    expect(
+      buildCommandState({ stackOutputs: undefined, fullCommand: 'remove' }),
+    ).toStrictEqual({})
+    expect(
+      buildCommandState({
+        stackOutputs: { QueueUrl: 'https://q' },
+        fullCommand: 'remove',
+      }),
+    ).toStrictEqual({})
+  })
+})


### PR DESCRIPTION
## Summary

- Only `deploy`, `info`, and `remove` may write a service's record in the Compose state store. Every other command — `package`, `print`, and single-service commands like `logs`, `invoke`, or `deploy function` — is read-only: previously each of them silently overwrote the stored outputs of every deployed service it touched with an empty record (the run itself exited 0), and the corruption only surfaced later, as a false "no deployed state found" failure in the next command that read the store.
- `serverless package` now resolves cross-service values (`${service-a.queueUrl}`) from the state of the last deployment, so packaging a deployed project works and the compiled artifacts carry the real values. When a referenced service has never been deployed, `package` fails with the existing error that names the exact `deploy` command to run — no placeholder values are ever written into an artifact.
- `serverless print` now renders the real resolved values for deployed references, consistent with how `print` already live-resolves `${aws:*}`, `${cf:*}`, and `${ssm:*}`. `NOT_AVAILABLE_IN_PRINT_COMMAND` still appears for values that do not exist yet, and `print` still never fails on an unresolvable reference. Note this means output values (queue URLs, endpoints) now appear in `print` output where the sentinel used to.
- Runners no longer fabricate state: commands that gathered no stack outputs return no state at all (`packages/sf-core/src/lib/runners/state-utils.js` shapes the contract), and the Compose layer additionally enforces the writer allowlist, so a future command or runner cannot reintroduce the wipe.

## Root cause

Stack outputs are only gathered by the `deploy` and `info` flows. Every other command returned a truthy-but-empty state object, which the Compose layer treated as authoritative: it persisted it over the stored record and used it for cross-service resolution. That single confusion produced both symptoms — `package` failing on deployed projects (#13437) and the store being silently wiped for the next reader. The store fallback that resolves values from the last deployment already existed in the code; it was unreachable because the fabricated empty state was truthy.

## Notes for review

- `packages/sf-core/src/lib/runners/compose/index.js` — `STATE_WRITER_COMMANDS` (exact match, so `deploy function` is read-only) and the `updateLocalState` guard; `get-state` keeps its existing role (populates the in-run view, never persists). `remove` still persists an explicit empty record, and a `deploy` whose stack lost its last output still clears the stale value.
- `packages/sf-core/src/lib/runners/framework.js` and `runners/cfn/cfn.js` — producers return `undefined` when nothing was gathered; the cfn `print` change is truthfulness only (its command already returned nothing).
- The store fallback fires only for services that something else depends on, so read-only commands add no state reads for leaf services.
- No changes to the parameter-resolution loop or its error messages.
- `docs/sf/guides/compose.md` documents where `package` and `print` values come from.

## Test plan

- [x] Unit — new suites pin the behavior matrix per command: writers persist (including `remove`'s clear and `deploy`'s stale-output clear), non-writers never persist and resolve from the store, `package` teaches with the stage-qualified message when a dependency was never deployed, `print` falls back to the sentinel and never fails, empty-string output values pass through, fan-out consumers resolve. The guard tests were verified non-vacuous by running them against the pre-fix code (8 fail).
- [x] Live control run on `main` reproducing the report: deploy a two-consumer Compose project, run `print`, observe every service's stored record replaced by an empty object with exit 0, then observe `deploy --service=<consumer>` fail against the deployed producer, and `producer info` repair it.
- [x] Live verification of this branch against real AWS: the same sequence keeps every record byte-identical (unchanged `LastModified`), `package` exits 0 with the real queue URL in the compiled template and no sentinel strings in any artifact, and the previously failing subset deploy succeeds. Edge cases covered: fresh stage (print sentinel / package teaching error with correct exit codes), output-name typo, producer redeployed with an output removed, subset remove, stage isolation, manually deleted store record repaired via `info`, single-service `package`/`print`, `invoke` and `deploy function` leaving the store untouched. All stages torn down; no leftover stacks.

## How to test

```bash
# a compose project where consumer reads ${producer.someOutput}
serverless deploy --stage dev
serverless print --stage dev      # real values; store intact afterwards
serverless package --stage dev    # exit 0; real values in .serverless/ artifacts
serverless deploy --service=consumer --stage dev   # resolves from stored state
```

## Related

Closes #13437. Supersedes #13438 — thanks @tmatilai for the report and the PR; this change adopts its state-fallback insight, extends the write guard from `package`/`print` to an allowlist covering all non-gathering commands (which `logs`, `invoke`, and `deploy function` also needed), and keeps `package` failing loudly instead of embedding placeholder values in deployable artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-service value handling across packaging, printing, deployment, and related commands.
  - Ensured command state is updated consistently, while read-only operations avoid unintended changes.
  - Improved handling of missing deployments, empty outputs, removed services, and dependent services.
  - Preserved empty-string values and improved reporting when cross-service resolution fails.

- **Documentation**
  - Clarified that referenced services must be deployed for packaging.
  - Documented that unavailable values appear as `NOT_AVAILABLE_IN_PRINT_COMMAND` when printing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->