### PR TITLE
chore(deps): bump Go to 1.27

### DIFF
--- a/.github/workflows/ci-binary-installer.yml
+++ b/.github/workflows/ci-binary-installer.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '>=1.26.5'
+          go-version: '>=1.27.0'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Test: Unit'
         run: make test

--- a/.github/workflows/release-binary-installer.yml
+++ b/.github/workflows/release-binary-installer.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Setup: Go'
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '>=1.26.5'
+          go-version: '>=1.27.0'
           cache-dependency-path: binary-installer/go.sum
       - name: 'Setup: AWS Credentials'
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/binary-installer/go.mod
+++ b/binary-installer/go.mod
@@ -1,6 +1,6 @@
 module sf-core
 
-go 1.26.5
+go 1.27.0
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Bumps the binary installer's Go version from 1.26.5 to 1.27.0 (released 2026-08-19):

- `binary-installer/go.mod`: `go 1.26.5` → `go 1.27.0`
- `ci-binary-installer.yml` / `release-binary-installer.yml`: `go-version: '>=1.26.5'` → `'>=1.27.0'`

Since the workflows resolve `>=` pins to the latest stable Go, builds have already been using the 1.27.0 toolchain since its release — this aligns the declared language version and raises the floor.

Verified under Go 1.27.0:
- `go test ./...` and `go vet ./...` pass
- all release targets cross-compile (darwin/linux amd64+arm64, windows/amd64)
- no dependency requires a floor above Go 1.25

Note: per the [Go 1.27 release notes](https://go.dev/doc/go1.27), darwin binaries built with Go 1.27 require macOS 13 Ventura or later (macOS 12 support was discontinued upstream). This already applies to installer releases built after 2026-08-19 due to the `>=` pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the binary installer’s required Go version to 1.27.0 across build, release, and module configuration.
  * Ensured installer validation and release workflows use the updated Go toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->