### PR TITLE
fix(esbuild): honor package.patterns negations in packaged artifacts

### DIFF
--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -149,6 +149,10 @@ module.exports = (serverless) => {
 }
 ```
 
+### Packaging Patterns
+
+`package.patterns` controls which files are packaged into esbuild artifacts: the patterns filter the artifact's `node_modules` content and select any additional files to include. The compiled handler bundle, the sourcemap when one is emitted, and the `package.json` and lockfile are always packaged. Function-level patterns apply when `package.individually` is enabled and are merged after the service-level patterns. See [Packaging](./packaging.md) for pattern syntax and merging rules.
+
 ## Plugin Conflicts
 
 Please note, plugins that build your code will not work unless you opt out of the default build experience. Some of the plugins affected are:

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -9,6 +9,12 @@ import _ from 'lodash'
 import pLimit from 'p-limit'
 import { globby } from 'globby'
 import micromatch from 'micromatch'
+import {
+  compilePatterns,
+  isPathIncluded,
+  isDirIncluded,
+  filterPaths,
+} from '../../utils/package-patterns.js'
 import ServerlessError from '../../serverless-error.js'
 import { log } from '@serverless/util'
 
@@ -49,26 +55,35 @@ const areSameSet = (a, b) => {
 // forces a needless redeploy of every function (issue #4240).
 const PINNED_ARTIFACT_DATE = new Date(0)
 
-// A pinned date alone doesn't make the zip reproducible: archiver resolves
-// `zip.file()` calls without `stats` through an internal stat queue with
-// concurrency 4, so entries land in the archive in lstat-completion order,
-// which races between runs and changes the whole-zip bytes (and therefore the
-// sha256 used by check-for-changes). Pre-fetching the stats makes archiver
-// enqueue the entry synchronously, so entries appear strictly in call order.
-// An unreadable file fails packaging (same contract as the classic packaging
-// path) — archiver's own stat queue would silently drop the entry and ship an
-// incomplete artifact.
-const appendFileEntry = async (zip, sourcePath, name) => {
-  let stats
+// lstat (not stat) so that a symlink becomes a symlink entry, which is what
+// this path has always produced. An unreadable file fails packaging (same
+// contract as the classic packaging path) — archiver's own stat queue would
+// silently drop the entry and ship an incomplete artifact.
+const lstatEntry = async (sourcePath) => {
   try {
-    stats = await lstat(sourcePath)
+    return await lstat(sourcePath)
   } catch (error) {
     throw new ServerlessError(
       `Cannot read file ${sourcePath} due to: ${error.message}`,
       'CANNOT_READ_FILE',
     )
   }
-  zip.file(sourcePath, { name, date: PINNED_ARTIFACT_DATE, stats })
+}
+
+// A pinned date alone doesn't make the zip reproducible: archiver resolves
+// `zip.file()` calls without `stats` through an internal stat queue with
+// concurrency 4, so entries land in the archive in lstat-completion order,
+// which races between runs and changes the whole-zip bytes (and therefore the
+// sha256 used by check-for-changes). Pre-fetching the stats makes archiver
+// enqueue the entry synchronously, so entries appear strictly in call order.
+// `stats` may be supplied by a caller that already had to look them up, so
+// that the entry is never lstat'ed twice.
+const appendFileEntry = async (zip, sourcePath, name, stats) => {
+  zip.file(sourcePath, {
+    name,
+    date: PINNED_ARTIFACT_DATE,
+    stats: stats ?? (await lstatEntry(sourcePath)),
+  })
 }
 
 // Deterministic replacement for zip.directory(): expand the tree ourselves
@@ -79,7 +94,12 @@ const appendFileEntry = async (zip, sourcePath, name) => {
 // deploy followed by a CI deploy saw phantom diffs. The globby options
 // reproduce zip.directory's walk entry-for-entry: directory entries included
 // (empty ones too), symlinks kept as symlinks, nothing followed.
-const appendDirectoryEntries = async (zip, dirPath, destPath) => {
+//
+// `filter(entry, stats)` — optional — decides per entry whether it is
+// appended; `entry` is the walk-relative posix path and `stats` are its
+// (already fetched) lstat results, so the caller can tell directories from
+// files. Filtering happens after the sort, so it can never reorder anything.
+const appendDirectoryEntries = async (zip, dirPath, destPath, filter) => {
   const entries = (
     await globby('**', {
       cwd: dirPath,
@@ -89,11 +109,10 @@ const appendDirectoryEntries = async (zip, dirPath, destPath) => {
     })
   ).sort()
   for (const entry of entries) {
-    await appendFileEntry(
-      zip,
-      path.join(dirPath, entry),
-      `${destPath}/${entry}`,
-    )
+    const sourcePath = path.join(dirPath, entry)
+    const stats = await lstatEntry(sourcePath)
+    if (filter && !filter(entry, stats)) continue
+    await appendFileEntry(zip, sourcePath, `${destPath}/${entry}`, stats)
   }
 }
 
@@ -116,6 +135,9 @@ class Esbuild {
     this.serverless = serverless
     this.options = options || {}
     this._functions = undefined
+    // Set once the `packages: external` / empty-node_modules warning has been
+    // emitted, so that it is reported per invocation rather than per function.
+    this._nodeModulesExclusionWarned = false
 
     this._buildProperties = _.memoize(this._buildProperties.bind(this))
     this._readPackageJson = _.memoize(this._readPackageJson.bind(this))
@@ -957,6 +979,38 @@ class Esbuild {
             zipName,
           )
 
+          // Service- and function-level patterns merge in that order so that
+          // a function can re-include (or further exclude) what the service
+          // level decided; `last match wins` then falls out of the ordering.
+          const compiledPatterns = compilePatterns([
+            ...(this.serverless.service.package?.patterns ?? []),
+            ...(functionObject.package?.patterns ?? []),
+          ])
+          let excludedEntryCount = 0
+          // Scoped to the node_modules walk: only this counter can attest that
+          // the patterns removed dependencies, which is what the
+          // `packages: external` warning claims.
+          let excludedNodeModulesEntryCount = 0
+          let includedNodeModulesFileCount = 0
+          const nodeModulesEntryFilter = (entry, stats) => {
+            // `entry` is relative to the walked directory, so it has to be
+            // re-prefixed to match patterns written against the zip root.
+            const entryZipPath = `node_modules/${entry}`
+            const isDirectory = stats.isDirectory()
+            const included = isDirectory
+              ? isDirIncluded(compiledPatterns, entryZipPath)
+              : isPathIncluded(compiledPatterns, entryZipPath)
+            if (!included) {
+              excludedEntryCount += 1
+              excludedNodeModulesEntryCount += 1
+              return false
+            }
+            if (!isDirectory) {
+              includedNodeModulesFileCount += 1
+            }
+            return true
+          }
+
           const zip = new ZipArchive()
           const output = createWriteStream(zipPath)
 
@@ -977,10 +1031,16 @@ class Esbuild {
 
                 // Sorted so the archive entry order doesn't depend on glob
                 // traversal order, which is filesystem-dependent.
-                const includesToPackage = _.union(
+                const unionedIncludes = _.union(
                   packageIncludes,
                   functionIncludes,
                 ).sort()
+                const includesToPackage = filterPaths(
+                  compiledPatterns,
+                  unionedIncludes,
+                )
+                excludedEntryCount +=
+                  unionedIncludes.length - includesToPackage.length
 
                 zip.pipe(output)
                 const handlerPath = stripHandlerExportSuffix(
@@ -1045,6 +1105,10 @@ class Esbuild {
                   )
                   const stats = await statIncludeEntry(absolutePath)
                   if (stats.isDirectory()) {
+                    // No pattern predicate on purpose: the patterns already
+                    // selected this include, and pattern resolution (globby with
+                    // its onlyFiles default) never yields a directory, so this
+                    // branch is defensive rather than reachable from config.
                     await appendDirectoryEntries(zip, absolutePath, filePath)
                   } else {
                     await appendFileEntry(zip, absolutePath, filePath)
@@ -1060,6 +1124,7 @@ class Esbuild {
                     'node_modules',
                   ),
                   'node_modules',
+                  nodeModulesEntryFilter,
                 )
 
                 await zip.finalize()
@@ -1072,6 +1137,16 @@ class Esbuild {
             })
           })
           await zipPromise
+          // Counters are only final once the output stream closed.
+          this._reportPatternFiltering({
+            zipName,
+            subject: functionAlias,
+            compiledPatterns,
+            excludedEntryCount,
+            excludedNodeModulesEntryCount,
+            includedNodeModulesFileCount,
+            buildProperties,
+          })
         })
       },
     )
@@ -1103,6 +1178,40 @@ class Esbuild {
         cwd: this.serverless.serviceDir,
       })
     ).sort()
+
+    // Only service-level patterns apply here: a single shared zip has no
+    // per-function view to narrow, so function-level patterns are ignored
+    // without `individually` — same as classic packaging.
+    const compiledPatterns = compilePatterns(
+      this.serverless.service.package.patterns ?? [],
+    )
+    let excludedEntryCount = 0
+    // Scoped to the node_modules walk: only this counter can attest that the
+    // patterns removed dependencies, which is what the `packages: external`
+    // warning claims.
+    let excludedNodeModulesEntryCount = 0
+    let includedNodeModulesFileCount = 0
+    const nodeModulesEntryFilter = (entry, stats) => {
+      // `entry` is relative to the walked directory, so it has to be
+      // re-prefixed to match patterns written against the zip root.
+      const entryZipPath = `node_modules/${entry}`
+      const isDirectory = stats.isDirectory()
+      const included = isDirectory
+        ? isDirIncluded(compiledPatterns, entryZipPath)
+        : isPathIncluded(compiledPatterns, entryZipPath)
+      if (!included) {
+        excludedEntryCount += 1
+        excludedNodeModulesEntryCount += 1
+        return false
+      }
+      if (!isDirectory) {
+        includedNodeModulesFileCount += 1
+      }
+      return true
+    }
+
+    const includesToPackage = filterPaths(compiledPatterns, packageIncludes)
+    excludedEntryCount += packageIncludes.length - includesToPackage.length
 
     const zip = new ZipArchive()
     const output = createWriteStream(zipPath)
@@ -1190,10 +1299,14 @@ class Esbuild {
             }
           }
 
-          for (const filePath of packageIncludes) {
+          for (const filePath of includesToPackage) {
             const absolutePath = path.join(this.serverless.serviceDir, filePath)
             const stats = await statIncludeEntry(absolutePath)
             if (stats.isDirectory()) {
+              // No pattern predicate on purpose: the patterns already selected
+              // this include, and pattern resolution (globby with its onlyFiles
+              // default) never yields a directory, so this branch is defensive
+              // rather than reachable from config.
               await appendDirectoryEntries(zip, absolutePath, filePath)
             } else if (!addedFiles.has(absolutePath)) {
               await appendFileEntry(zip, absolutePath, filePath)
@@ -1210,6 +1323,7 @@ class Esbuild {
               'node_modules',
             ),
             'node_modules',
+            nodeModulesEntryFilter,
           )
 
           await zip.finalize()
@@ -1225,6 +1339,75 @@ class Esbuild {
     } catch (err) {
       if (err instanceof ServerlessError) throw err
       throw new ServerlessError(err.message, 'ESBULD_PACKAGE_ALL_ERROR')
+    }
+
+    // Counters are only final once the output stream closed.
+    this._reportPatternFiltering({
+      zipName,
+      subject: zipName,
+      compiledPatterns,
+      excludedEntryCount,
+      excludedNodeModulesEntryCount,
+      includedNodeModulesFileCount,
+      buildProperties,
+    })
+  }
+
+  /**
+   * Report what `package.patterns` did to one artifact: an info line naming the
+   * artifact when anything was excluded, an unconditional debug trace of the
+   * patterns and the counters, and a once-per-invocation warning when the
+   * patterns leave no dependencies behind for `packages: external`.
+   *
+   * Call this only after the artifact's zip promise settled — the counters are
+   * incremented from the node_modules entry filter and are not final before
+   * then.
+   *
+   * @param {object} params
+   * @param {string} params.zipName - Artifact file name, e.g. `my-service-fn1.zip`.
+   * @param {string} params.subject - What the debug trace is about: the function
+   *   alias when packaging individually, the service zip name otherwise.
+   * @param {Array<object>} params.compiledPatterns - Compiled ordered patterns.
+   * @param {number} params.excludedEntryCount - Entries the patterns removed.
+   * @param {number} params.excludedNodeModulesEntryCount - Of those, entries
+   *   removed from the node_modules walk rather than from additive includes.
+   * @param {number} params.includedNodeModulesFileCount - node_modules files kept.
+   * @param {object} params.buildProperties - The merged esbuild build properties.
+   */
+  _reportPatternFiltering({
+    zipName,
+    subject,
+    compiledPatterns,
+    excludedEntryCount,
+    excludedNodeModulesEntryCount,
+    includedNodeModulesFileCount,
+    buildProperties,
+  }) {
+    if (excludedEntryCount > 0) {
+      logger.info(
+        `Excluded ${excludedEntryCount} entries from ${zipName} via package.patterns`,
+      )
+    }
+    logger.debug(
+      `package.patterns for ${subject}: ${JSON.stringify(
+        compiledPatterns,
+      )} (excluded ${excludedEntryCount}, node_modules entries excluded ${excludedNodeModulesEntryCount}, node_modules files kept ${includedNodeModulesFileCount})`,
+    )
+    // Scoped to the node_modules walk on purpose: excluding only additive
+    // includes says nothing about dependencies, and warning there would make a
+    // false claim. This cannot miss a real case -- if node_modules held
+    // anything that the patterns stripped, the entry filter ran and counted it.
+    if (
+      includedNodeModulesFileCount === 0 &&
+      excludedNodeModulesEntryCount > 0 &&
+      buildProperties.packages === 'external' &&
+      !this._nodeModulesExclusionWarned
+    ) {
+      this._nodeModulesExclusionWarned = true
+      logger.warning(
+        'package.patterns exclude everything under node_modules, but "packages: external" requires dependencies in the artifact. ' +
+          'If dependencies are provided another way (e.g. a Lambda layer) or this exclusion predates build.esbuild, review or remove these patterns.',
+      )
     }
   }
 

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -130,6 +130,39 @@ const statIncludeEntry = async (absolutePath) => {
   }
 }
 
+// Builds the per-artifact node_modules entry filter and its counters. One
+// shared factory for both packaging paths, so the twin filters cannot drift.
+// The `excludedNodeModulesEntryCount` counter is scoped to the node_modules
+// walk: only it can attest that the patterns removed dependencies, which is
+// what the `packages: external` warning claims. `excludedEntryCount` also
+// absorbs filtered additive includes at the call sites.
+const createNodeModulesEntryFilter = (compiledPatterns) => {
+  const counters = {
+    excludedEntryCount: 0,
+    excludedNodeModulesEntryCount: 0,
+    includedNodeModulesFileCount: 0,
+  }
+  const filter = (entry, stats) => {
+    // `entry` is relative to the walked directory, so it has to be
+    // re-prefixed to match patterns written against the zip root.
+    const entryZipPath = `node_modules/${entry}`
+    const isDirectory = stats.isDirectory()
+    const included = isDirectory
+      ? isDirIncluded(compiledPatterns, entryZipPath)
+      : isPathIncluded(compiledPatterns, entryZipPath)
+    if (!included) {
+      counters.excludedEntryCount += 1
+      counters.excludedNodeModulesEntryCount += 1
+      return false
+    }
+    if (!isDirectory) {
+      counters.includedNodeModulesFileCount += 1
+    }
+    return true
+  }
+  return { filter, counters }
+}
+
 class Esbuild {
   constructor(serverless, options) {
     this.serverless = serverless
@@ -986,30 +1019,8 @@ class Esbuild {
             ...(this.serverless.service.package?.patterns ?? []),
             ...(functionObject.package?.patterns ?? []),
           ])
-          let excludedEntryCount = 0
-          // Scoped to the node_modules walk: only this counter can attest that
-          // the patterns removed dependencies, which is what the
-          // `packages: external` warning claims.
-          let excludedNodeModulesEntryCount = 0
-          let includedNodeModulesFileCount = 0
-          const nodeModulesEntryFilter = (entry, stats) => {
-            // `entry` is relative to the walked directory, so it has to be
-            // re-prefixed to match patterns written against the zip root.
-            const entryZipPath = `node_modules/${entry}`
-            const isDirectory = stats.isDirectory()
-            const included = isDirectory
-              ? isDirIncluded(compiledPatterns, entryZipPath)
-              : isPathIncluded(compiledPatterns, entryZipPath)
-            if (!included) {
-              excludedEntryCount += 1
-              excludedNodeModulesEntryCount += 1
-              return false
-            }
-            if (!isDirectory) {
-              includedNodeModulesFileCount += 1
-            }
-            return true
-          }
+          const { filter: nodeModulesEntryFilter, counters: patternCounters } =
+            createNodeModulesEntryFilter(compiledPatterns)
 
           const zip = new ZipArchive()
           const output = createWriteStream(zipPath)
@@ -1031,15 +1042,14 @@ class Esbuild {
 
                 // Sorted so the archive entry order doesn't depend on glob
                 // traversal order, which is filesystem-dependent.
-                const unionedIncludes = _.union(
-                  packageIncludes,
-                  functionIncludes,
-                ).sort()
+                const unionedIncludes = [
+                  ...new Set([...packageIncludes, ...functionIncludes]),
+                ].sort()
                 const includesToPackage = filterPaths(
                   compiledPatterns,
                   unionedIncludes,
                 )
-                excludedEntryCount +=
+                patternCounters.excludedEntryCount +=
                   unionedIncludes.length - includesToPackage.length
 
                 zip.pipe(output)
@@ -1142,9 +1152,7 @@ class Esbuild {
             zipName,
             subject: functionAlias,
             compiledPatterns,
-            excludedEntryCount,
-            excludedNodeModulesEntryCount,
-            includedNodeModulesFileCount,
+            ...patternCounters,
             buildProperties,
           })
         })
@@ -1185,33 +1193,12 @@ class Esbuild {
     const compiledPatterns = compilePatterns(
       this.serverless.service.package.patterns ?? [],
     )
-    let excludedEntryCount = 0
-    // Scoped to the node_modules walk: only this counter can attest that the
-    // patterns removed dependencies, which is what the `packages: external`
-    // warning claims.
-    let excludedNodeModulesEntryCount = 0
-    let includedNodeModulesFileCount = 0
-    const nodeModulesEntryFilter = (entry, stats) => {
-      // `entry` is relative to the walked directory, so it has to be
-      // re-prefixed to match patterns written against the zip root.
-      const entryZipPath = `node_modules/${entry}`
-      const isDirectory = stats.isDirectory()
-      const included = isDirectory
-        ? isDirIncluded(compiledPatterns, entryZipPath)
-        : isPathIncluded(compiledPatterns, entryZipPath)
-      if (!included) {
-        excludedEntryCount += 1
-        excludedNodeModulesEntryCount += 1
-        return false
-      }
-      if (!isDirectory) {
-        includedNodeModulesFileCount += 1
-      }
-      return true
-    }
+    const { filter: nodeModulesEntryFilter, counters: patternCounters } =
+      createNodeModulesEntryFilter(compiledPatterns)
 
     const includesToPackage = filterPaths(compiledPatterns, packageIncludes)
-    excludedEntryCount += packageIncludes.length - includesToPackage.length
+    patternCounters.excludedEntryCount +=
+      packageIncludes.length - includesToPackage.length
 
     const zip = new ZipArchive()
     const output = createWriteStream(zipPath)
@@ -1346,9 +1333,7 @@ class Esbuild {
       zipName,
       subject: zipName,
       compiledPatterns,
-      excludedEntryCount,
-      excludedNodeModulesEntryCount,
-      includedNodeModulesFileCount,
+      ...patternCounters,
       buildProperties,
     })
   }

--- a/packages/serverless/lib/utils/package-patterns.js
+++ b/packages/serverless/lib/utils/package-patterns.js
@@ -1,0 +1,75 @@
+import micromatch from 'micromatch'
+
+/**
+ * Ordered `package.patterns` evaluation with classic-packaging semantics:
+ * every path starts included; patterns are applied in order; each match sets
+ * the path's state (positive → included, negated → excluded); last match wins.
+ *
+ * These helpers mirror the toggle embedded in the classic packaging engine
+ * (`resolveFilePathsFromPatterns`), so that a parity test suite -- added
+ * alongside the esbuild integration -- can pin the two implementations to
+ * identical behavior.
+ */
+
+const normalizeSeparators = (pattern) =>
+  process.platform === 'win32' ? pattern.replace(/\\/g, '/') : pattern
+
+export function compilePatterns(patterns = []) {
+  return (
+    patterns
+      .map((raw) => {
+        const normalized = normalizeSeparators(raw)
+        const negated = normalized.startsWith('!')
+        return { negated, pattern: negated ? normalized.slice(1) : normalized }
+      })
+      // An empty pattern (`''`, or a bare `'!'`) carries no glob to match, so it
+      // toggles nothing and is dropped here. Dropping is deliberate: micromatch
+      // rejects the empty string with "Expected pattern to be a non-empty
+      // string", so an empty pattern reaching micromatch would fail packaging.
+      // Empty patterns are reachable without a typo -- a variable resolving to
+      // nothing yields `'!${env:UNSET, ""}'` -- and they were simply inert on
+      // this path before, so dropping them keeps working configurations working
+      // rather than newly failing their deploys.
+      .filter(({ pattern }) => pattern !== '')
+  )
+}
+
+export function isPathIncluded(compiled, filePath, initialState = true) {
+  let included = initialState
+  for (const { negated, pattern } of compiled) {
+    if (micromatch.isMatch(filePath, pattern, { dot: true })) {
+      included = !negated
+    }
+  }
+  return included
+}
+
+export function isDirIncluded(compiled, dirPath, initialState = true) {
+  let included = initialState
+  for (const { negated, pattern } of compiled) {
+    const matches =
+      micromatch.isMatch(dirPath, pattern, { dot: true }) ||
+      // micromatch's globstar matches zero segments, so a literal-prefix
+      // `X/**` (e.g. `node_modules/fastify/**`) already matches the bare
+      // directory `node_modules/fastify` above. This branch extends that to
+      // `/**` patterns whose prefix holds wildcards: `foo/*/**` does NOT match
+      // `foo/bar`, but its base `foo/*` does. Either way a fully-excluded (or
+      // re-included) subtree carries its own directory entry.
+      (pattern.endsWith('/**') &&
+        micromatch.isMatch(dirPath, pattern.slice(0, -3), { dot: true }))
+    if (matches) {
+      included = !negated
+    }
+  }
+  return included
+}
+
+export function filterPaths(compiled, paths, initialState = true) {
+  const states = new Map(paths.map((p) => [p, initialState]))
+  for (const { negated, pattern } of compiled) {
+    for (const match of micromatch(paths, [pattern], { dot: true })) {
+      states.set(match, !negated)
+    }
+  }
+  return paths.filter((p) => states.get(p))
+}

--- a/packages/serverless/test/unit/lib/plugins/esbuild/package-patterns-filtering.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/package-patterns-filtering.test.js
@@ -26,11 +26,27 @@ jest.unstable_mockModule('fs/promises', () => {
 const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
   .default
 
+// Every fixture directory is tracked and removed after the suite: this file
+// creates dozens of them, each holding a node_modules tree and zip artifacts.
+const createdServiceDirs = []
+
+afterAll(() => {
+  for (const dir of createdServiceDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeFixtureDir() {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-pat-'))
+  createdServiceDirs.push(serviceDir)
+  return serviceDir
+}
+
 // `emptyNodeModules` builds the same fixture with an existing but empty
 // node_modules directory: the shape of a service that bundles everything, where
 // the entry filter never runs at all.
 function makeServiceDir({ emptyNodeModules = false } = {}) {
-  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-pat-'))
+  const serviceDir = makeFixtureDir()
   const buildDir = path.join(serviceDir, '.serverless', 'build')
   const write = (rel, content = 'x\n') => {
     fs.mkdirSync(path.dirname(path.join(buildDir, rel)), { recursive: true })
@@ -589,14 +605,14 @@ describe('esbuild patterns observability', () => {
 // order and the whole-zip sha256, the same way packaging-determinism.test.js
 // pins the unfiltered path.
 describe('esbuild patterns determinism', () => {
-  jest.setTimeout(60_000)
+  // The 6-run tests below carry a per-test 60s timeout (third argument):
+  // jest.setTimeout is file-global no matter where it is called, so a
+  // describe-scoped call here would be overridden by later calls in the file.
 
   // Many small files across several packages, so an ordering leak in the
   // filtered walk shows up reliably rather than by luck.
   function makeRacyServiceDir() {
-    const serviceDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), 'sls-esbuild-pat-'),
-    )
+    const serviceDir = makeFixtureDir()
     const buildDir = path.join(serviceDir, '.serverless', 'build')
     for (const dep of ['dep-a', 'dep-b', 'dep-c', 'keep']) {
       const depDir = path.join(buildDir, 'node_modules', dep)
@@ -680,7 +696,7 @@ describe('esbuild patterns determinism', () => {
           !name.startsWith('node_modules/keep'),
       ),
     ).toEqual([])
-  })
+  }, 60_000)
 
   test('_packageAll stays byte-identical across 6 runs with filtering active', async () => {
     const { serviceDir, racyFunctions } = makeRacyServiceDir()
@@ -714,7 +730,7 @@ describe('esbuild patterns determinism', () => {
           !name.startsWith('node_modules/keep'),
       ),
     ).toEqual([])
-  })
+  }, 60_000)
 })
 
 // package.patterns must not become a way to route around an unreadable file.

--- a/packages/serverless/test/unit/lib/plugins/esbuild/package-patterns-filtering.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/package-patterns-filtering.test.js
@@ -1,0 +1,793 @@
+import { jest } from '@jest/globals'
+import crypto from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import JsZip from 'jszip'
+import { log } from '@serverless/util'
+
+// Only this one file name is made unreadable; every other path goes to the real
+// filesystem, so the rest of the suite is unaffected by the mock.
+const UNREADABLE_ENTRY = 'unreadable.js'
+
+jest.unstable_mockModule('fs/promises', () => {
+  const actual = jest.requireActual('fs/promises')
+  const lstat = async (target, ...args) => {
+    if (String(target).endsWith(UNREADABLE_ENTRY)) {
+      const error = new Error(`EACCES: permission denied, lstat '${target}'`)
+      error.code = 'EACCES'
+      throw error
+    }
+    return actual.lstat(target, ...args)
+  }
+  return { ...actual, lstat, default: { ...actual, lstat } }
+})
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+// `emptyNodeModules` builds the same fixture with an existing but empty
+// node_modules directory: the shape of a service that bundles everything, where
+// the entry filter never runs at all.
+function makeServiceDir({ emptyNodeModules = false } = {}) {
+  const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-pat-'))
+  const buildDir = path.join(serviceDir, '.serverless', 'build')
+  const write = (rel, content = 'x\n') => {
+    fs.mkdirSync(path.dirname(path.join(buildDir, rel)), { recursive: true })
+    fs.writeFileSync(path.join(buildDir, rel), content)
+  }
+  if (emptyNodeModules) {
+    fs.mkdirSync(path.join(buildDir, 'node_modules'), { recursive: true })
+  } else {
+    write('node_modules/fastify/package.json')
+    write('node_modules/fastify/lib/route.js')
+    write('node_modules/serverless-http/index.js')
+    write('node_modules/keep/index.js')
+  }
+  write(
+    'handler.js',
+    'export const hello = async () => ({ statusCode: 200 })\n',
+  )
+  write('other.js', 'export const other = async () => ({ statusCode: 200 })\n')
+  // Source-dir file for additive-include tests.
+  fs.mkdirSync(path.join(serviceDir, 'assets'), { recursive: true })
+  fs.writeFileSync(path.join(serviceDir, 'assets', 'logo.png'), 'png\n')
+  fs.writeFileSync(path.join(serviceDir, 'assets', 'secret.txt'), 'ssh\n')
+  return serviceDir
+}
+
+function makePlugin(
+  serviceDir,
+  { servicePatterns = [], omitPatternsKey = false } = {},
+) {
+  const servicePackage = { individually: true }
+  if (!omitPatternsKey) servicePackage.patterns = servicePatterns
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      package: servicePackage,
+    },
+    pluginManager: { spawn: async () => {} },
+  }
+  const plugin = new Esbuild(serverless, {})
+  plugin._buildProperties = async () => ({})
+  return plugin
+}
+
+async function zipEntryNames(artifactPath) {
+  const zip = await JsZip.loadAsync(fs.readFileSync(artifactPath))
+  return Object.keys(zip.files).sort()
+}
+
+const artifactSha256 = (artifactPath) =>
+  crypto
+    .createHash('sha256')
+    .update(fs.readFileSync(artifactPath))
+    .digest('hex')
+
+// Package the standard fixture from scratch under the given plugin options and
+// return the artifact's sha256, so that configurations can be compared byte for
+// byte rather than entry-name by entry-name.
+async function packageFixtureSha256(pluginOptions) {
+  const serviceDir = makeServiceDir()
+  const plugin = makePlugin(serviceDir, pluginOptions)
+  await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+  return artifactSha256(
+    path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+  )
+}
+
+async function packageWith(serviceDir, plugin, functions) {
+  plugin.functions = async () => functions
+  await plugin._package()
+}
+
+// archiver emits entries INSIDE the walked dir (prefixed) — there is no bare
+// 'node_modules/' root entry in these zips.
+const FULL_NODE_MODULES = [
+  'node_modules/fastify/',
+  'node_modules/fastify/lib/',
+  'node_modules/fastify/lib/route.js',
+  'node_modules/fastify/package.json',
+  'node_modules/keep/',
+  'node_modules/keep/index.js',
+  'node_modules/serverless-http/',
+  'node_modules/serverless-http/index.js',
+]
+
+describe('esbuild packaging honors package.patterns (individually)', () => {
+  jest.setTimeout(30_000)
+
+  test('no patterns: full node_modules ships, including dir entries', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    for (const expected of FULL_NODE_MODULES) {
+      expect(entries).toContain(expected)
+    }
+  })
+
+  test('positive-only patterns leave node_modules untouched', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['assets/logo.png'],
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    for (const expected of FULL_NODE_MODULES) {
+      expect(entries).toContain(expected)
+    }
+    expect(entries).toContain('assets/logo.png')
+  })
+
+  test('function-level negation excludes package (files AND dir husks) from that zip only', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+    await packageWith(serviceDir, plugin, {
+      fn1: { handler: 'handler.hello' },
+      fn2: {
+        handler: 'other.other',
+        package: {
+          patterns: [
+            '!node_modules/fastify/**',
+            '!node_modules/serverless-http/**',
+          ],
+        },
+      },
+    })
+    const fn1 = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    const fn2 = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn2.zip'),
+    )
+    expect(fn1).toContain('node_modules/fastify/lib/route.js')
+    expect(fn1).toContain('node_modules/serverless-http/index.js')
+    expect(fn2).not.toContain('node_modules/fastify/lib/route.js')
+    expect(fn2).not.toContain('node_modules/fastify/package.json')
+    expect(fn2).not.toContain('node_modules/fastify/')
+    expect(fn2).not.toContain('node_modules/fastify/lib/')
+    expect(fn2).not.toContain('node_modules/serverless-http/index.js')
+    expect(fn2).not.toContain('node_modules/serverless-http/')
+    expect(fn2).toContain('node_modules/keep/index.js')
+  })
+
+  test('service-level negation applies to all function zips', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/serverless-http/**'],
+    })
+    await packageWith(serviceDir, plugin, {
+      fn1: { handler: 'handler.hello' },
+      fn2: { handler: 'other.other' },
+    })
+    for (const fn of ['fn1', 'fn2']) {
+      const entries = await zipEntryNames(
+        path.join(serviceDir, '.serverless', `my-service-${fn}.zip`),
+      )
+      expect(entries).not.toContain('node_modules/serverless-http/index.js')
+      expect(entries).toContain('node_modules/fastify/lib/route.js')
+    }
+  })
+
+  test('re-include after broad negation (last match wins)', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/**', 'node_modules/keep/**'],
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    expect(entries).toContain('node_modules/keep/index.js')
+    expect(entries).not.toContain('node_modules/fastify/lib/route.js')
+    expect(entries).not.toContain('node_modules/serverless-http/index.js')
+  })
+
+  test('function negation removes a service-level additive include from that zip', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, { servicePatterns: ['assets/**'] })
+    await packageWith(serviceDir, plugin, {
+      fn1: { handler: 'handler.hello' },
+      fn2: {
+        handler: 'other.other',
+        package: { patterns: ['!assets/secret.txt'] },
+      },
+    })
+    const fn1 = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    const fn2 = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn2.zip'),
+    )
+    expect(fn1).toContain('assets/secret.txt')
+    expect(fn2).toContain('assets/logo.png')
+    expect(fn2).not.toContain('assets/secret.txt')
+  })
+
+  test('handler bundle and manifest entries are never excluded by patterns', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, { servicePatterns: ['!**'] })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    expect(entries).toContain('handler.js')
+  })
+
+  // The dir-husk assertions above use a literal-prefix pattern
+  // (`!node_modules/fastify/**`), which micromatch already matches against the
+  // bare path `node_modules/fastify` — so they pass even if the directory
+  // branch is collapsed into isPathIncluded. A wildcard-prefix pattern is what
+  // discriminates: micromatch does not match `node_modules/fastify` against
+  // `node_modules/*/**`, so only the isDirIncluded bare-base rule removes the
+  // husks. Collapse the branch and the three package directories survive here.
+  test('wildcard-prefix negation leaves no node_modules entries at all', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/*/**'],
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    expect(entries.filter((name) => name.startsWith('node_modules/'))).toEqual(
+      [],
+    )
+    expect(entries).toContain('handler.js')
+  })
+
+  // Hard constraint: pattern-less and positive-only configurations must produce
+  // byte-identical artifacts, because the artifact sha256 drives
+  // check-for-changes — any drift there forces a needless redeploy of every
+  // function. `node_modules/**` is a positive pattern that matches every
+  // archived entry (exercising the filter's pass-through) while adding nothing,
+  // since the fixture's node_modules lives under .serverless/build rather than
+  // in the service directory that additive includes are globbed from.
+  test('pattern-less and positive-only configs produce byte-identical artifacts', async () => {
+    const [noKey, emptyList, positiveOnly] = await Promise.all([
+      packageFixtureSha256({ omitPatternsKey: true }),
+      packageFixtureSha256({ servicePatterns: [] }),
+      packageFixtureSha256({ servicePatterns: ['node_modules/**'] }),
+    ])
+    expect(emptyList).toBe(noKey)
+    expect(positiveOnly).toBe(noKey)
+  })
+
+  // A positive pattern that DOES match files in the service directory adds
+  // exactly those entries and must leave every other entry's bytes alone.
+  test('a matching positive pattern only adds entries, altering nothing else', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['assets/logo.png'],
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const withInclude = path.join(
+      serviceDir,
+      '.serverless',
+      'my-service-fn1.zip',
+    )
+    const baselineDir = makeServiceDir()
+    const baselinePlugin = makePlugin(baselineDir)
+    await packageWith(baselineDir, baselinePlugin, {
+      fn1: { handler: 'handler.hello' },
+    })
+    const baseline = path.join(baselineDir, '.serverless', 'my-service-fn1.zip')
+
+    const fingerprint = async (artifactPath) => {
+      const zip = await JsZip.loadAsync(fs.readFileSync(artifactPath))
+      const entries = await Promise.all(
+        Object.values(zip.files).map(async (entry) => ({
+          name: entry.name,
+          date: entry.date.getTime(),
+          sha256: crypto
+            .createHash('sha256')
+            .update(await entry.async('nodebuffer'))
+            .digest('hex'),
+        })),
+      )
+      return entries.sort((a, b) => a.name.localeCompare(b.name))
+    }
+
+    const added = await fingerprint(withInclude)
+    const base = await fingerprint(baseline)
+    expect(added.map((e) => e.name)).toEqual(
+      ['assets/logo.png', ...base.map((e) => e.name)].sort((a, b) =>
+        a.localeCompare(b),
+      ),
+    )
+    expect(added.filter((e) => e.name !== 'assets/logo.png')).toEqual(base)
+  })
+
+  // An empty pattern ('' or a bare '!') reaches the pattern helpers from a
+  // variable that resolved to nothing. micromatch throws on it, which would
+  // fail packaging outright for a configuration where such a pattern was
+  // previously inert. Empty patterns are dropped at compile time instead,
+  // excluding nothing.
+  test.each([[['!']], [['']], [['!', '']]])(
+    'empty patterns %j exclude nothing and never fail packaging',
+    async (servicePatterns) => {
+      const serviceDir = makeServiceDir()
+      const plugin = makePlugin(serviceDir, { servicePatterns })
+      await packageWith(serviceDir, plugin, {
+        fn1: { handler: 'handler.hello' },
+      })
+      const entries = await zipEntryNames(
+        path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+      )
+      for (const expected of FULL_NODE_MODULES) {
+        expect(entries).toContain(expected)
+      }
+      expect(entries).toContain('handler.js')
+    },
+  )
+
+  // Byte-identity is asserted for the bare '!' only. globby reads '' as "match
+  // everything", so a '' pattern additionally pulls the whole service directory
+  // in as additive includes — long-standing behavior of the include glob, not
+  // something the entry filter decides.
+  test("a bare '!' pattern leaves the artifact byte-identical", async () => {
+    const [bang, noKey] = await Promise.all([
+      packageFixtureSha256({ servicePatterns: ['!'] }),
+      packageFixtureSha256({ omitPatternsKey: true }),
+    ])
+    expect(bang).toBe(noKey)
+  })
+
+  test('entry dates stay pinned when the filter is active', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/serverless-http/**'],
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const zip = await JsZip.loadAsync(
+      fs.readFileSync(
+        path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+      ),
+    )
+    for (const entry of Object.values(zip.files)) {
+      expect(entry.date.getFullYear()).toBe(1980)
+    }
+  })
+})
+
+describe('esbuild packaging honors package.patterns (_packageAll)', () => {
+  jest.setTimeout(30_000)
+
+  test('service-level negation applies to the single service zip', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/serverless-http/**'],
+    })
+    plugin.serverless.service.package.individually = false
+    await plugin._packageAll({ fn1: { handler: 'handler.hello' } })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service.zip'),
+    )
+    expect(entries).not.toContain('node_modules/serverless-http/index.js')
+    expect(entries).not.toContain('node_modules/serverless-http/')
+    expect(entries).toContain('node_modules/fastify/lib/route.js')
+  })
+
+  // Function-level patterns are only honored when packaging individually, which
+  // matches classic packaging: a single shared zip has no per-function view to
+  // narrow. Pinned so the mirrored filter never silently starts reading them.
+  test('function-level patterns are ignored by _packageAll', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+    plugin.serverless.service.package.individually = false
+    await plugin._packageAll({
+      fn1: {
+        handler: 'handler.hello',
+        package: { patterns: ['!node_modules/fastify/**'] },
+      },
+    })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service.zip'),
+    )
+    expect(entries).toContain('node_modules/fastify/lib/route.js')
+  })
+
+  // Same hard constraint as the individually path: the single service zip's
+  // sha256 drives check-for-changes, so routing entries through the filter must
+  // not shift a single byte for configurations that exclude nothing.
+  test('pattern-less and positive-only configs produce byte-identical artifacts', async () => {
+    const packageAllSha256 = async (pluginOptions) => {
+      const serviceDir = makeServiceDir()
+      const plugin = makePlugin(serviceDir, pluginOptions)
+      plugin.serverless.service.package.individually = false
+      await plugin._packageAll({ fn1: { handler: 'handler.hello' } })
+      return artifactSha256(
+        path.join(serviceDir, '.serverless', 'my-service.zip'),
+      )
+    }
+    const [noKey, emptyList, positiveOnly] = await Promise.all([
+      packageAllSha256({ omitPatternsKey: true }),
+      packageAllSha256({ servicePatterns: [] }),
+      packageAllSha256({ servicePatterns: ['node_modules/**'] }),
+    ])
+    expect(emptyList).toBe(noKey)
+    expect(positiveOnly).toBe(noKey)
+  })
+})
+
+describe('esbuild patterns observability', () => {
+  jest.setTimeout(30_000)
+  const esbuildLogger = log.get('esbuild')
+  let infoSpy
+  let warningSpy
+  let debugSpy
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(esbuildLogger, 'info').mockImplementation(() => {})
+    warningSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    debugSpy = jest.spyOn(esbuildLogger, 'debug').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    infoSpy.mockRestore()
+    warningSpy.mockRestore()
+    debugSpy.mockRestore()
+  })
+
+  test('info log names the artifact and count only when entries were excluded', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/serverless-http/**'],
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const infoMessages = infoSpy.mock.calls.map((c) => c[0])
+    expect(
+      infoMessages.some(
+        (m) =>
+          m.includes('my-service-fn1.zip') && m.includes('package.patterns'),
+      ),
+    ).toBe(true)
+  })
+
+  test('no info log when nothing was excluded', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir)
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const infoMessages = infoSpy.mock.calls.map((c) => c[0])
+    expect(infoMessages.some((m) => m.includes('package.patterns'))).toBe(false)
+  })
+
+  test('warning fires once when patterns strip all of node_modules under packages: external', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/**'],
+    })
+    plugin._buildProperties = async () => ({ packages: 'external' })
+    await packageWith(serviceDir, plugin, {
+      fn1: { handler: 'handler.hello' },
+      fn2: { handler: 'other.other' },
+    })
+    const warnings = warningSpy.mock.calls
+      .map((c) => c[0])
+      .filter((m) => m.includes('node_modules'))
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('packages: external')
+  })
+
+  test('no warning without packages: external', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/**'],
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    expect(
+      warningSpy.mock.calls
+        .map((c) => c[0])
+        .filter((m) => m.includes('node_modules')),
+    ).toHaveLength(0)
+  })
+
+  // The warning claims the patterns emptied node_modules, so only exclusions
+  // made by the node_modules walk may arm it. A service that bundles its
+  // dependencies (nothing under node_modules to keep) and merely narrows an
+  // additive include has not touched node_modules, and telling it to review
+  // those patterns would be plainly wrong.
+  test('no warning when only additive includes were excluded', async () => {
+    const serviceDir = makeServiceDir({ emptyNodeModules: true })
+    const plugin = makePlugin(serviceDir, { servicePatterns: ['assets/**'] })
+    plugin._buildProperties = async () => ({ packages: 'external' })
+    await packageWith(serviceDir, plugin, {
+      fn1: {
+        handler: 'handler.hello',
+        package: { patterns: ['!assets/secret.txt'] },
+      },
+    })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    // Guard the premise: the additive include really was excluded, so the
+    // total counter is non-zero and only its node_modules scoping suppresses
+    // the warning.
+    expect(entries).toContain('assets/logo.png')
+    expect(entries).not.toContain('assets/secret.txt')
+    const infoMessages = infoSpy.mock.calls.map((c) => c[0])
+    expect(infoMessages.some((m) => m.includes('package.patterns'))).toBe(true)
+    expect(warningSpy.mock.calls.map((c) => c[0])).toEqual([])
+  })
+
+  // The debug trace is unconditional, so it is the only record of what the
+  // filter decided for a run that excluded nothing — it must carry the compiled
+  // patterns and both counters even then.
+  test('debug trace records patterns and counters for every function', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/serverless-http/**'],
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const traces = debugSpy.mock.calls
+      .map((c) => c[0])
+      .filter((m) => typeof m === 'string' && m.includes('package.patterns'))
+    expect(traces).toHaveLength(1)
+    expect(traces[0]).toContain('fn1')
+    expect(traces[0]).toContain('node_modules/serverless-http/**')
+    expect(traces[0]).toMatch(/excluded \d+/)
+    expect(traces[0]).toMatch(/node_modules entries excluded \d+/)
+    expect(traces[0]).toMatch(/node_modules files kept \d+/)
+  })
+
+  test('_packageAll logs the exclusion count against the service zip', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: ['!node_modules/serverless-http/**'],
+    })
+    plugin.serverless.service.package.individually = false
+    await plugin._packageAll({ fn1: { handler: 'handler.hello' } })
+    const infoMessages = infoSpy.mock.calls.map((c) => c[0])
+    expect(
+      infoMessages.some(
+        (m) => m.includes('my-service.zip') && m.includes('package.patterns'),
+      ),
+    ).toBe(true)
+    const traces = debugSpy.mock.calls
+      .map((c) => c[0])
+      .filter((m) => typeof m === 'string' && m.includes('package.patterns'))
+    expect(traces).toHaveLength(1)
+    expect(traces[0]).toContain('my-service.zip')
+  })
+})
+
+// Pattern filtering must not reintroduce the entry-order race that made
+// artifact hashes differ between identical runs (and therefore forced phantom
+// redeploys through check-for-changes). Entries are filtered after the sort, so
+// the sequence of appends stays fixed — pinned here by packaging the same
+// unchanged service repeatedly with filtering active and comparing the entry
+// order and the whole-zip sha256, the same way packaging-determinism.test.js
+// pins the unfiltered path.
+describe('esbuild patterns determinism', () => {
+  jest.setTimeout(60_000)
+
+  // Many small files across several packages, so an ordering leak in the
+  // filtered walk shows up reliably rather than by luck.
+  function makeRacyServiceDir() {
+    const serviceDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'sls-esbuild-pat-'),
+    )
+    const buildDir = path.join(serviceDir, '.serverless', 'build')
+    for (const dep of ['dep-a', 'dep-b', 'dep-c', 'keep']) {
+      const depDir = path.join(buildDir, 'node_modules', dep)
+      fs.mkdirSync(path.join(depDir, 'lib'), { recursive: true })
+      fs.writeFileSync(path.join(depDir, 'package.json'), `{"name":"${dep}"}\n`)
+      fs.writeFileSync(path.join(depDir, 'index.js'), 'module.exports = 1\n')
+      fs.writeFileSync(
+        path.join(depDir, 'lib', 'util.js'),
+        'module.exports = 2\n',
+      )
+    }
+    fs.writeFileSync(path.join(buildDir, 'package.json'), '{"name":"svc"}\n')
+    fs.writeFileSync(path.join(buildDir, 'package-lock.json'), '{}\n')
+    fs.mkdirSync(path.join(buildDir, 'src'), { recursive: true })
+    const racyFunctions = {}
+    for (let i = 0; i < 6; i++) {
+      fs.writeFileSync(
+        path.join(buildDir, 'src', `fn${i}.js`),
+        `export const handler = async () => ({ statusCode: 20${i} })\n`,
+      )
+      fs.writeFileSync(
+        path.join(buildDir, 'src', `fn${i}.js.map`),
+        `{"version":3,"file":"fn${i}.js"}\n`,
+      )
+      racyFunctions[`fn${i}`] = { handler: `src/fn${i}.handler` }
+    }
+    fs.writeFileSync(path.join(serviceDir, 'static-a.txt'), 'a\n')
+    fs.writeFileSync(path.join(serviceDir, 'static-b.txt'), 'b\n')
+    return { serviceDir, racyFunctions }
+  }
+
+  // Excludes whole packages, re-includes one of them, and drops one additive
+  // include — so every filtered code path (node_modules files, node_modules
+  // directory husks, and the includes list) contributes to the artifact.
+  const FILTERING_PATTERNS = [
+    'static-*.txt',
+    '!static-b.txt',
+    '!node_modules/**',
+    'node_modules/keep/**',
+  ]
+
+  async function zipFingerprint(artifactPath) {
+    const bytes = fs.readFileSync(artifactPath)
+    const zip = await JsZip.loadAsync(bytes)
+    return {
+      hash: crypto.createHash('sha256').update(bytes).digest('hex'),
+      order: Object.values(zip.files).map((entry) => entry.name),
+    }
+  }
+
+  test('individual packaging stays byte-identical across 6 runs with filtering active', async () => {
+    const { serviceDir, racyFunctions } = makeRacyServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: FILTERING_PATTERNS,
+    })
+    plugin.functions = async () => racyFunctions
+
+    const fingerprints = []
+    for (let run = 0; run < 6; run++) {
+      await plugin._package()
+      fingerprints.push(
+        await zipFingerprint(
+          path.join(serviceDir, '.serverless', 'my-service-fn0.zip'),
+        ),
+      )
+    }
+
+    for (const fingerprint of fingerprints.slice(1)) {
+      expect(fingerprint.order).toEqual(fingerprints[0].order)
+      expect(fingerprint.hash).toBe(fingerprints[0].hash)
+    }
+    // Guard the premise: the patterns really did filter this artifact.
+    const entries = fingerprints[0].order
+    expect(entries).toContain('node_modules/keep/lib/util.js')
+    expect(entries).toContain('static-a.txt')
+    expect(entries).not.toContain('static-b.txt')
+    expect(
+      entries.filter(
+        (name) =>
+          name.startsWith('node_modules/') &&
+          !name.startsWith('node_modules/keep'),
+      ),
+    ).toEqual([])
+  })
+
+  test('_packageAll stays byte-identical across 6 runs with filtering active', async () => {
+    const { serviceDir, racyFunctions } = makeRacyServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: FILTERING_PATTERNS,
+    })
+    plugin.serverless.service.package.individually = false
+
+    const fingerprints = []
+    for (let run = 0; run < 6; run++) {
+      await plugin._packageAll(racyFunctions)
+      fingerprints.push(
+        await zipFingerprint(
+          path.join(serviceDir, '.serverless', 'my-service.zip'),
+        ),
+      )
+    }
+
+    for (const fingerprint of fingerprints.slice(1)) {
+      expect(fingerprint.order).toEqual(fingerprints[0].order)
+      expect(fingerprint.hash).toBe(fingerprints[0].hash)
+    }
+    const entries = fingerprints[0].order
+    expect(entries).toContain('node_modules/keep/lib/util.js')
+    expect(entries).toContain('static-a.txt')
+    expect(entries).not.toContain('static-b.txt')
+    expect(
+      entries.filter(
+        (name) =>
+          name.startsWith('node_modules/') &&
+          !name.startsWith('node_modules/keep'),
+      ),
+    ).toEqual([])
+  })
+})
+
+// package.patterns must not become a way to route around an unreadable file.
+// Every walked entry is stat'ed before the patterns get a say, so an entry that
+// cannot be read fails packaging even when the patterns would have dropped it —
+// the same fail-fast contract as an entry that the patterns keep. Reordering the
+// walk to filter before the stat would silently turn "cannot read" into
+// "silently skipped", so both packaging paths pin the behavior here.
+describe('esbuild patterns cannot suppress an unreadable entry', () => {
+  jest.setTimeout(30_000)
+
+  // The unreadable file sits under a package that the patterns exclude wholesale.
+  function makeServiceDirWithUnreadableExcludedEntry() {
+    const serviceDir = makeServiceDir()
+    fs.writeFileSync(
+      path.join(
+        serviceDir,
+        '.serverless',
+        'build',
+        'node_modules',
+        'fastify',
+        UNREADABLE_ENTRY,
+      ),
+      'x\n',
+    )
+    return serviceDir
+  }
+
+  const EXCLUDING_PATTERNS = ['!node_modules/fastify/**']
+
+  test('individual packaging still fails when an excluded entry is unreadable', async () => {
+    const serviceDir = makeServiceDirWithUnreadableExcludedEntry()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: EXCLUDING_PATTERNS,
+    })
+    plugin.functions = async () => ({ fn1: { handler: 'handler.hello' } })
+
+    await expect(plugin._package()).rejects.toMatchObject({
+      code: 'CANNOT_READ_FILE',
+      message: expect.stringContaining(UNREADABLE_ENTRY),
+    })
+  })
+
+  test('_packageAll still fails when an excluded entry is unreadable', async () => {
+    const serviceDir = makeServiceDirWithUnreadableExcludedEntry()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: EXCLUDING_PATTERNS,
+    })
+    plugin.serverless.service.package.individually = false
+
+    await expect(
+      plugin._packageAll({ fn1: { handler: 'handler.hello' } }),
+    ).rejects.toMatchObject({
+      code: 'CANNOT_READ_FILE',
+      message: expect.stringContaining(UNREADABLE_ENTRY),
+    })
+  })
+
+  // Guard the premise: without the unreadable file, the very same patterns
+  // package cleanly and really do drop that package — so the rejections above
+  // are caused by the unreadable entry, not by the patterns themselves.
+  test('the same patterns package cleanly when every entry is readable', async () => {
+    const serviceDir = makeServiceDir()
+    const plugin = makePlugin(serviceDir, {
+      servicePatterns: EXCLUDING_PATTERNS,
+    })
+    await packageWith(serviceDir, plugin, { fn1: { handler: 'handler.hello' } })
+    const entries = await zipEntryNames(
+      path.join(serviceDir, '.serverless', 'my-service-fn1.zip'),
+    )
+    expect(entries).toContain('node_modules/keep/index.js')
+    expect(
+      entries.filter((name) => name.startsWith('node_modules/fastify')),
+    ).toEqual([])
+  })
+})

--- a/packages/serverless/test/unit/lib/utils/package-patterns-parity.test.js
+++ b/packages/serverless/test/unit/lib/utils/package-patterns-parity.test.js
@@ -1,0 +1,196 @@
+/**
+ * Pins the package-patterns helper to the exact semantics of the classic
+ * packaging engine's resolveFilePathsFromPatterns (which this PR deliberately
+ * does NOT modify). If either side ever drifts, this suite fails.
+ *
+ * Classic evaluates: enumerate globby(['**', ...include]) then apply the
+ * ordered toggle. The helper is handed the same enumeration; outputs must be
+ * identical (order-insensitive compare: classic returns object-key order).
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { globby } from 'globby'
+import packageService from '../../../../lib/plugins/package/lib/package-service.js'
+import {
+  compilePatterns,
+  filterPaths,
+} from '../../../../lib/utils/package-patterns.js'
+
+const fixtureDirs = []
+
+afterAll(() => {
+  for (const dir of fixtureDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+function makeFixtureDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-patterns-parity-'))
+  fixtureDirs.push(dir)
+  const write = (rel, content = 'x\n') => {
+    fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true })
+    fs.writeFileSync(path.join(dir, rel), content)
+  }
+  write('handler.js')
+  write('assets/logo.png')
+  write('assets/secret.txt')
+  write('.env')
+  write('dist/handler.js.map')
+  write('node_modules/fastify/package.json')
+  write('node_modules/fastify/lib/route.js')
+  write('node_modules/fastify/.internal/hidden.js')
+  write('node_modules/keep/index.js')
+  write('node_modules/serverless-http/index.js')
+  return dir
+}
+
+async function classicResolve(serviceDir, includePatterns) {
+  const ctx = { serverless: { serviceDir, config: { serviceDir } } }
+  return packageService.resolveFilePathsFromPatterns.call(ctx, {
+    exclude: [],
+    include: includePatterns,
+    devDependencyExcludeSet: new Set(),
+  })
+}
+
+async function helperResolve(serviceDir, includePatterns) {
+  // Same enumeration the classic engine performs.
+  const allFilePaths = await globby(['**'].concat(includePatterns), {
+    cwd: serviceDir,
+    dot: true,
+    silent: true,
+    follow: true,
+    nodir: true,
+    expandDirectories: false,
+  })
+  return filterPaths(compilePatterns(includePatterns), allFilePaths)
+}
+
+/**
+ * Second harness: patterns routed through classic's `exclude` parameter.
+ *
+ * Classic hands globby only `['**', ...include]`, so negations that arrive via
+ * `include` are already applied at enumeration time and its micromatch toggle
+ * has nothing left to drop. Negations routed through `exclude` reach the toggle
+ * *only* -- which is how the framework feeds `defaultExcludes`, the
+ * service-config excludes and the dev-dependency exclusions. Comparing on that
+ * route is what actually exercises the exclusion half of the toggle.
+ *
+ * Classic's ordering is `exclude...` first, then `include...` (see
+ * resolveFilePathsFromPatterns); the helper is handed that same ordered list.
+ *
+ * Note how classic normalizes an exclude entry: a plain entry is negated, but
+ * an entry that ALREADY starts with `!` has that `!` *stripped* and becomes a
+ * positive pattern (package-service.js, the params.exclude loop). That is the
+ * only way to get a positive-then-negation pattern order out of this route, so
+ * it is also how the ordering row below is built -- do not "simplify" the
+ * mapping to an unconditional `!` prefix.
+ */
+async function classicResolveSplit(serviceDir, { exclude, include }) {
+  const ctx = { serverless: { serviceDir, config: { serviceDir } } }
+  return packageService.resolveFilePathsFromPatterns.call(ctx, {
+    exclude,
+    include,
+    devDependencyExcludeSet: new Set(),
+  })
+}
+
+async function helperResolveSplit(serviceDir, { exclude, include }) {
+  const allFilePaths = await globby(['**'].concat(include), {
+    cwd: serviceDir,
+    dot: true,
+    silent: true,
+    follow: true,
+    nodir: true,
+    expandDirectories: false,
+  })
+  const ordered = [
+    ...exclude.map((pattern) =>
+      pattern.startsWith('!') ? pattern.slice(1) : `!${pattern}`,
+    ),
+    ...include,
+  ]
+  return filterPaths(compilePatterns(ordered), allFilePaths)
+}
+
+const SPLIT_PATTERN_SETS = [
+  { exclude: ['node_modules/fastify/**'], include: [] },
+  { exclude: ['node_modules/**'], include: ['node_modules/keep/**'] },
+  { exclude: ['**/*.map', '.env'], include: [] },
+  { exclude: ['assets/**'], include: ['assets/logo.png'] },
+  {
+    exclude: ['node_modules/**'],
+    include: ['node_modules/keep/index.js', 'assets/**'],
+  },
+  // Negation AFTER a positive -- the shape of the commonest real pattern list
+  // (`['assets/**', '!assets/secret.txt']`). Classic's exclude loop turns this
+  // into patterns `['assets/logo.png', '!assets/**']`, so the negation is last
+  // and must win over the earlier positive. Every other row here emits all
+  // negations first, which leaves "last match wins" unpinned: a matcher that
+  // sorted negations to the front would pass them all.
+  { exclude: ['!assets/logo.png', 'assets/**'], include: [] },
+  // Same shape, with the trailing negation re-excluding a path an earlier
+  // positive had rescued from a broader pattern.
+  {
+    exclude: ['!node_modules/keep/index.js', 'node_modules/**'],
+    include: [],
+  },
+]
+
+const PATTERN_SETS = [
+  ['!node_modules/fastify/**'],
+  ['!node_modules/**'],
+  ['!node_modules/**', 'node_modules/keep/**'],
+  ['!**/*.map'],
+  ['assets/**', '!assets/secret.txt'],
+  ['!.env'],
+  ['!assets/**', 'assets/logo.png', '!node_modules/serverless-http/**'],
+  [
+    'node_modules/keep/**',
+    '!node_modules/keep/**',
+    'node_modules/keep/index.js',
+  ],
+]
+
+describe('package-patterns parity with classic resolveFilePathsFromPatterns', () => {
+  test.each(PATTERN_SETS.map((p) => [p.join(' , '), p]))(
+    'patterns: %s',
+    async (_label, patterns) => {
+      const dir = makeFixtureDir()
+      const classic = await classicResolve(dir, patterns)
+      const helper = await helperResolve(dir, patterns)
+      expect(helper.sort()).toEqual(classic.sort())
+    },
+  )
+
+  test('all-excluded: classic throws, helper returns empty list', async () => {
+    const dir = makeFixtureDir()
+    await expect(classicResolve(dir, ['!**'])).rejects.toThrow(
+      'No file matches include / exclude patterns',
+    )
+    await expect(helperResolve(dir, ['!**'])).resolves.toEqual([])
+  })
+
+  test.each(
+    SPLIT_PATTERN_SETS.map((set) => [
+      `exclude ${JSON.stringify(set.exclude)} include ${JSON.stringify(set.include)}`,
+      set,
+    ]),
+  )('exclude-routed %s', async (_label, set) => {
+    const dir = makeFixtureDir()
+    const classic = await classicResolveSplit(dir, set)
+    const helper = await helperResolveSplit(dir, set)
+    // Guard against a vacuous comparison: on this route the toggle must have
+    // dropped something, otherwise the row proves nothing about exclusion.
+    const everyFile = await globby(['**'], {
+      cwd: dir,
+      dot: true,
+      nodir: true,
+      expandDirectories: false,
+    })
+    expect(classic.length).toBeLessThan(everyFile.length)
+    expect(helper.sort()).toEqual(classic.sort())
+  })
+})

--- a/packages/serverless/test/unit/lib/utils/package-patterns.test.js
+++ b/packages/serverless/test/unit/lib/utils/package-patterns.test.js
@@ -1,0 +1,160 @@
+import {
+  compilePatterns,
+  isPathIncluded,
+  isDirIncluded,
+  filterPaths,
+} from '../../../../lib/utils/package-patterns.js'
+
+describe('package-patterns', () => {
+  describe('compilePatterns', () => {
+    test('splits negation prefix and keeps order', () => {
+      expect(
+        compilePatterns(['!node_modules/**', 'node_modules/keep/**']),
+      ).toEqual([
+        { negated: true, pattern: 'node_modules/**' },
+        { negated: false, pattern: 'node_modules/keep/**' },
+      ])
+    })
+
+    test('defaults to empty list', () => {
+      expect(compilePatterns()).toEqual([])
+      expect(compilePatterns([])).toEqual([])
+    })
+
+    // An empty pattern carries no glob, so it cannot toggle anything -- and
+    // micromatch rejects the empty string outright ("Expected pattern to be a
+    // non-empty string"), which would fail packaging for a configuration that
+    // used to package fine. `''` and a bare `'!'` are reachable without a typo,
+    // from a variable resolving to nothing.
+    test('drops empty patterns, keeping the surrounding ones', () => {
+      expect(compilePatterns(['', '!'])).toEqual([])
+      expect(
+        compilePatterns(['!', 'assets/**', '', '!assets/secret.txt']),
+      ).toEqual([
+        { negated: false, pattern: 'assets/**' },
+        { negated: true, pattern: 'assets/secret.txt' },
+      ])
+    })
+
+    test('every helper tolerates empty patterns instead of throwing', () => {
+      const compiled = compilePatterns(['!', '', '!assets/secret.txt'])
+      expect(() => isPathIncluded(compiled, 'assets/logo.png')).not.toThrow()
+      expect(() => isDirIncluded(compiled, 'assets')).not.toThrow()
+      expect(() => filterPaths(compiled, ['assets/logo.png'])).not.toThrow()
+      // The surviving real pattern still applies.
+      expect(isPathIncluded(compiled, 'assets/secret.txt')).toBe(false)
+      expect(isPathIncluded(compiled, 'assets/logo.png')).toBe(true)
+      expect(filterPaths(compiled, [])).toEqual([])
+    })
+  })
+
+  describe('isPathIncluded (ordered toggle, last match wins)', () => {
+    test('no patterns keeps everything included', () => {
+      expect(isPathIncluded([], 'node_modules/fastify/lib/route.js')).toBe(true)
+    })
+
+    test('negation excludes matching file', () => {
+      const compiled = compilePatterns(['!node_modules/fastify/**'])
+      expect(
+        isPathIncluded(compiled, 'node_modules/fastify/lib/route.js'),
+      ).toBe(false)
+      expect(isPathIncluded(compiled, 'node_modules/other/index.js')).toBe(true)
+    })
+
+    test('later positive pattern re-includes (last match wins)', () => {
+      const compiled = compilePatterns([
+        '!node_modules/**',
+        'node_modules/keep/**',
+      ])
+      expect(isPathIncluded(compiled, 'node_modules/keep/index.js')).toBe(true)
+      expect(isPathIncluded(compiled, 'node_modules/drop/index.js')).toBe(false)
+    })
+
+    test('later negation wins over earlier positive', () => {
+      const compiled = compilePatterns(['assets/**', '!assets/secret.txt'])
+      expect(isPathIncluded(compiled, 'assets/logo.png')).toBe(true)
+      expect(isPathIncluded(compiled, 'assets/secret.txt')).toBe(false)
+    })
+
+    test('matches dotfiles (dot: true)', () => {
+      const compiled = compilePatterns(['!node_modules/pkg/.internal/**'])
+      expect(isPathIncluded(compiled, 'node_modules/pkg/.internal/x.js')).toBe(
+        false,
+      )
+    })
+
+    // micromatch's globstar matches zero segments, so `X/**` also matches the
+    // bare path `X`. Classic packaging feeds this toggle file paths only
+    // (globby runs with `nodir: true`), so bare directory entries never reach
+    // it there; the directory-aware form below is what deals with them.
+    test('bare directory path is matched by X/** (globstar matches zero segments)', () => {
+      const compiled = compilePatterns(['!node_modules/fastify/**'])
+      expect(isPathIncluded(compiled, 'node_modules/fastify')).toBe(false)
+    })
+  })
+
+  describe('isDirIncluded (bare-base rule for directory entries)', () => {
+    test('negated X/** also excludes the bare directory X', () => {
+      const compiled = compilePatterns(['!node_modules/fastify/**'])
+      expect(isDirIncluded(compiled, 'node_modules/fastify')).toBe(false)
+      expect(isDirIncluded(compiled, 'node_modules/fastify/lib')).toBe(false)
+      expect(isDirIncluded(compiled, 'node_modules/other')).toBe(true)
+    })
+
+    test('re-included subtree keeps its bare directory', () => {
+      const compiled = compilePatterns([
+        '!node_modules/**',
+        'node_modules/keep/**',
+      ])
+      expect(isDirIncluded(compiled, 'node_modules/keep')).toBe(true)
+      expect(isDirIncluded(compiled, 'node_modules/drop')).toBe(false)
+    })
+
+    // Do NOT collapse isDirIncluded into isPathIncluded. For a literal prefix
+    // the two agree (micromatch's globstar matches zero segments), but for a
+    // `/**` pattern with a wildcard in its prefix they diverge: micromatch does
+    // not match `foo/bar` against `foo/*/**`, while the stripped base `foo/*`
+    // does — which is exactly what makes the directory entry get dropped.
+    test('diverges from isPathIncluded for /** patterns with a wildcard prefix', () => {
+      const compiled = compilePatterns(['!foo/*/**'])
+      expect(isPathIncluded(compiled, 'foo/bar')).toBe(true)
+      expect(isDirIncluded(compiled, 'foo/bar')).toBe(false)
+      // Files under the excluded subtree drop out of both forms.
+      expect(isPathIncluded(compiled, 'foo/bar/index.js')).toBe(false)
+      expect(isDirIncluded(compiled, 'foo/bar/lib')).toBe(false)
+    })
+  })
+
+  describe('filterPaths (batch form)', () => {
+    test('applies ordered toggle over a list, preserving list order', () => {
+      const compiled = compilePatterns([
+        '!node_modules/**',
+        'node_modules/keep/**',
+      ])
+      expect(
+        filterPaths(compiled, [
+          'src/handler.js',
+          'node_modules/drop/index.js',
+          'node_modules/keep/index.js',
+        ]),
+      ).toEqual(['src/handler.js', 'node_modules/keep/index.js'])
+    })
+
+    test('agrees with isPathIncluded on every path', () => {
+      const compiled = compilePatterns([
+        'assets/**',
+        '!assets/secret.txt',
+        '!**/*.map',
+      ])
+      const paths = [
+        'assets/logo.png',
+        'assets/secret.txt',
+        'dist/handler.js.map',
+        'dist/handler.js',
+      ]
+      expect(filterPaths(compiled, paths)).toEqual(
+        paths.filter((p) => isPathIncluded(compiled, p)),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Honor `package.patterns` negation patterns (`!...`) when the built-in esbuild build packages function artifacts — both with `package.individually` (per-function zips) and for combined-service packaging
- Function-level patterns are merged after service-level patterns (function wins on conflict), matching the merge order documented for classic packaging; without `individually`, function-level patterns are ignored, consistent with classic packaging, which already warns about that combination
- Fully excluded `node_modules` subtrees leave no empty directory entries in the zip
- The compiled handler bundle, its sourcemap (when emitted), and `package.json`/lockfile are always packaged and cannot be excluded via patterns
- Observability: a per-artifact `Excluded <N> entries from <zip> via package.patterns` info line (visible with `--verbose`), a once-per-run warning when patterns exclude everything under `node_modules` while `packages: external` is active, and debug traces of the merged pattern list and included/excluded entry counts
- New pure helper `packages/serverless/lib/utils/package-patterns.js` mirrors classic packaging's ordered last-match-wins pattern semantics; a parity test suite runs the helper and the real classic `resolveFilePathsFromPatterns` against the same fixture trees and fails CI on any drift
- Docs: `docs/sf/providers/aws/guide/building.md` gains a "Packaging Patterns" section stating which parts of an esbuild artifact patterns apply to
- Classic (non-esbuild) packaging source is untouched; artifacts for configs without negation patterns remain content-identical

## Root cause

With `build.esbuild` active, `package.patterns` were only used as a positive glob to add extra files from the source directory. Negation patterns match nothing in a positive glob, so they were silently ignored, and the entire shared `.serverless/build/node_modules` tree was copied into every function artifact via `zip.directory()` with no filtering. This contradicted the packaging docs ("Packaging functions separately"), which state that per-function patterns merge with service-wide patterns and support `!` exclusions.

The fix applies the ordered pattern toggle (last match wins, same semantics as classic packaging) as a predicate over the deterministic sorted entry walk introduced in #13794, and runs the additional-include list through the same compiled toggle, so a function-level negation can also drop a service-level include. Filtering happens after the sort, so entry-order determinism is preserved (pinned by 6-run hash-stability tests with filtering active). Patterns cannot suppress the fail-fast contract: an unreadable file under `node_modules` still fails packaging with `CANNOT_READ_FILE` even when patterns exclude it (test-enforced on both packaging paths).

## Test plan

- [x] 61 new unit tests across 3 suites: helper semantics (`package-patterns.test.js`), classic-engine parity (`package-patterns-parity.test.js`), and artifact filtering incl. whole-zip sha256 identity for pattern-less configs, 6-run hash stability with filtering active, directory-entry pruning, warning dedupe, unreadable-entry fail-fast, and `_packageAll` (`package-patterns-filtering.test.js`)
- [x] Full unit suite green: 191 suites, 3697 tests; all determinism/fail-fast suites from #13794 untouched and passing
- [x] Live A/B packaging against `main`: the function with negations loses exactly the 416 targeted entries (2361 → 1945 zip entries), zero collateral; the function without patterns produces a **byte-identical artifact** (whole-zip sha256 equal between the `main` CLI and this branch's CLI)
- [x] Hash stability with negations at scale: a ~2,700-entry service packaged 3× with a `!node_modules/<dep>/**` negation — hashes constant across runs, entry-list diff shows exactly that dependency's subtree (+ its directory entry) removed and nothing else
- [x] Exclude-everything warning fires exactly once per run (both functions met the trigger; one line printed), visible without `--verbose`
- [x] Lint and Prettier clean on all changed files
- [x] No classic packaging source file modified (`git status` on `packages/serverless/lib/plugins/package/` clean)

Coverage notes, for reviewer awareness:

- The parity suite does not cover `devDependencyExcludeSet` ordering (untested on both engines) or directory-entry pruning (classic packaging enumerates files only, so zip directory entries have no classic counterpart to compare against; the pruning behavior is pinned by dedicated esbuild-side tests instead).
- The `Excluded <N> entries` line is emitted at the `info` level, so it appears only with `--verbose` — consistent with classic packaging's exclusion logging.
- Directory includes (a defensively-handled branch that globby's `onlyFiles` default makes unreachable from user config) intentionally receive no pattern predicate; commented at both call sites.

## How to test

Use a project with `build.esbuild` + `packages: external`, `package.individually: true`, and per-function negation patterns:

```yaml
build:
  esbuild:
    bundle: true
    packages: external

package:
  individually: true

functions:
  function1:
    handler: src/fn1.handler
  function2:
    handler: src/fn2.handler
    package:
      patterns:
        - '!node_modules/fastify/**'
        - '!node_modules/serverless-http/**'
```

where both functions depend on `fastify` and `serverless-http` among other dependencies.

```bash
# 1. Bug on the released CLI: negations are silently ignored
rm -rf .serverless
serverless package
unzip -l .serverless/*function2.zip | grep -cE "node_modules/(fastify|serverless-http)/"
# -> 416 (entries the patterns should have excluded are all present)

# 2. Fix on this branch (CLI run from source)
rm -rf .serverless
node <path-to-this-checkout>/packages/sf-core/bin/sf-core.js package
unzip -l .serverless/*function2.zip | grep -cE "node_modules/(fastify|serverless-http)/"
# -> 0
unzip -l .serverless/*function2.zip | grep -E "node_modules/(fastify|serverless-http)/$"
# -> no output: no empty directory entries left behind
unzip -l .serverless/*function1.zip | tail -2
# -> same entry count as before the fix: a function without patterns is untouched

# 3. Exclusion visibility (info level, requires --verbose)
rm -rf .serverless
node <path-to-this-checkout>/packages/sf-core/bin/sf-core.js package --verbose 2>&1 | grep "via package.patterns"
# -> Excluded 416 entries from <service>-function2.zip via package.patterns

# 4. Exclude-everything warning: temporarily add a service-level pattern
#      package:
#        patterns:
#          - '!node_modules/**'
#    and repackage. Exactly one warning prints (no --verbose needed):
#    "package.patterns exclude everything under node_modules, but "packages: external"
#     requires dependencies in the artifact. If dependencies are provided another way
#     (e.g. a Lambda layer) or this exclusion predates build.esbuild, review or remove
#     these patterns."

# 5. Unit tests
npm run test:unit -w @serverless/framework -- package-patterns
# -> 3 suites, 61 tests
```

## Release note callout (behavior-activating fix)

This fix activates configuration that was previously inert. Any existing `package.patterns` negations in a `build.esbuild` service — patterns that have had no effect until now — take effect on the next deploy and remove the matched files from the artifacts.

Two configurations deserve explicit attention:

- **Exclude-everything:** `!node_modules/**` combined with `packages: external` (common in Lambda-layer setups, or carried over from before adopting `build.esbuild`) now produces artifacts without their dependencies. The new once-per-run warning flags exactly this case.
- **Cherry-picking (activates silently):** exclude-everything plus re-includes, e.g. `!node_modules/**` + `node_modules/some-dep/**`. Re-include patterns match only the named package's own files — never its transitive dependencies, which live as sibling directories. These are the documented semantics (classic packaging has always worked this way), but the re-include list has not been enforced while `build.esbuild` ignored patterns, so lists written before that period may no longer cover everything the kept packages need. Verify the list still includes the transitive dependencies of every package you keep, or the function fails at invocation with `Cannot find module`. No warning covers this case, since partial exclusion is indistinguishable from intended use.

Recommendation: ship in the same **minor** release as #13794 with a prominent release-note entry asking users to review existing negation patterns under `build.esbuild` before upgrading. This change adds no independent artifact churn on top of #13794: configurations without negation patterns produce byte-identical artifacts to that base, so the two changes share a single "artifacts re-upload once on the first post-upgrade deploy" story.

## Related

Closes #12813
Closes #12742


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `package.patterns` when packaging esbuild artifacts.
  - Patterns can include or exclude dependencies, additional files, and directories, with ordered re-inclusion support.
  - Added documentation explaining how packaging patterns affect build artifacts.

- **Bug Fixes**
  - Improved packaging consistency and archive determinism.
  - Preserved symlinks and required build outputs during filtering.
  - Added clearer diagnostics for packaging patterns and missing external dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->