### PR TITLE
chore: release 4.41.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13201,7 +13201,7 @@
     },
     "packages/sf-core": {
       "name": "@serverlessinc/sf-core",
-      "version": "4.41.0",
+      "version": "4.41.1",
       "dependencies": {
         "@aws-sdk/client-cloudformation": "3.1103.0",
         "@aws-sdk/client-s3": "3.1103.0",

--- a/packages/framework-dist/package.json
+++ b/packages/framework-dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/framework-alpha",
-  "version": "4.41.0",
+  "version": "4.41.1",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/packages/sf-core-installer/package-lock.json
+++ b/packages/sf-core-installer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless",
-  "version": "4.41.0",
+  "version": "4.41.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless",
-      "version": "4.41.0",
+      "version": "4.41.1",
       "hasInstallScript": true,
       "dependencies": {
         "undici": "6.28.0"

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless",
-  "version": "4.41.0",
+  "version": "4.41.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/sf-core/package.json
+++ b/packages/sf-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverlessinc/sf-core",
-  "version": "4.41.0",
+  "version": "4.41.1",
   "main": "src/index.js",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Bug Fixes

- **Fixed packaging producing a different artifact on every run.** When using the built-in build system, repeated `serverless package` runs of an unchanged service produced artifacts with different checksums, so change detection could see phantom diffs and redeploy unchanged services. Artifacts are now byte-for-byte identical across runs. (#13794)

- **Fixed `package.patterns` exclusions being ignored in packaged artifacts.** When using the built-in build system, negation patterns (`!...`) are now honored when packaging function artifacts — both for combined-service packaging and with `package.individually`. Function-level patterns are merged after service-level patterns, so function settings win on conflict, matching classic packaging behavior. (#13795)

## Maintenance

- **Framework-managed custom resources now run on Node.js 24.** Deployments that use existing S3 buckets, existing Cognito User Pools, EventBridge events, or the API Gateway CloudWatch role pick up the `nodejs24.x` runtime automatically on the next deploy. No action is needed. Thanks @Hiroki-Aoki for raising this! (#13802, #13807)
- Bumped the AWS SDK group with 37 updates (#13796)
- Upgraded esbuild to v0.28.2 (#13798)
- Upgraded tsx to v4.23.11 (#13798)
- Upgraded ws to v8.21.3 (#13798)
- Upgraded eslint to v10.8.1 (#13797)
- Upgraded lint-staged to v17.3.0 (#13797)
- Upgraded hono to v4.13.1 (#13797)
- Upgraded globals to v17.9.0 (#13797)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime or packaging logic modified in this diff.
> 
> **Overview**
> This is a **release version bump** from `4.41.0` to `4.41.1` across the publishable packages: npm `serverless` (`packages/sf-core-installer`), `@serverlessinc/sf-core`, and `@serverlessinc/framework-alpha` (`packages/framework-dist`), with matching updates in the root and installer **package-lock** files.
> 
> No source or behavior changes appear in this diff—only `version` fields—so it prepares the monorepo artifacts for a **4.41.1** publish after the fixes and dependency updates already landed on the release branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f436f52acb4cd86364d6cfbd6e46c10f56db5885. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the framework, installer, and core package releases to version **4.41.1**.
  - Aligned package versions across the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->