### PR TITLE
chore: release 4.41.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13201,7 +13201,7 @@
     },
     "packages/sf-core": {
       "name": "@serverlessinc/sf-core",
-      "version": "4.40.0",
+      "version": "4.41.0",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "3.1097.0",
         "@aws-sdk/client-s3": "3.1097.0",

--- a/packages/framework-dist/package.json
+++ b/packages/framework-dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/framework-alpha",
-  "version": "4.40.0",
+  "version": "4.41.0",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/sf-core-installer/package-lock.json
+++ b/packages/sf-core-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless",
-  "version": "4.40.0",
+  "version": "4.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless",
-      "version": "4.40.0",
+      "version": "4.41.0",
       "hasInstallScript": true,
       "dependencies": {
         "undici": "6.28.0"

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "4.40.0",
+  "version": "4.41.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/sf-core/package.json
+++ b/packages/sf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/sf-core",
-  "version": "4.40.0",
+  "version": "4.41.0",
   "main": "src/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Release 4.41.0.

Version bump across the installer, `sf-core`, `framework-dist`, and the lockfile (`4.40.0` → `4.41.0`), mirroring previous release PRs. Minor bump for the new feature landing this cycle.

**Highlights**
- **MCP servers on AWS Lambda** (#13778, #13784): an `mcp` section in `serverless.yml` deploys official MCP TypeScript SDK servers behind API Gateway with response streaming, protection via user-supplied authorizers, OAuth protected-resource discovery, and optional sealed request state. Servers behave as ordinary functions (`logs`, `invoke`, `rollback`, metrics).
- Fixes: per-function artifacts included in change detection (#13771), case-insensitive function URL `invokeMode` values (#13756), esbuild `outExtension` honored end-to-end (#13740), esbuild config-file `sourcemap` setting respected for `NODE_OPTIONS` (#13741), Compose root dependencies with `packages: external` (#13742), SAM/CFN project detection restricted to SAM-supported extensions (#13739), sandbox dev images built for the Docker daemon's architecture (#13787), no spinner animations on zero-width terminals (#13788), Compose `package`/`print` no longer wipe deployed service state (#13437, #13792).
- Dependency updates, including three AWS SDK group bumps, glob v13, and security updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the framework and core packages to version 4.41.0.
  * Updated the core installer package to version 4.41.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->