### PR TITLE
fix(sf-core): ignore directories when resolving config files

### DIFF
--- a/packages/sf-core/src/utils/fs/index.js
+++ b/packages/sf-core/src/utils/fs/index.js
@@ -296,7 +296,8 @@ const getConfigFilePath = async (options) => {
         options.configFileDirPath || process.cwd(),
         `${options.configFileName}.${extension}`,
       )
-      if (await fsp.stat(eventualServiceConfigPath)) {
+      const stats = await fsp.stat(eventualServiceConfigPath)
+      if (stats.isFile()) {
         return eventualServiceConfigPath
       }
     } catch (err) {

--- a/packages/sf-core/tests/unit/utils/fs/get-config-file-path.test.js
+++ b/packages/sf-core/tests/unit/utils/fs/get-config-file-path.test.js
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from 'fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'fs/promises'
 import { tmpdir } from 'os'
 import path from 'path'
 import { getConfigFilePath } from '../../../../src/utils/index.js'
@@ -19,6 +19,16 @@ describe('getConfigFilePath', () => {
       configFileDirPath: dir,
     })
     expect(result).toBe(path.join(dir, 'serverless.yml'))
+  })
+
+  test('ignores directories matching a supported config file name', async () => {
+    const dir = await makeDir(['serverless.yaml'])
+    await mkdir(path.join(dir, 'serverless.yml'))
+    const result = await getConfigFilePath({
+      configFileName: 'serverless',
+      configFileDirPath: dir,
+    })
+    expect(result).toBe(path.join(dir, 'serverless.yaml'))
   })
 
   describe('with the "extensions" option', () => {


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

<!--
⚠️⚠️ Ensure to follow code style guidelines
https://github.com/serverless/serverless/blob/main/CONTRIBUTING.md#code-style
-->

<!--
⚠️⚠️ Ensure to cover changes with tests written according to test guidelines
https://github.com/serverless/serverless/blob/main/TESTING.md
-->

<!-- ⚠️⚠️ Ensure that support for Node.js v18 is maintained. -->

<!--
⚠️⚠️ Ensure that the proposed change passes CI. Confirm that by running the following scripts:
• npm run prettier
• npm run lint
• npm test
-->

<!--
⚠️⚠️ If proposed change touches integration with AWS services, confirm integration tests pass:
https://github.com/serverless/serverless/blob/main/TESTING.md#integration-tests
-->

<!-- ⚠️⚠️ After your PR is submitted, review the final CI status and address eventual failure -->

<!-- ⚠️⚠️ Answer below questions -->

<!--
Q1: Provide a link to the corresponding issue

• If PR *partially* addresses issue, ensure to rename "Closes" to "Addresses" ("Closes" term will automatically close an issue on PR merge)
• If it's a documentation update or obvious bug fix that has no corresponding issue, replace this line with a short description of made changes
-->

Closes: #{ISSUE_NUMBER}


`getConfigFilePath()` treated any existing path as a valid configuration file because it only checked whether `fs.stat()` succeeded.

When a directory has the same name as an earlier supported configuration extension, that directory was returned instead of continuing to the next extension.

For example:

```text
tmp/
  serverless.yml/       # directory
  serverless.yaml       # valid configuration file
```

The resolver incorrectly returned:

`tmp/serverless.yml`

This change ensures that only regular files are returned, so the resolver correctly continues to:

`tmp/serverless.yaml`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration discovery now ignores directories that share supported configuration-file names.
  - The correct YAML configuration file is selected when a same-named directory is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->