### PR TITLE
fix(sf-core-installer): don't fail npm install on binary download errors

### DIFF
--- a/.github/workflows/ci-framework.yml
+++ b/.github/workflows/ci-framework.yml
@@ -68,12 +68,17 @@ jobs:
     name: 'Test: Installer'
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    # Runs PR-controlled test code; needs neither the OIDC token nor git credentials
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./packages/sf-core-installer
     steps:
       - name: 'Checkout Code'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 'Setup: Node.js'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/ci-framework.yml
+++ b/.github/workflows/ci-framework.yml
@@ -64,6 +64,32 @@ jobs:
       - name: 'Test: Engine Unit'
         run: npm test
 
+  test-installer:
+    name: 'Test: Installer'
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/sf-core-installer
+    steps:
+      - name: 'Checkout Code'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: 'Setup: Node.js'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          check-latest: true
+          cache: npm
+          cache-dependency-path: packages/sf-core-installer/package-lock.json
+      - name: 'Setup: Enable Corepack'
+        run: corepack enable npm
+      - name: 'Install: Dependencies'
+        # --ignore-scripts keeps CI hermetic: the package's own postinstall
+        # would download the launcher binary.
+        run: npm ci --ignore-scripts
+      - name: 'Test: Unit (sf-core-installer)'
+        run: npm test
+
   test-framework:
     name: 'Test: Framework'
     if: ${{ !github.event.pull_request.draft }}

--- a/docs/sf/getting-started.md
+++ b/docs/sf/getting-started.md
@@ -30,6 +30,21 @@ npm i serverless -g
 
 Run `serverless` to verify your installation is working, and show the current version.
 
+### Installing behind a proxy or firewall
+
+The Serverless Framework CLI downloads its binary during installation and connects to two hosts over HTTPS (port 443), both when installing and when running:
+
+- `install.serverless.com` — downloads of the CLI binary and framework releases, and version checks for automatic updates
+- `core.serverless.com` — license key validation, authentication, and usage reporting
+
+If your network restricts outbound traffic, allow both hosts. `npm install` itself needs access to your npm registry as usual.
+
+**Proxies.** Set the standard `HTTPS_PROXY` environment variable (and `NO_PROXY` for hosts that must be reached directly). The CLI uses these both while installing and every time it runs. During `npm install`, proxy settings from your npm configuration (`https-proxy`, `proxy`, and `noproxy` in `.npmrc`) are also applied to the binary download when no proxy environment variables are set.
+
+**Custom certificate authorities.** If your proxy inspects TLS traffic using a corporate certificate, point `NODE_EXTRA_CA_CERTS` at your CA bundle in PEM format. The CLI trusts it for all of its connections.
+
+**If the download is blocked during installation.** `npm install` still completes, with a warning that names the network error, and the CLI downloads its binary the first time you run `serverless`. In CI, set the variables above for the job that runs `serverless`, not only for the step that installs it.
+
 ## Update Serverless Framework
 
 As of version 4, the Serverless Framework automatically updates itself and performs a check to do so every 24 hours.

--- a/packages/sf-core-installer/binary.js
+++ b/packages/sf-core-installer/binary.js
@@ -10,6 +10,42 @@ const error = (msg) => {
   process.exit(1)
 }
 
+// fetch() reports every network-level failure as a bare "fetch failed" and
+// hides the actual reason (DNS, TLS, connection refused) in the `cause`
+// chain, so the chain has to be included for failures to be diagnosable
+// from install logs.
+const describeNode = (e) => {
+  if (!(e instanceof Error)) return String(e)
+  const message = e.message || e.name
+  return e.code ? `${message} (${e.code})` : message
+}
+
+const describeError = (err) => {
+  if (!(err instanceof Error)) return String(err)
+  const parts = []
+  // A cyclic cause chain would otherwise hang the process — worse than exiting
+  const seen = new Set()
+  let node = err
+  while (node !== undefined && node !== null && !seen.has(node)) {
+    seen.add(node)
+    parts.push(describeNode(node))
+    if (Array.isArray(node.errors) && node.errors.length > 0) {
+      parts.push(node.errors.map(describeNode).join(', '))
+    }
+    node = node instanceof Error ? node.cause : undefined
+  }
+  return parts.join(': ')
+}
+
+// spawnSync reports a signal-terminated child as `status: null`; passing
+// that to process.exit() would report success. Use the shell convention of
+// 128 + signal number instead.
+const childExitCode = ({ status, signal }) => {
+  if (status !== null) return status
+  const signalNumber = os.constants.signals[signal]
+  return signalNumber ? 128 + signalNumber : 1
+}
+
 const formatHostName = (hostname) => hostname.replace(/^\.*/, '.').toLowerCase()
 
 const parseNoProxyZone = (zone) => {
@@ -22,7 +58,11 @@ const parseNoProxyZone = (zone) => {
 }
 
 const shouldBypassProxy = (requestURL) => {
-  const noProxy = process.env.NO_PROXY || process.env.no_proxy || ''
+  const noProxy =
+    process.env.NO_PROXY ||
+    process.env.no_proxy ||
+    process.env.npm_config_noproxy ||
+    ''
   if (noProxy === '*') return true
   if (noProxy === '') return false
 
@@ -30,8 +70,10 @@ const shouldBypassProxy = (requestURL) => {
     requestURL.port || (requestURL.protocol === 'https:' ? '443' : '80')
   const hostname = formatHostName(requestURL.hostname)
 
+  // npm exports array-form `noproxy[]=` entries newline-joined
   return noProxy
-    .split(',')
+    .split(/[,\n]/)
+    .filter((zone) => zone.trim() !== '')
     .map(parseNoProxyZone)
     .some((noProxyZone) => {
       const isMatchedAt = hostname.indexOf(noProxyZone.hostname)
@@ -45,16 +87,33 @@ const shouldBypassProxy = (requestURL) => {
     })
 }
 
+// npm applies the proxy settings from .npmrc to its own downloads but does
+// not translate them into HTTP(S)_PROXY for lifecycle scripts — they reach
+// this script only as npm_config_* variables, so those serve as fallbacks
+// when no proxy environment variables are set. Scheme mapping mirrors npm's
+// own (npm-registry-fetch: `httpsProxy || proxy`): `https-proxy` is preferred
+// for https requests and `proxy` is the fallback for both schemes.
 const getProxyUrl = (url) => {
   const requestURL = new URL(url)
 
   if (shouldBypassProxy(requestURL)) return null
 
   if (requestURL.protocol === 'http:') {
-    return process.env.HTTP_PROXY || process.env.http_proxy || null
+    return (
+      process.env.HTTP_PROXY ||
+      process.env.http_proxy ||
+      process.env.npm_config_proxy ||
+      null
+    )
   }
   if (requestURL.protocol === 'https:') {
-    return process.env.HTTPS_PROXY || process.env.https_proxy || null
+    return (
+      process.env.HTTPS_PROXY ||
+      process.env.https_proxy ||
+      process.env.npm_config_https_proxy ||
+      process.env.npm_config_proxy ||
+      null
+    )
   }
   return null
 }
@@ -103,7 +162,7 @@ class Binary {
       })
       errorMsg +=
         '\n\nCorrect usage: new Binary("my-binary", "https://example.com/binary/download.tar.gz", "v1.0.0")'
-      error(errorMsg)
+      throw new Error(errorMsg)
     }
     this.url = url
     this.name = name
@@ -133,14 +192,17 @@ class Binary {
     }
   }
 
-  install(suppressLogs = false) {
+  // Downloads the binary. Rejects on any failure — how a failure is handled
+  // (warn vs abort) is decided by the entrypoints (postInstall.js, run.js),
+  // never here.
+  async install(suppressLogs = false) {
     if (this.exists()) {
       if (!suppressLogs) {
         console.error(
           `${this.name} is already installed, skipping installation.`,
         )
       }
-      return Promise.resolve()
+      return
     }
 
     // maxRetries/retryDelay cover transient EBUSY/EPERM on Windows, where
@@ -158,40 +220,34 @@ class Binary {
       console.error(`Downloading release from ${this.url}`)
     }
 
-    process.on('SIGINT', () => {
-      error('Could not download Serverless')
+    const abort = () => {
       this.removeBinary()
-    })
+      error('Serverless Framework binary download was interrupted')
+    }
+    process.on('SIGINT', abort)
+    process.on('SIGTERM', abort)
 
-    process.on('SIGTERM', () => {
-      error('Could not download Serverless')
+    try {
+      const proxyUrl = getProxyUrl(this.url)
+      const fetchOptions = proxyUrl
+        ? { dispatcher: new ProxyAgent(proxyUrl) }
+        : {}
+      const res = await fetch(this.url, fetchOptions)
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      }
+      const buffer = await res.arrayBuffer()
+      writeFileSync(this.binaryPath, Buffer.from(buffer), { mode: 0o755 })
+      if (!suppressLogs) {
+        console.error(`${this.name} has been installed!`)
+      }
+    } catch (e) {
       this.removeBinary()
-    })
-
-    const proxyUrl = getProxyUrl(this.url)
-    const fetchOptions = proxyUrl
-      ? { dispatcher: new ProxyAgent(proxyUrl) }
-      : {}
-
-    return fetch(this.url, fetchOptions)
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}: ${res.statusText}`)
-        }
-        return res.arrayBuffer()
-      })
-      .then((buffer) => {
-        writeFileSync(this.binaryPath, Buffer.from(buffer), { mode: 0o755 })
-      })
-      .then(() => {
-        if (!suppressLogs) {
-          console.error(`${this.name} has been installed!`)
-        }
-      })
-      .catch((e) => {
-        error(`Error fetching release: ${e.message}`)
-        this.removeBinary()
-      })
+      throw e
+    } finally {
+      process.removeListener('SIGINT', abort)
+      process.removeListener('SIGTERM', abort)
+    }
   }
 
   run() {
@@ -214,11 +270,12 @@ class Binary {
           error(result.error)
         }
 
-        process.exit(result.status)
+        process.exit(childExitCode(result))
       })
       .catch((e) => {
-        error(e.message)
-        process.exit(1)
+        error(
+          `Could not download the Serverless Framework binary: ${describeError(e)}`,
+        )
       })
   }
 }
@@ -240,11 +297,10 @@ const getBinaryName = () => {
   let architecture = os.arch()
 
   if (architecture !== 'arm64' && architecture !== 'x64') {
-    console.error(`Architecture ${architecture} is not supported.`)
-    process.exit(1)
-  } else if (architecture === 'arm64' && osType === 'windows') {
-    console.error(`Platform ${osType} - ${architecture} is not supported.`)
-    process.exit(1)
+    throw new Error(`Architecture ${architecture} is not supported.`)
+  }
+  if (architecture === 'arm64' && osType === 'windows') {
+    throw new Error(`Platform ${osType} - ${architecture} is not supported.`)
   }
 
   if (architecture === 'x64') {
@@ -275,4 +331,8 @@ module.exports = {
   install,
   run,
   getBinary,
+  Binary,
+  childExitCode,
+  describeError,
+  getProxyUrl,
 }

--- a/packages/sf-core-installer/binary.js
+++ b/packages/sf-core-installer/binary.js
@@ -220,9 +220,10 @@ class Binary {
       console.error(`Downloading release from ${this.url}`)
     }
 
-    const abort = () => {
+    const abort = (signal) => {
       this.removeBinary()
-      error('Serverless Framework binary download was interrupted')
+      console.error('Serverless Framework binary download was interrupted')
+      process.exit(childExitCode({ status: null, signal }))
     }
     process.on('SIGINT', abort)
     process.on('SIGTERM', abort)

--- a/packages/sf-core-installer/binary.js
+++ b/packages/sf-core-installer/binary.js
@@ -37,14 +37,16 @@ const describeError = (err) => {
   return parts.join(': ')
 }
 
-// spawnSync reports a signal-terminated child as `status: null`; passing
-// that to process.exit() would report success. Use the shell convention of
-// 128 + signal number instead.
-const childExitCode = ({ status, signal }) => {
-  if (status !== null) return status
+// Shell convention for a process ended by a signal: 128 + signal number
+const signalExitCode = (signal) => {
   const signalNumber = os.constants.signals[signal]
   return signalNumber ? 128 + signalNumber : 1
 }
+
+// spawnSync reports a signal-terminated child as `status: null`; passing
+// that to process.exit() would report success.
+const childExitCode = ({ status, signal }) =>
+  status !== null ? status : signalExitCode(signal)
 
 const formatHostName = (hostname) => hostname.replace(/^\.*/, '.').toLowerCase()
 
@@ -223,7 +225,7 @@ class Binary {
     const abort = (signal) => {
       this.removeBinary()
       console.error('Serverless Framework binary download was interrupted')
-      process.exit(childExitCode({ status: null, signal }))
+      process.exit(signalExitCode(signal))
     }
     process.on('SIGINT', abort)
     process.on('SIGTERM', abort)

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -3,11 +3,17 @@
   "version": "4.41.1",
   "description": "",
   "main": "index.js",
+  "files": [
+    "binary.js",
+    "postInstall.js",
+    "run.js"
+  ],
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "prettier": "prettier -c . --ignore-path ../../.prettierignore",
     "prettier:fix": "prettier -w . --ignore-path ../../.prettierignore",
+    "test": "node --test \"tests/*.test.js\"",
     "postinstall": "node ./postInstall.js"
   },
   "keywords": [],

--- a/packages/sf-core-installer/postInstall.js
+++ b/packages/sf-core-installer/postInstall.js
@@ -1,4 +1,17 @@
 #!/usr/bin/env node
 
-const { install: maybeInstall } = require('./binary')
-maybeInstall().then(() => {})
+const { install, describeError } = require('./binary')
+
+// npm aborts the entire `npm install` when this script exits non-zero. A
+// binary that could not be pre-downloaded here is always recoverable — run.js
+// downloads it on first invocation — so no failure in this script justifies
+// failing the install.
+install().catch((e) => {
+  console.error(
+    `Could not pre-download the Serverless Framework binary: ${describeError(e)}\n` +
+      'The download will be retried the first time "serverless" runs. If your ' +
+      'network requires a proxy, set the HTTPS_PROXY environment variable (or ' +
+      "npm's https-proxy setting) and allow access to install.serverless.com. " +
+      'See https://www.serverless.com/framework/docs/getting-started',
+  )
+})

--- a/packages/sf-core-installer/run.js
+++ b/packages/sf-core-installer/run.js
@@ -1,4 +1,14 @@
 #!/usr/bin/env node
 
-const { run, install: maybeInstall } = require('./binary')
-maybeInstall().then(run)
+const { run, install: maybeInstall, describeError } = require('./binary')
+
+// Unlike postInstall.js, a missing binary is fatal here: without it there is
+// nothing to run.
+maybeInstall()
+  .then(run)
+  .catch((e) => {
+    console.error(
+      `Could not download the Serverless Framework binary: ${describeError(e)}`,
+    )
+    process.exit(1)
+  })

--- a/packages/sf-core-installer/tests/binary.test.js
+++ b/packages/sf-core-installer/tests/binary.test.js
@@ -1,0 +1,312 @@
+const { test, describe, beforeEach, afterEach } = require('node:test')
+const assert = require('node:assert/strict')
+const os = require('node:os')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const {
+  Binary,
+  childExitCode,
+  describeError,
+  getProxyUrl,
+  install,
+} = require('../binary')
+
+const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'NO_PROXY',
+  'no_proxy',
+  'npm_config_proxy',
+  'npm_config_https_proxy',
+  'npm_config_noproxy',
+]
+
+const savedEnv = {}
+const realFetch = globalThis.fetch
+
+beforeEach(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const key of PROXY_ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key]
+    else process.env[key] = savedEnv[key]
+  }
+  globalThis.fetch = realFetch
+})
+
+describe('describeError', () => {
+  test('returns the message for a plain error', () => {
+    assert.equal(describeError(new Error('boom')), 'boom')
+  })
+
+  test('includes both message and code of the cause', () => {
+    const error = new Error('fetch failed', {
+      cause: Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:9'), {
+        code: 'ECONNREFUSED',
+      }),
+    })
+    assert.equal(
+      describeError(error),
+      'fetch failed: connect ECONNREFUSED 127.0.0.1:9 (ECONNREFUSED)',
+    )
+  })
+
+  test('includes the code of the root error', () => {
+    const error = Object.assign(new Error('boom'), { code: 'EBOOM' })
+    assert.equal(describeError(error), 'boom (EBOOM)')
+  })
+
+  test('falls back to the error name when the message is empty', () => {
+    const error = new AggregateError([
+      Object.assign(new Error('x'), { code: 'E1' }),
+    ])
+    assert.equal(describeError(error), 'AggregateError: x (E1)')
+  })
+
+  test('falls back to the cause message when there is no code', () => {
+    const error = new Error('fetch failed', {
+      cause: new Error('unexpected TLS alert'),
+    })
+    assert.equal(describeError(error), 'fetch failed: unexpected TLS alert')
+  })
+
+  test('walks nested causes', () => {
+    const inner = Object.assign(new Error('inner'), { code: 'ETIMEDOUT' })
+    const error = new Error('fetch failed', {
+      cause: new Error('request to host failed', { cause: inner }),
+    })
+    assert.equal(
+      describeError(error),
+      'fetch failed: request to host failed: inner (ETIMEDOUT)',
+    )
+  })
+
+  test('lists AggregateError sub-errors', () => {
+    const aggregate = new AggregateError([
+      Object.assign(new Error('a'), { code: 'ECONNREFUSED' }),
+      Object.assign(new Error('b'), { code: 'ETIMEDOUT' }),
+    ])
+    const error = new Error('fetch failed', { cause: aggregate })
+    assert.equal(
+      describeError(error),
+      'fetch failed: AggregateError: a (ECONNREFUSED), b (ETIMEDOUT)',
+    )
+  })
+
+  test('handles a non-error cause', () => {
+    const error = new Error('fetch failed', { cause: 'plain string cause' })
+    assert.equal(describeError(error), 'fetch failed: plain string cause')
+  })
+
+  test('terminates on a cyclic cause chain', () => {
+    const a = new Error('a')
+    const b = new Error('b', { cause: a })
+    a.cause = b
+    assert.equal(describeError(a), 'a: b')
+  })
+
+  test('never throws on non-error input', () => {
+    assert.equal(typeof describeError(undefined), 'string')
+    assert.equal(typeof describeError(null), 'string')
+    assert.equal(describeError('oops'), 'oops')
+  })
+})
+
+describe('getProxyUrl', () => {
+  const httpsUrl = 'https://install.serverless.com/installer-builds/x'
+  const httpUrl = 'http://install.serverless.com/installer-builds/x'
+
+  test('returns null when no proxy is configured', () => {
+    assert.equal(getProxyUrl(httpsUrl), null)
+  })
+
+  test('uses HTTPS_PROXY for https urls', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080'
+    assert.equal(getProxyUrl(httpsUrl), 'http://proxy:8080')
+  })
+
+  test('uses HTTP_PROXY for http urls', () => {
+    process.env.HTTP_PROXY = 'http://proxy:8080'
+    assert.equal(getProxyUrl(httpUrl), 'http://proxy:8080')
+  })
+
+  test('falls back to npm_config_https_proxy for https urls', () => {
+    process.env.npm_config_https_proxy = 'http://npm-proxy:8080'
+    assert.equal(getProxyUrl(httpsUrl), 'http://npm-proxy:8080')
+  })
+
+  // npm itself resolves https requests as `httpsProxy || proxy`
+  test('falls back to npm_config_proxy for https urls (mirrors npm)', () => {
+    process.env.npm_config_proxy = 'http://npm-proxy:8080'
+    assert.equal(getProxyUrl(httpsUrl), 'http://npm-proxy:8080')
+  })
+
+  test('npm_config_https_proxy wins over npm_config_proxy', () => {
+    process.env.npm_config_https_proxy = 'http://npm-https-proxy:8080'
+    process.env.npm_config_proxy = 'http://npm-proxy:8080'
+    assert.equal(getProxyUrl(httpsUrl), 'http://npm-https-proxy:8080')
+  })
+
+  test('falls back to npm_config_proxy for http urls', () => {
+    process.env.npm_config_proxy = 'http://npm-proxy:8080'
+    assert.equal(getProxyUrl(httpUrl), 'http://npm-proxy:8080')
+  })
+
+  test('environment variables win over npm config', () => {
+    process.env.HTTPS_PROXY = 'http://env-proxy:8080'
+    process.env.npm_config_https_proxy = 'http://npm-proxy:8080'
+    assert.equal(getProxyUrl(httpsUrl), 'http://env-proxy:8080')
+  })
+
+  test('NO_PROXY=* bypasses the proxy', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080'
+    process.env.NO_PROXY = '*'
+    assert.equal(getProxyUrl(httpsUrl), null)
+  })
+
+  test('NO_PROXY host suffix match bypasses the proxy', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080'
+    process.env.NO_PROXY = 'serverless.com'
+    assert.equal(getProxyUrl(httpsUrl), null)
+  })
+
+  test('npm_config_noproxy bypasses the proxy', () => {
+    process.env.npm_config_https_proxy = 'http://npm-proxy:8080'
+    process.env.npm_config_noproxy = 'serverless.com'
+    assert.equal(getProxyUrl(httpsUrl), null)
+  })
+
+  test('newline-joined npm_config_noproxy (array-form .npmrc) bypasses the proxy', () => {
+    process.env.npm_config_https_proxy = 'http://npm-proxy:8080'
+    process.env.npm_config_noproxy = 'example.com\n\nserverless.com'
+    assert.equal(getProxyUrl(httpsUrl), null)
+  })
+
+  test('empty NO_PROXY entries never match', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080'
+    process.env.NO_PROXY = 'example.com,,'
+    assert.equal(getProxyUrl(httpsUrl), 'http://proxy:8080')
+  })
+
+  test('non-matching NO_PROXY keeps the proxy', () => {
+    process.env.HTTPS_PROXY = 'http://proxy:8080'
+    process.env.NO_PROXY = 'example.com'
+    assert.equal(getProxyUrl(httpsUrl), 'http://proxy:8080')
+  })
+})
+
+describe('Binary.install', () => {
+  let installDirectory
+
+  const makeBinary = () =>
+    new Binary('test-binary', 'https://install.serverless.com/x', '0.0.0', {
+      installDirectory,
+    })
+
+  beforeEach(() => {
+    installDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'sf-installer-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(installDirectory, { recursive: true, force: true })
+  })
+
+  test('downloads and writes an executable binary', async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      arrayBuffer: async () =>
+        new TextEncoder().encode('binary-content').buffer,
+    })
+    const binary = makeBinary()
+    await binary.install(true)
+    assert.equal(fs.readFileSync(binary.binaryPath, 'utf8'), 'binary-content')
+    if (process.platform !== 'win32') {
+      assert.equal(fs.statSync(binary.binaryPath).mode & 0o777, 0o755)
+    }
+  })
+
+  test('skips the download when the binary already exists', async () => {
+    let fetchCalls = 0
+    globalThis.fetch = async () => {
+      fetchCalls += 1
+      throw new Error('should not be called')
+    }
+    const binary = makeBinary()
+    fs.writeFileSync(binary.binaryPath, 'existing')
+    await binary.install(true)
+    assert.equal(fetchCalls, 0)
+  })
+
+  test('rejects with the original error on network failure', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('fetch failed', {
+        cause: Object.assign(new Error('reset'), { code: 'ECONNRESET' }),
+      })
+    }
+    const binary = makeBinary()
+    await assert.rejects(binary.install(true), (error) => {
+      assert.equal(describeError(error), 'fetch failed: reset (ECONNRESET)')
+      return true
+    })
+    assert.equal(fs.existsSync(binary.binaryPath), false)
+  })
+
+  test('rejects on a non-2xx response and leaves no binary behind', async () => {
+    globalThis.fetch = async () => ({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+    })
+    const binary = makeBinary()
+    await assert.rejects(binary.install(true), /HTTP 403/)
+    assert.equal(fs.existsSync(binary.binaryPath), false)
+  })
+
+  test('rejects instead of throwing on an invalid proxy configuration', async () => {
+    process.env.HTTPS_PROXY = '://not a url'
+    const binary = makeBinary()
+    // A synchronous throw here would escape entrypoint .catch() handlers and
+    // abort npm install; it must surface as a rejection.
+    await assert.rejects(binary.install(true))
+  })
+
+  test('constructor rejects invalid parameters by throwing', () => {
+    assert.throws(() => new Binary('name', 42, '0.0.0'), /url must be a string/)
+  })
+})
+
+describe('childExitCode', () => {
+  test('forwards a numeric status', () => {
+    assert.equal(childExitCode({ status: 0, signal: null }), 0)
+    assert.equal(childExitCode({ status: 3, signal: null }), 3)
+  })
+
+  test('maps a signal death to 128 + signal number', () => {
+    assert.equal(childExitCode({ status: null, signal: 'SIGTERM' }), 143)
+    assert.equal(childExitCode({ status: null, signal: 'SIGKILL' }), 137)
+  })
+
+  test('falls back to 1 for an unknown signal', () => {
+    assert.equal(childExitCode({ status: null, signal: 'SIGWHATEVER' }), 1)
+  })
+})
+
+describe('install (module entrypoint)', () => {
+  test('rejects on an unsupported architecture instead of exiting', async () => {
+    const realArch = os.arch
+    os.arch = () => 'ia32'
+    try {
+      await assert.rejects(install(), /not supported/)
+    } finally {
+      os.arch = realArch
+    }
+  })
+})

--- a/packages/sf-core-installer/tests/entrypoints.test.js
+++ b/packages/sf-core-installer/tests/entrypoints.test.js
@@ -1,6 +1,6 @@
 const { test, describe, before, after } = require('node:test')
 const assert = require('node:assert/strict')
-const { spawnSync } = require('node:child_process')
+const { spawn, spawnSync } = require('node:child_process')
 const os = require('node:os')
 const fs = require('node:fs')
 const path = require('node:path')
@@ -124,6 +124,51 @@ new Binary('fake', 'https://example.com/x', '0.0.0', { installDirectory: ${JSON.
       // Previously status null became process.exit(null) === success.
       const result = runWithFakeBinary('kill -9 $$')
       assert.equal(result.status, 128 + 9)
+    })
+  },
+)
+
+describe(
+  'Binary.install — interrupted download',
+  { skip: process.platform === 'win32' },
+  () => {
+    // Starts a download that never completes (fetch is stubbed to hang), then
+    // signals the process; the exit status must follow the 128 + signal
+    // convention rather than a generic 1.
+    const interruptDownload = (signal) =>
+      new Promise((resolve, reject) => {
+        const dir = fs.mkdtempSync(path.join(workDir, 'interrupt-'))
+        const runner = path.join(dir, 'runner.js')
+        fs.writeFileSync(
+          runner,
+          `const { Binary } = require('../binary')
+// The marker is emitted from inside fetch(), i.e. after install() has
+// registered its signal handlers — printing earlier races the kill. A bare
+// pending Promise would not keep the event loop alive (the process would
+// exit 0 by itself), so hold a timer like a real socket would.
+globalThis.fetch = () => {
+  process.stdout.write('downloading\\n')
+  setTimeout(() => {}, 60000)
+  return new Promise(() => {})
+}
+new Binary('fake', 'https://example.com/x', '0.0.0', { installDirectory: ${JSON.stringify(path.join(dir, 'bin'))} })
+  .install(true)
+  .then(() => process.exit(0), () => process.exit(1))`,
+        )
+        const child = spawn(process.execPath, [runner], { cwd: workDir })
+        child.stdout.once('data', () => child.kill(signal))
+        child.on('error', reject)
+        child.on('close', (code, sig) => resolve({ code, sig }))
+      })
+
+    test('SIGTERM during the download exits 143', async () => {
+      const { code } = await interruptDownload('SIGTERM')
+      assert.equal(code, 128 + 15)
+    })
+
+    test('SIGINT during the download exits 130', async () => {
+      const { code } = await interruptDownload('SIGINT')
+      assert.equal(code, 128 + 2)
     })
   },
 )

--- a/packages/sf-core-installer/tests/entrypoints.test.js
+++ b/packages/sf-core-installer/tests/entrypoints.test.js
@@ -1,0 +1,149 @@
+const { test, describe, before, after } = require('node:test')
+const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
+const os = require('node:os')
+const fs = require('node:fs')
+const path = require('node:path')
+
+// The contract under test is the exit code npm (or the shell) observes, so
+// these tests run the real entrypoint scripts as subprocesses, from a copy of
+// the package so download attempts cannot touch the working tree.
+const packageDir = path.join(__dirname, '..')
+let workDir
+
+const PROXY_ENV_KEYS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'NO_PROXY',
+  'no_proxy',
+  'npm_config_proxy',
+  'npm_config_https_proxy',
+  'npm_config_noproxy',
+]
+
+const runScript = (script, env, args = []) => {
+  const cleanEnv = { ...process.env }
+  for (const key of PROXY_ENV_KEYS) delete cleanEnv[key]
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd: workDir,
+    env: { ...cleanEnv, ...env },
+    encoding: 'utf8',
+    timeout: 30000,
+  })
+}
+
+before(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sf-installer-e2e-'))
+  for (const file of ['binary.js', 'postInstall.js', 'run.js']) {
+    fs.copyFileSync(path.join(packageDir, file), path.join(workDir, file))
+  }
+  // Copy only the undici dependency — the package's own node_modules/.bin may
+  // already hold a downloaded launcher binary, which would let run.js skip the
+  // download under test.
+  if (!fs.existsSync(path.join(packageDir, 'node_modules', 'undici'))) {
+    throw new Error(
+      'packages/sf-core-installer has no node_modules/undici — the package is ' +
+        'outside the npm workspaces; run `npm ci --ignore-scripts` in it first.',
+    )
+  }
+  fs.cpSync(
+    path.join(packageDir, 'node_modules', 'undici'),
+    path.join(workDir, 'node_modules', 'undici'),
+    { recursive: true },
+  )
+})
+
+after(() => {
+  fs.rmSync(workDir, { recursive: true, force: true })
+})
+
+describe('postInstall.js — must never fail npm install', () => {
+  test('exits 0 when the download cannot go through (unreachable proxy)', () => {
+    const result = runScript('postInstall.js', {
+      HTTPS_PROXY: 'http://127.0.0.1:9',
+    })
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stderr, /Could not pre-download/)
+    assert.match(result.stderr, /first time/)
+  })
+
+  test('exits 0 on an invalid proxy configuration', () => {
+    const result = runScript('postInstall.js', {
+      HTTPS_PROXY: '://not a url',
+    })
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stderr, /Could not pre-download/)
+  })
+
+  test('exits 0 on an invalid npm-provided proxy configuration', () => {
+    const result = runScript('postInstall.js', {
+      npm_config_https_proxy: '://not a url',
+    })
+    assert.equal(result.status, 0, result.stderr)
+  })
+})
+
+describe(
+  'Binary.run — exit code propagation',
+  { skip: process.platform === 'win32' },
+  () => {
+    // Runs Binary.run() against a fake executable placed where the binary is
+    // expected, so spawnSync's result handling is exercised for real.
+    const runWithFakeBinary = (script) => {
+      const dir = fs.mkdtempSync(path.join(workDir, 'fake-'))
+      fs.writeFileSync(path.join(dir, 'fake-0.0.0'), `#!/bin/sh\n${script}\n`, {
+        mode: 0o755,
+      })
+      const runner = path.join(dir, 'runner.js')
+      fs.writeFileSync(
+        runner,
+        `const { Binary } = require('../binary')
+new Binary('fake', 'https://example.com/x', '0.0.0', { installDirectory: ${JSON.stringify(dir)} }).run()`,
+      )
+      return spawnSync(process.execPath, [runner, 'arg1', 'arg2'], {
+        cwd: workDir,
+        encoding: 'utf8',
+        timeout: 30000,
+      })
+    }
+
+    test('forwards the child exit code', () => {
+      const result = runWithFakeBinary('exit 3')
+      assert.equal(result.status, 3)
+    })
+
+    test('forwards arguments to the binary', () => {
+      const result = runWithFakeBinary('echo "$@"')
+      assert.equal(result.status, 0)
+      assert.equal(result.stdout.trim(), 'arg1 arg2')
+    })
+
+    test('reports 128 + signal number when the child is killed by a signal', () => {
+      // Previously status null became process.exit(null) === success.
+      const result = runWithFakeBinary('kill -9 $$')
+      assert.equal(result.status, 128 + 9)
+    })
+  },
+)
+
+describe('run.js — must fail hard when the binary cannot be obtained', () => {
+  test('exits 1 with the underlying error when the download fails', () => {
+    const result = runScript('run.js', { HTTPS_PROXY: 'http://127.0.0.1:9' }, [
+      '--version',
+    ])
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /Could not download the Serverless Framework/)
+    // The message must carry the underlying cause, not just "fetch failed".
+    assert.match(result.stderr, /ECONNREFUSED|EADDRNOTAVAIL/)
+  })
+
+  test('exits 1 on an invalid proxy configuration', () => {
+    const result = runScript('run.js', { HTTPS_PROXY: '://not a url' }, [
+      '--version',
+    ])
+    assert.equal(result.status, 1)
+    assert.match(result.stderr, /Could not download the Serverless Framework/)
+  })
+})


### PR DESCRIPTION
## Summary

The `serverless` npm package downloads the CLI launcher binary in its `postinstall` script. Any failure of that download — blocked egress, a proxy that is not configured for the script, TLS interception — exited 1 and aborted the entire `npm install`, even though every package had installed correctly. The only workaround was `npm install --ignore-scripts`.

A binary that is missing after `postinstall` is always recoverable: `run.js` downloads it on the first invocation. So `postinstall` failures now produce a warning and the install succeeds; running the CLI without an obtainable binary still fails hard.

- `packages/sf-core-installer/postInstall.js` catches every failure — including synchronous ones such as an invalid proxy URL, which previously escaped as an unhandled rejection with a raw stack trace — prints a warning saying the download is retried on first run, and exits 0
- Error messages include the whole `fetch()` cause chain, message and code of every error (for example `fetch failed: connect ECONNREFUSED 127.0.0.1:9 (ECONNREFUSED)`) instead of the bare `fetch failed`
- Proxy resolution honors npm's own configuration when no proxy environment variables are set: `npm_config_https_proxy`, `npm_config_proxy` (the https fallback, as npm itself resolves it) and `npm_config_noproxy` (including the newline-joined array form npm exports), which npm passes to lifecycle scripts from `.npmrc`; `HTTP(S)_PROXY` / `NO_PROXY` keep precedence
- `Binary.install`, its constructor and `getBinaryName` throw or reject instead of calling `process.exit`, so the two entrypoints own the failure policy; the signal handlers registered during a download are removed afterwards, and a partial file left by a failed write is cleaned up (the cleanup previously sat after `process.exit` and never ran)
- When the launcher process is terminated by a signal, the CLI now exits with `128 + signal number` (143 for `SIGTERM`) instead of 0 — `spawnSync` reports such a child with `status: null`, and `process.exit(null)` meant success
- New zero-dependency test suite (`node --test`) in `packages/sf-core-installer/tests/` covering the proxy resolution matrix, install outcomes and the entrypoint exit-code contracts via real subprocesses; new `Test: Installer` CI job; a `files` whitelist keeps the tests out of the published package (its contents are unchanged)
- Docs: `docs/sf/getting-started.md` gains "Installing behind a proxy or firewall" — the hosts the CLI connects to, the proxy and CA environment variables, the `.npmrc` settings honored during installation, and the install-time warning / first-run download behavior

## Root cause

`binary.js` handled a download failure with `console.error` + `process.exit(1)` inside the fetch `.catch`, and npm treats a non-zero lifecycle script as a failed install. Two further paths bypassed even that handler: undici's `ProxyAgent` constructor throws synchronously on a malformed proxy URL, and an unsupported CPU architecture called `process.exit(1)` directly — both surfaced as crashes with raw stack traces. Separately, `.npmrc` proxy settings are applied by npm to its own downloads but are only exposed to scripts as `npm_config_*` variables, which the script never read, so a proxy-only network failed the download while every tarball fetched fine.

## Test plan

- [x] `cd packages/sf-core-installer && npm test` — 42 tests, 8 suites, all passing; eslint and prettier clean
- [x] Packed tarball, normal network: `npm install` downloads the binary, exit 0
- [x] Packed tarball, `HTTPS_PROXY=http://127.0.0.1:9`: `npm install` exits 0 with `Could not pre-download the Serverless Framework binary: fetch failed: connect ECONNREFUSED 127.0.0.1:9 (ECONNREFUSED)`; `serverless --version` under the same proxy exits 1 with the same cause; with the proxy removed, the binary downloads on first run and `serverless --version` prints the version
- [x] Malformed proxy values (`HTTPS_PROXY="://not a url"`, `proxy.corp.com:8080`): `npm install` exits 0 with the warning (previously an uncaught `Invalid URL` stack trace, exit 1)
- [x] Real launcher killed with `SIGTERM` / `SIGKILL` while running: CLI exits 143 / 137 (previously 0)

## Behavior change

An install on a machine without egress now succeeds without the binary and fails at the first `serverless` run instead of at install time. The warning is visible with `npm install --foreground-scripts`; default npm hides the output of successful scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer error messages when binary downloads fail.
  * Installer failures during package installation now show actionable proxy guidance without blocking installation.
  * Improved handling of proxy settings, certificates, unsupported platforms, and interrupted processes.
  * Runtime launches now return clearer errors and accurate exit codes when the binary is unavailable.

* **Documentation**
  * Added guidance for installing behind proxies or firewalls.

* **Tests**
  * Expanded installer and runtime test coverage, including downloads, proxy behavior, interruptions, and command execution.
  * Added automated CI coverage for the installer package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->