### PR TITLE
feat(aws): SnapStart for container-image functions

### DIFF
--- a/docs/sf/providers/aws/guide/functions.md
+++ b/docs/sf/providers/aws/guide/functions.md
@@ -488,19 +488,56 @@ Finally, `auto` and `onFunctionUpdate` can be set as the `mode` property as well
 
 ## SnapStart
 
-[Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) for Java can improve startup performance for latency-sensitive applications.
+[Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) reduces cold-start latency: when a function version is published, Lambda runs the initialization code once, takes a snapshot of the initialized execution environment, and later restores new environments from that snapshot instead of initializing again.
 
-To enable SnapStart for your lambda function you can add the `snapStart` object property in the function configuration which can be put to true and will result in the value `PublishedVersions` for this function.
+Enable it per function with `snapStart: true`. It works for functions deployed as `.zip` packages and for functions deployed as container images.
 
 ```yaml
 functions:
-  hello:
-    ...
-    runtime: java11
+  api:
+    handler: com.example.Handler
+    runtime: java21
+    snapStart: true
+  inference:
+    image: inference
     snapStart: true
 ```
 
-**Note:** Lambda SnapStart only supports the Java 11, Java 17 and Java 21 runtimes and does not support provisioned concurrency, the arm64 architecture, the Lambda Extensions API, Amazon Elastic File System (Amazon EFS), AWS X-Ray, or ephemeral storage greater than 512 MB.
+### Supported runtimes and images
+
+AWS supports SnapStart for Java 11 and later, Python 3.12 and later, and .NET 8 and later, both as managed runtimes and as the corresponding AWS base images for container images. Functions on those need nothing beyond `snapStart: true`.
+
+A container image built on any other base — the AWS base images for Node.js, Ruby or `provided.al2023`, or a custom base image — must declare that it is safe to snapshot, either by adding this label in its Dockerfile:
+
+```dockerfile
+LABEL com.amazonaws.lambda.feature.snapstart="Allow"
+```
+
+or by implementing the [SnapStart runtime hooks](https://docs.aws.amazon.com/lambda/latest/dg/snapstart-runtime-hooks-custom.html). Before adding the label, make sure the code does not create state during initialization that must be unique per environment, such as random seeds, unique IDs or cached credentials; see [Handling uniqueness](https://docs.aws.amazon.com/lambda/latest/dg/snapstart-uniqueness.html).
+
+If an image has neither the label nor the hooks, publishing the function version fails during deployment and the deploy output includes:
+
+```text
+Resource of type 'AWS::Lambda::Version' with identifier '...' did not stabilize. Status Reason is An error occurred during function initialization.
+```
+
+The same message appears when the function's own initialization code throws, so check the function's CloudWatch logs as well. On a first deployment the failed stack is rolled back together with its log group; to read the initialization logs in that case, deploy once without `snapStart`.
+
+### How invocations reach the snapshot
+
+SnapStart applies only to published versions, never to `$LATEST`. On every deploy of a function with `snapStart: true`, the Framework publishes a version and points an alias named `snapstart` at it, and every event source configured on the function invokes that alias. Invoking the unqualified function name — for example `serverless invoke -f api` or a direct `Invoke` call without a qualifier — runs a regular cold start. To exercise the snapshot by hand, invoke the `snapstart` alias or the version number.
+
+### Limitations
+
+AWS does not support SnapStart together with provisioned concurrency, Amazon EFS file systems, S3 Files, or ephemeral storage larger than 512 MB. The Framework rejects `snapStart` combined with `provisionedConcurrency`, or with `ephemeralStorageSize` above 512, when packaging the service; the remaining combinations are rejected by AWS during deployment. SnapStart is not available in every AWS Region; see the [AWS SnapStart documentation](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) for the current list.
+
+### Cost of retained versions
+
+For every runtime except the Java managed runtimes, AWS charges for caching each published version's snapshot for as long as that version exists, plus a charge per restore; see [Lambda pricing](https://aws.amazon.com/lambda/pricing/). With the default `versionFunctions: true`, the Framework keeps the previous version in place when it deploys a new one, so every deploy of a SnapStart function adds another billed snapshot. Set `provider.versionFunctions: false` to have the superseded version deleted on deploy. Deletion starts with the deploy after the one that applies the change, and versions retained before the change stay until you delete them, for example with `aws lambda delete-function --function-name <name>:<version>`. See [Versioning Deployed Functions](#versioning-deployed-functions).
+
+### Examples
+
+- [Container image with SnapStart (Node.js)](https://github.com/serverless/examples/tree/v4/aws-node-container-snapstart)
 
 ## Recursive Loop Detection
 
@@ -770,6 +807,8 @@ The Infrequent Access class supports a reduced subset of CloudWatch Logs feature
 By default, the framework creates function versions for every deploy. This behavior is optional, and can be turned off in cases where you don't invoke past versions by their qualifier. If you would like to do this, you can invoke your functions as `arn:aws:lambda:....:function/myFunc:3` to invoke version 3 for example.
 
 Versions are not cleaned up by serverless, so make sure you use a plugin or other tool to prune sufficiently old versions. The framework can't clean up versions because it doesn't have information about whether older versions are invoked or not. This feature adds to the number of total stack outputs and resources because a function version is a separate resource from the function it refers to.
+
+For functions with `snapStart` enabled, every retained version also keeps a cached snapshot that AWS bills for outside the Java managed runtimes; see [Cost of retained versions](#cost-of-retained-versions).
 
 To turn off function versioning, set the provider-level option `versionFunctions`.
 

--- a/docs/sf/providers/aws/guide/functions.md
+++ b/docs/sf/providers/aws/guide/functions.md
@@ -525,7 +525,7 @@ The same message appears when the function's own initialization code throws, so 
 
 ### How invocations reach the snapshot
 
-SnapStart applies only to published versions, never to `$LATEST`. On every deploy of a function with `snapStart: true`, the Framework publishes a version and points an alias named `snapstart` at it, and every event source configured on the function invokes that alias. Invoking the unqualified function name — for example `serverless invoke -f api` or a direct `Invoke` call without a qualifier — runs a regular cold start. To exercise the snapshot by hand, invoke the `snapstart` alias or the version number.
+SnapStart applies only to published versions, never to `$LATEST`. Whenever a deploy changes the function's code, image or configuration, the Framework publishes a new version and points an alias named `snapstart` at it; a deploy that changes nothing keeps the current version. Every event source configured on the function invokes that alias. Invoking the unqualified function name — for example `serverless invoke -f api` or a direct `Invoke` call without a qualifier — runs a regular cold start. To exercise the snapshot by hand, invoke the `snapstart` alias or the version number.
 
 ### Limitations
 
@@ -533,7 +533,7 @@ AWS does not support SnapStart together with provisioned concurrency, Amazon EFS
 
 ### Cost of retained versions
 
-For every runtime except the Java managed runtimes, AWS charges for caching each published version's snapshot for as long as that version exists, plus a charge per restore; see [Lambda pricing](https://aws.amazon.com/lambda/pricing/). With the default `versionFunctions: true`, the Framework keeps the previous version in place when it deploys a new one, so every deploy of a SnapStart function adds another billed snapshot. Set `provider.versionFunctions: false` to have the superseded version deleted on deploy. Deletion starts with the deploy after the one that applies the change, and versions retained before the change stay until you delete them, for example with `aws lambda delete-function --function-name <name>:<version>`. See [Versioning Deployed Functions](#versioning-deployed-functions).
+For every runtime except the Java managed runtimes, AWS charges for caching each published version's snapshot for as long as that version exists, plus a charge per restore; see [Lambda pricing](https://aws.amazon.com/lambda/pricing/). With the default `versionFunctions: true`, the Framework keeps the previous version in place when it publishes a new one, so each deploy that changes a SnapStart function retains another billed snapshot. Set `provider.versionFunctions: false` to have the superseded version deleted on deploy. Deletion starts with the deploy after the one that applies the change, and versions retained before the change stay until you delete them, for example with `aws lambda delete-function --function-name <name>:<version>`. See [Versioning Deployed Functions](#versioning-deployed-functions).
 
 ### Examples
 

--- a/docs/sf/providers/aws/guide/serverless.yml.md
+++ b/docs/sf/providers/aws/guide/serverless.yml.md
@@ -919,7 +919,7 @@ functions:
     onError: arn:aws:sns:us-east-1:XXXXXX:sns-topic
     # KMS key ARN to use for encryption for this function
     kmsKeyArn: arn:aws:kms:us-east-1:XXXXXX:key/some-hash
-    # Defines if you want to make use of SnapStart, this feature can only be used in combination with a Java runtime. Configuring this property will result in either None or PublishedVersions for the Lambda function
+    # Enable Lambda SnapStart (Java 11+, Python 3.12+, .NET 8+ runtimes, and container images). Publishes a version and a "snapstart" alias that event sources invoke
     snapStart: true
     # allow or terminate recursive invocation loops between supported AWS services (default: terminate). Case-insensitive.
     recursiveLoop: allow

--- a/packages/serverless/lib/plugins/aws/package/compile/functions.js
+++ b/packages/serverless/lib/plugins/aws/package/compile/functions.js
@@ -203,6 +203,21 @@ class AwsCompileFunctions {
         'FUNCTION_BOTH_HANDLER_AND_IMAGE_DEFINED_ERROR',
       )
     }
+
+    if (functionObject.provisionedConcurrency && functionObject.snapStart) {
+      throw new ServerlessError(
+        `Functions with enabled SnapStart does not support provisioned concurrency. Please remove at least one of the settings on function "${functionName}".`,
+        'FUNCTION_BOTH_PROVISIONED_CONCURRENCY_AND_SNAPSTART_ENABLED_ERROR',
+      )
+    }
+
+    if (functionObject.snapStart && functionObject.ephemeralStorageSize > 512) {
+      throw new ServerlessError(
+        `Functions with enabled SnapStart do not support ephemeral storage greater than 512 MB. Please lower "ephemeralStorageSize" or remove "snapStart" on function "${functionName}".`,
+        'FUNCTION_SNAPSTART_EPHEMERAL_STORAGE_TOO_LARGE_ERROR',
+      )
+    }
+
     const effectiveLogGroupClass =
       this.provider.getLogGroupClass(functionObject)
     if (
@@ -990,13 +1005,6 @@ class AwsCompileFunctions {
       Object.assign(cfTemplate.Outputs, {
         [functionVersionOutputLogicalId]: newVersionOutput,
       })
-
-      if (functionObject.provisionedConcurrency && functionObject.snapStart) {
-        throw new ServerlessError(
-          `Functions with enabled SnapStart does not support provisioned concurrency. Please remove at least one of the settings on function "${functionName}".`,
-          'FUNCTION_BOTH_PROVISIONED_CONCURRENCY_AND_SNAPSTART_ENABLED_ERROR',
-        )
-      }
 
       if (functionObject.provisionedConcurrency) {
         if (!shouldVersionFunction) delete versionResource.DeletionPolicy

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -2738,8 +2738,9 @@ destinations:
               $ref: '#/definitions/awsKmsArn',
             },
             snapStart: {
-              description: `Enable Lambda SnapStart.
-@since v4`,
+              description: `Enable Lambda SnapStart. Supported for Java 11+, Python 3.12+ and .NET 8+ runtimes and for container images; publishes a version and a "snapstart" alias that event sources invoke.
+@since v4
+@see https://www.serverless.com/framework/docs/providers/aws/guide/functions#snapstart`,
               type: 'boolean',
             },
             layers: {

--- a/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/package/compile/functions.test.js
@@ -2062,6 +2062,134 @@ describe('AwsCompileFunctions', () => {
         /SnapStart.*provisioned concurrency/i,
       )
     })
+
+    it('should throw error when SnapStart is combined with ephemeralStorageSize above 512 MB', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          snapStart: true,
+          ephemeralStorageSize: 1024,
+        },
+      }
+
+      await expect(awsCompileFunctions.compileFunctions()).rejects.toThrow(
+        /SnapStart.*ephemeral storage greater than 512 MB/i,
+      )
+    })
+
+    it('should reject an invalid SnapStart configuration before resolving the container image', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          image: 'repoimage',
+          name: 'func',
+          snapStart: true,
+          ephemeralStorageSize: 1024,
+        },
+      }
+
+      await expect(awsCompileFunctions.compileFunctions()).rejects.toThrow(
+        /SnapStart.*ephemeral storage greater than 512 MB/i,
+      )
+      expect(
+        awsCompileFunctions.provider.resolveImageUriAndSha,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('should accept SnapStart with the default 512 MB ephemeral storage', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          handler: 'handler',
+          name: 'func',
+          snapStart: true,
+          ephemeralStorageSize: 512,
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const props =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources.FuncLambdaFunction
+          .Properties
+      expect(props.SnapStart).toEqual({ ApplyOn: 'PublishedVersions' })
+      expect(props.EphemeralStorage).toEqual({ Size: 512 })
+    })
+
+    it('should enable SnapStart on a container-image function and publish a version from the image digest', async () => {
+      awsCompileFunctions.provider.resolveImageUriAndSha.mockResolvedValue({
+        functionImageUri:
+          '000000000000.dkr.ecr.us-east-1.amazonaws.com/repo@sha256:abc',
+        functionImageSha: 'sha256:abc',
+      })
+      awsCompileFunctions.serverless.service.functions = {
+        func: {
+          image: 'repoimage',
+          name: 'func',
+          snapStart: true,
+        },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const props = resources.FuncLambdaFunction.Properties
+
+      expect(props.PackageType).toBe('Image')
+      expect(props.Runtime).toBeUndefined()
+      expect(props.SnapStart).toEqual({ ApplyOn: 'PublishedVersions' })
+
+      const versionLogicalId = Object.keys(resources).find(
+        (id) => resources[id].Type === 'AWS::Lambda::Version',
+      )
+      expect(versionLogicalId).toBeDefined()
+      expect(resources[versionLogicalId].Properties.CodeSha256).toBe(
+        'sha256:abc',
+      )
+
+      expect(resources.FuncSnapStartAlias.Type).toBe('AWS::Lambda::Alias')
+      expect(resources.FuncSnapStartAlias.Properties.Name).toBe('snapstart')
+      expect(resources.FuncSnapStartAlias.Properties.FunctionVersion).toEqual({
+        'Fn::GetAtt': [versionLogicalId, 'Version'],
+      })
+    })
+
+    it('should retain superseded versions by default (DeletionPolicy Retain)', async () => {
+      awsCompileFunctions.serverless.service.functions = {
+        func: { handler: 'handler', name: 'func', snapStart: true },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const versionLogicalId = Object.keys(resources).find(
+        (id) => resources[id].Type === 'AWS::Lambda::Version',
+      )
+      expect(resources[versionLogicalId].DeletionPolicy).toBe('Retain')
+    })
+
+    it('should not retain superseded versions when versionFunctions is false', async () => {
+      awsCompileFunctions.serverless.service.provider.versionFunctions = false
+      awsCompileFunctions.serverless.service.functions = {
+        func: { handler: 'handler', name: 'func', snapStart: true },
+      }
+
+      await awsCompileFunctions.compileFunctions()
+
+      const resources =
+        awsCompileFunctions.serverless.service.provider
+          .compiledCloudFormationTemplate.Resources
+      const versionLogicalId = Object.keys(resources).find(
+        (id) => resources[id].Type === 'AWS::Lambda::Version',
+      )
+      expect(versionLogicalId).toBeDefined()
+      expect(resources[versionLogicalId].DeletionPolicy).toBeUndefined()
+      expect(resources.FuncSnapStartAlias).toBeDefined()
+    })
   })
 
   describe('Disable Logs', () => {

--- a/packages/sf-core/src/lib/runners/framework.js
+++ b/packages/sf-core/src/lib/runners/framework.js
@@ -288,17 +288,21 @@ export class TraditionalRunner extends Runner {
       details.plugins = this.config.plugins
     }
 
-    // runtimes
-    const functionRuntimes = Object.entries(this.config?.functions || {})
-      .map(([, functionObject]) => {
-        if (functionObject.runtime) {
-          return functionObject.runtime
-        }
-        return undefined
-      })
-      .filter((runtime) => runtime !== undefined)
-    if (functionRuntimes.length > 0) {
-      details.runtimes = Array.from(new Set(functionRuntimes))
+    // runtimes — explicit per-function runtimes, plus the value "image" for
+    // container-image functions (which do not set `runtime`). Total: a throw
+    // while reading a function must not abort the analysis event.
+    try {
+      const functionRuntimes = Object.values(this.config?.functions || {})
+        .map((functionObject) => {
+          if (functionObject?.image) return 'image'
+          return functionObject?.runtime || undefined
+        })
+        .filter((runtime) => runtime !== undefined)
+      if (functionRuntimes.length > 0) {
+        details.runtimes = Array.from(new Set(functionRuntimes))
+      }
+    } catch {
+      // leave `runtimes` unset
     }
 
     return details

--- a/packages/sf-core/tests/unit/lib/runners/framework-image-runtimes-analytics.test.js
+++ b/packages/sf-core/tests/unit/lib/runners/framework-image-runtimes-analytics.test.js
@@ -1,0 +1,70 @@
+import { TraditionalRunner } from '../../../../src/lib/runners/framework.js'
+
+// getAnalysisEventDetails only reads instance fields — call it on a minimal
+// fake `this` to avoid constructing the full runner.
+const detailsFor = (config) =>
+  TraditionalRunner.prototype.getAnalysisEventDetails.call({
+    config,
+    configFilePath: '/svc/serverless.yml',
+    serviceUniqueId: undefined,
+    integrations: {},
+    analyticsMetrics: undefined,
+    compiledCloudFormationTemplate: undefined,
+    command: ['deploy'],
+  })
+
+test('reports a container-image function as the runtime value "image"', () => {
+  const details = detailsFor({
+    service: 'svc',
+    provider: { name: 'aws' },
+    functions: { inference: { image: 'app' } },
+  })
+  expect(details.runtimes).toEqual(['image'])
+})
+
+test('reports "image" alongside explicit runtimes in a mixed service, deduplicated', () => {
+  const details = detailsFor({
+    service: 'svc',
+    provider: { name: 'aws' },
+    functions: {
+      a: { image: { name: 'app' } },
+      b: { handler: 'h.b', runtime: 'nodejs22.x' },
+      c: { image: 'other' },
+    },
+  })
+  expect(details.runtimes).toEqual(['image', 'nodejs22.x'])
+})
+
+test('leaves runtimes unchanged for zip functions and omits the key when none is explicit', () => {
+  expect(
+    detailsFor({
+      service: 'svc',
+      provider: { name: 'aws', runtime: 'python3.12' },
+      functions: { a: { handler: 'h.a' } },
+    }).runtimes,
+  ).toBeUndefined()
+  expect(
+    detailsFor({
+      service: 'svc',
+      provider: { name: 'aws' },
+      functions: { a: { handler: 'h.a', runtime: 'java21' } },
+    }).runtimes,
+  ).toEqual(['java21'])
+})
+
+test('a throw while reading a function is swallowed and the rest of details stays intact', () => {
+  const fn = { handler: 'h.a' }
+  Object.defineProperty(fn, 'image', {
+    enumerable: true,
+    get() {
+      throw new Error('boom')
+    },
+  })
+  const details = detailsFor({
+    service: 'svc',
+    provider: { name: 'aws', runtime: 'nodejs22.x' },
+    functions: { a: fn },
+  })
+  expect('runtimes' in details).toBe(false)
+  expect(details.providerRuntime).toBe('nodejs22.x')
+})


### PR DESCRIPTION
## Summary

- Document that `snapStart: true` works for container-image functions as well as `.zip` packages; the SnapStart guide previously described it as Java-only.
- Rewrite the SnapStart section of `docs/sf/providers/aws/guide/functions.md`: supported runtimes and AWS base images, the `LABEL com.amazonaws.lambda.feature.snapstart="Allow"` or runtime-hooks requirement for other images, the failure reason shown when it is missing, how event sources reach the `snapstart` alias, limitations, and the cost of retained versions with `versionFunctions: false` as the way to avoid it. Cross-link from the versioning section; update the `serverless.yml` reference comment and the `snapStart` schema description.
- Validate `snapStart` combined with `ephemeralStorageSize` above 512 MB when packaging (`FUNCTION_SNAPSTART_EPHEMERAL_STORAGE_TOO_LARGE_ERROR`), and run both SnapStart validations before the function image is resolved, so an invalid configuration no longer builds and pushes the image first.
- Add regression tests pinning the compiled output for container-image functions with SnapStart and the version-retention behavior.
- Report container-image functions as `image` in the runtime list of the usage analytics event.

## Test plan

- [x] Unit suites for `@serverless/framework` and `@serverlessinc/sf-core`, lint and prettier
- [x] Live deploy of a container-image function with `snapStart: true`: version published, alias invocation restored from the snapshot (`RESTORE_REPORT`, `AWS_LAMBDA_INITIALIZATION_TYPE=snap-start`)
- [x] `deploy` with `ephemeralStorageSize: 1024` and `snapStart: true` fails at packaging before any image build; `remove` leaves no resources

## Related

- Closes #13834
- Supersedes #12068


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded AWS Lambda SnapStart support for Java 11+, Python 3.12+, .NET 8+, and container-image functions.
  - SnapStart deployments now publish a version and `snapstart` alias for event-source invocations.
  - Container-image functions are identified correctly in analysis data.

- **Bug Fixes**
  - Added validation for unsupported SnapStart combinations, including provisioned concurrency and ephemeral storage above 512 MB.
  - Improved resilience when function configuration cannot be read during analysis.

- **Documentation**
  - Updated SnapStart guidance, limitations, deployment behavior, version retention, and supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->