### PR TITLE
fix(esbuild): make packaged zip entry order deterministic

### DIFF
--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -71,6 +71,20 @@ const appendFileEntry = async (zip, sourcePath, name) => {
   zip.file(sourcePath, { name, date: PINNED_ARTIFACT_DATE, stats })
 }
 
+// The file-vs-directory probe for a package-pattern include (stat, following
+// symlinks, as the include pipeline always has) with the same failure
+// contract as appendFileEntry.
+const statIncludeEntry = async (absolutePath) => {
+  try {
+    return await stat(absolutePath)
+  } catch (error) {
+    throw new ServerlessError(
+      `Cannot read file ${absolutePath} due to: ${error.message}`,
+      'CANNOT_READ_FILE',
+    )
+  }
+}
+
 class Esbuild {
   constructor(serverless, options) {
     this.serverless = serverless
@@ -1003,7 +1017,7 @@ class Esbuild {
                     this.serverless.config.serviceDir,
                     filePath,
                   )
-                  const stats = await stat(absolutePath)
+                  const stats = await statIncludeEntry(absolutePath)
                   if (stats.isDirectory()) {
                     // Expand the directory ourselves (sorted) instead of
                     // zip.directory(): concurrent directory walks feed the
@@ -1176,7 +1190,7 @@ class Esbuild {
 
           for (const filePath of packageIncludes) {
             const absolutePath = path.join(this.serverless.serviceDir, filePath)
-            const stats = await stat(absolutePath)
+            const stats = await statIncludeEntry(absolutePath)
             if (stats.isDirectory()) {
               // Expand the directory ourselves (sorted) instead of
               // zip.directory(): concurrent directory walks feed the archive

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -1,6 +1,6 @@
 import path from 'path'
 import { pathToFileURL } from 'url'
-import { copyFile, readFile, rm, stat, writeFile } from 'fs/promises'
+import { copyFile, lstat, readFile, rm, stat, writeFile } from 'fs/promises'
 import { createWriteStream, existsSync } from 'fs'
 import * as esbuild from 'esbuild'
 import { ZipArchive } from 'archiver'
@@ -48,6 +48,24 @@ const areSameSet = (a, b) => {
 // build), so the artifact hash changes on every deploy and check-for-changes
 // forces a needless redeploy of every function (issue #4240).
 const PINNED_ARTIFACT_DATE = new Date(0)
+
+// A pinned date alone doesn't make the zip reproducible: archiver resolves
+// `zip.file()` calls without `stats` through an internal stat queue with
+// concurrency 4, so entries land in the archive in lstat-completion order,
+// which races between runs and changes the whole-zip bytes (and therefore the
+// sha256 used by check-for-changes). Pre-fetching the stats makes archiver
+// enqueue the entry synchronously, so entries appear strictly in call order.
+// A failed lstat is skipped, matching archiver's own stat-queue behavior for
+// unreadable files.
+const appendFileEntry = async (zip, sourcePath, name) => {
+  let stats
+  try {
+    stats = await lstat(sourcePath)
+  } catch {
+    return
+  }
+  zip.file(sourcePath, { name, date: PINNED_ARTIFACT_DATE, stats })
+}
 
 class Esbuild {
   constructor(serverless, options) {
@@ -908,10 +926,12 @@ class Esbuild {
                 { cwd: this.serverless.serviceDir },
               )
 
+              // Sorted so the archive entry order doesn't depend on glob
+              // traversal order, which is filesystem-dependent.
               const includesToPackage = _.union(
                 packageIncludes,
                 functionIncludes,
-              )
+              ).sort()
 
               zip.pipe(output)
               const handlerPath = stripHandlerExportSuffix(
@@ -926,10 +946,7 @@ class Esbuild {
               )
 
               if (existsSync(packageJsonPath)) {
-                zip.file(packageJsonPath, {
-                  name: `package.json`,
-                  date: PINNED_ARTIFACT_DATE,
-                })
+                await appendFileEntry(zip, packageJsonPath, 'package.json')
               }
 
               // Add lockfiles if they exist
@@ -947,10 +964,7 @@ class Esbuild {
                   lockFile,
                 )
                 if (existsSync(lockFilePath)) {
-                  zip.file(lockFilePath, {
-                    name: destName,
-                    date: PINNED_ARTIFACT_DATE,
-                  })
+                  await appendFileEntry(zip, lockFilePath, destName)
                 }
               }
 
@@ -961,18 +975,49 @@ class Esbuild {
                 handlerPath + outputExtension,
               )
 
-              zip.file(handlerZipPath, {
-                name: `${handlerPath}${outputExtension}`,
-                date: PINNED_ARTIFACT_DATE,
-              })
+              await appendFileEntry(
+                zip,
+                handlerZipPath,
+                `${handlerPath}${outputExtension}`,
+              )
 
               if (existsSync(`${handlerZipPath}.map`)) {
-                zip.file(`${handlerZipPath}.map`, {
-                  name: `${handlerPath}${outputExtension}.map`,
-                  date: PINNED_ARTIFACT_DATE,
-                })
+                await appendFileEntry(
+                  zip,
+                  `${handlerZipPath}.map`,
+                  `${handlerPath}${outputExtension}.map`,
+                )
               }
 
+              for (const filePath of includesToPackage) {
+                const absolutePath = path.join(
+                  this.serverless.config.serviceDir,
+                  filePath,
+                )
+                const stats = await stat(absolutePath)
+                if (stats.isDirectory()) {
+                  // Expand the directory ourselves (sorted) instead of
+                  // zip.directory(): concurrent directory walks feed the
+                  // archive in racy, nondeterministic order.
+                  const children = (
+                    await globby('**', { cwd: absolutePath, dot: true })
+                  ).sort()
+                  for (const child of children) {
+                    await appendFileEntry(
+                      zip,
+                      path.join(absolutePath, child),
+                      `${filePath}/${child}`,
+                    )
+                  }
+                } else {
+                  await appendFileEntry(zip, absolutePath, filePath)
+                }
+              }
+
+              // The node_modules walk is async and feeds the archive as it
+              // discovers files. Keeping it as the last append (after every
+              // file entry is already enqueued) keeps the entry order
+              // deterministic.
               zip.directory(
                 path.join(
                   this.serverless.config.serviceDir,
@@ -982,26 +1027,6 @@ class Esbuild {
                 ),
                 'node_modules',
                 { date: PINNED_ARTIFACT_DATE },
-              )
-
-              await Promise.all(
-                includesToPackage.map(async (filePath) => {
-                  const absolutePath = path.join(
-                    this.serverless.config.serviceDir,
-                    filePath,
-                  )
-                  const stats = await stat(absolutePath)
-                  if (stats.isDirectory()) {
-                    zip.directory(absolutePath, filePath, {
-                      date: PINNED_ARTIFACT_DATE,
-                    })
-                  } else {
-                    zip.file(absolutePath, {
-                      name: filePath,
-                      date: PINNED_ARTIFACT_DATE,
-                    })
-                  }
-                }),
               )
 
               await zip.finalize()
@@ -1034,10 +1059,13 @@ class Esbuild {
 
     await this.serverless.pluginManager.spawn('esbuild-package')
 
-    const packageIncludes = await globby(
-      this.serverless.service.package.patterns ?? [],
-      { cwd: this.serverless.serviceDir },
-    )
+    // Sorted so the archive entry order doesn't depend on glob traversal
+    // order, which is filesystem-dependent.
+    const packageIncludes = (
+      await globby(this.serverless.service.package.patterns ?? [], {
+        cwd: this.serverless.serviceDir,
+      })
+    ).sort()
 
     const zip = new ZipArchive()
     const output = createWriteStream(zipPath)
@@ -1063,10 +1091,7 @@ class Esbuild {
           )
 
           if (existsSync(packageJsonPath) && !addedFiles.has(packageJsonPath)) {
-            zip.file(packageJsonPath, {
-              name: `package.json`,
-              date: PINNED_ARTIFACT_DATE,
-            })
+            await appendFileEntry(zip, packageJsonPath, 'package.json')
             addedFiles.add(packageJsonPath)
           }
 
@@ -1085,10 +1110,7 @@ class Esbuild {
               lockFile,
             )
             if (existsSync(lockFilePath) && !addedFiles.has(lockFilePath)) {
-              zip.file(lockFilePath, {
-                name: destName,
-                date: PINNED_ARTIFACT_DATE,
-              })
+              await appendFileEntry(zip, lockFilePath, destName)
               addedFiles.add(lockFilePath)
             }
           }
@@ -1101,10 +1123,11 @@ class Esbuild {
           )
 
           if (!addedFiles.has(handlerZipPath)) {
-            zip.file(handlerZipPath, {
-              name: `${handlerPath}${outputExtension}`,
-              date: PINNED_ARTIFACT_DATE,
-            })
+            await appendFileEntry(
+              zip,
+              handlerZipPath,
+              `${handlerPath}${outputExtension}`,
+            )
             addedFiles.add(handlerZipPath)
           }
 
@@ -1112,15 +1135,42 @@ class Esbuild {
             existsSync(`${handlerZipPath}.map`) &&
             !addedFiles.has(`${handlerZipPath}.map`)
           ) {
-            zip.file(`${handlerZipPath}.map`, {
-              name: `${handlerPath}${outputExtension}.map`,
-              date: PINNED_ARTIFACT_DATE,
-            })
+            await appendFileEntry(
+              zip,
+              `${handlerZipPath}.map`,
+              `${handlerPath}${outputExtension}.map`,
+            )
 
             addedFiles.add(`${handlerZipPath}.map`)
           }
         }
 
+        for (const filePath of packageIncludes) {
+          const absolutePath = path.join(this.serverless.serviceDir, filePath)
+          const stats = await stat(absolutePath)
+          if (stats.isDirectory()) {
+            // Expand the directory ourselves (sorted) instead of
+            // zip.directory(): concurrent directory walks feed the archive
+            // in racy, nondeterministic order.
+            const children = (
+              await globby('**', { cwd: absolutePath, dot: true })
+            ).sort()
+            for (const child of children) {
+              await appendFileEntry(
+                zip,
+                path.join(absolutePath, child),
+                `${filePath}/${child}`,
+              )
+            }
+          } else if (!addedFiles.has(absolutePath)) {
+            await appendFileEntry(zip, absolutePath, filePath)
+            addedFiles.add(absolutePath)
+          }
+        }
+
+        // The node_modules walk is async and feeds the archive as it
+        // discovers files. Keeping it as the last append (after every file
+        // entry is already enqueued) keeps the entry order deterministic.
         zip.directory(
           path.join(
             this.serverless.config.serviceDir,
@@ -1130,24 +1180,6 @@ class Esbuild {
           ),
           'node_modules',
           { date: PINNED_ARTIFACT_DATE },
-        )
-
-        await Promise.all(
-          packageIncludes.map(async (filePath) => {
-            const absolutePath = path.join(this.serverless.serviceDir, filePath)
-            const stats = await stat(absolutePath)
-            if (stats.isDirectory()) {
-              zip.directory(absolutePath, filePath, {
-                date: PINNED_ARTIFACT_DATE,
-              })
-            } else if (!addedFiles.has(absolutePath)) {
-              zip.file(absolutePath, {
-                name: filePath,
-                date: PINNED_ARTIFACT_DATE,
-              })
-              addedFiles.add(absolutePath)
-            }
-          }),
         )
 
         await zip.finalize()

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -71,6 +71,32 @@ const appendFileEntry = async (zip, sourcePath, name) => {
   zip.file(sourcePath, { name, date: PINNED_ARTIFACT_DATE, stats })
 }
 
+// Deterministic replacement for zip.directory(): expand the tree ourselves
+// and append sequentially in sorted order. zip.directory()'s async walk
+// feeds the archive in readdir order, which differs per filesystem/volume
+// (e.g. ext4 hashes directory entries with a per-filesystem seed), so the
+// same unchanged service hashed differently between machines — a laptop
+// deploy followed by a CI deploy saw phantom diffs. The globby options
+// reproduce zip.directory's walk entry-for-entry: directory entries included
+// (empty ones too), symlinks kept as symlinks, nothing followed.
+const appendDirectoryEntries = async (zip, dirPath, destPath) => {
+  const entries = (
+    await globby('**', {
+      cwd: dirPath,
+      dot: true,
+      onlyFiles: false,
+      followSymbolicLinks: false,
+    })
+  ).sort()
+  for (const entry of entries) {
+    await appendFileEntry(
+      zip,
+      path.join(dirPath, entry),
+      `${destPath}/${entry}`,
+    )
+  }
+}
+
 // The file-vs-directory probe for a package-pattern include (stat, following
 // symlinks, as the include pipeline always has) with the same failure
 // contract as appendFileEntry.
@@ -1019,37 +1045,14 @@ class Esbuild {
                   )
                   const stats = await statIncludeEntry(absolutePath)
                   if (stats.isDirectory()) {
-                    // Expand the directory ourselves (sorted) instead of
-                    // zip.directory(): concurrent directory walks feed the
-                    // archive in racy, nondeterministic order. The options
-                    // reproduce zip.directory's walk exactly — directory
-                    // entries included, symlinks kept as symlinks, nothing
-                    // followed.
-                    const children = (
-                      await globby('**', {
-                        cwd: absolutePath,
-                        dot: true,
-                        onlyFiles: false,
-                        followSymbolicLinks: false,
-                      })
-                    ).sort()
-                    for (const child of children) {
-                      await appendFileEntry(
-                        zip,
-                        path.join(absolutePath, child),
-                        `${filePath}/${child}`,
-                      )
-                    }
+                    await appendDirectoryEntries(zip, absolutePath, filePath)
                   } else {
                     await appendFileEntry(zip, absolutePath, filePath)
                   }
                 }
 
-                // The node_modules walk is async and feeds the archive as it
-                // discovers files. Keeping it as the last append (after every
-                // file entry is already enqueued) keeps the entry order
-                // deterministic.
-                zip.directory(
+                await appendDirectoryEntries(
+                  zip,
                   path.join(
                     this.serverless.config.serviceDir,
                     '.serverless',
@@ -1057,7 +1060,6 @@ class Esbuild {
                     'node_modules',
                   ),
                   'node_modules',
-                  { date: PINNED_ARTIFACT_DATE },
                 )
 
                 await zip.finalize()
@@ -1192,36 +1194,15 @@ class Esbuild {
             const absolutePath = path.join(this.serverless.serviceDir, filePath)
             const stats = await statIncludeEntry(absolutePath)
             if (stats.isDirectory()) {
-              // Expand the directory ourselves (sorted) instead of
-              // zip.directory(): concurrent directory walks feed the archive
-              // in racy, nondeterministic order. The options reproduce
-              // zip.directory's walk exactly — directory entries included,
-              // symlinks kept as symlinks, nothing followed.
-              const children = (
-                await globby('**', {
-                  cwd: absolutePath,
-                  dot: true,
-                  onlyFiles: false,
-                  followSymbolicLinks: false,
-                })
-              ).sort()
-              for (const child of children) {
-                await appendFileEntry(
-                  zip,
-                  path.join(absolutePath, child),
-                  `${filePath}/${child}`,
-                )
-              }
+              await appendDirectoryEntries(zip, absolutePath, filePath)
             } else if (!addedFiles.has(absolutePath)) {
               await appendFileEntry(zip, absolutePath, filePath)
               addedFiles.add(absolutePath)
             }
           }
 
-          // The node_modules walk is async and feeds the archive as it
-          // discovers files. Keeping it as the last append (after every file
-          // entry is already enqueued) keeps the entry order deterministic.
-          zip.directory(
+          await appendDirectoryEntries(
+            zip,
             path.join(
               this.serverless.config.serviceDir,
               '.serverless',
@@ -1229,7 +1210,6 @@ class Esbuild {
               'node_modules',
             ),
             'node_modules',
-            { date: PINNED_ARTIFACT_DATE },
           )
 
           await zip.finalize()

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -1007,9 +1007,17 @@ class Esbuild {
                   if (stats.isDirectory()) {
                     // Expand the directory ourselves (sorted) instead of
                     // zip.directory(): concurrent directory walks feed the
-                    // archive in racy, nondeterministic order.
+                    // archive in racy, nondeterministic order. The options
+                    // reproduce zip.directory's walk exactly — directory
+                    // entries included, symlinks kept as symlinks, nothing
+                    // followed.
                     const children = (
-                      await globby('**', { cwd: absolutePath, dot: true })
+                      await globby('**', {
+                        cwd: absolutePath,
+                        dot: true,
+                        onlyFiles: false,
+                        followSymbolicLinks: false,
+                      })
                     ).sort()
                     for (const child of children) {
                       await appendFileEntry(
@@ -1172,9 +1180,16 @@ class Esbuild {
             if (stats.isDirectory()) {
               // Expand the directory ourselves (sorted) instead of
               // zip.directory(): concurrent directory walks feed the archive
-              // in racy, nondeterministic order.
+              // in racy, nondeterministic order. The options reproduce
+              // zip.directory's walk exactly — directory entries included,
+              // symlinks kept as symlinks, nothing followed.
               const children = (
-                await globby('**', { cwd: absolutePath, dot: true })
+                await globby('**', {
+                  cwd: absolutePath,
+                  dot: true,
+                  onlyFiles: false,
+                  followSymbolicLinks: false,
+                })
               ).sort()
               for (const child of children) {
                 await appendFileEntry(

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -55,14 +55,18 @@ const PINNED_ARTIFACT_DATE = new Date(0)
 // which races between runs and changes the whole-zip bytes (and therefore the
 // sha256 used by check-for-changes). Pre-fetching the stats makes archiver
 // enqueue the entry synchronously, so entries appear strictly in call order.
-// A failed lstat is skipped, matching archiver's own stat-queue behavior for
-// unreadable files.
+// An unreadable file fails packaging (same contract as the classic packaging
+// path) — archiver's own stat queue would silently drop the entry and ship an
+// incomplete artifact.
 const appendFileEntry = async (zip, sourcePath, name) => {
   let stats
   try {
     stats = await lstat(sourcePath)
-  } catch {
-    return
+  } catch (error) {
+    throw new ServerlessError(
+      `Cannot read file ${sourcePath} due to: ${error.message}`,
+      'CANNOT_READ_FILE',
+    )
   }
   zip.file(sourcePath, { name, date: PINNED_ARTIFACT_DATE, stats })
 }
@@ -919,119 +923,127 @@ class Esbuild {
           const zipPromise = new Promise(async (resolve, reject) => {
             output.on('close', () => resolve(zipPath))
             output.on('error', (err) => reject(err))
+            zip.on('error', (err) => reject(err))
 
+            // Failures anywhere in the append sequence must reject the
+            // archive promise — an escaped rejection in this listener would
+            // otherwise leave the promise pending forever.
             output.on('open', async () => {
-              const functionIncludes = await globby(
-                functionObject.package?.patterns ?? [],
-                { cwd: this.serverless.serviceDir },
-              )
+              try {
+                const functionIncludes = await globby(
+                  functionObject.package?.patterns ?? [],
+                  { cwd: this.serverless.serviceDir },
+                )
 
-              // Sorted so the archive entry order doesn't depend on glob
-              // traversal order, which is filesystem-dependent.
-              const includesToPackage = _.union(
-                packageIncludes,
-                functionIncludes,
-              ).sort()
+                // Sorted so the archive entry order doesn't depend on glob
+                // traversal order, which is filesystem-dependent.
+                const includesToPackage = _.union(
+                  packageIncludes,
+                  functionIncludes,
+                ).sort()
 
-              zip.pipe(output)
-              const handlerPath = stripHandlerExportSuffix(
-                functionObject[handlerPropertyName],
-              )
+                zip.pipe(output)
+                const handlerPath = stripHandlerExportSuffix(
+                  functionObject[handlerPropertyName],
+                )
 
-              const packageJsonPath = path.join(
-                this.serverless.config.serviceDir,
-                '.serverless',
-                'build',
-                'package.json',
-              )
-
-              if (existsSync(packageJsonPath)) {
-                await appendFileEntry(zip, packageJsonPath, 'package.json')
-              }
-
-              // Add lockfiles if they exist
-              const lockFiles = {
-                'package-lock.json': 'package-lock.json',
-                'yarn.lock': 'yarn.lock',
-                'pnpm-lock.yaml': 'pnpm-lock.yaml',
-              }
-
-              for (const [lockFile, destName] of Object.entries(lockFiles)) {
-                const lockFilePath = path.join(
+                const packageJsonPath = path.join(
                   this.serverless.config.serviceDir,
                   '.serverless',
                   'build',
-                  lockFile,
+                  'package.json',
                 )
-                if (existsSync(lockFilePath)) {
-                  await appendFileEntry(zip, lockFilePath, destName)
+
+                if (existsSync(packageJsonPath)) {
+                  await appendFileEntry(zip, packageJsonPath, 'package.json')
                 }
-              }
 
-              const handlerZipPath = path.join(
-                this.serverless.config.serviceDir,
-                '.serverless',
-                'build',
-                handlerPath + outputExtension,
-              )
+                // Add lockfiles if they exist
+                const lockFiles = {
+                  'package-lock.json': 'package-lock.json',
+                  'yarn.lock': 'yarn.lock',
+                  'pnpm-lock.yaml': 'pnpm-lock.yaml',
+                }
 
-              await appendFileEntry(
-                zip,
-                handlerZipPath,
-                `${handlerPath}${outputExtension}`,
-              )
+                for (const [lockFile, destName] of Object.entries(lockFiles)) {
+                  const lockFilePath = path.join(
+                    this.serverless.config.serviceDir,
+                    '.serverless',
+                    'build',
+                    lockFile,
+                  )
+                  if (existsSync(lockFilePath)) {
+                    await appendFileEntry(zip, lockFilePath, destName)
+                  }
+                }
 
-              if (existsSync(`${handlerZipPath}.map`)) {
+                const handlerZipPath = path.join(
+                  this.serverless.config.serviceDir,
+                  '.serverless',
+                  'build',
+                  handlerPath + outputExtension,
+                )
+
                 await appendFileEntry(
                   zip,
-                  `${handlerZipPath}.map`,
-                  `${handlerPath}${outputExtension}.map`,
+                  handlerZipPath,
+                  `${handlerPath}${outputExtension}`,
                 )
-              }
 
-              for (const filePath of includesToPackage) {
-                const absolutePath = path.join(
-                  this.serverless.config.serviceDir,
-                  filePath,
-                )
-                const stats = await stat(absolutePath)
-                if (stats.isDirectory()) {
-                  // Expand the directory ourselves (sorted) instead of
-                  // zip.directory(): concurrent directory walks feed the
-                  // archive in racy, nondeterministic order.
-                  const children = (
-                    await globby('**', { cwd: absolutePath, dot: true })
-                  ).sort()
-                  for (const child of children) {
-                    await appendFileEntry(
-                      zip,
-                      path.join(absolutePath, child),
-                      `${filePath}/${child}`,
-                    )
-                  }
-                } else {
-                  await appendFileEntry(zip, absolutePath, filePath)
+                if (existsSync(`${handlerZipPath}.map`)) {
+                  await appendFileEntry(
+                    zip,
+                    `${handlerZipPath}.map`,
+                    `${handlerPath}${outputExtension}.map`,
+                  )
                 }
-              }
 
-              // The node_modules walk is async and feeds the archive as it
-              // discovers files. Keeping it as the last append (after every
-              // file entry is already enqueued) keeps the entry order
-              // deterministic.
-              zip.directory(
-                path.join(
-                  this.serverless.config.serviceDir,
-                  '.serverless',
-                  'build',
+                for (const filePath of includesToPackage) {
+                  const absolutePath = path.join(
+                    this.serverless.config.serviceDir,
+                    filePath,
+                  )
+                  const stats = await stat(absolutePath)
+                  if (stats.isDirectory()) {
+                    // Expand the directory ourselves (sorted) instead of
+                    // zip.directory(): concurrent directory walks feed the
+                    // archive in racy, nondeterministic order.
+                    const children = (
+                      await globby('**', { cwd: absolutePath, dot: true })
+                    ).sort()
+                    for (const child of children) {
+                      await appendFileEntry(
+                        zip,
+                        path.join(absolutePath, child),
+                        `${filePath}/${child}`,
+                      )
+                    }
+                  } else {
+                    await appendFileEntry(zip, absolutePath, filePath)
+                  }
+                }
+
+                // The node_modules walk is async and feeds the archive as it
+                // discovers files. Keeping it as the last append (after every
+                // file entry is already enqueued) keeps the entry order
+                // deterministic.
+                zip.directory(
+                  path.join(
+                    this.serverless.config.serviceDir,
+                    '.serverless',
+                    'build',
+                    'node_modules',
+                  ),
                   'node_modules',
-                ),
-                'node_modules',
-                { date: PINNED_ARTIFACT_DATE },
-              )
+                  { date: PINNED_ARTIFACT_DATE },
+                )
 
-              await zip.finalize()
-              functionObject.package = {
-                artifact: zipPath,
+                await zip.finalize()
+                functionObject.package = {
+                  artifact: zipPath,
+                }
+              } catch (err) {
+                reject(err)
               }
             })
           })
@@ -1043,6 +1055,7 @@ class Esbuild {
     try {
       await Promise.all(zipPromises)
     } catch (err) {
+      if (err instanceof ServerlessError) throw err
       throw new ServerlessError(err.message, 'ESBULD_PACKAGE_ERROR')
     }
   }
@@ -1074,122 +1087,134 @@ class Esbuild {
     const zipPromise = new Promise(async (resolve, reject) => {
       output.on('close', () => resolve(zipPath))
       output.on('error', (err) => reject(err))
+      zip.on('error', (err) => reject(err))
 
+      // Failures anywhere in the append sequence must reject the archive
+      // promise — an escaped rejection in this listener would otherwise
+      // leave the promise pending forever.
       output.on('open', async () => {
-        zip.pipe(output)
+        try {
+          zip.pipe(output)
 
-        for (const [, functionObject] of Object.entries(functions)) {
-          const handlerPath = stripHandlerExportSuffix(
-            functionObject[handlerPropertyName],
-          )
+          for (const [, functionObject] of Object.entries(functions)) {
+            const handlerPath = stripHandlerExportSuffix(
+              functionObject[handlerPropertyName],
+            )
 
-          const packageJsonPath = path.join(
-            this.serverless.config.serviceDir,
-            '.serverless',
-            'build',
-            'package.json',
-          )
-
-          if (existsSync(packageJsonPath) && !addedFiles.has(packageJsonPath)) {
-            await appendFileEntry(zip, packageJsonPath, 'package.json')
-            addedFiles.add(packageJsonPath)
-          }
-
-          // Add lockfiles if they exist
-          const lockFiles = {
-            'package-lock.json': 'package-lock.json',
-            'yarn.lock': 'yarn.lock',
-            'pnpm-lock.yaml': 'pnpm-lock.yaml',
-          }
-
-          for (const [lockFile, destName] of Object.entries(lockFiles)) {
-            const lockFilePath = path.join(
+            const packageJsonPath = path.join(
               this.serverless.config.serviceDir,
               '.serverless',
               'build',
-              lockFile,
+              'package.json',
             )
-            if (existsSync(lockFilePath) && !addedFiles.has(lockFilePath)) {
-              await appendFileEntry(zip, lockFilePath, destName)
-              addedFiles.add(lockFilePath)
+
+            if (
+              existsSync(packageJsonPath) &&
+              !addedFiles.has(packageJsonPath)
+            ) {
+              await appendFileEntry(zip, packageJsonPath, 'package.json')
+              addedFiles.add(packageJsonPath)
             }
-          }
 
-          const handlerZipPath = path.join(
-            this.serverless.config.serviceDir,
-            '.serverless',
-            'build',
-            handlerPath + outputExtension,
-          )
+            // Add lockfiles if they exist
+            const lockFiles = {
+              'package-lock.json': 'package-lock.json',
+              'yarn.lock': 'yarn.lock',
+              'pnpm-lock.yaml': 'pnpm-lock.yaml',
+            }
 
-          if (!addedFiles.has(handlerZipPath)) {
-            await appendFileEntry(
-              zip,
-              handlerZipPath,
-              `${handlerPath}${outputExtension}`,
+            for (const [lockFile, destName] of Object.entries(lockFiles)) {
+              const lockFilePath = path.join(
+                this.serverless.config.serviceDir,
+                '.serverless',
+                'build',
+                lockFile,
+              )
+              if (existsSync(lockFilePath) && !addedFiles.has(lockFilePath)) {
+                await appendFileEntry(zip, lockFilePath, destName)
+                addedFiles.add(lockFilePath)
+              }
+            }
+
+            const handlerZipPath = path.join(
+              this.serverless.config.serviceDir,
+              '.serverless',
+              'build',
+              handlerPath + outputExtension,
             )
-            addedFiles.add(handlerZipPath)
-          }
 
-          if (
-            existsSync(`${handlerZipPath}.map`) &&
-            !addedFiles.has(`${handlerZipPath}.map`)
-          ) {
-            await appendFileEntry(
-              zip,
-              `${handlerZipPath}.map`,
-              `${handlerPath}${outputExtension}.map`,
-            )
-
-            addedFiles.add(`${handlerZipPath}.map`)
-          }
-        }
-
-        for (const filePath of packageIncludes) {
-          const absolutePath = path.join(this.serverless.serviceDir, filePath)
-          const stats = await stat(absolutePath)
-          if (stats.isDirectory()) {
-            // Expand the directory ourselves (sorted) instead of
-            // zip.directory(): concurrent directory walks feed the archive
-            // in racy, nondeterministic order.
-            const children = (
-              await globby('**', { cwd: absolutePath, dot: true })
-            ).sort()
-            for (const child of children) {
+            if (!addedFiles.has(handlerZipPath)) {
               await appendFileEntry(
                 zip,
-                path.join(absolutePath, child),
-                `${filePath}/${child}`,
+                handlerZipPath,
+                `${handlerPath}${outputExtension}`,
               )
+              addedFiles.add(handlerZipPath)
             }
-          } else if (!addedFiles.has(absolutePath)) {
-            await appendFileEntry(zip, absolutePath, filePath)
-            addedFiles.add(absolutePath)
+
+            if (
+              existsSync(`${handlerZipPath}.map`) &&
+              !addedFiles.has(`${handlerZipPath}.map`)
+            ) {
+              await appendFileEntry(
+                zip,
+                `${handlerZipPath}.map`,
+                `${handlerPath}${outputExtension}.map`,
+              )
+
+              addedFiles.add(`${handlerZipPath}.map`)
+            }
           }
-        }
 
-        // The node_modules walk is async and feeds the archive as it
-        // discovers files. Keeping it as the last append (after every file
-        // entry is already enqueued) keeps the entry order deterministic.
-        zip.directory(
-          path.join(
-            this.serverless.config.serviceDir,
-            '.serverless',
-            'build',
+          for (const filePath of packageIncludes) {
+            const absolutePath = path.join(this.serverless.serviceDir, filePath)
+            const stats = await stat(absolutePath)
+            if (stats.isDirectory()) {
+              // Expand the directory ourselves (sorted) instead of
+              // zip.directory(): concurrent directory walks feed the archive
+              // in racy, nondeterministic order.
+              const children = (
+                await globby('**', { cwd: absolutePath, dot: true })
+              ).sort()
+              for (const child of children) {
+                await appendFileEntry(
+                  zip,
+                  path.join(absolutePath, child),
+                  `${filePath}/${child}`,
+                )
+              }
+            } else if (!addedFiles.has(absolutePath)) {
+              await appendFileEntry(zip, absolutePath, filePath)
+              addedFiles.add(absolutePath)
+            }
+          }
+
+          // The node_modules walk is async and feeds the archive as it
+          // discovers files. Keeping it as the last append (after every file
+          // entry is already enqueued) keeps the entry order deterministic.
+          zip.directory(
+            path.join(
+              this.serverless.config.serviceDir,
+              '.serverless',
+              'build',
+              'node_modules',
+            ),
             'node_modules',
-          ),
-          'node_modules',
-          { date: PINNED_ARTIFACT_DATE },
-        )
+            { date: PINNED_ARTIFACT_DATE },
+          )
 
-        await zip.finalize()
-        this.serverless.service.package.artifact = zipPath
+          await zip.finalize()
+          this.serverless.service.package.artifact = zipPath
+        } catch (err) {
+          reject(err)
+        }
       })
     })
 
     try {
       await zipPromise
     } catch (err) {
+      if (err instanceof ServerlessError) throw err
       throw new ServerlessError(err.message, 'ESBULD_PACKAGE_ALL_ERROR')
     }
   }

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-determinism.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-determinism.test.js
@@ -13,9 +13,17 @@
  * entry's stored timestamp is pinned to the epoch (DOS-clamped to 1980) rather
  * than the file's mtime. This is robust regardless of the test runner's clock,
  * unlike comparing artifact hashes across simulated rebuilds.
+ *
+ * Pinned dates alone are not enough: archiver resolves `zip.file()` calls
+ * through an internal stat queue with concurrency 4, so the order in which
+ * entries land in the archive follows lstat completion order, not call order.
+ * That makes the whole-zip bytes race between identical runs. The suite below
+ * also packages the same unchanged service several times and asserts the
+ * entry order and whole-zip sha256 are identical on every run.
  */
 
 import { jest } from '@jest/globals'
+import crypto from 'crypto'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -80,6 +88,97 @@ describe('esbuild packaging determinism', () => {
     expect(entries.length).toBeGreaterThan(0)
     for (const entry of entries) {
       expect(entry.year).toBe(PINNED_EPOCH_YEAR)
+    }
+  })
+
+  // Many small files racing through archiver's stat queue make ordering
+  // nondeterminism show up reliably when present.
+  function makeRacyServiceDir() {
+    const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+    const buildDir = path.join(serviceDir, '.serverless', 'build')
+    fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(buildDir, 'node_modules', 'dep', 'index.js'),
+      'module.exports = 1\n',
+    )
+    fs.writeFileSync(path.join(buildDir, 'package.json'), '{"name":"svc"}\n')
+    fs.writeFileSync(path.join(buildDir, 'package-lock.json'), '{}\n')
+    fs.writeFileSync(path.join(buildDir, 'yarn.lock'), '# lock\n')
+    fs.writeFileSync(
+      path.join(buildDir, 'pnpm-lock.yaml'),
+      'lockfileVersion: 9\n',
+    )
+    fs.mkdirSync(path.join(buildDir, 'src'), { recursive: true })
+    const racyFunctions = {}
+    for (let i = 0; i < 6; i++) {
+      fs.writeFileSync(
+        path.join(buildDir, 'src', `fn${i}.js`),
+        `export const handler = async () => ({ statusCode: 20${i} })\n`,
+      )
+      fs.writeFileSync(
+        path.join(buildDir, 'src', `fn${i}.js.map`),
+        `{"version":3,"file":"fn${i}.js"}\n`,
+      )
+      racyFunctions[`fn${i}`] = { handler: `src/fn${i}.handler` }
+    }
+    fs.writeFileSync(path.join(serviceDir, 'static-a.txt'), 'a\n')
+    fs.writeFileSync(path.join(serviceDir, 'static-b.txt'), 'b\n')
+    return { serviceDir, racyFunctions }
+  }
+
+  async function zipFingerprint(artifactPath) {
+    const bytes = fs.readFileSync(artifactPath)
+    const zip = await JsZip.loadAsync(bytes)
+    return {
+      hash: crypto.createHash('sha256').update(bytes).digest('hex'),
+      order: Object.values(zip.files).map((entry) => entry.name),
+    }
+  }
+
+  test('_packageAll produces byte-identical zips across repeated runs', async () => {
+    const { serviceDir, racyFunctions } = makeRacyServiceDir()
+    const plugin = makePlugin(serviceDir)
+    plugin.serverless.service.package.patterns = ['static-*.txt']
+
+    const fingerprints = []
+    for (let run = 0; run < 6; run++) {
+      await plugin._packageAll(racyFunctions)
+      fingerprints.push(
+        await zipFingerprint(
+          path.join(serviceDir, '.serverless', 'my-service.zip'),
+        ),
+      )
+    }
+
+    for (const fingerprint of fingerprints.slice(1)) {
+      expect(fingerprint.order).toEqual(fingerprints[0].order)
+      expect(fingerprint.hash).toBe(fingerprints[0].hash)
+    }
+  })
+
+  test('individual packaging produces byte-identical zips across repeated runs', async () => {
+    const { serviceDir, racyFunctions } = makeRacyServiceDir()
+    const plugin = makePlugin(serviceDir)
+    plugin.serverless.service.package.individually = true
+    plugin.serverless.service.package.patterns = ['static-*.txt']
+    plugin.functions = async () => racyFunctions
+    plugin._buildProperties = async () => ({})
+
+    const fingerprints = []
+    for (let run = 0; run < 6; run++) {
+      await plugin._package()
+      fingerprints.push(
+        await zipFingerprint(
+          path.join(serviceDir, '.serverless', 'my-service-fn0.zip'),
+        ),
+      )
+    }
+
+    for (const fingerprint of fingerprints.slice(1)) {
+      expect(fingerprint.order).toEqual(fingerprints[0].order)
+      expect(fingerprint.hash).toBe(fingerprints[0].hash)
     }
   })
 

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-determinism.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-determinism.test.js
@@ -96,13 +96,18 @@ describe('esbuild packaging determinism', () => {
   function makeRacyServiceDir() {
     const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
     const buildDir = path.join(serviceDir, '.serverless', 'build')
-    fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep'), {
-      recursive: true,
-    })
-    fs.writeFileSync(
-      path.join(buildDir, 'node_modules', 'dep', 'index.js'),
-      'module.exports = 1\n',
-    )
+    // Several packages with nested files so node_modules ordering itself is
+    // exercised, not just the position of a single entry.
+    for (const dep of ['dep-a', 'dep-b', 'dep-c']) {
+      const depDir = path.join(buildDir, 'node_modules', dep)
+      fs.mkdirSync(path.join(depDir, 'lib'), { recursive: true })
+      fs.writeFileSync(path.join(depDir, 'package.json'), `{"name":"${dep}"}\n`)
+      fs.writeFileSync(path.join(depDir, 'index.js'), 'module.exports = 1\n')
+      fs.writeFileSync(
+        path.join(depDir, 'lib', 'util.js'),
+        'module.exports = 2\n',
+      )
+    }
     fs.writeFileSync(path.join(buildDir, 'package.json'), '{"name":"svc"}\n')
     fs.writeFileSync(path.join(buildDir, 'package-lock.json'), '{}\n')
     fs.writeFileSync(path.join(buildDir, 'yarn.lock'), '# lock\n')

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-directory-include.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-directory-include.test.js
@@ -59,6 +59,10 @@ function makeServiceDir() {
       path.join(assetsDir, 'file.txt'),
       path.join(assetsDir, 'link-to-file'),
     )
+    fs.symlinkSync(
+      path.join(assetsDir, 'sub'),
+      path.join(assetsDir, 'link-to-sub'),
+    )
     fs.symlinkSync('/nonexistent-target', path.join(assetsDir, 'broken-link'))
     symlinksCreated = true
   } catch {
@@ -105,6 +109,12 @@ describe('esbuild packaging with a directory include', () => {
       // Symlinks are stored as entries (broken ones too), not followed.
       expect(names).toContain('assets/link-to-file')
       expect(names).toContain('assets/broken-link')
+      // A symlinked directory is stored as a symlink entry; its target's
+      // contents are not walked through the link.
+      expect(names).toContain('assets/link-to-sub')
+      expect(names.filter((n) => n.startsWith('assets/link-to-sub/'))).toEqual(
+        [],
+      )
     }
   })
 })

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-directory-include.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-directory-include.test.js
@@ -1,0 +1,110 @@
+/**
+ * Package-pattern resolution (globby with its onlyFiles default) only ever
+ * yields files, so the directory branch of the includes loop is defensive —
+ * but if it fires it must reproduce the walk semantics that zip.directory()
+ * historically gave that branch: directory entries recorded (including empty
+ * directories), symlinks stored as symlinks (broken ones included), symlinked
+ * directories not followed — while appending in sorted order so the archive
+ * stays deterministic.
+ *
+ * The patterns lookup is mocked to return a directory; the expansion walk
+ * itself runs against the real filesystem.
+ */
+
+import { jest } from '@jest/globals'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import JsZip from 'jszip'
+
+const actualGlobbyModule = await import('globby')
+
+jest.unstable_mockModule('globby', () => ({
+  ...actualGlobbyModule,
+  globby: async (patterns, options) => {
+    if (Array.isArray(patterns) && patterns.includes('__DIR_INCLUDE__')) {
+      return ['assets']
+    }
+    return actualGlobbyModule.globby(patterns, options)
+  },
+}))
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+function makeServiceDir() {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+  const buildDir = path.join(serviceDir, '.serverless', 'build')
+  fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep'), { recursive: true })
+  fs.writeFileSync(
+    path.join(buildDir, 'node_modules', 'dep', 'index.js'),
+    'module.exports = 1\n',
+  )
+  fs.writeFileSync(
+    path.join(buildDir, 'handler.js'),
+    'export const hello = async () => ({ statusCode: 200 })\n',
+  )
+
+  const assetsDir = path.join(serviceDir, 'assets')
+  fs.mkdirSync(path.join(assetsDir, 'sub'), { recursive: true })
+  fs.mkdirSync(path.join(assetsDir, 'empty-dir'))
+  fs.writeFileSync(path.join(assetsDir, 'file.txt'), 'f\n')
+  fs.writeFileSync(path.join(assetsDir, 'sub', 'a.txt'), 'a\n')
+
+  // Symlink creation needs privileges on some Windows setups; assert on
+  // symlink entries only when they could be created.
+  let symlinksCreated = false
+  try {
+    fs.symlinkSync(
+      path.join(assetsDir, 'file.txt'),
+      path.join(assetsDir, 'link-to-file'),
+    )
+    fs.symlinkSync('/nonexistent-target', path.join(assetsDir, 'broken-link'))
+    symlinksCreated = true
+  } catch {
+    // proceed without symlink coverage
+  }
+  return { serviceDir, symlinksCreated }
+}
+
+function makePlugin(serviceDir) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      package: { patterns: ['__DIR_INCLUDE__'] },
+    },
+    pluginManager: { spawn: async () => {} },
+  }
+  return new Esbuild(serverless, {})
+}
+
+const functions = { hello: { handler: 'handler.hello' } }
+
+describe('esbuild packaging with a directory include', () => {
+  jest.setTimeout(30_000)
+
+  test('_packageAll walks the directory like zip.directory did', async () => {
+    const { serviceDir, symlinksCreated } = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+
+    await plugin._packageAll(functions)
+
+    const zip = await JsZip.loadAsync(
+      fs.readFileSync(path.join(serviceDir, '.serverless', 'my-service.zip')),
+    )
+    const names = Object.values(zip.files).map((entry) => entry.name)
+
+    expect(names).toContain('assets/file.txt')
+    expect(names).toContain('assets/sub/')
+    expect(names).toContain('assets/sub/a.txt')
+    // Directory entries are preserved, including empty directories.
+    expect(names).toContain('assets/empty-dir/')
+    if (symlinksCreated) {
+      // Symlinks are stored as entries (broken ones too), not followed.
+      expect(names).toContain('assets/link-to-file')
+      expect(names).toContain('assets/broken-link')
+    }
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-vanished-include.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-vanished-include.test.js
@@ -1,0 +1,111 @@
+/**
+ * A file can vanish between glob expansion (or the build step) and packaging.
+ * The lookups for it reject inside the archive's stream-open listener, where
+ * an escaped rejection would bypass the archive promise: embedders hang on a
+ * never-settling promise and the CLI aborts through the global
+ * unhandledRejection handler. Worse, archiver's own stat queue silently drops
+ * entries it cannot stat, which can ship an incomplete artifact (e.g. a zip
+ * without its handler) that only fails at runtime.
+ *
+ * Packaging must instead fail fast with a clean CANNOT_READ_FILE error routed
+ * through the archive promise — the same contract as the classic (non-esbuild)
+ * packaging path.
+ *
+ * fs/promises is mocked so stat deterministically rejects for the marked
+ * include while everything else uses the real filesystem.
+ */
+
+import { jest } from '@jest/globals'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+jest.unstable_mockModule('fs/promises', () => {
+  const actual = jest.requireActual('fs/promises')
+  const stat = async (target, ...args) => {
+    if (String(target).endsWith('vanished.txt')) {
+      const error = new Error(
+        `ENOENT: no such file or directory, stat '${target}'`,
+      )
+      error.code = 'ENOENT'
+      throw error
+    }
+    return actual.stat(target, ...args)
+  }
+  return { ...actual, stat, default: { ...actual, stat } }
+})
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+function makeServiceDir({ withHandler = true } = {}) {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+  const buildDir = path.join(serviceDir, '.serverless', 'build')
+  fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep'), { recursive: true })
+  fs.writeFileSync(
+    path.join(buildDir, 'node_modules', 'dep', 'index.js'),
+    'module.exports = 1\n',
+  )
+  if (withHandler) {
+    fs.writeFileSync(
+      path.join(buildDir, 'handler.js'),
+      'export const hello = async () => ({ statusCode: 200 })\n',
+    )
+  }
+  // Both exist at glob time; stat is mocked to reject for vanished.txt,
+  // simulating a file deleted between glob expansion and packaging.
+  fs.writeFileSync(path.join(serviceDir, 'kept.txt'), 'kept\n')
+  fs.writeFileSync(path.join(serviceDir, 'vanished.txt'), 'vanished\n')
+  return serviceDir
+}
+
+function makePlugin(serviceDir) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      package: { patterns: ['*.txt'] },
+    },
+    pluginManager: { spawn: async () => {} },
+  }
+  return new Esbuild(serverless, {})
+}
+
+const functions = { hello: { handler: 'handler.hello' } }
+
+describe('esbuild packaging with a vanished file', () => {
+  jest.setTimeout(30_000)
+
+  test('_packageAll rejects cleanly when an include vanished', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+
+    await expect(plugin._packageAll(functions)).rejects.toMatchObject({
+      message: expect.stringMatching(/vanished\.txt/),
+    })
+  })
+
+  test('individual packaging rejects cleanly when an include vanished', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+    plugin.serverless.service.package.individually = true
+    plugin.functions = async () => functions
+    plugin._buildProperties = async () => ({})
+
+    await expect(plugin._package()).rejects.toMatchObject({
+      message: expect.stringMatching(/vanished\.txt/),
+    })
+  })
+
+  test('_packageAll rejects with CANNOT_READ_FILE when the handler bundle is missing', async () => {
+    const serviceDir = makeServiceDir({ withHandler: false })
+    const plugin = makePlugin(serviceDir)
+    plugin.serverless.service.package.patterns = []
+
+    await expect(plugin._packageAll(functions)).rejects.toMatchObject({
+      code: 'CANNOT_READ_FILE',
+      message: expect.stringMatching(/handler\.js/),
+    })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-vanished-include.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-vanished-include.test.js
@@ -82,6 +82,7 @@ describe('esbuild packaging with a vanished file', () => {
     const plugin = makePlugin(serviceDir)
 
     await expect(plugin._packageAll(functions)).rejects.toMatchObject({
+      code: 'CANNOT_READ_FILE',
       message: expect.stringMatching(/vanished\.txt/),
     })
   })
@@ -94,6 +95,7 @@ describe('esbuild packaging with a vanished file', () => {
     plugin._buildProperties = async () => ({})
 
     await expect(plugin._package()).rejects.toMatchObject({
+      code: 'CANNOT_READ_FILE',
       message: expect.stringMatching(/vanished\.txt/),
     })
   })


### PR DESCRIPTION
Obvious bug fix in the built-in esbuild packaging path — no corresponding issue; full description below.

### Problem

Repeated `serverless package` runs of the same unchanged service produce zips with different whole-file sha256 hashes. The set of entries (names, sizes, CRCs) is identical and entry dates are already pinned to the epoch, but the **entry order races** between runs — e.g. the handler bundle shifts position relative to `package.json`/lockfile/`.map` entries. Since change detection hashes the artifact, unchanged services can see phantom diffs and be needlessly redeployed. On a realistic service (7 external dependencies, ~2,700 zip entries) every single run produced a different hash.

A second, quieter variant: even for a single machine's stable output, `node_modules` entries were appended in filesystem readdir order, which varies per volume (ext4 hashes directory entries with a per-filesystem seed) — so deploying the same unchanged service from a different machine (a teammate's laptop, a fresh CI volume) also produced a different hash and a phantom redeploy.

### Root cause

`archiver` resolves `zip.file()` calls that carry no `stats` through an internal stat queue with concurrency 4 (`statConcurrency`), so entries land in the archive in **lstat-completion order, not call order**. Two more races compound it:

- `zip.directory()` matches arrive from the readdir walk *with* stats and bypass the stat queue, so they can leapfrog `zip.file()` entries whose lstat is still in flight.
- Package-pattern includes were appended from a `Promise.all(stat → append)`, i.e. in stat-completion order.

### Fix (in `_package` and `_packageAll`)

- Pre-fetch `lstat` stats for every file entry and pass them to `zip.file()`, so archiver enqueues each entry synchronously, strictly in call order. Using `lstat` preserves its existing symlink semantics.
- Append package-pattern includes sequentially, in sorted order (glob traversal order is filesystem-dependent).
- Replace every `zip.directory()` walk (directory includes and `node_modules`) with a shared sorted expansion whose walk semantics were verified entry-for-entry against `zip.directory`'s: directory entries included (empty ones too), symlinks stored as symlinks, nothing followed, missing directory tolerated. Sorting uses code-unit order, so the archive bytes depend only on content — identical on any machine, filesystem, or locale.
- Error handling now matches the classic packaging path: an unreadable file (deleted mid-packaging, or a handler bundle a broken build never emitted) fails packaging with a clean `CANNOT_READ_FILE` error. Previously archiver's stat queue silently dropped such entries — a zip could ship without its handler and only fail at runtime — while a failed include lookup escaped as an unhandled rejection. All failures inside the archive stream listeners now route through the archive promise, and archiver stream errors reject it too.

### Behavior notes

- **One-time re-upload on upgrade**: because entry order inside artifacts changes, the first deploy after upgrading re-uploads each esbuild-packaged function once (functionally identical bytes, routine code update). Artifacts are stable from then on, including across machines.
- Silent packaging failures now fail loudly: pipelines that previously deployed incomplete artifacts (which crashed at runtime) will now fail at `package` time with `CANNOT_READ_FILE`.
- No other observable changes: entry sets, file contents, symlink handling, modes, and pinned dates were verified unchanged against the previous implementation, including on a 2,704-entry archive.

### Tests

`packaging-determinism.test.js` gains two regression tests (`_packageAll` + individual packaging) that package the same service six times over a fixture with many small files (6 handlers + source maps, 3 lockfiles, includes, multi-package node_modules) and assert identical entry order and whole-zip sha256 on every run. Before the fix these fail consistently with entry-order shuffles. `packaging-vanished-include.test.js` pins the `CANNOT_READ_FILE` contract (vanished include on both packaging paths, missing handler bundle). `packaging-directory-include.test.js` forces the directory-include branch and pins the walk semantics (directory entries, empty dirs, symlink entries).

### Verification

- `npm run test:unit` (packages/serverless): full suite passes; `npm run lint` and prettier clean.
- Live checks with the CLI run from this branch:
  - Small service (two functions, `package.individually`, sourcemaps, external dependency, package patterns): 3 consecutive `package` runs → byte-identical zips; same service on `main` diverged.
  - Big service (7 external dependencies, 6,205 files in node_modules, 2,704-entry archives): 6 consecutive runs byte-identical, both default and `individually` modes; the same service on `main` produced a different hash on every run. Entry lists of `main`-produced and branch-produced zips are identical.
  - Wall time at parity with `main` (7–9s for the big service on both); in-process `_packageAll` on the same tree: 520ms (sorted expansion) vs 633ms (`zip.directory`). Memory profile unchanged — entries still stream one at a time; file contents are never buffered in bulk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment package reliability with consistent archive contents and repeatable builds.
  * Reports clear errors when required files disappear or cannot be read.
  * Preserves directory contents, empty directories, and symlinks—including broken symlinks—when packaging.

* **Tests**
  * Added coverage for deterministic service-wide and individual-function packages.
  * Added validation for missing and unreadable files.
  * Added coverage for directory-based packaging and symlink preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->