### PR TITLE
chore: bump internal custom-resource runtime to nodejs24.x

### DIFF
--- a/packages/serverless/lib/plugins/aws/custom-resources/index.js
+++ b/packages/serverless/lib/plugins/aws/custom-resources/index.js
@@ -189,7 +189,7 @@ async function addCustomResourceToService(
       FunctionName: absoluteFunctionName,
       Handler,
       MemorySize: 1024,
-      Runtime: 'nodejs22.x',
+      Runtime: 'nodejs24.x',
       Timeout: 180,
     },
     DependsOn: [],

--- a/packages/serverless/lib/plugins/aws/custom-resources/resources/utils.js
+++ b/packages/serverless/lib/plugins/aws/custom-resources/resources/utils.js
@@ -81,15 +81,16 @@ function getEnvironment(context) {
 }
 
 function handlerWrapper(handler, PhysicalResourceId) {
-  return async (event, context, callback) => {
+  // The nodejs24.x runtime rejects three-argument (callback-style) handlers
+  // with Runtime.CallbackHandlerDeprecated, so this must stay a two-argument
+  // async handler.
+  return async (event, context) => {
     // extend the `event` object to include the PhysicalResourceId
     event = Object.assign({}, event, { PhysicalResourceId })
-    return Promise.resolve(handler(event, context, callback))
-      .then(
-        (result) => response(event, context, 'SUCCESS', result),
-        (error) => response(event, context, 'FAILED', {}, error),
-      )
-      .then((result) => callback(null, result), callback)
+    return Promise.resolve(handler(event, context)).then(
+      (result) => response(event, context, 'SUCCESS', result),
+      (error) => response(event, context, 'FAILED', {}, error),
+    )
   }
 }
 


### PR DESCRIPTION
## Summary

Bumps the framework-managed custom-resource Lambda runtime from `nodejs22.x` to `nodejs24.x`, and updates `handlerWrapper` to the two-argument async signature that the new runtime requires.

Addresses the nodejs24.x part of #13802.

## Required code change

The nodejs24.x runtime [no longer supports callback-based handlers](https://aws.amazon.com/blogs/compute/node-js-24-runtime-now-available-in-aws-lambda) — it detects them by formal parameter count and rejects them with `Runtime.CallbackHandlerDeprecated`. `handlerWrapper` returned an `async (event, context, callback)` function, so the runtime bump alone would have broken every framework custom resource (S3, Cognito, EventBridge, API Gateway CloudWatch role). The wrapper is now `async (event, context)`; all wrapped handlers were already async and never used the callback.

## Why the rest is safe

- The handler code is framework-shipped (no user code runs on this function). It uses AWS SDK v3 clients and core `crypto`/`https` — compatible with nodejs24.x.
- `nodejs24.x` has been [GA on Lambda since November 2025](https://aws.amazon.com/about-aws/whats-new/2025/11/aws-lambda-nodejs-24), including the [China regions](https://www.amazonaws.cn/en/new/2025/amazon-lambda-adds-support-for-node-js-24-in-amazon-web-services-china-regions/).
- CloudFormation updates `Runtime` in place — no resource replacement, no user action needed.

## Why not nodejs26.x

Node.js 26 is only in [public preview on Lambda](https://aws.amazon.com/blogs/compute/introducing-public-preview-runtimes-on-aws-lambda-starting-with-node-js-26-and-python-3-15/) (not covered by SLA, not for production). It reaches Active LTS in October 2026; a follow-up bump can land after Lambda GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the custom resource runtime to Node.js 24 for improved platform compatibility.
  * Improved custom resource handler compatibility with the Node.js 24 runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->