### PR TITLE
fix(aws): use regional S3 endpoints for CloudFormation template URLs

### DIFF
--- a/packages/serverless/lib/plugins/aws/alerts/external-stack.js
+++ b/packages/serverless/lib/plugins/aws/alerts/external-stack.js
@@ -13,6 +13,8 @@
  *     externalStack:
  *       nameSuffix: Alerts
  */
+import getS3EndpointForRegion from '../utils/get-s3-endpoint-for-region.js'
+
 class ExternalStack {
   constructor(serverless, options) {
     this.serverless = serverless
@@ -352,17 +354,6 @@ class ExternalStack {
   }
 
   // From Serverless
-  getS3EndpointForRegion(region) {
-    const strRegion = region.toLowerCase()
-    // look for govcloud - currently s3-us-gov-west-1.amazonaws.com
-    if (strRegion.match(/us-gov/)) return `s3-${strRegion}.amazonaws.com`
-    // look for china - currently s3.cn-north-1.amazonaws.com.cn
-    if (strRegion.match(/cn-/)) return `s3.${strRegion}.amazonaws.com.cn`
-    // default s3 endpoint for other regions
-    return 's3.amazonaws.com'
-  }
-
-  // From Serverless
   uploadCloudFormationTemplate(compiledCloudFormationTemplate) {
     this.serverless.cli.log('Uploading external alerts template to S3...')
 
@@ -391,9 +382,7 @@ class ExternalStack {
       })
       .then(() => {
         // Return the template URL
-        const s3Endpoint = this.getS3EndpointForRegion(
-          this.provider.getRegion(),
-        )
+        const s3Endpoint = getS3EndpointForRegion(this.provider.getRegion())
         const templateUrl = `https://${s3Endpoint}/${params.Bucket}/${this.serverless.service.package.artifactDirectoryName}/${compiledTemplateFileName}`
         return templateUrl
       })

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -3371,10 +3371,12 @@ destinations:
   // This function will be used to block the addition of transfer acceleration options
   // to the cloudformation template for regions where acceleration is not supported (ie, govcloud)
   isS3TransferAccelerationSupported() {
-    // Only enable s3 transfer acceleration for standard regions (non govcloud/china)
-    // since those regions do not yet support it
-    const endpoint = getS3EndpointForRegion(this.getRegion())
-    return endpoint === 's3.amazonaws.com'
+    // S3 Transfer Acceleration is not offered in the GovCloud, China and ISO
+    // partitions — exactly the regions the endpoint helper special-cases — so a
+    // regional-form endpoint identifies a standard-partition region
+    const region = this.getRegion().toLowerCase()
+    const endpoint = getS3EndpointForRegion(region)
+    return endpoint === `s3.${region}.amazonaws.com`
   }
 
   isS3TransferAccelerationEnabled() {

--- a/packages/serverless/lib/plugins/aws/utils/get-s3-endpoint-for-region.js
+++ b/packages/serverless/lib/plugins/aws/utils/get-s3-endpoint-for-region.js
@@ -8,6 +8,13 @@ export default function getS3EndpointForRegion(region) {
   if (strRegion.match(/iso-/)) return `s3.${strRegion}.c2s.ic.gov`
   // look for AWS ISOB (US)
   if (strRegion.match(/isob-/)) return `s3.${strRegion}.sc2s.sgov.gov`
-  // default s3 endpoint for other regions
-  return 's3.amazonaws.com'
+  // regional endpoint for all other regions. The legacy global endpoint
+  // ("s3.amazonaws.com") routes to us-east-1; for a bucket in any other region
+  // S3 answers with a redirect ("The bucket you are attempting to access must
+  // be addressed using the specified endpoint"). CloudFormation normally
+  // resolves the bucket's region itself, but under restrictive caller IAM
+  // conditions (e.g. aws:SourceIp allowlists without an aws:ViaAWSService
+  // exemption) the deploy fails with that redirect error. The regional
+  // endpoint removes the resolution step.
+  return `s3.${strRegion}.amazonaws.com`
 }

--- a/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/validate-template.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/deploy/lib/validate-template.test.js
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals'
+import validateTemplate from '../../../../../../../lib/plugins/aws/deploy/lib/validate-template.js'
+import ServerlessError from '../../../../../../../lib/serverless-error.js'
+
+const createContext = ({ region = 'us-west-2', request } = {}) => ({
+  ...validateTemplate,
+  bucketName: 'deployment-bucket',
+  serverless: {
+    service: {
+      package: { artifactDirectoryName: 'serverless/my-service/dev/12345' },
+    },
+  },
+  provider: {
+    getRegion: () => region,
+    naming: {
+      getCompiledTemplateS3Suffix: () =>
+        'compiled-cloudformation-template.json',
+    },
+    request: request || jest.fn().mockResolvedValue({}),
+  },
+})
+
+describe('validateTemplate', () => {
+  it('should call CloudFormation validateTemplate with a regional TemplateURL', async () => {
+    const request = jest.fn().mockResolvedValue({})
+    const context = createContext({ region: 'us-west-2', request })
+
+    await context.validateTemplate()
+
+    expect(request).toHaveBeenCalledWith('CloudFormation', 'validateTemplate', {
+      TemplateURL:
+        'https://s3.us-west-2.amazonaws.com/deployment-bucket/serverless/my-service/dev/12345/compiled-cloudformation-template.json',
+    })
+  })
+
+  it('should use the regional endpoint for us-east-1 as well', async () => {
+    const request = jest.fn().mockResolvedValue({})
+    const context = createContext({ region: 'us-east-1', request })
+
+    await context.validateTemplate()
+
+    expect(request).toHaveBeenCalledWith('CloudFormation', 'validateTemplate', {
+      TemplateURL:
+        'https://s3.us-east-1.amazonaws.com/deployment-bucket/serverless/my-service/dev/12345/compiled-cloudformation-template.json',
+    })
+  })
+
+  it('should wrap validation errors in a ServerlessError', async () => {
+    const request = jest.fn().mockRejectedValue(new Error('Invalid template'))
+    const context = createContext({ request })
+
+    await expect(context.validateTemplate()).rejects.toThrow(ServerlessError)
+    await expect(context.validateTemplate()).rejects.toThrow(
+      'The CloudFormation template is invalid: Invalid template',
+    )
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/provider.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/provider.test.js
@@ -470,6 +470,52 @@ describe('AwsProvider', () => {
       })
     })
 
+    describe('#isS3TransferAccelerationSupported()', () => {
+      const providerForRegion = (region) => {
+        const newOptions = { ...options, region }
+        return new AwsProvider(serverless, newOptions)
+      }
+
+      it('should return true for standard regions', () => {
+        expect(
+          providerForRegion('us-east-1').isS3TransferAccelerationSupported(),
+        ).toBe(true)
+        expect(
+          providerForRegion('us-west-2').isS3TransferAccelerationSupported(),
+        ).toBe(true)
+        expect(
+          providerForRegion('eu-central-1').isS3TransferAccelerationSupported(),
+        ).toBe(true)
+      })
+
+      it('should not depend on region casing', () => {
+        expect(
+          providerForRegion('US-WEST-2').isS3TransferAccelerationSupported(),
+        ).toBe(true)
+      })
+
+      it('should return false for GovCloud, China, and ISO regions', () => {
+        expect(
+          providerForRegion(
+            'us-gov-west-1',
+          ).isS3TransferAccelerationSupported(),
+        ).toBe(false)
+        expect(
+          providerForRegion('cn-north-1').isS3TransferAccelerationSupported(),
+        ).toBe(false)
+        expect(
+          providerForRegion(
+            'us-iso-east-1',
+          ).isS3TransferAccelerationSupported(),
+        ).toBe(false)
+        expect(
+          providerForRegion(
+            'us-isob-east-1',
+          ).isS3TransferAccelerationSupported(),
+        ).toBe(false)
+      })
+    })
+
     describe('#disableTransferAccelerationForCurrentDeploy()', () => {
       it('should remove the corresponding option for the current deploy', () => {
         awsProvider.options['aws-s3-accelerate'] = true

--- a/packages/serverless/test/unit/lib/plugins/aws/utils/get-s3-endpoint-for-region.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/utils/get-s3-endpoint-for-region.test.js
@@ -1,0 +1,66 @@
+import getS3EndpointForRegion from '../../../../../../lib/plugins/aws/utils/get-s3-endpoint-for-region.js'
+
+describe('getS3EndpointForRegion', () => {
+  it('should return the regional endpoint for us-east-1', () => {
+    expect(getS3EndpointForRegion('us-east-1')).toBe(
+      's3.us-east-1.amazonaws.com',
+    )
+  })
+
+  it('should return the regional endpoint for standard regions', () => {
+    expect(getS3EndpointForRegion('us-west-2')).toBe(
+      's3.us-west-2.amazonaws.com',
+    )
+    expect(getS3EndpointForRegion('eu-central-1')).toBe(
+      's3.eu-central-1.amazonaws.com',
+    )
+    expect(getS3EndpointForRegion('ap-southeast-1')).toBe(
+      's3.ap-southeast-1.amazonaws.com',
+    )
+  })
+
+  it('should return the regional endpoint for opt-in regions', () => {
+    expect(getS3EndpointForRegion('af-south-1')).toBe(
+      's3.af-south-1.amazonaws.com',
+    )
+    expect(getS3EndpointForRegion('il-central-1')).toBe(
+      's3.il-central-1.amazonaws.com',
+    )
+  })
+
+  it('should lowercase the region', () => {
+    expect(getS3EndpointForRegion('US-WEST-2')).toBe(
+      's3.us-west-2.amazonaws.com',
+    )
+  })
+
+  it('should return the GovCloud endpoint for us-gov regions', () => {
+    expect(getS3EndpointForRegion('us-gov-west-1')).toBe(
+      's3-us-gov-west-1.amazonaws.com',
+    )
+    expect(getS3EndpointForRegion('us-gov-east-1')).toBe(
+      's3-us-gov-east-1.amazonaws.com',
+    )
+  })
+
+  it('should return the China endpoint for cn regions', () => {
+    expect(getS3EndpointForRegion('cn-north-1')).toBe(
+      's3.cn-north-1.amazonaws.com.cn',
+    )
+    expect(getS3EndpointForRegion('cn-northwest-1')).toBe(
+      's3.cn-northwest-1.amazonaws.com.cn',
+    )
+  })
+
+  it('should return the ISO endpoint for iso regions', () => {
+    expect(getS3EndpointForRegion('us-iso-east-1')).toBe(
+      's3.us-iso-east-1.c2s.ic.gov',
+    )
+  })
+
+  it('should return the ISOB endpoint for isob regions', () => {
+    expect(getS3EndpointForRegion('us-isob-east-1')).toBe(
+      's3.us-isob-east-1.sc2s.sgov.gov',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- The `TemplateURL` passed to CloudFormation (`validateTemplate`, `createStack`, `updateStack`, `createChangeSet`) was built on the legacy global S3 endpoint `s3.amazonaws.com` for every standard region. For a bucket outside us-east-1, S3 answers that URL with a `PermanentRedirect`. CloudFormation resolves the bucket's region itself, but when its forwarded read of the template is denied by the caller's IAM — a principal without `s3:GetObject` on the deployment bucket, or a policy condition that service-forwarded requests cannot satisfy — it reports S3's *redirect* message instead of the denial: deploys outside us-east-1 fail at template validation with `S3 error: The bucket you are attempting to access must be addressed using the specified endpoint`, which points users at the wrong problem, and nothing in `serverless.yml` can change the URL. With the regional URL the same denial surfaces as `S3 error: Access Denied`, the actual cause.
- `getS3EndpointForRegion` now returns the bucket's regional endpoint `s3.<region>.amazonaws.com` for all standard regions (including us-east-1), which is the form AWS documents and the only form available in opt-in regions. GovCloud, China, ISO and ISOB endpoints are unchanged.
- `isS3TransferAccelerationSupported()` keyed off the old global-endpoint string; it now compares against the regional form so `--aws-s3-accelerate` keeps working in standard regions and stays disabled in the partitions that do not support it.
- The alerts external stack (`custom.alerts.externalStack`) carried its own copy of the endpoint helper; it now uses the shared one, so its `TemplateURL` gets the same regional endpoint.
- No change to configuration, output, errors, IAM, or generated CloudFormation; CloudFormation fetches the same template object through the regional host.

## Test plan

- [x] New unit tests: `getS3EndpointForRegion` for standard, opt-in, upper-cased, GovCloud, China, ISO and ISOB regions; `validateTemplate` sends the regional `TemplateURL` (us-west-2 and us-east-1) and wraps validation errors; `isS3TransferAccelerationSupported` truth table across partitions plus region casing
- [x] `@serverless/framework` unit suite green (3734 tests), lint and prettier clean
- [x] Live: deployed a service from source to us-west-2 (create, then update) and to us-east-1 (create) — `validateTemplate` and stack create/update accepted the regional URL; stacks removed afterwards
- [x] Direct `aws cloudformation validate-template` probes confirmed the regional path-style URL is accepted in-region and cross-region
- [x] Live, additionally: `deploymentMethod: changesets` create + update; `rollback`; `deploy --package --force`; custom `deploymentBucket.name` in-region; cross-region custom bucket still rejected; alerts `externalStack` create and remove
- [x] Reproduction: principals whose forwarded S3 read is denied fail with the reported redirect message on the global URL and with `S3 error: Access Denied` on the regional URL; a permissive principal passes both; an `aws:RequestedRegion`-restricted principal passes both

## Related

- #6539 (2019 report of the same error; the fix applied then covered GovCloud and China only)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CloudFormation template uploads now use regional Amazon S3 endpoints for improved compatibility across standard AWS regions.
  * S3 Transfer Acceleration detection now recognizes supported regional endpoints and handles region names without regard to capitalization.
  * Specialized endpoint handling remains available for GovCloud, China, ISO, and ISOB regions.

* **Tests**
  * Added coverage for regional endpoints, supported regions, and validation error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->