### PR TITLE
feat(aws): support provisioned mode for sqs, kafka, and msk events

### DIFF
--- a/docs/sf/providers/aws/events/kafka.md
+++ b/docs/sf/providers/aws/events/kafka.md
@@ -195,3 +195,30 @@ functions:
           maximumBatchingWindow: 30
           startingPosition: LATEST
 ```
+
+## Provisioned mode
+
+[Provisioned mode](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html#invocation-eventsourcemapping-provisioned-mode) gives the event source mapping a dedicated pool of event pollers with minimum and maximum bounds, for consistent low-latency processing. Configure it with `provisionedPollers`:
+
+```yml
+functions:
+  compute:
+    handler: handler.compute
+    events:
+      - kafka:
+          accessConfigurations:
+            saslScram512Auth: arn:aws:secretsmanager:us-east-1:01234567890:secret:MyBrokerSecretName
+          bootstrapServers:
+            - abc3.xyz.com:9092
+          topic: MyTopic
+          provisionedPollers:
+            min: 1 # optional, 1-200, AWS default 1
+            max: 100 # optional, 1-2000, AWS default 200
+            group: shared-capacity # optional poller group name
+```
+
+Provisioned mode incurs additional AWS charges per event poller — the `min` value is an always-on cost. See [AWS Lambda pricing](https://aws.amazon.com/lambda/pricing/).
+
+`group` (letters, digits, hyphens and underscores, up to 128 characters) groups up to 100 event source mappings within the event source's VPC to share Event Poller Unit capacity, reducing provisioned-mode cost; the aggregate `max` across a group cannot exceed 2,000.
+
+**Disabling provisioned mode:** removing `provisionedPollers` from your configuration does **not** disable it — provisioned mode stays active on the deployed event source mapping, so the pollers (and their cost) remain. The same applies to `rollback` to an older deployment. To actually disable it, deploy once with `provisionedPollers: false`. `false` clears provisioned mode on an existing mapping; it cannot be used on a mapping that is being created for the first time — for new mappings, simply omit the key.

--- a/docs/sf/providers/aws/events/kafka.md
+++ b/docs/sf/providers/aws/events/kafka.md
@@ -221,4 +221,6 @@ Provisioned mode incurs additional AWS charges per event poller — the `min` va
 
 `group` (letters, digits, hyphens and underscores, up to 128 characters) groups up to 100 event source mappings within the event source's VPC to share Event Poller Unit capacity, reducing provisioned-mode cost; the aggregate `max` across a group cannot exceed 2,000.
 
+Deleting the `group` line removes the mapping from its poller group on the next deploy; its own `min` and `max` are unaffected.
+
 **Disabling provisioned mode:** removing `provisionedPollers` from your configuration does **not** disable it — provisioned mode stays active on the deployed event source mapping, so the pollers (and their cost) remain. The same applies to `rollback` to an older deployment. To actually disable it, deploy once with `provisionedPollers: false`. `false` clears provisioned mode on an existing mapping; it cannot be used on a mapping that is being created for the first time — for new mappings, simply omit the key.

--- a/docs/sf/providers/aws/events/msk.md
+++ b/docs/sf/providers/aws/events/msk.md
@@ -147,3 +147,27 @@ functions:
 ## IAM Permissions
 
 The Serverless Framework will automatically configure the most minimal set of IAM permissions for you. However you can still add additional permissions if you need to. Read the official [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/with-msk.html) for more information about IAM Permissions for MSK events.
+
+## Provisioned mode
+
+[Provisioned mode](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html#invocation-eventsourcemapping-provisioned-mode) gives the event source mapping a dedicated pool of event pollers with minimum and maximum bounds, for consistent low-latency processing. Configure it with `provisionedPollers`:
+
+```yml
+functions:
+  compute:
+    handler: handler.compute
+    events:
+      - msk:
+          arn: arn:aws:kafka:region:XXXXXX:cluster/MyCluster/xxxx-xxxxx-xxxx
+          topic: mytopic
+          provisionedPollers:
+            min: 1 # optional, 1-200, AWS default 1
+            max: 100 # optional, 1-2000, AWS default 200
+            group: shared-capacity # optional poller group name
+```
+
+Provisioned mode incurs additional AWS charges per event poller — the `min` value is an always-on cost. See [AWS Lambda pricing](https://aws.amazon.com/lambda/pricing/).
+
+`group` (letters, digits, hyphens and underscores, up to 128 characters) groups up to 100 event source mappings within the event source's VPC to share Event Poller Unit capacity, reducing provisioned-mode cost; the aggregate `max` across a group cannot exceed 2,000.
+
+**Disabling provisioned mode:** removing `provisionedPollers` from your configuration does **not** disable it — provisioned mode stays active on the deployed event source mapping, so the pollers (and their cost) remain. The same applies to `rollback` to an older deployment. To actually disable it, deploy once with `provisionedPollers: false`. `false` clears provisioned mode on an existing mapping; it cannot be used on a mapping that is being created for the first time — for new mappings, simply omit the key.

--- a/docs/sf/providers/aws/events/msk.md
+++ b/docs/sf/providers/aws/events/msk.md
@@ -170,4 +170,6 @@ Provisioned mode incurs additional AWS charges per event poller — the `min` va
 
 `group` (letters, digits, hyphens and underscores, up to 128 characters) groups up to 100 event source mappings within the event source's VPC to share Event Poller Unit capacity, reducing provisioned-mode cost; the aggregate `max` across a group cannot exceed 2,000.
 
+Deleting the `group` line removes the mapping from its poller group on the next deploy; its own `min` and `max` are unaffected.
+
 **Disabling provisioned mode:** removing `provisionedPollers` from your configuration does **not** disable it — provisioned mode stays active on the deployed event source mapping, so the pollers (and their cost) remain. The same applies to `rollback` to an older deployment. To actually disable it, deploy once with `provisionedPollers: false`. `false` clears provisioned mode on an existing mapping; it cannot be used on a mapping that is being created for the first time — for new mappings, simply omit the key.

--- a/docs/sf/providers/aws/events/sqs.md
+++ b/docs/sf/providers/aws/events/sqs.md
@@ -116,6 +116,43 @@ functions:
           maximumConcurrency: 250
 ```
 
+## Provisioned mode
+
+[Provisioned mode](https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-scaling.html) gives the event source mapping a dedicated pool of event pollers with minimum and maximum bounds, for faster scaling and higher throughput than the default on-demand polling. Configure it with `provisionedPollers`:
+
+```yml
+functions:
+  compute:
+    handler: handler.compute
+    events:
+      - sqs:
+          arn: arn:aws:sqs:region:XXXXXX:myQueue
+          provisionedPollers:
+            min: 2 # optional, 2-200, AWS default 2
+            max: 500 # optional, 2-10000, AWS default 200
+```
+
+Provisioned mode incurs additional AWS charges per event poller — the `min` value is an always-on cost. See [AWS Lambda pricing](https://aws.amazon.com/lambda/pricing/).
+
+`provisionedPollers` and `maximumConcurrency` are mutually exclusive scaling modes — setting both fails validation at package time. In provisioned mode, control concurrency through `max` (each SQS event poller drives up to 10 concurrent invocations).
+
+**Disabling provisioned mode:** removing `provisionedPollers` from your configuration does **not** disable it — provisioned mode stays active on the deployed event source mapping, so the pollers (and their cost) remain. The same applies to `rollback` to an older deployment. To actually disable it, deploy once with:
+
+```yml
+provisionedPollers: false
+```
+
+`false` clears provisioned mode on an existing mapping. It cannot be used on a mapping that is being created for the first time — for new mappings, simply omit the key.
+
+**Switching back to `maximumConcurrency`:** set both keys for one deploy — `false` clears provisioned mode while the concurrency limit applies — then optionally remove the `false` line:
+
+```yml
+- sqs:
+    arn: arn:aws:sqs:region:XXXXXX:myQueue
+    maximumConcurrency: 250
+    provisionedPollers: false
+```
+
 ## IAM Permissions
 
 The Serverless Framework will automatically configure the most minimal set of IAM permissions for you. However you can still add additional permissions if you need to. Read the official [AWS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-lambda-function-trigger.html) for more information about IAM Permissions for SQS events.

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -1231,6 +1231,14 @@ functions:
           functionResponseType: ReportBatchItemFailures
           filterPatterns:
             - a: [1, 2]
+          # Optional, must be in 2-1000 range. Mutually exclusive with provisionedPollers
+          maximumConcurrency: 250
+          # Optional, provisioned mode: dedicated event pollers (additional cost). Set to false to disable on an existing mapping
+          provisionedPollers:
+            # Optional, must be in 2-200 range
+            min: 2
+            # Optional, must be in 2-10000 range
+            max: 500
 ```
 
 ### Streams
@@ -1286,6 +1294,14 @@ functions:
           filterPatterns:
             - value:
                 a: [1, 2]
+          # Optional, provisioned mode: dedicated event pollers (additional cost). Set to false to disable on an existing mapping
+          provisionedPollers:
+            # Optional, must be in 1-200 range
+            min: 1
+            # Optional, must be in 1-2000 range
+            max: 100
+            # Optional, poller group name (letters, digits, hyphens, underscores) shared by up to 100 mappings in the same VPC
+            group: shared-capacity
 ```
 
 ### ActiveMQ
@@ -1352,6 +1368,14 @@ functions:
           # Optional, specifies event pattern content filtering
           filterPatterns:
             - eventName: INSERT
+          # Optional, provisioned mode: dedicated event pollers (additional cost). Set to false to disable on an existing mapping
+          provisionedPollers:
+            # Optional, must be in 1-200 range
+            min: 1
+            # Optional, must be in 1-2000 range
+            max: 100
+            # Optional, poller group name (letters, digits, hyphens, underscores) shared by up to 100 mappings in the same VPC
+            group: shared-capacity
 ```
 
 ### RabbitMQ

--- a/packages/serverless/lib/plugins/aws/package/compile/events/kafka.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/kafka.js
@@ -408,7 +408,7 @@ provisionedPollers:
             ...(provisionedPollers.max != null && {
               MaximumPollers: provisionedPollers.max,
             }),
-            ...(provisionedPollers.group != null && {
+            ...(provisionedPollers.group && {
               PollerGroupName: provisionedPollers.group,
             }),
           }

--- a/packages/serverless/lib/plugins/aws/package/compile/events/kafka.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/kafka.js
@@ -128,6 +128,43 @@ events:
           pattern: '[a-zA-Z0-9-/*:_+=.@-]*',
         },
         filterPatterns: { $ref: '#/definitions/filterPatterns' },
+        provisionedPollers: {
+          description: `Provisioned mode for the event source mapping — dedicated event pollers with min/max bounds and optional poller group. Set to false to disable provisioned mode on an existing mapping.
+@see https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html#invocation-eventsourcemapping-provisioned-mode
+@example
+provisionedPollers:
+  min: 1
+  max: 100`,
+          anyOf: [
+            { const: false },
+            {
+              type: 'object',
+              properties: {
+                min: {
+                  description: `Minimum number of provisioned event pollers (1-200). AWS default: 1.`,
+                  type: 'integer',
+                  minimum: 1,
+                  maximum: 200,
+                },
+                max: {
+                  description: `Maximum number of provisioned event pollers (1-2000). AWS default: 200.`,
+                  type: 'integer',
+                  minimum: 1,
+                  maximum: 2000,
+                },
+                group: {
+                  description: `Provisioned poller group name — groups up to 100 event source mappings in the event source's VPC to share Event Poller Unit capacity. Letters, digits, hyphens and underscores only.`,
+                  type: 'string',
+                  minLength: 1,
+                  maxLength: 128,
+                  pattern: '^[a-zA-Z0-9_-]+$',
+                },
+              },
+              minProperties: 1,
+              additionalProperties: false,
+            },
+          ],
+        },
       },
       additionalProperties: false,
       required: ['accessConfigurations', 'bootstrapServers', 'topic'],
@@ -350,6 +387,33 @@ events:
               Pattern: JSON.stringify(pattern),
             })),
           }
+        }
+
+        const provisionedPollers = event.kafka.provisionedPollers
+        if (provisionedPollers && typeof provisionedPollers === 'object') {
+          if (
+            provisionedPollers.min != null &&
+            provisionedPollers.max != null &&
+            provisionedPollers.min > provisionedPollers.max
+          ) {
+            throw new ServerlessError(
+              `The "kafka" event of function "${functionName}" has "provisionedPollers.min" (${provisionedPollers.min}) greater than "max" (${provisionedPollers.max}).`,
+              'EVENT_PROVISIONED_POLLERS_INVALID',
+            )
+          }
+          kafkaResource.Properties.ProvisionedPollerConfig = {
+            ...(provisionedPollers.min != null && {
+              MinimumPollers: provisionedPollers.min,
+            }),
+            ...(provisionedPollers.max != null && {
+              MaximumPollers: provisionedPollers.max,
+            }),
+            ...(provisionedPollers.group != null && {
+              PollerGroupName: provisionedPollers.group,
+            }),
+          }
+        } else if (provisionedPollers === false) {
+          kafkaResource.Properties.ProvisionedPollerConfig = {}
         }
 
         cfTemplate.Resources[kafkaEventLogicalId] = kafkaResource

--- a/packages/serverless/lib/plugins/aws/package/compile/events/lib/provisioned-pollers-analytics.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/lib/provisioned-pollers-analytics.js
@@ -1,0 +1,65 @@
+/**
+ * Pure builder for the `provisionedPollers` block of the
+ * sfcore.analysis.generated.v1 analytics event. Consumed by the sf-core
+ * framework runner's getAnalysisEventDetails().
+ *
+ * Contract (mirrors sandboxes/mcp analytics builders):
+ *  - Fixed keys only — never a user-authored string (the poller group NAME
+ *    is never reported, only its presence count).
+ *  - Explicit-only + omit-empty: a key appears only when a user set it.
+ *  - HARD REQUIREMENT: total function — never throws; malformed input
+ *    degrades to {} so analytics can never break a user command.
+ */
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v)
+
+const sortedUniqueNumbers = (values) =>
+  [...new Set(values.filter((n) => typeof n === 'number'))].sort(
+    (a, b) => a - b,
+  )
+
+const SOURCES = ['sqs', 'kafka', 'msk']
+// `group` (PollerGroupName) exists only on kafka/msk; the sqs schema rejects it,
+// so a group on sqs is invalid config and is never reported.
+const SOURCES_WITH_GROUP = new Set(['kafka', 'msk'])
+
+export const buildProvisionedPollersAnalytics = (config) => {
+  try {
+    const functions = isObj(config?.functions)
+      ? Object.values(config.functions)
+      : []
+    const perSource = {}
+    for (const source of SOURCES) {
+      const values = []
+      for (const fn of functions) {
+        const events = Array.isArray(fn?.events) ? fn.events : []
+        for (const event of events) {
+          if (!isObj(event?.[source])) continue
+          const value = event[source].provisionedPollers
+          if (value !== undefined) values.push(value)
+        }
+      }
+      const objects = values.filter(isObj)
+      const block = {}
+      if (objects.length > 0) block.configured = objects.length
+      const disabled = values.filter((v) => v === false).length
+      if (disabled > 0) block.disabled = disabled
+      const min = sortedUniqueNumbers(objects.map((o) => o.min))
+      if (min.length > 0) block.min = min
+      const max = sortedUniqueNumbers(objects.map((o) => o.max))
+      if (max.length > 0) block.max = max
+      if (SOURCES_WITH_GROUP.has(source)) {
+        const groups = objects.filter(
+          (o) => typeof o.group === 'string' && o.group.length > 0,
+        ).length
+        if (groups > 0) block.groups = groups
+      }
+      if (Object.keys(block).length > 0) perSource[source] = block
+    }
+    return Object.keys(perSource).length > 0
+      ? { provisionedPollers: perSource }
+      : {}
+  } catch {
+    return {}
+  }
+}

--- a/packages/serverless/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/msk/index.js
@@ -256,7 +256,7 @@ provisionedPollers:
               ...(provisionedPollers.max != null && {
                 MaximumPollers: provisionedPollers.max,
               }),
-              ...(provisionedPollers.group != null && {
+              ...(provisionedPollers.group && {
                 PollerGroupName: provisionedPollers.group,
               }),
             }

--- a/packages/serverless/lib/plugins/aws/package/compile/events/msk/index.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/msk/index.js
@@ -76,6 +76,43 @@ msk:
 @see https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html`,
           $ref: '#/definitions/filterPatterns',
         },
+        provisionedPollers: {
+          description: `Provisioned mode for the event source mapping — dedicated event pollers with min/max bounds and optional poller group. Set to false to disable provisioned mode on an existing mapping.
+@see https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html#invocation-eventsourcemapping-provisioned-mode
+@example
+provisionedPollers:
+  min: 1
+  max: 100`,
+          anyOf: [
+            { const: false },
+            {
+              type: 'object',
+              properties: {
+                min: {
+                  description: `Minimum number of provisioned event pollers (1-200). AWS default: 1.`,
+                  type: 'integer',
+                  minimum: 1,
+                  maximum: 200,
+                },
+                max: {
+                  description: `Maximum number of provisioned event pollers (1-2000). AWS default: 200.`,
+                  type: 'integer',
+                  minimum: 1,
+                  maximum: 2000,
+                },
+                group: {
+                  description: `Provisioned poller group name — groups up to 100 event source mappings in the event source's VPC to share Event Poller Unit capacity. Letters, digits, hyphens and underscores only.`,
+                  type: 'string',
+                  minLength: 1,
+                  maxLength: 128,
+                  pattern: '^[a-zA-Z0-9_-]+$',
+                },
+              },
+              minProperties: 1,
+              additionalProperties: false,
+            },
+          ],
+        },
       },
       additionalProperties: false,
       required: ['arn', 'topic'],
@@ -198,6 +235,33 @@ msk:
                 Pattern: JSON.stringify(pattern),
               })),
             }
+          }
+
+          const provisionedPollers = event.msk.provisionedPollers
+          if (provisionedPollers && typeof provisionedPollers === 'object') {
+            if (
+              provisionedPollers.min != null &&
+              provisionedPollers.max != null &&
+              provisionedPollers.min > provisionedPollers.max
+            ) {
+              throw new ServerlessError(
+                `The "msk" event of function "${functionName}" has "provisionedPollers.min" (${provisionedPollers.min}) greater than "max" (${provisionedPollers.max}).`,
+                'EVENT_PROVISIONED_POLLERS_INVALID',
+              )
+            }
+            mskResource.Properties.ProvisionedPollerConfig = {
+              ...(provisionedPollers.min != null && {
+                MinimumPollers: provisionedPollers.min,
+              }),
+              ...(provisionedPollers.max != null && {
+                MaximumPollers: provisionedPollers.max,
+              }),
+              ...(provisionedPollers.group != null && {
+                PollerGroupName: provisionedPollers.group,
+              }),
+            }
+          } else if (provisionedPollers === false) {
+            mskResource.Properties.ProvisionedPollerConfig = {}
           }
 
           mskStatement.Resource.push(eventSourceArn)

--- a/packages/serverless/lib/plugins/aws/package/compile/events/sqs.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/events/sqs.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import ServerlessError from '../../../../../serverless-error.js'
 import resolveLambdaTarget from '../../../utils/resolve-lambda-target.js'
 import usesDedicatedPerFunctionRole from '../../lib/uses-dedicated-per-function-role.js'
 
@@ -62,6 +63,36 @@ events:
               type: 'integer',
               minimum: 2,
               maximum: 1000,
+            },
+            provisionedPollers: {
+              description: `Provisioned mode for the event source mapping — dedicated event pollers with min/max bounds. Mutually exclusive with maximumConcurrency. Set to false to disable provisioned mode on an existing mapping.
+@see https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-scaling.html
+@example
+provisionedPollers:
+  min: 2
+  max: 500`,
+              anyOf: [
+                { const: false },
+                {
+                  type: 'object',
+                  properties: {
+                    min: {
+                      description: `Minimum number of provisioned event pollers (2-200). AWS default: 2.`,
+                      type: 'integer',
+                      minimum: 2,
+                      maximum: 200,
+                    },
+                    max: {
+                      description: `Maximum number of provisioned event pollers (2-10000). AWS default: 200.`,
+                      type: 'integer',
+                      minimum: 2,
+                      maximum: 10000,
+                    },
+                  },
+                  minProperties: 1,
+                  additionalProperties: false,
+                },
+              ],
             },
           },
           required: ['arn'],
@@ -169,6 +200,38 @@ events:
               sqsTemplate.Properties.ScalingConfig = {
                 MaximumConcurrency: event.sqs.maximumConcurrency,
               }
+            }
+
+            const provisionedPollers = event.sqs.provisionedPollers
+            if (provisionedPollers && typeof provisionedPollers === 'object') {
+              if (event.sqs.maximumConcurrency) {
+                throw new ServerlessError(
+                  `The "sqs" event of function "${functionName}" cannot set both "maximumConcurrency" and "provisionedPollers". They are mutually exclusive scaling modes: in provisioned mode, control concurrency with "provisionedPollers.max" instead.`,
+                  'SQS_EVENT_SCALING_MODE_CONFLICT',
+                )
+              }
+              if (
+                provisionedPollers.min != null &&
+                provisionedPollers.max != null &&
+                provisionedPollers.min > provisionedPollers.max
+              ) {
+                throw new ServerlessError(
+                  `The "sqs" event of function "${functionName}" has "provisionedPollers.min" (${provisionedPollers.min}) greater than "max" (${provisionedPollers.max}).`,
+                  'EVENT_PROVISIONED_POLLERS_INVALID',
+                )
+              }
+              sqsTemplate.Properties.ProvisionedPollerConfig = {
+                ...(provisionedPollers.min != null && {
+                  MinimumPollers: provisionedPollers.min,
+                }),
+                ...(provisionedPollers.max != null && {
+                  MaximumPollers: provisionedPollers.max,
+                }),
+              }
+            } else if (provisionedPollers === false) {
+              // Update-time clear ({} disables provisioned mode). On a brand-new
+              // mapping AWS rejects {} at create — documented; users remove the line.
+              sqsTemplate.Properties.ProvisionedPollerConfig = {}
             }
 
             if (!skipGlobalRolePermissions) {

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
@@ -661,4 +661,56 @@ describe('AwsCompileKafkaEvents', () => {
       expect(allResources).toContain(saslScram256AuthArn)
     })
   })
+
+  describe('provisionedPollers', () => {
+    const baseKafkaEvent = {
+      accessConfigurations: {
+        saslScram512Auth: [
+          'arn:aws:secretsmanager:us-east-1:111111111111:secret:name',
+        ],
+      },
+      bootstrapServers: ['broker1.example.com:9092'],
+      topic: 'my-topic',
+    }
+
+    const compileWithKafkaEvent = (extra) => {
+      awsCompileKafkaEvents.serverless.service.functions = {
+        first: { events: [{ kafka: { ...baseKafkaEvent, ...extra } }] },
+      }
+      awsCompileKafkaEvents.compileKafkaEvents()
+      const resources =
+        awsCompileKafkaEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      return Object.values(resources).find(
+        (r) => r.Type === 'AWS::Lambda::EventSourceMapping',
+      )
+    }
+
+    it('maps min/max/group to ProvisionedPollerConfig', () => {
+      const esm = compileWithKafkaEvent({
+        provisionedPollers: { min: 1, max: 100, group: 'shared-epu' },
+      })
+      expect(esm.Properties.ProvisionedPollerConfig).toEqual({
+        MinimumPollers: 1,
+        MaximumPollers: 100,
+        PollerGroupName: 'shared-epu',
+      })
+    })
+
+    it('compiles false to an empty ProvisionedPollerConfig', () => {
+      const esm = compileWithKafkaEvent({ provisionedPollers: false })
+      expect(esm.Properties.ProvisionedPollerConfig).toEqual({})
+    })
+
+    it('emits nothing when the key is absent', () => {
+      const esm = compileWithKafkaEvent({})
+      expect(esm.Properties.ProvisionedPollerConfig).toBeUndefined()
+    })
+
+    it('throws when min > max', () => {
+      expect(() =>
+        compileWithKafkaEvent({ provisionedPollers: { min: 100, max: 5 } }),
+      ).toThrow(/greater than "max"/)
+    })
+  })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/kafka.test.js
@@ -707,6 +707,16 @@ describe('AwsCompileKafkaEvents', () => {
       expect(esm.Properties.ProvisionedPollerConfig).toBeUndefined()
     })
 
+    it('never emits an empty poller group name', () => {
+      const esm = compileWithKafkaEvent({
+        provisionedPollers: { min: 1, max: 100, group: '' },
+      })
+      expect(esm.Properties.ProvisionedPollerConfig).toEqual({
+        MinimumPollers: 1,
+        MaximumPollers: 100,
+      })
+    })
+
     it('throws when min > max', () => {
       expect(() =>
         compileWithKafkaEvent({ provisionedPollers: { min: 100, max: 5 } }),

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/lib/provisioned-pollers-analytics.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/lib/provisioned-pollers-analytics.test.js
@@ -1,0 +1,101 @@
+import { buildProvisionedPollersAnalytics } from '../../../../../../../../../lib/plugins/aws/package/compile/events/lib/provisioned-pollers-analytics.js'
+
+const configWith = (events) => ({
+  service: 'svc',
+  functions: { fn: { events } },
+})
+
+test('returns {} when no event uses the key', () => {
+  expect(
+    buildProvisionedPollersAnalytics(
+      configWith([{ sqs: { arn: 'arn:aws:sqs:r:a:q' } }]),
+    ),
+  ).toEqual({})
+})
+
+test('reports per-source configured counts and sorted unique bounds', () => {
+  const out = buildProvisionedPollersAnalytics({
+    service: 'svc',
+    functions: {
+      a: {
+        events: [
+          { sqs: { arn: 'q1', provisionedPollers: { min: 5, max: 500 } } },
+          { sqs: { arn: 'q2', provisionedPollers: { max: 500 } } },
+        ],
+      },
+      b: {
+        events: [
+          {
+            kafka: {
+              topic: 't',
+              provisionedPollers: { min: 1, max: 100, group: 'g1' },
+            },
+          },
+        ],
+      },
+    },
+  })
+  expect(out).toEqual({
+    provisionedPollers: {
+      sqs: { configured: 2, min: [5], max: [500] },
+      kafka: { configured: 1, min: [1], max: [100], groups: 1 },
+    },
+  })
+})
+
+test('reports explicit disables', () => {
+  const out = buildProvisionedPollersAnalytics(
+    configWith([{ sqs: { arn: 'q', provisionedPollers: false } }]),
+  )
+  expect(out).toEqual({ provisionedPollers: { sqs: { disabled: 1 } } })
+})
+
+test('never reports the group name string', () => {
+  const out = buildProvisionedPollersAnalytics(
+    configWith([
+      {
+        msk: {
+          arn: 'a',
+          topic: 't',
+          provisionedPollers: { min: 1, group: 'secret-name' },
+        },
+      },
+    ]),
+  )
+  expect(JSON.stringify(out)).not.toContain('secret-name')
+  expect(out.provisionedPollers.msk.groups).toBe(1)
+})
+
+test('never reports groups for sqs (group is invalid config there)', () => {
+  const out = buildProvisionedPollersAnalytics(
+    configWith([
+      { sqs: { arn: 'q', provisionedPollers: { min: 2, group: 'smuggled' } } },
+      { kafka: { topic: 't', provisionedPollers: { min: 1, group: 'g' } } },
+    ]),
+  )
+  expect(out.provisionedPollers.sqs).toEqual({ configured: 1, min: [2] })
+  expect(out.provisionedPollers.kafka.groups).toBe(1)
+})
+
+test('is total: throwing getters degrade to {}', () => {
+  const evil = {}
+  Object.defineProperty(evil, 'functions', {
+    get() {
+      throw new Error('boom')
+    },
+  })
+  expect(buildProvisionedPollersAnalytics(evil)).toEqual({})
+})
+
+test('is total: malformed shapes degrade gracefully', () => {
+  expect(buildProvisionedPollersAnalytics(null)).toEqual({})
+  expect(
+    buildProvisionedPollersAnalytics(
+      configWith([
+        { sqs: 'arn:aws:sqs:r:a:q' },
+        null,
+        { sqs: { provisionedPollers: 'junk' } },
+      ]),
+    ),
+  ).toEqual({})
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/msk.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/msk.test.js
@@ -453,6 +453,16 @@ describe('AwsCompileMSKEvents', () => {
       expect(esm.Properties.ProvisionedPollerConfig).toBeUndefined()
     })
 
+    it('never emits an empty poller group name', () => {
+      const esm = compileWithMskEvent({
+        provisionedPollers: { min: 1, max: 100, group: '' },
+      })
+      expect(esm.Properties.ProvisionedPollerConfig).toEqual({
+        MinimumPollers: 1,
+        MaximumPollers: 100,
+      })
+    })
+
     it('throws when min > max', () => {
       expect(() =>
         compileWithMskEvent({ provisionedPollers: { min: 100, max: 5 } }),

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/msk.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/msk.test.js
@@ -412,4 +412,51 @@ describe('AwsCompileMSKEvents', () => {
       expect(allResources).toContain(mskArn)
     })
   })
+
+  describe('provisionedPollers', () => {
+    const baseMskEvent = {
+      arn: 'arn:aws:kafka:us-east-1:111111111111:cluster/my-cluster/abc-123',
+      topic: 'my-topic',
+    }
+
+    const compileWithMskEvent = (extra) => {
+      awsCompileMSKEvents.serverless.service.functions = {
+        first: { events: [{ msk: { ...baseMskEvent, ...extra } }] },
+      }
+      awsCompileMSKEvents.compileMSKEvents()
+      const resources =
+        awsCompileMSKEvents.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      return Object.values(resources).find(
+        (r) => r.Type === 'AWS::Lambda::EventSourceMapping',
+      )
+    }
+
+    it('maps min/max/group to ProvisionedPollerConfig', () => {
+      const esm = compileWithMskEvent({
+        provisionedPollers: { min: 1, max: 100, group: 'shared-epu' },
+      })
+      expect(esm.Properties.ProvisionedPollerConfig).toEqual({
+        MinimumPollers: 1,
+        MaximumPollers: 100,
+        PollerGroupName: 'shared-epu',
+      })
+    })
+
+    it('compiles false to an empty ProvisionedPollerConfig', () => {
+      const esm = compileWithMskEvent({ provisionedPollers: false })
+      expect(esm.Properties.ProvisionedPollerConfig).toEqual({})
+    })
+
+    it('emits nothing when the key is absent', () => {
+      const esm = compileWithMskEvent({})
+      expect(esm.Properties.ProvisionedPollerConfig).toBeUndefined()
+    })
+
+    it('throws when min > max', () => {
+      expect(() =>
+        compileWithMskEvent({ provisionedPollers: { min: 100, max: 5 } }),
+      ).toThrow(/greater than "max"/)
+    })
+  })
 })

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/sqs.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/events/sqs.test.js
@@ -512,5 +512,87 @@ describe('AwsCompileSQSEvents', () => {
 
       expect(() => awsCompileSQSEvents.compileSQSEvents()).not.toThrow()
     })
+
+    describe('provisionedPollers', () => {
+      const compileWithSqsEvent = (sqsEvent) => {
+        awsCompileSQSEvents.serverless.service.functions = {
+          first: { events: [{ sqs: sqsEvent }] },
+        }
+        awsCompileSQSEvents.compileSQSEvents()
+        const resources =
+          awsCompileSQSEvents.serverless.service.provider
+            .compiledCloudFormationTemplate.Resources
+        return Object.values(resources).find(
+          (r) => r.Type === 'AWS::Lambda::EventSourceMapping',
+        )
+      }
+
+      it('maps min/max to ProvisionedPollerConfig', () => {
+        const esm = compileWithSqsEvent({
+          arn: 'arn:aws:sqs:region:account:MyQueue',
+          provisionedPollers: { min: 5, max: 500 },
+        })
+        expect(esm.Properties.ProvisionedPollerConfig).toEqual({
+          MinimumPollers: 5,
+          MaximumPollers: 500,
+        })
+        expect(esm.Properties.ScalingConfig).toBeUndefined()
+      })
+
+      it('supports partial config (only max)', () => {
+        const esm = compileWithSqsEvent({
+          arn: 'arn:aws:sqs:region:account:MyQueue',
+          provisionedPollers: { max: 300 },
+        })
+        expect(esm.Properties.ProvisionedPollerConfig).toEqual({
+          MaximumPollers: 300,
+        })
+      })
+
+      it('compiles false to an empty ProvisionedPollerConfig (disable)', () => {
+        const esm = compileWithSqsEvent({
+          arn: 'arn:aws:sqs:region:account:MyQueue',
+          provisionedPollers: false,
+        })
+        expect(esm.Properties.ProvisionedPollerConfig).toEqual({})
+      })
+
+      it('allows false together with maximumConcurrency (mode-switch recipe)', () => {
+        const esm = compileWithSqsEvent({
+          arn: 'arn:aws:sqs:region:account:MyQueue',
+          maximumConcurrency: 50,
+          provisionedPollers: false,
+        })
+        expect(esm.Properties.ScalingConfig).toEqual({ MaximumConcurrency: 50 })
+        expect(esm.Properties.ProvisionedPollerConfig).toEqual({})
+      })
+
+      it('emits neither property when the key is absent', () => {
+        const esm = compileWithSqsEvent({
+          arn: 'arn:aws:sqs:region:account:MyQueue',
+        })
+        expect(esm.Properties.ProvisionedPollerConfig).toBeUndefined()
+        expect(esm.Properties.ScalingConfig).toBeUndefined()
+      })
+
+      it('throws when object form is combined with maximumConcurrency', () => {
+        expect(() =>
+          compileWithSqsEvent({
+            arn: 'arn:aws:sqs:region:account:MyQueue',
+            maximumConcurrency: 50,
+            provisionedPollers: { min: 2, max: 10 },
+          }),
+        ).toThrow(/mutually exclusive scaling modes/)
+      })
+
+      it('throws when min > max', () => {
+        expect(() =>
+          compileWithSqsEvent({
+            arn: 'arn:aws:sqs:region:account:MyQueue',
+            provisionedPollers: { min: 50, max: 10 },
+          }),
+        ).toThrow(/greater than "max"/)
+      })
+    })
   })
 })

--- a/packages/sf-core/src/lib/runners/framework.js
+++ b/packages/sf-core/src/lib/runners/framework.js
@@ -27,6 +27,7 @@ import {
 import { buildCommandState } from './state-utils.js'
 import { buildSandboxesAnalytics } from '@serverless/framework/lib/plugins/aws/sandboxes/analytics.js'
 import { buildMcpAnalytics } from '@serverless/framework/lib/plugins/aws/mcp/analytics.js'
+import { buildProvisionedPollersAnalytics } from '@serverless/framework/lib/plugins/aws/package/compile/events/lib/provisioned-pollers-analytics.js'
 import { Deployment } from '../platform/deployments.js'
 
 export class TraditionalRunner extends Runner {
@@ -271,6 +272,10 @@ export class TraditionalRunner extends Runner {
       // guard and is total (never throws) — `{}` when the service defines no
       // MCP servers, `{ mcp: <block> }` otherwise.
       ...buildMcpAnalytics(this.config),
+      // Provisioned-mode (provisionedPollers) config-shape block, same
+      // contract as the sandboxes/mcp ones: total (never throws), `{}` when
+      // no event uses the key, `{ provisionedPollers: <block> }` otherwise.
+      ...buildProvisionedPollersAnalytics(this.config),
     }
 
     // plugins

--- a/packages/sf-core/tests/unit/lib/runners/framework-provisioned-pollers-analytics.test.js
+++ b/packages/sf-core/tests/unit/lib/runners/framework-provisioned-pollers-analytics.test.js
@@ -1,0 +1,46 @@
+import { TraditionalRunner } from '../../../../src/lib/runners/framework.js'
+
+// getAnalysisEventDetails only reads instance fields — call it on a minimal
+// fake `this` to avoid constructing the full runner. Mirrors
+// framework-mcp-analytics.test.js.
+const detailsFor = (config) =>
+  TraditionalRunner.prototype.getAnalysisEventDetails.call({
+    config,
+    configFilePath: '/svc/serverless.yml',
+    serviceUniqueId: undefined,
+    integrations: {},
+    analyticsMetrics: undefined,
+    compiledCloudFormationTemplate: undefined,
+    command: ['deploy'],
+  })
+
+test('attaches provisionedPollers block when an event configures it', () => {
+  const details = detailsFor({
+    service: 'svc',
+    provider: { name: 'aws' },
+    functions: {
+      worker: {
+        events: [
+          {
+            sqs: {
+              arn: 'arn:aws:sqs:r:a:q',
+              provisionedPollers: { min: 2, max: 10 },
+            },
+          },
+        ],
+      },
+    },
+  })
+  expect(details.provisionedPollers).toEqual({
+    sqs: { configured: 1, min: [2], max: [10] },
+  })
+})
+
+test('omits the field entirely when unused', () => {
+  const details = detailsFor({
+    service: 'svc',
+    provider: { name: 'aws' },
+    functions: { worker: { events: [{ sqs: 'arn:aws:sqs:r:a:q' }] } },
+  })
+  expect(details).not.toHaveProperty('provisionedPollers')
+})


### PR DESCRIPTION
## Summary

- New event property `provisionedPollers` on the `sqs`, `kafka`, and `msk` function events, enabling AWS Lambda event source mapping [Provisioned mode](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html#invocation-eventsourcemapping-provisioned-mode): a dedicated pool of event pollers with `min`/`max` bounds, plus `group` on kafka/msk to share Event Poller Unit capacity. `provisionedPollers: false` clears provisioned mode on an existing mapping.
- Bounds follow AWS per source type: SQS `min` 2–200 / `max` 2–10000; Kafka and MSK `min` 1–200 / `max` 1–2000; `group` 1–128 characters of letters, digits, hyphens and underscores.
- Package-time validation instead of a deploy-time AWS error: `SQS_EVENT_SCALING_MODE_CONFLICT` when `provisionedPollers` is combined with `maximumConcurrency` (AWS treats them as mutually exclusive scaling modes), and `EVENT_PROVISIONED_POLLERS_INVALID` when `min > max`.
- The compilers emit only what the user configured — the property is compiled to `ProvisionedPollerConfig` on `AWS::Lambda::EventSourceMapping`, nothing is synthesized for services that don't use the key, and templates for existing services are byte-identical.
- Docs: a "Provisioned mode" section on the sqs, kafka and msk event pages, plus the `serverless.yml` reference. They cover the per-poller cost, the fact that removing the property does not disable provisioned mode (it stays active on the deployed mapping, and so does its cost), the `false` off-switch, and the mutual exclusion with `maximumConcurrency`.

Closes #13024

## Test plan

- [x] Unit: `@serverless/framework` 194 suites / 3756 tests, `@serverlessinc/sf-core` 52 suites / 645 tests, `lint` and `prettier` green
- [x] New unit tests across the three compilers and the analytics builder: property mapping, partial config, the `false` form, absent key, and both validation errors
- [x] Live AWS: deployed a service with `provisionedPollers` and confirmed the applied configuration on the mapping; switched to `maximumConcurrency` and back, confirming each mode took effect; reproduced all four package-time validation errors; removed the stack and verified no leftover resources


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring provisioned pollers for SQS, MSK, and Kafka event sources, including minimum, maximum, and optional grouping settings.
  * Added the ability to explicitly disable provisioned mode.
  * Added analytics reporting for provisioned poller usage and configuration.

* **Bug Fixes**
  * Added validation for invalid poller ranges and conflicting SQS scaling settings.

* **Documentation**
  * Documented configuration, limits, pricing, poller groups, and disabling provisioned mode for supported event sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->