### PR TITLE
chore(deps): bump undici from 6.28.0 to 6.28.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12746,9 +12746,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -13493,7 +13493,7 @@
         "@aws-sdk/client-cloudformation": "3.1120.0",
         "@aws-sdk/client-s3": "3.1120.0",
         "@aws-sdk/client-ssm": "3.1120.0",
-        "@aws-sdk/client-sso-oidc": "^3.1120.0",
+        "@aws-sdk/client-sso-oidc": "3.1120.0",
         "@aws-sdk/client-sts": "3.1120.0",
         "@aws-sdk/core": "^3.974.25",
         "@aws-sdk/credential-providers": "3.1120.0",

--- a/packages/sf-core-installer/package-lock.json
+++ b/packages/sf-core-installer/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.41.1",
       "hasInstallScript": true,
       "dependencies": {
-        "undici": "6.28.0"
+        "undici": "6.28.1"
       },
       "bin": {
         "serverless": "run.js",
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "version": "6.28.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.1.tgz",
+      "integrity": "sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"

--- a/packages/sf-core-installer/package.json
+++ b/packages/sf-core-installer/package.json
@@ -27,7 +27,7 @@
     "sls": "run.js"
   },
   "dependencies": {
-    "undici": "6.28.0"
+    "undici": "6.28.1"
   },
   "devDependencies": {},
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Bump `undici` from 6.28.0 to 6.28.1 in `packages/sf-core-installer` (exact pin in `package.json` and `package-lock.json`)
- Update the root `package-lock.json` resolution of `undici` to 6.28.1 (reached via `packages/util`'s `^6.25.0` range)
- Patch release on the 6.x line: same `engines.node` (`>=18.17`), still zero dependencies. Changelog: https://github.com/nodejs/undici/compare/v6.28.0...v6.28.1
- The root lockfile write also syncs the `packages/sf-core` entry's `@aws-sdk/client-sso-oidc` spec from `^3.1120.0` to `3.1120.0`, matching what `packages/sf-core/package.json` already declares (no resolution change)

## Test plan

- [x] `packages/sf-core-installer`: `npm install --ignore-scripts` leaves the lockfile unchanged; `npm ls undici` resolves 6.28.1; `node --test tests/*.test.js` 44/44 pass
- [x] Root: `npm ci` passes; `npm ls undici` resolves 6.28.1 for both `@serverless/util` and `@serverless-inc/sdk`
- [x] Lockfiles written with npm 12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the networking dependency to a newer patch version for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->