### PR TITLE
feat(esbuild): package non-bundled services like classic packaging, with TypeScript compiled in place

### DIFF
--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -46,11 +46,8 @@ build:
     # decides which dependencies are installed into the artifact at all — see
     # "Building Without Bundling" below.
     #
-    # If no excludes (see below) are specified, and the runtime is set to nodejs16.x or lower,
-    # we automatically add "aws-sdk" to the list of externals.
-    #
-    # If no excludes (see below) are specified, and the runtime is set to nodejs18.x or higher,
-    # we automatically add "aws-sdk/*" to the list of externals.
+    # The runtime's built-in AWS SDK is added to the externals automatically:
+    # "aws-sdk" for nodejs16.x and lower, "@aws-sdk/*" for nodejs18.x and higher.
     #
     # Glob patterns are supported here.
     external:
@@ -62,10 +59,12 @@ build:
 
     # NPM packages to not be included in node_modules, and the zip file uploaded to Lambda.
     #
-    # This option only makes most sense if bundling is disabled. But if bundling is enabled and externals are specified
-    # this property can be useful to further control which external packages to be included/excluded from the zip file.
-    #
-    # Everything specified here is also added to the list of externals (see above).
+    # Packages listed here are removed from the generated package.json, so they
+    # are never installed into the artifact. They are not added to `external`:
+    # with bundling enabled, list a package in both `external` and `exclude`
+    # when it must be neither bundled nor installed (for example, one a Lambda
+    # layer provides). With `bundle: false` this decides what is left out of
+    # the artifact's node_modules.
     #
     # Glob patterns are supported here.
     exclude:
@@ -111,8 +110,8 @@ build:
 
     # This option tells esbuild to produce some metadata about the build in
     # the <service-root>/.serverless/build directory: a meta.json file for
-    # bundled builds, or one meta.<class><format>.json file per compile group
-    # (for example meta.jscjs.json) when `bundle: false` is set.
+    # bundled builds, or one file per output format (for example
+    # meta.jscjs.json) when `bundle: false` is set.
     metafile: true
 ```
 
@@ -165,21 +164,23 @@ module.exports = (serverless) => {
 
 ### Packaging Patterns
 
-[`package.patterns`](./packaging.md) decides what the deployment artifact contains: the patterns filter the artifact's `node_modules` and select additional files from the service directory to ship alongside the build output. Function-level patterns apply when `package.individually` is enabled and are merged after the service-level ones, so a function can narrow — or re-include — what the service level decided. See [Packaging](./packaging.md) for pattern syntax and merging rules.
+[`package.patterns`](./packaging.md) decides what the deployment artifact contains beyond what the build produced: patterns select additional files from the service directory and filter the artifact's `node_modules`. Function-level patterns apply when `package.individually` is enabled and are merged after the service-level ones, so a function can narrow — or re-include — what the service level decided. See [Packaging](./packaging.md) for pattern syntax and merging rules.
 
-When bundling (the default), the artifact holds what the build produced: the compiled handler bundle, its sourcemap when one is emitted, and the generated `package.json` with the lockfile beside it. Patterns add to that and filter `node_modules`; the handler bundle is always packaged, and packaging fails rather than shipping an artifact that lost it. Under `package.individually`, a function-level negation can additionally drop build outputs — sourcemaps, plugin-emitted files — from that one function's archive; the generated `package.json` and its lockfile always ship.
+The build reads `package.patterns` only. The legacy `package.include` and `package.exclude` keys, which classic packaging still honors, are ignored in both bundle modes, and a warning names them when they are present. Move includes into `patterns` as they are, and excludes with a leading `!`.
 
-A positive pattern naming `node_modules/...` ships those files from your service directory — a vendored or patched dependency the generated `package.json` does not declare, and which the artifact's install therefore never produces. Where such a file and an installed one claim the same path, the pattern's copy is what ships. The installed tree in the build directory is never overwritten by this.
+With bundling (the default), the artifact holds what the build produced — the compiled handler bundle, its sourcemap, and the generated `package.json` with the lockfile beside it — plus the files patterns add and the parts of `node_modules` the patterns leave in place. The handler bundle always ships: packaging fails rather than producing an artifact without it. Service-level negations act on the files patterns add and on `node_modules`; they do not remove build outputs. To leave sourcemaps out of the whole service, set `sourcemap: false`.
 
-A pattern may reach above the service directory, for example `../shared/**` in a monorepo. Such files are packaged at the path that remains once the leading `../` is removed — `../shared/config.json` ships as `shared/config.json` — the same placement classic packaging gives them. Code that reads the file must use that path.
+Under `package.individually`, a function-level negation also filters build outputs in that function's archive: `'!**/*.map'` drops its sourcemaps, `'!vendor/**'` drops files a plugin emitted there. The generated `package.json` and lockfile always ship. A negation that matches the function's own handler file — `'!src/**'` on a function whose handler lives under `src/` — fails packaging with `ESBUILD_HANDLER_MISSING_FROM_ARTIFACT`. If the intent was to keep source files out of the artifact, no pattern is needed: a bundled artifact contains no sources.
 
-Excluding every file under `node_modules` while the artifact still needs its dependencies at runtime — `packages: external`, or a non-bundled build whose generated `package.json` declares dependencies — deploys a function that fails on its first invocation. The build warns when it detects that combination.
+A positive pattern naming `node_modules/...` ships those files from your service directory: a vendored or patched dependency the generated `package.json` does not declare, and which the install into the artifact therefore never produces. Where such a file and an installed one share a path, the pattern's copy is what ships. A broad positive pattern such as `'**'` therefore also selects your local `node_modules`, devDependencies included, and ships it in place of the installed tree — follow it with `'!node_modules/**'`, or name the directories you mean.
 
-With `bundle: false` the artifact is the whole project tree and the patterns also decide which project files are compiled and copied in the first place; see [Building Without Bundling](#building-without-bundling).
+A pattern may reach above the service directory, for example `../shared/**` in a monorepo. Such files are packaged at the path that remains once the leading `../` is removed — `../shared/config.json` ships as `shared/config.json`, as in classic packaging — and code must read them at that path.
+
+Excluding everything under `node_modules` while the artifact still needs its dependencies at runtime — `packages: external`, or any build whose generated `package.json` declares dependencies (`bundle: false` with `external` entries, or a bundled build with `external` entries) — deploys a function that fails on its first invocation. The build warns when it detects that combination.
+
+With `bundle: false` the patterns also decide which project files enter the build in the first place; see [Building Without Bundling](#building-without-bundling).
 
 ### Building Without Bundling
-
-`bundle: false` packages your service following classic packaging's rules, with TypeScript compiled in place. The build selects the files classic packaging would ship, compiles the TypeScript among them, copies everything else as-is, and preserves your project's directory layout in the deployment archive. Type declaration files (`.d.ts`, `.d.mts`, `.d.cts`), nested `node_modules` directories, and package-manager internals (the Yarn PnP files `.yarn/**`, `.pnp.cjs`, `.pnp.loader.mjs`, and `pnpm-workspace.yaml`) are additionally excluded. Like every default exclusion they can be re-included through `package.patterns`: a nested `node_modules` a handler requires ships when a positive pattern names it (`patterns: ['lib/node_modules/**']`). As with classic packaging, everything else in the service directory ships — including the output directories of other tools — so exclude those with `package.patterns` negations. Three things are never packaged, whatever the patterns say: `.serverless/`, `.git/`, and the directory that `serverless package --package <dir>` (or `package.path`) writes to.
 
 ```yaml
 build:
@@ -187,7 +188,63 @@ build:
     bundle: false
 ```
 
-Nothing is inlined without a bundler, so every runtime dependency has to be installed into the artifact. Set `packages: external` to install all of them, or list the ones you need in `external`; without either, the generated `package.json` declares no dependencies and the artifact ships no `node_modules`.
+`bundle: false` packages your service the way classic packaging does (the Framework's packaging for services that are not built; see [Packaging](./packaging.md)), with TypeScript compiled in place: the project tree is the artifact, each TypeScript file is replaced by its compiled output, and everything else is copied as it is. Take this project:
+
+```text
+serverless.yml
+package.json          "dependencies": { "uuid": "^11.1.0" }, plus devDependencies
+package-lock.json
+tsconfig.json
+.env
+src/handler.ts        imports ./util and uuid, reads ../assets/banner.txt at runtime
+src/util.ts
+src/types.d.ts
+assets/banner.txt
+README.md
+```
+
+With `bundle: false` and `packages: external` the deployment archive contains:
+
+```text
+package.json          generated from yours: devDependencies removed, dependencies pruned to what the artifact installs
+package-lock.json     your lockfile (or yarn.lock / pnpm-lock.yaml), refreshed by the install into the artifact
+node_modules/uuid/    installed from the generated package.json
+src/handler.js
+src/handler.js.map
+src/util.js
+src/util.js.map
+assets/banner.txt
+tsconfig.json
+README.md
+```
+
+`serverless.yml`, `.env` and `src/types.d.ts` are not in it, and neither is your local `node_modules`. Three kinds of exclusion produce that result.
+
+**Never packaged, whatever the patterns say:** `.serverless/`, `.git/`, and the directory that `serverless package --package <dir>` (or `package.path`) writes to.
+
+**Excluded by default, re-included by any positive pattern that matches:**
+
+- Files whose name starts with `.env`, at any depth (details below).
+- `node_modules` directories at any depth. The artifact's dependencies come from the install described below; a nested `node_modules` a handler requires ships when a pattern names it, for example `patterns: ['lib/node_modules/**']`; such files are copied as they are, not compiled.
+- Type declarations: `.d.ts`, `.d.mts`, `.d.cts`.
+- The service configuration file, layer source directories, and local plugin directories (`plugins.localPath` and `.serverless_plugins/`).
+- `.gitignore`, `.DS_Store`, `npm-debug.log` and `yarn-*.log`.
+- Package-manager internals: `.yarn/**`, `.pnp.cjs`, `.pnp.loader.mjs`, `pnpm-workspace.yaml` and `pnpm-workspace.yml`.
+
+**Everything else ships**, including other dotfiles (`.npmrc`, `.nvmrc`) and the output directories of other tools. Exclude those with `package.patterns` negations, for example `'!.npmrc'` if it holds a registry token.
+
+#### Dependencies
+
+Nothing is inlined without a bundler, so every runtime dependency has to be installed into the artifact. `packages: external` installs everything under `dependencies` in your `package.json`; `external` installs only the packages it lists. Without either, the generated `package.json` declares no dependencies, the artifact ships no `node_modules`, and the function fails on its first invocation with a `Cannot find module` (CommonJS) or `Cannot find package` (ES module) error.
+
+```yaml
+build:
+  esbuild:
+    bundle: false
+    packages: external
+```
+
+The AWS SDK v3 packages (`@aws-sdk/*`) are left out by default because the Node.js runtime provides them; `exclude` controls that list (see the configuration reference above). The `package.json` in the artifact is generated from yours: devDependencies are removed and `dependencies` is pruned to what the artifact installs. A pattern that re-includes `package.json` — directly, or through a broad positive pattern such as `'**'` — replaces the generated manifest with your own file, devDependencies included, and the build warns when the copy differs from the generated file. Drop `package.json` from the patterns, or follow the broad pattern with `'!package.json'`; the last match wins.
 
 #### What Is Compiled and What Is Copied
 
@@ -197,16 +254,16 @@ Nothing is inlined without a bundler, so every runtime dependency has to be inst
 | `.js`, `.mjs`, `.cjs`                 | Copied as-is |
 | Everything else (JSON, assets, ...)   | Copied as-is |
 
-Handler files are always compiled, whatever their extension. With sourcemaps enabled (the default), every compiled file gets a `.map` file beside it in the artifact, and `--enable-source-maps` is set on the functions as it is for bundled builds.
+Handler files are always compiled, whatever their extension: a `.js` handler is passed through esbuild too, so it gets a sourcemap and its module syntax is normalized. With sourcemaps enabled (the default), every compiled file gets a `.map` file beside it in the artifact and `--enable-source-maps` is set on the functions, as for bundled builds; `sourcemap: false` turns both off.
 
 #### Output Formats
 
 Each compiled file is emitted in the module format Node.js will load it with:
 
-- Compiled `.ts`, `.tsx`, and `.jsx` files follow the `type` of the nearest `package.json` at or above the file, so a nested `package.json` with its own `type` governs its subtree.
+- Files that compile to `.js` — from `.ts`, `.tsx`, `.jsx`, or a compiled `.js` handler — follow the `type` of the nearest `package.json` at or above the file, within the service directory. A nested `package.json` with its own `type` governs its subtree, and it ships with the artifact so Node.js applies the same rule at runtime.
 - `.mts` always compiles to `.mjs` (ES module) and `.cts` always compiles to `.cjs` (CommonJS), regardless of any `package.json`.
-- An explicit `format` or `outExtension` in the esbuild configuration applies to the `.js` output class only; `.mjs` and `.cjs` outputs keep their fixed formats. A `format` matching the one the build itself derives — `esm` on a service whose root `package.json` declares `"type": "module"` — is treated as derived, so nested `package.json` subtrees still decide their own files; any other configured `format` overrides the per-file rule.
-- With an `outExtension` remap such as `{ '.js': '.mjs' }`, compiled files are emitted with the remapped extension and relative imports must name it (`./util.mjs`, not `./util.js`). The import scan does not detect a `.js` specifier whose file was emitted under another extension.
+- A configured `format` applies to the files that compile to `.js`. When it names the format the root `package.json` already implies — `format: esm` on a `"type": "module"` service — the per-file rule above stays in charge, so nested `package.json` subtrees keep deciding their own files. Any other configured `format` overrides the per-file rule for all of those files.
+- `outExtension` also applies to the files that compile to `.js`. With `{ '.js': '.mjs' }` they are emitted with the remapped extension and relative imports must name it (`./util.mjs`, not `./util.js`); the import scan does not detect a `.js` specifier whose file was emitted under another extension. Emitting `.mjs` requires the ES module format for every one of those files: a CommonJS subtree fails the build with an error naming the file.
 
 #### ES Module Imports Need Explicit Extensions
 
@@ -219,11 +276,11 @@ import { helper } from './util.js' // resolves the compiled util.ts
 
 This is the same convention TypeScript's `NodeNext` module resolution requires, so a project that type-checks under `NodeNext` deploys unchanged.
 
-The build scans the compiled output and warns about relative specifiers Node.js will not resolve, including extensionless imports in ES module output, imports that name a source file the artifact does not contain (`./util.ts` — the artifact holds the compiled `util.js`), and dynamic `import()` specifiers in CommonJS output (Node.js routes `import()` through the ES module resolver even from CommonJS). Dynamic `require(variable)` calls cannot be detected. Files read at runtime and dynamically required modules belong in `package.patterns`, which ships them without the build having to understand them.
+The build scans the compiled output and warns about two kinds of relative specifier Node.js will not resolve: extensionless imports in ES module output, and imports that name a source file the artifact does not contain (`./util.ts` — the artifact holds the compiled `util.js`). The same two checks apply to dynamic `import()` in CommonJS output, because Node.js routes `import()` through the ES module resolver even from CommonJS. Dynamic `require(variable)` calls cannot be detected. Files read at runtime ship with the rest of the project tree and need no pattern; `package.patterns` is only needed for files the defaults exclude, such as a nested `node_modules` a handler requires. A dependency loaded dynamically still has to be declared through `external` or `packages: external`.
 
 #### Selecting Which TypeScript Compiles
 
-A service often carries TypeScript that is not part of the deployed program — test suites, infrastructure stacks, codegen scripts. The `tsconfig` option decides which TypeScript sources compile, using the config's `files`, `include`, and `exclude`; the config is also passed to esbuild, so its `compilerOptions` apply to compilation.
+A service often carries TypeScript that is not part of the deployed program — test suites, infrastructure stacks, codegen scripts. The `tsconfig` option decides which TypeScript sources compile, using the config's `files`, `include` and `exclude`; the config is also passed to esbuild, so its `compilerOptions` apply to compilation.
 
 ```yaml
 build:
@@ -232,7 +289,7 @@ build:
     tsconfig: ./tsconfig.build.json
 ```
 
-When `tsconfig` is not set, the build reads `tsconfig.json` from the service directory, if present. Auto-discovery looks only there — it never walks up into parent directories, so a monorepo root config cannot take over a service's build. If an auto-discovered config cannot be resolved (for example, an `extends` target that is not installed), the build warns and compiles every TypeScript file in the package instead. A config named explicitly in `tsconfig` must resolve: the build fails if it cannot be read.
+When `tsconfig` is not set, the build reads `tsconfig.json` from the service directory, if present. Auto-discovery looks only there — it never walks up into parent directories, so a monorepo root config cannot take over a service's build. A config named explicitly in `tsconfig` must exist and resolve: the build fails if the file is missing or its `extends` chain cannot be read. A config that is empty or cannot be parsed — named or auto-discovered — produces a warning and every TypeScript file in the package compiles; so does an auto-discovered config whose `extends` target is not installed. A config that selects no TypeScript at all — typically a solution-style root with `files: []` and `references` — also warns, and only handler files compile.
 
 A dedicated `tsconfig.build.json` keeps tests out of the artifact while your editor keeps type-checking them through the regular `tsconfig.json`:
 
@@ -243,11 +300,11 @@ A dedicated `tsconfig.build.json` keeps tests out of the artifact while your edi
 }
 ```
 
-The tsconfig only narrows what compiles: it cannot add files the package excludes, and handler files always compile even when the config omits them. Unlike `tsc`, the build does not follow imports: a TypeScript file outside `files` and `include` is not compiled even when a compiled file imports it, and the artifact will lack it. Make sure `include` covers every source the deployed code reaches — or keep the editor's `tsconfig.json` as it is and point `tsconfig` at a build config that only excludes what should not ship.
+The tsconfig only narrows what compiles: it cannot add files the package excludes, it selects TypeScript only (`.jsx` files always compile), and handler files always compile even when the config omits them. Unlike `tsc`, the build does not follow imports: a TypeScript file outside `files` and `include` is not compiled even when a compiled file imports it, and the artifact will lack it. Make sure `include` covers every source the deployed code reaches — or keep the editor's `tsconfig.json` as it is and point `tsconfig` at a build config that only excludes what should not ship.
 
 #### Excluding Files with `package.patterns`
 
-[`package.patterns`](./packaging.md) works exactly as in classic packaging: patterns apply in order and the last match wins, so negations narrow what ships:
+Under `bundle: false`, [`package.patterns`](./packaging.md) also decides which project files enter the build, with classic semantics: patterns apply in order and the last match wins, so negations narrow what ships and a later positive pattern re-includes a default exclusion (`patterns: ['serverless.yml']` ships the configuration file). Negations select project files; they do not remove build outputs such as sourcemaps — set `sourcemap: false`, or use a function-level negation under `package.individually`.
 
 ```yaml
 package:
@@ -256,11 +313,7 @@ package:
     - '!**/*.md'
 ```
 
-The classic default exclusions apply — the service configuration file, layer source directories, local plugin directories (`plugins.localPath` and `.serverless_plugins/`), and the development artifacts `.gitignore`, `.DS_Store`, `npm-debug.log`, and `yarn-*.log` — and because the last match wins, patterns can re-include them: `patterns: ['serverless.yml']` ships the config file. The legacy `package.include` and `package.exclude` keys are not applied by the esbuild build, in either bundle mode; a warning names them when they are present. Move includes to `package.patterns` as they are, and excludes with a leading `!`. Patterns can also filter the contents of `node_modules`, per function when set under a function's `package.patterns`.
-
-Files whose name starts with `.env` (`.env`, `.env.production`, but also `.envrc`) are excluded by default at any depth, whatever `useDotenv` is set to — stricter than classic packaging, which drops them only at the service root and only when `useDotenv` is enabled. The Framework reads these files at deploy time, so the values your function needs are already environment variables by the time it runs, and shipping the file itself puts secrets in the artifact. Like every default exclusion, a positive pattern that matches an env file re-includes it: `patterns: ['.env']` ships that file deliberately, but a broad glob such as `config/**` or `**` also matches any env file beneath it. Review globs with that in mind, or follow them with a negation such as `!**/.env*`.
-
-The `package.json` in the artifact is generated, pruned to the dependencies the deployed code needs. A pattern that re-includes `package.json` — directly, or through a broad positive pattern such as `'**'` — replaces that generated manifest with the service's own file, devDependencies included.
+Env files deserve a closer look. Every file whose name starts with `.env` (`.env`, `.env.production`, but also `.envrc`) is excluded by default at any depth, whatever `useDotenv` is set to — stricter than classic packaging, which drops them only at the service root and only when `useDotenv` is set. The Framework loads `.env` and `.env.<stage>` from the service directory automatically (see [Dotenv files](./serverless.yml.md#dotenv-files)) so that `${env:VAR}` references in `serverless.yml` resolve on your machine at deploy time; a function receives only the variables declared under `environment` (its own or `provider.environment`). Shipping the file itself does not make its values available to the function — it only puts secrets in the artifact. Like every default exclusion, a positive pattern that matches an env file re-includes it: `patterns: ['.env']` ships that file deliberately, but a broad glob such as `config/**` or `**` also matches any env file beneath it. Review globs with that in mind, or follow them with a negation such as `'!**/.env*'`. Only `.env*` files get this treatment: other dotfiles such as `.npmrc` ship like any other project file.
 
 Positive patterns ship the files they match as they are. A pattern such as `src/**` therefore packages the TypeScript sources next to their compiled output; the sources are inert at runtime, but they add to the artifact and travel with it.
 
@@ -268,16 +321,20 @@ Positive patterns ship the files they match as they are. A pattern such as `src/
 
 Every source file is emitted, so two source files cannot produce the same output. A `util.ts` next to a hand-written `util.js` would both produce `util.js`, and the build stops with an error naming both files instead of shipping whichever was written last. To resolve a collision:
 
-- Exclude one side with a `package.patterns` negation, e.g. `'!src/util.ts'`. For a handler file, negate the TypeScript side: handlers always compile whatever the patterns say, so negating the `.js` leaves the collision in place.
+- Exclude one side with a `package.patterns` negation, e.g. `'!src/util.ts'`. For a handler file, negate the TypeScript side: when `handler.js` and `handler.ts` both exist, the handler path resolves to the `.js` file (extensions are probed in the order `.js`, `.ts`, `.cjs`, `.mjs`, `.cts`, `.mts`, `.jsx`, `.tsx`), and handlers always compile whatever the patterns say, so negating the `.js` leaves the collision in place.
 - Point `build.esbuild.tsconfig` at a config that excludes the TypeScript you don't want compiled.
 - Remove `build.esbuild` from the service if your project compiles itself before deploying.
 
-A function-level `build: false` exempts that function from being built and from the build's handler checks, but its source files stay in the project sweep, so it does not resolve collisions. Unless the service uses `package.individually`, an opted-out function still receives the shared service artifact.
-
 For projects that precompile with `tsc`:
 
-- In-place output (no `outDir`) leaves each `.js` next to its `.ts` source, which is exactly this collision. Exclude the TypeScript side, e.g. `patterns: ['!**/*.ts']` — handler paths resolve to the `.js` file first.
-- `outDir`-style output ships both the sources and the compiled tree unless the sources are excluded, e.g. `patterns: ['!src/**']`.
+- In-place output (no `outDir`) leaves each `.js` next to its `.ts` source, which is exactly this collision. Exclude the TypeScript side with `patterns: ['!**/*.ts']`; the precompiled tree ships, and the handler file itself is still passed through esbuild (see [What Is Compiled and What Is Copied](#what-is-compiled-and-what-is-copied)), so it gains a sourcemap.
+- `outDir`-style output ships both the sources and the compiled tree unless the sources are excluded, e.g. `patterns: ['!src/**']` with handlers pointing into `dist/`.
+
+A function-level `build: false`:
+
+- exempts that function from the build and from the build's handler checks;
+- does not resolve collisions — its source files stay in the project sweep;
+- leaves the function with the shared service artifact, or, under `package.individually`, with an archive of the raw project tree as classic packaging produces it.
 
 #### Individual Packaging
 
@@ -295,14 +352,16 @@ functions:
         - '!src/workers/**'
 ```
 
+A function's negations apply to build outputs as well as project files, so `'!**/*.map'` drops that function's sourcemaps; the generated `package.json` and lockfile always ship, and a negation that removes the function's own handler file fails packaging (see [Packaging Patterns](#packaging-patterns)).
+
 #### Dev Mode
 
-In dev mode, non-bundled rebuilds recompile the project on every change. Outputs of source files deleted during a session persist until the next deploy.
+`serverless invoke local` runs the same build and executes the function from the build directory. In dev mode, non-bundled rebuilds recompile the project on every change. Outputs of source files deleted during a session persist until the next `serverless package` or `deploy`, which start from a clean build directory; if a deleted file's output is still being served in dev mode, run one of those and restart the session.
 
 #### Limitations
 
 - esbuild compiles TypeScript but does not type-check it. Keep `tsc --noEmit` in your CI pipeline.
-- esbuild does not support `emitDecoratorMetadata`. Services that depend on it should precompile with `tsc` and remove `build.esbuild`.
+- esbuild does not support `emitDecoratorMetadata`: decorators compile, but the metadata is silently omitted. Services that depend on it should precompile with `tsc` and remove `build.esbuild`.
 - The import diagnostics scan compiled output only; copied JavaScript files are not scanned. Extensionless ES module imports are warned about, not rewritten.
 
 ## Plugin Conflicts
@@ -313,4 +372,4 @@ Please note, plugins that build your code will not work unless you opt out of th
 - `serverless-webpack`
 - `serverless-plugin-typescript`
 
-The new `build` configuration is customizable by plugins. We will be introducing more features around this soon.
+The new `build` configuration is customizable by plugins.

--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -230,8 +230,9 @@ README.md
 - The service configuration file, layer source directories, and local plugin directories (`plugins.localPath` and `.serverless_plugins/`).
 - `.gitignore`, `.DS_Store`, `npm-debug.log` and `yarn-*.log`.
 - Package-manager internals: `.yarn/**`, `.pnp.cjs`, `.pnp.loader.mjs`, `pnpm-workspace.yaml` and `pnpm-workspace.yml`.
+- Package-manager configuration, at any depth: `.npmrc`, `.yarnrc` and `.yarnrc.yml`. These files can hold registry credentials, and nothing reads them at runtime.
 
-**Everything else ships**, including other dotfiles (`.npmrc`, `.nvmrc`) and the output directories of other tools. Exclude those with `package.patterns` negations, for example `'!.npmrc'` if it holds a registry token.
+**Everything else ships**, including other dotfiles (`.nvmrc`, `.prettierrc`) and the output directories of other tools. Exclude those with `package.patterns` negations.
 
 #### Dependencies
 
@@ -313,7 +314,7 @@ package:
     - '!**/*.md'
 ```
 
-Env files deserve a closer look. Every file whose name starts with `.env` (`.env`, `.env.production`, but also `.envrc`) is excluded by default at any depth, whatever `useDotenv` is set to — stricter than classic packaging, which drops them only at the service root and only when `useDotenv` is set. The Framework loads `.env` and `.env.<stage>` from the service directory automatically (see [Dotenv files](./serverless.yml.md#dotenv-files)) so that `${env:VAR}` references in `serverless.yml` resolve on your machine at deploy time; a function receives only the variables declared under `environment` (its own or `provider.environment`). Shipping the file itself does not make its values available to the function — it only puts secrets in the artifact. Like every default exclusion, a positive pattern that matches an env file re-includes it: `patterns: ['.env']` ships that file deliberately, but a broad glob such as `config/**` or `**` also matches any env file beneath it. Review globs with that in mind, or follow them with a negation such as `'!**/.env*'`. Only `.env*` files get this treatment: other dotfiles such as `.npmrc` ship like any other project file.
+Env files deserve a closer look. Every file whose name starts with `.env` (`.env`, `.env.production`, but also `.envrc`) is excluded by default at any depth, whatever `useDotenv` is set to — stricter than classic packaging, which drops them only at the service root and only when `useDotenv` is set. The Framework loads `.env` and `.env.<stage>` from the service directory automatically (see [Dotenv files](./serverless.yml.md#dotenv-files)) so that `${env:VAR}` references in `serverless.yml` resolve on your machine at deploy time; a function receives only the variables declared under `environment` (its own or `provider.environment`). Shipping the file itself does not make its values available to the function — it only puts secrets in the artifact. Like every default exclusion, a positive pattern that matches an env file re-includes it: `patterns: ['.env']` ships that file deliberately, but a broad glob such as `config/**` or `**` also matches any env file beneath it. Review globs with that in mind, or follow them with a negation such as `'!**/.env*'`. Package-manager configuration files (`.npmrc`, `.yarnrc`, `.yarnrc.yml`) are excluded on the same terms, since they are where registry tokens live; every other dotfile ships like any other project file.
 
 Positive patterns ship the files they match as they are. A pattern such as `src/**` therefore packages the TypeScript sources next to their compiled output; the sources are inert at runtime, but they add to the artifact and travel with it.
 

--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -28,11 +28,23 @@ V.4 introduces a new `build` configuration block, which you can use to customize
 build:
   esbuild:
     # Enable or Disable bundling the function code and dependencies into a single file. (Default: true)
+    #
+    # When disabled, the service is packaged like classic packaging, with
+    # TypeScript compiled in place. See "Building Without Bundling" below.
     bundle: true
+
+    # Path to a tsconfig file, relative to the `serverless.yml` file.
+    # Its compilerOptions are passed to esbuild, and with `bundle: false` its
+    # files/include/exclude select which TypeScript sources are compiled.
+    # See "Building Without Bundling" below.
+    tsconfig: ./tsconfig.build.json
 
     # NPM packages to not be bundled, and instead be available in node_modules, and the zip file uploaded to Lambda.
     #
-    # This property only makes sense if bundling is enabled.
+    # With bundling enabled, these packages are left out of the bundle. With
+    # `bundle: false` nothing is inlined, so this list (or `packages: external`)
+    # decides which dependencies are installed into the artifact at all — see
+    # "Building Without Bundling" below.
     #
     # If no excludes (see below) are specified, and the runtime is set to nodejs16.x or lower,
     # we automatically add "aws-sdk" to the list of externals.
@@ -98,7 +110,9 @@ build:
       setNodeOptions: true
 
     # This option tells esbuild to produce some metadata about the build in
-    # a meta.json file in the <service-root>/.serverless/build directory.
+    # the <service-root>/.serverless/build directory: a meta.json file for
+    # bundled builds, or one meta.<class><format>.json file per compile group
+    # (for example meta.jscjs.json) when `bundle: false` is set.
     metafile: true
 ```
 
@@ -151,7 +165,145 @@ module.exports = (serverless) => {
 
 ### Packaging Patterns
 
-`package.patterns` controls which files are packaged into esbuild artifacts: the patterns filter the artifact's `node_modules` content and select any additional files to include. The compiled handler bundle, the sourcemap when one is emitted, and the `package.json` and lockfile are always packaged. Function-level patterns apply when `package.individually` is enabled and are merged after the service-level patterns. See [Packaging](./packaging.md) for pattern syntax and merging rules.
+[`package.patterns`](./packaging.md) decides what the deployment artifact contains: the patterns filter the artifact's `node_modules` and select additional files from the service directory to ship alongside the build output. Function-level patterns apply when `package.individually` is enabled and are merged after the service-level ones, so a function can narrow — or re-include — what the service level decided. See [Packaging](./packaging.md) for pattern syntax and merging rules.
+
+When bundling (the default), the artifact holds what the build produced: the compiled handler bundle, its sourcemap when one is emitted, and the generated `package.json` with the lockfile beside it. Patterns add to that and filter `node_modules`; the handler bundle is always packaged, and packaging fails rather than shipping an artifact that lost it. Under `package.individually`, a function-level negation can additionally drop build outputs — sourcemaps, plugin-emitted files — from that one function's archive; the generated `package.json` and its lockfile always ship.
+
+A positive pattern naming `node_modules/...` ships those files from your service directory — a vendored or patched dependency the generated `package.json` does not declare, and which the artifact's install therefore never produces. Where such a file and an installed one claim the same path, the pattern's copy is what ships. The installed tree in the build directory is never overwritten by this.
+
+A pattern may reach above the service directory, for example `../shared/**` in a monorepo. Such files are packaged at the path that remains once the leading `../` is removed — `../shared/config.json` ships as `shared/config.json` — the same placement classic packaging gives them. Code that reads the file must use that path.
+
+Excluding every file under `node_modules` while the artifact still needs its dependencies at runtime — `packages: external`, or a non-bundled build whose generated `package.json` declares dependencies — deploys a function that fails on its first invocation. The build warns when it detects that combination.
+
+With `bundle: false` the artifact is the whole project tree and the patterns also decide which project files are compiled and copied in the first place; see [Building Without Bundling](#building-without-bundling).
+
+### Building Without Bundling
+
+`bundle: false` packages your service following classic packaging's rules, with TypeScript compiled in place. The build selects the files classic packaging would ship, compiles the TypeScript among them, copies everything else as-is, and preserves your project's directory layout in the deployment archive. Type declaration files (`.d.ts`, `.d.mts`, `.d.cts`), nested `node_modules` directories, and package-manager internals (the Yarn PnP files `.yarn/**`, `.pnp.cjs`, `.pnp.loader.mjs`, and `pnpm-workspace.yaml`) are additionally excluded. Like every default exclusion they can be re-included through `package.patterns`: a nested `node_modules` a handler requires ships when a positive pattern names it (`patterns: ['lib/node_modules/**']`). As with classic packaging, everything else in the service directory ships — including the output directories of other tools — so exclude those with `package.patterns` negations. Three things are never packaged, whatever the patterns say: `.serverless/`, `.git/`, and the directory that `serverless package --package <dir>` (or `package.path`) writes to.
+
+```yaml
+build:
+  esbuild:
+    bundle: false
+```
+
+Nothing is inlined without a bundler, so every runtime dependency has to be installed into the artifact. Set `packages: external` to install all of them, or list the ones you need in `external`; without either, the generated `package.json` declares no dependencies and the artifact ships no `node_modules`.
+
+#### What Is Compiled and What Is Copied
+
+| Files                                 | Behavior     |
+| ------------------------------------- | ------------ |
+| `.ts`, `.tsx`, `.mts`, `.cts`, `.jsx` | Compiled     |
+| `.js`, `.mjs`, `.cjs`                 | Copied as-is |
+| Everything else (JSON, assets, ...)   | Copied as-is |
+
+Handler files are always compiled, whatever their extension. With sourcemaps enabled (the default), every compiled file gets a `.map` file beside it in the artifact, and `--enable-source-maps` is set on the functions as it is for bundled builds.
+
+#### Output Formats
+
+Each compiled file is emitted in the module format Node.js will load it with:
+
+- Compiled `.ts`, `.tsx`, and `.jsx` files follow the `type` of the nearest `package.json` at or above the file, so a nested `package.json` with its own `type` governs its subtree.
+- `.mts` always compiles to `.mjs` (ES module) and `.cts` always compiles to `.cjs` (CommonJS), regardless of any `package.json`.
+- An explicit `format` or `outExtension` in the esbuild configuration applies to the `.js` output class only; `.mjs` and `.cjs` outputs keep their fixed formats. A `format` matching the one the build itself derives — `esm` on a service whose root `package.json` declares `"type": "module"` — is treated as derived, so nested `package.json` subtrees still decide their own files; any other configured `format` overrides the per-file rule.
+- With an `outExtension` remap such as `{ '.js': '.mjs' }`, compiled files are emitted with the remapped extension and relative imports must name it (`./util.mjs`, not `./util.js`). The import scan does not detect a `.js` specifier whose file was emitted under another extension.
+
+#### ES Module Imports Need Explicit Extensions
+
+Without a bundler, emitted files keep the import specifiers you wrote, and Node.js's ES module resolver does not add extensions or resolve `index.js`. In ES module code, relative imports must name the emitted file, extension included:
+
+```typescript
+// In ESM ("type": "module"), write the extension the emitted file will have:
+import { helper } from './util.js' // resolves the compiled util.ts
+```
+
+This is the same convention TypeScript's `NodeNext` module resolution requires, so a project that type-checks under `NodeNext` deploys unchanged.
+
+The build scans the compiled output and warns about relative specifiers Node.js will not resolve, including extensionless imports in ES module output, imports that name a source file the artifact does not contain (`./util.ts` — the artifact holds the compiled `util.js`), and dynamic `import()` specifiers in CommonJS output (Node.js routes `import()` through the ES module resolver even from CommonJS). Dynamic `require(variable)` calls cannot be detected. Files read at runtime and dynamically required modules belong in `package.patterns`, which ships them without the build having to understand them.
+
+#### Selecting Which TypeScript Compiles
+
+A service often carries TypeScript that is not part of the deployed program — test suites, infrastructure stacks, codegen scripts. The `tsconfig` option decides which TypeScript sources compile, using the config's `files`, `include`, and `exclude`; the config is also passed to esbuild, so its `compilerOptions` apply to compilation.
+
+```yaml
+build:
+  esbuild:
+    bundle: false
+    tsconfig: ./tsconfig.build.json
+```
+
+When `tsconfig` is not set, the build reads `tsconfig.json` from the service directory, if present. Auto-discovery looks only there — it never walks up into parent directories, so a monorepo root config cannot take over a service's build. If an auto-discovered config cannot be resolved (for example, an `extends` target that is not installed), the build warns and compiles every TypeScript file in the package instead.
+
+A dedicated `tsconfig.build.json` keeps tests out of the artifact while your editor keeps type-checking them through the regular `tsconfig.json`:
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts", "test/**"]
+}
+```
+
+The tsconfig only narrows what compiles: it cannot add files the package excludes, and handler files always compile even when the config omits them. Unlike `tsc`, the build does not follow imports: a TypeScript file outside `files` and `include` is not compiled even when a compiled file imports it, and the artifact will lack it. Make sure `include` covers every source the deployed code reaches — or keep the editor's `tsconfig.json` as it is and point `tsconfig` at a build config that only excludes what should not ship.
+
+#### Excluding Files with `package.patterns`
+
+[`package.patterns`](./packaging.md) works exactly as in classic packaging: patterns apply in order and the last match wins, so negations narrow what ships:
+
+```yaml
+package:
+  patterns:
+    - '!tests/**'
+    - '!**/*.md'
+```
+
+The classic default exclusions apply — the service configuration file, layer source directories, local plugin directories (`plugins.localPath` and `.serverless_plugins/`), and the development artifacts `.gitignore`, `.DS_Store`, `npm-debug.log`, and `yarn-*.log` — and because the last match wins, patterns can re-include them: `patterns: ['serverless.yml']` ships the config file. The legacy `package.include` and `package.exclude` keys are honored the way classic packaging honors them: includes are applied ahead of `patterns`, excludes join the default exclusions. Patterns can also filter the contents of `node_modules`, per function when set under a function's `package.patterns`.
+
+Files whose name starts with `.env` (`.env`, `.env.production`, but also `.envrc`) are excluded by default at any depth, whatever `useDotenv` is set to — stricter than classic packaging, which drops them only at the service root and only when `useDotenv` is enabled. The Framework reads these files at deploy time, so the values your function needs are already environment variables by the time it runs, and shipping the file itself puts secrets in the artifact. Like every default exclusion, a positive pattern that matches an env file re-includes it: `patterns: ['.env']` ships that file deliberately, but a broad glob such as `config/**` or `**` also matches any env file beneath it. Review globs with that in mind, or follow them with a negation such as `!**/.env*`.
+
+The `package.json` in the artifact is generated, pruned to the dependencies the deployed code needs. A pattern that re-includes `package.json` — directly, or through a broad positive pattern such as `'**'` — replaces that generated manifest with the service's own file, devDependencies included.
+
+Positive patterns ship the files they match as they are. A pattern such as `src/**` therefore packages the TypeScript sources next to their compiled output; the sources are inert at runtime, but they add to the artifact and travel with it.
+
+#### One Output per File
+
+Every source file is emitted, so two source files cannot produce the same output. A `util.ts` next to a hand-written `util.js` would both produce `util.js`, and the build stops with an error naming both files instead of shipping whichever was written last. To resolve a collision:
+
+- Exclude one side with a `package.patterns` negation, e.g. `'!src/util.ts'`. For a handler file, negate the TypeScript side: handlers always compile whatever the patterns say, so negating the `.js` leaves the collision in place.
+- Point `build.esbuild.tsconfig` at a config that excludes the TypeScript you don't want compiled.
+- Remove `build.esbuild` from the service if your project compiles itself before deploying.
+
+A function-level `build: false` exempts that function from being built and from the build's handler checks, but its source files stay in the project sweep, so it does not resolve collisions. Unless the service uses `package.individually`, an opted-out function still receives the shared service artifact.
+
+For projects that precompile with `tsc`:
+
+- In-place output (no `outDir`) leaves each `.js` next to its `.ts` source, which is exactly this collision. Exclude the TypeScript side, e.g. `patterns: ['!**/*.ts']` — handler paths resolve to the `.js` file first.
+- `outDir`-style output ships both the sources and the compiled tree unless the sources are excluded, e.g. `patterns: ['!src/**']`.
+
+#### Individual Packaging
+
+With `package.individually: true`, every function's archive contains the whole project tree, matching classic packaging. Per-function pattern negations narrow individual archives:
+
+```yaml
+package:
+  individually: true
+
+functions:
+  api:
+    handler: src/api.handler
+    package:
+      patterns:
+        - '!src/workers/**'
+```
+
+#### Dev Mode
+
+In dev mode, non-bundled rebuilds recompile the project on every change. Outputs of source files deleted during a session persist until the next deploy.
+
+#### Limitations
+
+- esbuild compiles TypeScript but does not type-check it. Keep `tsc --noEmit` in your CI pipeline.
+- esbuild does not support `emitDecoratorMetadata`. Services that depend on it should precompile with `tsc` and remove `build.esbuild`.
+- The import diagnostics scan compiled output only; copied JavaScript files are not scanned. Extensionless ES module imports are warned about, not rewritten.
 
 ## Plugin Conflicts
 

--- a/docs/sf/providers/aws/guide/building.md
+++ b/docs/sf/providers/aws/guide/building.md
@@ -232,7 +232,7 @@ build:
     tsconfig: ./tsconfig.build.json
 ```
 
-When `tsconfig` is not set, the build reads `tsconfig.json` from the service directory, if present. Auto-discovery looks only there — it never walks up into parent directories, so a monorepo root config cannot take over a service's build. If an auto-discovered config cannot be resolved (for example, an `extends` target that is not installed), the build warns and compiles every TypeScript file in the package instead.
+When `tsconfig` is not set, the build reads `tsconfig.json` from the service directory, if present. Auto-discovery looks only there — it never walks up into parent directories, so a monorepo root config cannot take over a service's build. If an auto-discovered config cannot be resolved (for example, an `extends` target that is not installed), the build warns and compiles every TypeScript file in the package instead. A config named explicitly in `tsconfig` must resolve: the build fails if it cannot be read.
 
 A dedicated `tsconfig.build.json` keeps tests out of the artifact while your editor keeps type-checking them through the regular `tsconfig.json`:
 
@@ -256,7 +256,7 @@ package:
     - '!**/*.md'
 ```
 
-The classic default exclusions apply — the service configuration file, layer source directories, local plugin directories (`plugins.localPath` and `.serverless_plugins/`), and the development artifacts `.gitignore`, `.DS_Store`, `npm-debug.log`, and `yarn-*.log` — and because the last match wins, patterns can re-include them: `patterns: ['serverless.yml']` ships the config file. The legacy `package.include` and `package.exclude` keys are honored the way classic packaging honors them: includes are applied ahead of `patterns`, excludes join the default exclusions. Patterns can also filter the contents of `node_modules`, per function when set under a function's `package.patterns`.
+The classic default exclusions apply — the service configuration file, layer source directories, local plugin directories (`plugins.localPath` and `.serverless_plugins/`), and the development artifacts `.gitignore`, `.DS_Store`, `npm-debug.log`, and `yarn-*.log` — and because the last match wins, patterns can re-include them: `patterns: ['serverless.yml']` ships the config file. The legacy `package.include` and `package.exclude` keys are not applied by the esbuild build, in either bundle mode; a warning names them when they are present. Move includes to `package.patterns` as they are, and excludes with a leading `!`. Patterns can also filter the contents of `node_modules`, per function when set under a function's `package.patterns`.
 
 Files whose name starts with `.env` (`.env`, `.env.production`, but also `.envrc`) are excluded by default at any depth, whatever `useDotenv` is set to — stricter than classic packaging, which drops them only at the service root and only when `useDotenv` is enabled. The Framework reads these files at deploy time, so the values your function needs are already environment variables by the time it runs, and shipping the file itself puts secrets in the artifact. Like every default exclusion, a positive pattern that matches an env file re-includes it: `patterns: ['.env']` ships that file deliberately, but a broad glob such as `config/**` or `**` also matches any env file beneath it. Review globs with that in mind, or follow them with a negation such as `!**/.env*`.
 

--- a/docs/sf/providers/aws/guide/packaging.md
+++ b/docs/sf/providers/aws/guide/packaging.md
@@ -69,6 +69,8 @@ By default, serverless will exclude the following patterns:
 
 and the serverless configuration file being used (i.e. `serverless.yml`). In addition, if `useDotenv` is set, all files satisfying pattern `.env*` will be excluded as well.
 
+Node.js functions built by the built-in esbuild build (TypeScript handlers, or a `build.esbuild` configuration that enables it) apply patterns on top of the build output: patterns add files to the artifact and filter its `node_modules`, and with `bundle: false` they also select which project files are compiled and copied. The legacy `package.include` and `package.exclude` keys are not applied there. See [Packaging Patterns](./building.md#packaging-patterns) in the build guide.
+
 ### Examples
 
 Exclude all node_modules but then re-include a specific modules (in this case node-fetch) using `exclude` exclusively

--- a/package-lock.json
+++ b/package-lock.json
@@ -7828,6 +7828,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.1.tgz",
+      "integrity": "sha512-Dz/6HxkrxgNehhxLVeyv8sad9UzF2xBVeaKBQNDfJ5XiSXmp2gTR0eO0RWiT2NCKS5aGP9jjkOMggTN90qU50A==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -11341,6 +11353,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -13408,6 +13429,7 @@
         "filesize": "^11.0.22",
         "fs-extra": "^11.4.0",
         "get-stdin": "^9.0.0",
+        "get-tsconfig": "^4.14.1",
         "glob": "^13.0.6",
         "globby": "^14.1.0",
         "graphql": "^16.14.2",

--- a/packages/serverless/lib/plugins/aws/provider.js
+++ b/packages/serverless/lib/plugins/aws/provider.js
@@ -2828,9 +2828,16 @@ destinations:
               $ref: '#/definitions/awsLambdaRuntime',
             },
             build: {
-              description: `Function-level build strategy.
-@since v4`,
-              type: 'string',
+              description: `Function-level build strategy, or \`false\` to exclude this function from building.
+@since v4
+@example build: false`,
+              // The `false` branch comes first and uses `const` (value
+              // equality, no coercion): the schema is compiled with ajv's
+              // `coerceTypes: 'array'`, so a leading `type: 'string'` branch
+              // would rewrite the boolean to the string "false" before the
+              // plugin ever sees it, and the strict-equality opt-out check
+              // would miss it.
+              anyOf: [{ const: false }, { type: 'string' }],
             },
             runtimeManagement: {
               description: `Function-level runtime management mode.`,

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -366,6 +366,8 @@ class Esbuild {
     // Set once the `packages: external` / empty-node_modules warning has been
     // emitted, so that it is reported per invocation rather than per function.
     this._nodeModulesExclusionWarned = false
+    // Same shape for the legacy `package.include` / `package.exclude` notice.
+    this._legacyPackageKeysWarned = false
 
     // Captured once at construction so the reset target stays stable: `invoke
     // local` and `offline` repoint the live service path AT this directory
@@ -839,7 +841,11 @@ class Esbuild {
    *   from the nearest package.json rather than service-wide.
    * @returns {string} The configured output extension, defaulting to '.js'
    */
-  _outputExtension(buildProperties, format = buildProperties.format) {
+  _outputExtension(
+    buildProperties,
+    format = buildProperties.format,
+    derivedForFile = null,
+  ) {
     const extension = buildProperties.outExtension?.['.js'] ?? '.js'
 
     if (!['.js', '.cjs', '.mjs'].includes(extension)) {
@@ -860,8 +866,15 @@ class Esbuild {
       )
     }
     if (!isEsm && extension === '.mjs') {
+      // `derivedForFile` names a file whose format came from its nearest
+      // package.json rather than from the configuration: the service root is
+      // ESM (or the mapping would have failed up front), so "set format: esm"
+      // is not the fix here — a nested `package.json` decided this subtree is
+      // CommonJS, and a `.mjs` name would make Lambda load it as ESM anyway.
       throw new ServerlessError(
-        'Emitting ".mjs" files requires the esbuild format "esm". Set "format: esm" in the esbuild configuration or remove the "outExtension" mapping',
+        derivedForFile
+          ? `Emitting ".mjs" files requires the ES module format, but "${derivedForFile}" compiles as CommonJS because its nearest package.json does not declare "type": "module". Declare "type": "module" in that package.json, exclude those files from the build, or remove the "outExtension" mapping`
+          : 'Emitting ".mjs" files requires the esbuild format "esm". Set "format: esm" in the esbuild configuration or remove the "outExtension" mapping',
         'ESBUILD_OUT_EXTENSION_FORMAT_MISMATCH',
       )
     }
@@ -1021,6 +1034,7 @@ class Esbuild {
     }
 
     const buildProperties = await this._buildProperties()
+    this._warnOnLegacyPackageKeys(functionsToBuild)
 
     // Without bundling, a handler's `import`s stay in the emitted file and are
     // resolved by Node at runtime, so the artifact has to carry the whole
@@ -1030,9 +1044,10 @@ class Esbuild {
     if (buildProperties.bundle === false) {
       // Dev mode (the only caller passing `originalHandler`) keeps the
       // last-good outputs, exactly as on the bundling path. The reset belongs
-      // HERE, in `_build`: `before:esbuild-package` fires after it and is the
-      // plugin injection point whose outputs the zip must include, so a reset
-      // in `_package` would wipe plugin-injected files (see `_resetBuildDir`).
+      // HERE, in `_build`: `before:esbuild-package:package` fires after it and
+      // is the plugin injection point whose outputs the zip must include, so a
+      // reset in `_package` would wipe plugin-injected files (see
+      // `_resetBuildDir`).
       if (handlerPropertyName !== 'originalHandler') {
         await this._resetBuildDir()
       }
@@ -1390,27 +1405,13 @@ class Esbuild {
     const swept = await sweepProjectFiles({
       serviceDir,
       additionalIgnores: this._packageDirectoryIgnores(),
-      // `package.include` is the other half of the legacy pre-`patterns` pair
-      // (see `package.exclude` below). Classic merges it ahead of `patterns`
-      // (`getIncludes`: include first, patterns after), so a patterns negation
-      // still gets the last word over an include.
-      patterns: [
-        ...(service.package?.include ?? []),
-        ...(service.package?.patterns ?? []),
-      ],
+      patterns: service.package?.patterns ?? [],
       configFileNames: resolveServerlessConfigFileExcludes(this.serverless),
       layerPaths,
       localPluginPath:
         this.serverless.pluginManager?.parsePluginsObject?.(service.plugins)
           ?.localPath ?? null,
-      additionalExclusions: [
-        ...CLASSIC_DEFAULT_EXCLUDES,
-        // `package.exclude` is the pre-`patterns` spelling. Classic still
-        // merges it into its exclude list, so a service that never migrated
-        // has to keep excluding the same files here.
-        ...(service.package?.exclude ?? []),
-        DOTENV_EXCLUDE,
-      ],
+      additionalExclusions: [...CLASSIC_DEFAULT_EXCLUDES, DOTENV_EXCLUDE],
     })
 
     const handlerFiles = [...handlerFileByAlias.values()]
@@ -1466,7 +1467,11 @@ class Esbuild {
             : 'cjs')
         // `outExtension` is a `.js`-class setting: the other classes carry a
         // module system in their name and renaming their output discards it.
-        outputExtension = this._outputExtension(buildProperties, format)
+        outputExtension = this._outputExtension(
+          buildProperties,
+          format,
+          explicitFormat ? null : file,
+        )
       }
 
       // Keyed by SOURCE class, not by the extension it ends up with: with
@@ -2072,6 +2077,49 @@ class Esbuild {
    *
    * @returns {string[]} zero or one POSIX glob, service-relative
    */
+  /**
+   * Warn, once per process, when the pre-`patterns` keys are configured.
+   *
+   * The esbuild build reads `package.patterns` only -- at the service level
+   * and, under `package.individually`, per function. `package.include` and
+   * `package.exclude` are the legacy pair classic packaging still honors, so
+   * a service that never migrated them validates fine and then silently gets
+   * a different artifact than its configuration describes: an `exclude` that
+   * removes nothing, an `include` that adds nothing. Naming the keys is the
+   * cheapest way to make that visible; honoring them would activate entries
+   * the build has always ignored, which is its own surprise.
+   *
+   * @param {Record<string, object>} functionsToBuild functions this build covers
+   */
+  _warnOnLegacyPackageKeys(functionsToBuild) {
+    if (this._legacyPackageKeysWarned) return
+    const legacyKeysOf = (packageConfig) =>
+      ['include', 'exclude'].filter(
+        (key) =>
+          Array.isArray(packageConfig?.[key]) && packageConfig[key].length > 0,
+      )
+    const quoted = (keys) => keys.map((key) => `"package.${key}"`).join(' and ')
+
+    const where = []
+    const serviceKeys = legacyKeysOf(this.serverless.service.package)
+    if (serviceKeys.length > 0) {
+      where.push(`the service-level ${quoted(serviceKeys)}`)
+    }
+    for (const [alias, functionObject] of Object.entries(functionsToBuild)) {
+      const functionKeys = legacyKeysOf(functionObject.package)
+      if (functionKeys.length > 0) {
+        where.push(`${quoted(functionKeys)} on function "${alias}"`)
+      }
+    }
+    if (where.length === 0) return
+
+    this._legacyPackageKeysWarned = true
+    logger.warning(
+      `The esbuild build applies "package.patterns" only; ${where.join('; ')} ${where.length === 1 && !where[0].includes(' and ') ? 'is' : 'are'} ignored. ` +
+        'Move these entries to "package.patterns", prefixing excludes with "!".',
+    )
+  }
+
   _packageDirectoryIgnores() {
     const configured =
       this.options.package || this.serverless.service.package?.path
@@ -3106,10 +3154,11 @@ class Esbuild {
    * every deploy is a measured multi-second regression.
    *
    * The wipe MUST stay in `_build`, before `spawn('esbuild-package')` runs.
-   * `before:esbuild-package` is the supported injection point for plugins that
-   * add files to the build directory, and the zip has to include what they
-   * wrote -- moving the reset into `_package` would delete those files right
-   * before packaging.
+   * `before:esbuild-package:package` (the spawned command's `package`
+   * lifecycle event; a bare `before:esbuild-package` hook never fires) is the
+   * supported injection point for plugins that add files to the build
+   * directory, and the zip has to include what they wrote -- moving the reset
+   * into `_package` would delete those files right before packaging.
    */
   async _resetBuildDir() {
     const preserved = new Set([

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -1,6 +1,16 @@
 import path from 'path'
 import { pathToFileURL } from 'url'
-import { copyFile, lstat, readFile, rm, stat, writeFile } from 'fs/promises'
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'fs/promises'
 import { createWriteStream, existsSync } from 'fs'
 import * as esbuild from 'esbuild'
 import { ZipArchive } from 'archiver'
@@ -9,16 +19,156 @@ import _ from 'lodash'
 import pLimit from 'p-limit'
 import { globby } from 'globby'
 import micromatch from 'micromatch'
-import {
-  compilePatterns,
-  isPathIncluded,
-  isDirIncluded,
-  filterPaths,
-} from '../../utils/package-patterns.js'
 import ServerlessError from '../../serverless-error.js'
 import { log } from '@serverless/util'
+import { resolveServerlessConfigFileExcludes } from '../package/lib/package-service.js'
+import {
+  compilePatterns,
+  filterPaths,
+  isDirIncluded,
+  isPathIncluded,
+} from '../../utils/package-patterns.js'
+import {
+  applyTsconfigCompileFilter,
+  detectOutputCollisions,
+  nearestPackageJsonType,
+  outputPathFor,
+  scanUnresolvableRelativeImports,
+  splitCompileAndCopy,
+  sweepProjectFiles,
+  toSweptPath,
+} from './project-sweep.js'
 
 const nodeRuntimeRe = /nodejs(?<version>\d+).x/
+
+// Every extension the plugin will probe when turning a `handler` string into a
+// source file. Single source of truth so the "checked extensions" wording in
+// the unresolvable-handler error can never drift from what is actually probed.
+const BUILDABLE_HANDLER_EXTENSIONS = [
+  '.js',
+  '.ts',
+  '.cjs',
+  '.mjs',
+  '.cts',
+  '.mts',
+  '.jsx',
+  '.tsx',
+]
+
+// The files classic packaging drops from every artifact no matter how the
+// service is configured. Mirrors `defaultExcludes` in
+// `lib/plugins/package/lib/package-service.js`, minus the entries the project
+// sweep already handles itself (`.git`, `.serverless`, `.serverless_plugins`).
+const CLASSIC_DEFAULT_EXCLUDES = [
+  '.gitignore',
+  '.DS_Store',
+  'npm-debug.log',
+  'yarn-*.log',
+]
+
+// Env files never reach an artifact. This is deliberately stricter than
+// classic packaging on two counts: classic drops them only when `useDotenv` is
+// set, and only at the service root. Here the rule is unconditional and
+// applies at any depth, because a file of secrets in a Lambda package is the
+// same hazard wherever it sits, and the framework reads these files at deploy
+// time — the values a function needs have already become environment variables
+// by the time it runs. A service that genuinely needs the file at runtime (the
+// `dotenv`-at-startup pattern) asks for it with a positive `package.patterns`
+// entry: exclusions are leading negations, so any later positive match — the
+// file's own name or a glob that covers it — re-includes it.
+const DOTENV_EXCLUDE = '**/.env*'
+
+// How many raw file copies run at once during a non-bundled build. A large
+// service can sweep tens of thousands of files, and an unbounded `Promise.all`
+// over them opens every source and destination descriptor at the same time,
+// which is an EMFILE away from failing the build on default ulimits.
+const COPY_CONCURRENCY = 32
+
+// How many `file → specifier` pairs the extensionless-import warning prints
+// before it stops naming them and just counts. A half-migrated service can
+// produce hundreds, and a wall of them buries every other line of build
+// output; ten is enough to recognize the pattern and go fix it.
+const ESM_SPECIFIER_WARNING_LIMIT = 10
+
+// Build-dir root entries the artifact walk never picks up.
+//
+// `node_modules` is appended separately, by its own sorted walk, so picking it
+// up here would append every dependency file twice.
+//
+// The Yarn PnP runtime and cache belong to the developer's resolution setup:
+// `.yarn/cache` alone is routinely larger than the whole artifact. The project
+// sweep already keeps them out of the build directory by default, so what
+// reaches it is a Yarn Berry install run inside it — and none of them shipped
+// before the artifact became "everything in the build directory" either.
+//
+// These are default exclusions, not a hard rule: a positive `package.patterns`
+// entry gets the last word here as everywhere else. Files a pattern put under
+// one of these roots are recorded in `patternClaimedBuildPaths` and the walk
+// keeps exactly those (see `_collectBuildDirEntries`).
+const BUILD_DIR_EXCLUDED_ROOT_ENTRIES = new Set([
+  'node_modules',
+  '.yarn',
+  '.pnp.cjs',
+  '.pnp.loader.mjs',
+  // Copied in by `_preparePackageJson` so that a pnpm install run inside the
+  // build directory puts node_modules there. It is the install's scaffolding,
+  // not the function's, and no earlier release packaged it.
+  'pnpm-workspace.yaml',
+  'pnpm-workspace.yml',
+])
+
+// The artifact's own manifest: `package.json` as `_preparePackageJson`
+// generates it, and the lockfile copied beside it. Function-level negations
+// slim a function's archive, but these are the plugin's files, not project
+// files, and every earlier release shipped them unconditionally. For a
+// `"type": "module"` service emitting `.js`, the manifest is the only thing
+// telling Lambda to load the handler as ES module code; a classic slimming
+// idiom such as `!**/*.json` would otherwise deploy a function that fails at
+// initialization with no diagnostic at build time.
+const ARTIFACT_MANIFEST_ENTRIES = new Set([
+  'package.json',
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+])
+
+// esbuild's own build metadata: `meta.json` from the bundling path, and one
+// `meta.<class><format>.json` per partition from the non-bundled one. A regex
+// rather than a glob because every character in these names is literal.
+const BUILD_METAFILE_RE = /^meta\.(?:[^/]*\.)?json$/
+
+// Directories `package.patterns` can never select, whatever the patterns say.
+// `.serverless` holds the build directory itself (selecting it would nest a
+// copy of the artifact inside the artifact) and `.git` is never part of a
+// deployment package. The configured `--package` directory belongs in the same
+// class and is appended per instance by `_packageDirectoryIgnores`.
+//
+// `node_modules` is deliberately NOT here. Writing the service's own tree over
+// the one installed into the build directory from the pruned package.json would
+// corrupt the install — which `_resetBuildDir` then preserves into every later
+// deploy — so the COPY step refuses those paths (see
+// `isInstalledDependencyPath`). Refusing to package them is a different thing
+// entirely, and dropping them here did exactly that: a positive pattern naming
+// a vendored or patched dependency silently produced an artifact without it.
+const PATTERN_RESOLVE_IGNORE = ['.serverless/**', '.git/**']
+
+// A pattern match that lands on the installed dependency tree at the artifact
+// root. Only the root tree is the install; a nested `packages/x/node_modules/y`
+// is just another project file and is copied like any other.
+const isInstalledDependencyPath = (zipPath) =>
+  zipPath === 'node_modules' || zipPath.startsWith('node_modules/')
+
+// Where a `package.patterns` match lands in the artifact. A pattern that reaches
+// above the service directory (`../shared/**`) comes back from globby as a
+// `../`-prefixed path; an archive has no parent directory to put that in, so
+// the leading segments come off and the file sits at what remains
+// (`shared/x.json`). archiver applies exactly this rule to every entry name it
+// is handed, which is how classic packaging and every earlier esbuild release
+// placed such files. It is applied here explicitly, before the path is used,
+// so the build-directory copy, the dedup against the installed tree and the
+// post-zip handler assertion all see the entry the archive will actually hold.
+const archivePathFor = (relativePath) =>
+  path.posix.normalize(relativePath).replace(/^(\.\.\/)+/, '')
 
 const logger = log.get('esbuild')
 
@@ -78,13 +228,32 @@ const lstatEntry = async (sourcePath) => {
 // enqueue the entry synchronously, so entries appear strictly in call order.
 // `stats` may be supplied by a caller that already had to look them up, so
 // that the entry is never lstat'ed twice.
-const appendFileEntry = async (zip, sourcePath, name, stats) => {
+// `mode` — optional — overrides the mode archiver would take off the
+// filesystem. Left undefined (the default) the entry keeps the stats-derived
+// mode, so callers that only want deterministic ORDER are untouched; callers
+// that also need deterministic PERMISSIONS pass a normalized value, because
+// the same tree installed under a different umask otherwise hashes
+// differently.
+const appendFileEntry = async (zip, sourcePath, name, stats, mode) => {
   zip.file(sourcePath, {
     name,
     date: PINNED_ARTIFACT_DATE,
     stats: stats ?? (await lstatEntry(sourcePath)),
+    ...(mode === undefined ? {} : { mode }),
   })
 }
+
+// The mode the artifact records for a walked entry, independent of the umask
+// the tree was created under: 0755 for directories and for anything carrying
+// the owner-executable bit, 0644 otherwise. Windows has no executable bit and
+// reports none, so everything there is marked executable rather than stripping
+// the bit off files that need it.
+const normalizedEntryMode = (stats) =>
+  stats.isDirectory()
+    ? 0o755
+    : stats.mode & 0o100 || process.platform === 'win32'
+      ? 0o755
+      : 0o644
 
 // Deterministic replacement for zip.directory(): expand the tree ourselves
 // and append sequentially in sorted order. zip.directory()'s async walk
@@ -99,7 +268,19 @@ const appendFileEntry = async (zip, sourcePath, name, stats) => {
 // appended; `entry` is the walk-relative posix path and `stats` are its
 // (already fetched) lstat results, so the caller can tell directories from
 // files. Filtering happens after the sort, so it can never reorder anything.
-const appendDirectoryEntries = async (zip, dirPath, destPath, filter) => {
+//
+// `normalizeEntryModes` — optional — records a umask-independent mode for
+// every appended entry instead of the filesystem's. Enabled only for the
+// node_modules walk, where the tree comes from a package manager install
+// whose permissions vary between machines; the include expansion keeps the
+// source tree's own modes, as it always has.
+const appendDirectoryEntries = async (
+  zip,
+  dirPath,
+  destPath,
+  filter,
+  normalizeEntryModes = false,
+) => {
   const entries = (
     await globby('**', {
       cwd: dirPath,
@@ -112,7 +293,13 @@ const appendDirectoryEntries = async (zip, dirPath, destPath, filter) => {
     const sourcePath = path.join(dirPath, entry)
     const stats = await lstatEntry(sourcePath)
     if (filter && !filter(entry, stats)) continue
-    await appendFileEntry(zip, sourcePath, `${destPath}/${entry}`, stats)
+    await appendFileEntry(
+      zip,
+      sourcePath,
+      `${destPath}/${entry}`,
+      stats,
+      normalizeEntryModes ? normalizedEntryMode(stats) : undefined,
+    )
   }
 }
 
@@ -134,12 +321,17 @@ const statIncludeEntry = async (absolutePath) => {
 // shared factory for both packaging paths, so the twin filters cannot drift.
 // The `excludedNodeModulesEntryCount` counter is scoped to the node_modules
 // walk: only it can attest that the patterns removed dependencies, which is
-// what the `packages: external` warning claims. `excludedEntryCount` also
-// absorbs filtered additive includes at the call sites.
+// what the emptied-node_modules warning claims. `excludedEntryCount` also
+// absorbs filtered additive includes and build-directory entries at the call
+// sites. `excludedNodeModulesFileCount` narrows the walk-scoped count to FILES,
+// because directory entries are structure rather than payload: a node_modules
+// holding nothing but empty directories loses no dependency when a pattern
+// strips those husks, and the warning must not claim otherwise.
 const createNodeModulesEntryFilter = (compiledPatterns) => {
   const counters = {
     excludedEntryCount: 0,
     excludedNodeModulesEntryCount: 0,
+    excludedNodeModulesFileCount: 0,
     includedNodeModulesFileCount: 0,
   }
   const filter = (entry, stats) => {
@@ -153,6 +345,9 @@ const createNodeModulesEntryFilter = (compiledPatterns) => {
     if (!included) {
       counters.excludedEntryCount += 1
       counters.excludedNodeModulesEntryCount += 1
+      if (!isDirectory) {
+        counters.excludedNodeModulesFileCount += 1
+      }
       return false
     }
     if (!isDirectory) {
@@ -171,6 +366,23 @@ class Esbuild {
     // Set once the `packages: external` / empty-node_modules warning has been
     // emitted, so that it is reported per invocation rather than per function.
     this._nodeModulesExclusionWarned = false
+
+    // Captured once at construction so the reset target stays stable: `invoke
+    // local` and `offline` repoint the live service path AT this directory
+    // (see `_setConfigForLocalInvocation`), and a value derived after that
+    // would nest a second `.serverless/build` inside the build output.
+    // `serviceDir` is null when the CLI runs outside a service (e.g.
+    // `serverless create`) — the plugin is still constructed there, but
+    // nothing is ever built.
+    this.buildDirPath = this.serverless.config.serviceDir
+      ? path.join(this.serverless.config.serviceDir, '.serverless', 'build')
+      : undefined
+
+    // Build-directory paths under a `BUILD_DIR_EXCLUDED_ROOT_ENTRIES` root
+    // that a positive pattern selected (see `_claimBuildPaths`). Reset per
+    // build; empty when packaging runs on a build directory this instance did
+    // not populate.
+    this.patternClaimedBuildPaths = new Set()
 
     this._buildProperties = _.memoize(this._buildProperties.bind(this))
     this._readPackageJson = _.memoize(this._readPackageJson.bind(this))
@@ -254,6 +466,16 @@ class Esbuild {
             },
             // Whether to bundle or not. Default is true
             bundle: { type: 'boolean' },
+            tsconfig: {
+              description: `Path to a tsconfig file used to select which TypeScript sources are compiled when bundle is false, and passed to esbuild for compilerOptions.
+@example './tsconfig.build.json'
+@since v4`,
+              type: 'string',
+              // An empty string would resolve to the service directory and be
+              // read as "discover one for me", which is not what anyone who
+              // wrote `tsconfig: ''` meant.
+              minLength: 1,
+            },
             outExtension: {
               description: `Output file extension for the bundled handlers, e.g. { '.js': '.mjs' } to emit ES module bundles.
 @example { '.js': '.mjs' }`,
@@ -378,16 +600,7 @@ class Esbuild {
 
       const handlerPath = stripHandlerExportSuffix(functionHandler)
       let parsedExtension = undefined
-      for (const extension of [
-        '.js',
-        '.ts',
-        '.cjs',
-        '.mjs',
-        '.cts',
-        '.mts',
-        '.jsx',
-        '.tsx',
-      ]) {
+      for (const extension of BUILDABLE_HANDLER_EXTENSIONS) {
         if (existsSync(path.join(serviceDir, handlerPath + extension))) {
           parsedExtension = extension
           break
@@ -413,6 +626,15 @@ class Esbuild {
    */
   async _shouldBuildFunction(functionObject, handlerPropertyName = 'handler') {
     if (this.serverless.service.build?.esbuild === false) {
+      return false
+    }
+    // An explicit function-level `build: false` opts a single function out of
+    // building. This has to be checked up front: `false` is falsy, so it fell
+    // through both the zero-config TypeScript detection and the
+    // `functionBuildParam` branches below into the provider-level default,
+    // and the function got built anyway. It is the escape hatch the
+    // unresolvable-handler error points people at, so it has to work.
+    if (functionObject.build === false) {
       return false
     }
     // If handler isn't set then it is a docker function so do not attempt to build
@@ -483,16 +705,7 @@ class Esbuild {
   // This is all the possible extensions that the esbuild plugin can build for
   async _extensionForFunction(functionHandler) {
     const handlerPath = stripHandlerExportSuffix(functionHandler)
-    for (const extension of [
-      '.js',
-      '.ts',
-      '.cjs',
-      '.mjs',
-      '.cts',
-      '.mts',
-      '.jsx',
-      '.tsx',
-    ]) {
+    for (const extension of BUILDABLE_HANDLER_EXTENSIONS) {
       if (
         existsSync(
           path.join(this.serverless.config.serviceDir, handlerPath + extension),
@@ -594,6 +807,19 @@ class Esbuild {
         mergedOptions.sourcemap = true
       }
 
+      // esbuild resolves a relative `tsconfig` against its own working
+      // directory, which under Compose is the compose root and not this
+      // service -- the build then dies with `Cannot find tsconfig file`.
+      // Making it absolute once, here, is what lets every consumer (both
+      // build paths and the compile-selection filter) agree on which file the
+      // user meant, whatever the process happens to be cd'ed into.
+      if (mergedOptions.tsconfig) {
+        mergedOptions.tsconfig = path.resolve(
+          this.serverless.config.serviceDir,
+          mergedOptions.tsconfig,
+        )
+      }
+
       return mergedOptions
     }
 
@@ -607,9 +833,13 @@ class Esbuild {
    * applied here — to the outfile passed to esbuild and to the file names the
    * packaging step zips — instead of by esbuild itself.
    * @param {object} buildProperties - The merged esbuild build properties
+   * @param {string} [format] - The format the extension is checked against.
+   *   Defaults to the service-wide `format`; the non-bundled build passes the
+   *   format it resolved for the `.js` class instead, which is decided per file
+   *   from the nearest package.json rather than service-wide.
    * @returns {string} The configured output extension, defaulting to '.js'
    */
-  _outputExtension(buildProperties) {
+  _outputExtension(buildProperties, format = buildProperties.format) {
     const extension = buildProperties.outExtension?.['.js'] ?? '.js'
 
     if (!['.js', '.cjs', '.mjs'].includes(extension)) {
@@ -622,7 +852,7 @@ class Esbuild {
     // Mirrors esbuild's own coherence rules: Lambda decides between the CJS
     // and ESM loaders by file extension, so a mismatched pair produces a
     // bundle that crashes at initialization. Fail at build time instead.
-    const isEsm = buildProperties.format === 'esm'
+    const isEsm = format === 'esm'
     if (isEsm && extension === '.cjs') {
       throw new ServerlessError(
         'esbuild format "esm" cannot emit files with the ".cjs" extension. Remove the "outExtension" mapping or set the format to "cjs"',
@@ -776,6 +1006,13 @@ class Esbuild {
    * @param {string} handlerPropertyName - The property name of the handler in the function object. In the case of dev mode this will be different, so we need to be able to set it.
    */
   async _build(handlerPropertyName = 'handler') {
+    // Where each function's handler artifact was actually emitted, recorded by
+    // the build itself so packaging never has to re-derive it. Rebuilt from
+    // scratch on every invocation (dev mode rebuilds through the same plugin
+    // instance) so it can never report an artifact from a previous build.
+    this.builtArtifacts = new Map()
+    this.patternClaimedBuildPaths = new Set()
+
     const functionsToBuild = await this.functions(handlerPropertyName)
 
     if (Object.keys(functionsToBuild).length === 0) {
@@ -784,6 +1021,48 @@ class Esbuild {
     }
 
     const buildProperties = await this._buildProperties()
+
+    // Without bundling, a handler's `import`s stay in the emitted file and are
+    // resolved by Node at runtime, so the artifact has to carry the whole
+    // project rather than one file per handler. That is a different build
+    // entirely — different entry points, different output layout — so it runs
+    // as its own path and leaves the bundling one below untouched.
+    if (buildProperties.bundle === false) {
+      // Dev mode (the only caller passing `originalHandler`) keeps the
+      // last-good outputs, exactly as on the bundling path. The reset belongs
+      // HERE, in `_build`: `before:esbuild-package` fires after it and is the
+      // plugin injection point whose outputs the zip must include, so a reset
+      // in `_package` would wipe plugin-injected files (see `_resetBuildDir`).
+      if (handlerPropertyName !== 'originalHandler') {
+        await this._resetBuildDir()
+      }
+
+      try {
+        await this._buildProject(
+          functionsToBuild,
+          handlerPropertyName,
+          buildProperties,
+        )
+      } catch (err) {
+        if (this.serverless.devmodeEnabled === true) {
+          return
+        }
+        // Errors this path raises deliberately (an output collision, an
+        // unusable `outExtension`) already say what to do about them; only
+        // esbuild's own failures need wrapping.
+        if (err instanceof ServerlessError) {
+          throw err
+        }
+        throw new ServerlessError(err.message, 'ESBULD_BUILD_ERROR')
+      }
+
+      if (handlerPropertyName !== 'originalHandler') {
+        this._assertAllHandlersBuilt(functionsToBuild, handlerPropertyName)
+      }
+
+      return
+    }
+
     const outputExtension = this._outputExtension(buildProperties)
 
     // Multiple functions can share a single handler file (e.g. one module
@@ -837,7 +1116,31 @@ class Esbuild {
 
     if (buildGroups.size === 0) {
       log.debug('No buildable handler files resolved for esbuild')
+      // "No buildable handlers" is not "nothing to package". A service whose
+      // every handler lives in a Lambda layer (`/opt/nodejs/...`) resolves no
+      // entry point and is a perfectly normal configuration — the assertion
+      // below says so out loud — and it still gets packaged. So the build
+      // directory has to exist AND be clean before packaging walks it:
+      // without the reset it never existed at all and `_preparePackageJson`
+      // wrote into a missing directory, and a stale outfile left by a build
+      // made before the handler was switched to a layer-provided path would
+      // otherwise ship.
+      //
+      // Nothing resolving also means EVERY approved function is unresolvable,
+      // so this path needs the same assertion as a completed build — otherwise
+      // the worst case is the one case that stays silent. Dev mode
+      // (`originalHandler`) keeps its last-good outputs and skips both.
+      if (handlerPropertyName !== 'originalHandler') {
+        await this._resetBuildDir()
+        this._assertAllHandlersBuilt(functionsToBuild, handlerPropertyName)
+      }
       return
+    }
+
+    // Dev mode (the only caller passing `originalHandler`) must keep the
+    // last-good outputs, so the reset is limited to the deploy/package flows.
+    if (handlerPropertyName !== 'originalHandler') {
+      await this._resetBuildDir()
     }
 
     // Determine the concurrency to use for building, by default framework will
@@ -847,18 +1150,7 @@ class Esbuild {
 
     const limit = pLimit(concurrency)
 
-    // Whether to inject NODE_OPTIONS=--enable-source-maps. A yml `sourcemap`
-    // value decides when present (the object form via its `setNodeOptions`
-    // flag, false by default); otherwise the decision follows the effective
-    // merged setting so that `sourcemap: false` inside a `configFile`
-    // suppresses the env var just like its yml equivalent (#12997).
-    const ymlSourcemap = this.serverless.service.build?.esbuild?.sourcemap
-    const shouldSetNodeOptions =
-      typeof ymlSourcemap === 'object' && ymlSourcemap !== null
-        ? ymlSourcemap.setNodeOptions === true
-        : ymlSourcemap === undefined
-          ? Boolean(buildProperties.sourcemap)
-          : ymlSourcemap === true
+    const shouldSetNodeOptions = this._shouldSetNodeOptions(buildProperties)
 
     try {
       await Promise.all(
@@ -891,6 +1183,11 @@ class Esbuild {
               }
             }
 
+            const outfile = path.join(
+              this.buildDirPath,
+              group.handlerPath + outputExtension,
+            )
+
             const esbuildProps = {
               ...buildProperties,
               platform: 'node',
@@ -898,12 +1195,7 @@ class Esbuild {
                 ? { external }
                 : { external: [] }),
               entryPoints: [group.entry],
-              outfile: path.join(
-                this.serverless.config.serviceDir,
-                '.serverless',
-                'build',
-                group.handlerPath + outputExtension,
-              ),
+              outfile,
               logLevel: 'error',
             }
 
@@ -936,10 +1228,39 @@ class Esbuild {
               this.serverless.builtFunctions = new Set()
             }
 
+            // Recorded here, where the emitted paths are known for certain,
+            // rather than re-derived from the handler string at packaging
+            // time. Zip-relative and POSIX-separated because that is what an
+            // archive entry name has to be, on every platform.
+            //
+            // The outfile is probed rather than assumed: a configFile can
+            // merge `write: false`, which makes esbuild return the output in
+            // memory and touch nothing on disk. Recording a path that was
+            // never written would give packaging a phantom artifact and
+            // satisfy the end-of-build assertion.
+            const zipRelativeOutfile = path
+              .relative(this.buildDirPath, outfile)
+              .split(path.sep)
+              .join('/')
+            const artifact = existsSync(outfile)
+              ? {
+                  outfile: zipRelativeOutfile,
+                  // `sourcemap: 'inline'`/`false` emit no map file.
+                  mapfile: existsSync(`${outfile}.map`)
+                    ? `${zipRelativeOutfile}.map`
+                    : null,
+                }
+              : null
+
             // Apply the per-function side effects to every alias sharing this
-            // handler file, not just the one whose build we ran.
+            // handler file, not just the one whose build we ran. Each alias
+            // gets its own copy of the record so a consumer mutating one
+            // cannot reach into its group siblings.
             for (const alias of group.aliases) {
               this.serverless.builtFunctions.add(alias)
+              if (artifact) {
+                this.builtArtifacts.set(alias, { ...artifact })
+              }
               if (shouldSetNodeOptions) {
                 const functionObject =
                   this.serverless.service.getFunction(alias)
@@ -964,7 +1285,1353 @@ class Esbuild {
       throw new ServerlessError(err.message, 'ESBULD_BUILD_ERROR')
     }
 
+    // Dev mode deliberately swallows build failures above so the dev loop
+    // keeps serving the last-good outputs; the same reasoning applies here.
+    if (handlerPropertyName !== 'originalHandler') {
+      this._assertAllHandlersBuilt(functionsToBuild, handlerPropertyName)
+    }
+
     return
+  }
+
+  /**
+   * Whether to inject `NODE_OPTIONS=--enable-source-maps` into the built
+   * functions. A yml `sourcemap` value decides when present (the object form
+   * via its `setNodeOptions` flag, false by default); otherwise the decision
+   * follows the effective merged setting so that `sourcemap: false` inside a
+   * `configFile` suppresses the env var just like its yml equivalent (#12997).
+   *
+   * @param {object} buildProperties - The merged esbuild build properties
+   * @returns {boolean}
+   */
+  _shouldSetNodeOptions(buildProperties) {
+    const ymlSourcemap = this.serverless.service.build?.esbuild?.sourcemap
+    return typeof ymlSourcemap === 'object' && ymlSourcemap !== null
+      ? ymlSourcemap.setNodeOptions === true
+      : ymlSourcemap === undefined
+        ? Boolean(buildProperties.sourcemap)
+        : ymlSourcemap === true
+  }
+
+  /**
+   * Build a service with `bundle: false`.
+   *
+   * Unbundled output keeps its `import`/`require` specifiers, so the artifact
+   * has to contain every file the handler can reach at runtime, at the path it
+   * reaches it by. This selects the same files classic packaging would have
+   * shipped, transpiles the ones esbuild has to handle, copies the rest
+   * verbatim, and preserves the directory layout in both cases.
+   *
+   * Transpilation is partitioned by (module-system class, format): the format
+   * and the output extension are precisely what esbuild cannot vary within one
+   * call, and both genuinely vary across a project. `.mts`/`.mjs` must stay
+   * ESM, `.cts`/`.cjs` must stay CommonJS, and a plain `.ts`/`.js` follows the
+   * `type` of its nearest package.json the same way Node will when it loads the
+   * emitted file. Options the user scopes to their own module system —
+   * `format`, `outExtension`, `banner`, `footer`, `inject` — apply to the `.js`
+   * class only, since the other classes are defined by refusing to move.
+   *
+   * @param {Object} functionsToBuild - Functions approved by `_shouldBuildFunction`
+   * @param {string} handlerPropertyName - The handler property to resolve from
+   * @param {object} buildProperties - The merged esbuild build properties
+   */
+  async _buildProject(functionsToBuild, handlerPropertyName, buildProperties) {
+    const serviceDir = this.serverless.config.serviceDir
+    const service = this.serverless.service
+
+    // A `format` the user actually asked for governs the `.js` class outright.
+    // The one `_buildProperties` derives from the root package.json `type` does
+    // not: that derivation is the service-wide special case of the per-file
+    // rule applied below, and letting it win here would make a nested
+    // `"type"` — the only thing that rule can tell you that the root cannot —
+    // unreachable.
+    const rootPackageJson = await this._readPackageJson()
+    const derivedFormat =
+      rootPackageJson.type === 'module' ? 'esm' : /* c8 ignore next */ undefined
+    const explicitFormat =
+      buildProperties.format && buildProperties.format !== derivedFormat
+        ? buildProperties.format
+        : undefined
+
+    // Validated once, up front, against the format the `.js` class takes at the
+    // service root. Leaving it to the per-partition call below would let an
+    // unusable mapping through unchecked in a service that happens to have no
+    // `.js`-class file to compile — and an `outExtension` the runtime cannot
+    // load is worth refusing whether or not this particular build trips over
+    // it. The per-partition call still runs, and still catches a subdirectory
+    // whose resolved format disagrees with the root's.
+    this._outputExtension(buildProperties, explicitFormat ?? derivedFormat)
+
+    // Resolved handler files, normalized onto the form the sweep produces so
+    // that `./src/handler.ts` and the swept `src/handler.ts` are one file.
+    const handlerFileByAlias = new Map()
+    for (const [alias, functionObject] of Object.entries(functionsToBuild)) {
+      const functionHandler = functionObject[handlerPropertyName]
+      const extension = await this._extensionForFunction(functionHandler)
+      // No local file. That is not necessarily an error — layer-provided
+      // wrappers resolve inside the Lambda at runtime — and
+      // `_assertAllHandlersBuilt` is what decides, so this path stays silent
+      // and simply builds the rest of the project.
+      if (!extension) continue
+      handlerFileByAlias.set(
+        alias,
+        toSweptPath(stripHandlerExportSuffix(functionHandler) + extension),
+      )
+    }
+
+    const layerPaths =
+      typeof service.getAllLayers === 'function'
+        ? service
+            .getAllLayers()
+            .map((layer) => service.getLayer(layer)?.path)
+            .filter(Boolean)
+        : []
+
+    const swept = await sweepProjectFiles({
+      serviceDir,
+      additionalIgnores: this._packageDirectoryIgnores(),
+      // `package.include` is the other half of the legacy pre-`patterns` pair
+      // (see `package.exclude` below). Classic merges it ahead of `patterns`
+      // (`getIncludes`: include first, patterns after), so a patterns negation
+      // still gets the last word over an include.
+      patterns: [
+        ...(service.package?.include ?? []),
+        ...(service.package?.patterns ?? []),
+      ],
+      configFileNames: resolveServerlessConfigFileExcludes(this.serverless),
+      layerPaths,
+      localPluginPath:
+        this.serverless.pluginManager?.parsePluginsObject?.(service.plugins)
+          ?.localPath ?? null,
+      additionalExclusions: [
+        ...CLASSIC_DEFAULT_EXCLUDES,
+        // `package.exclude` is the pre-`patterns` spelling. Classic still
+        // merges it into its exclude list, so a service that never migrated
+        // has to keep excluding the same files here.
+        ...(service.package?.exclude ?? []),
+        DOTENV_EXCLUDE,
+      ],
+    })
+
+    const handlerFiles = [...handlerFileByAlias.values()]
+    const { compile: sweptCompile, copy } = splitCompileAndCopy(
+      swept,
+      handlerFiles,
+    )
+
+    // The sweep decides what the artifact ships; the tsconfig decides which of
+    // that TypeScript is part of the program. Narrowing here -- before the
+    // collision check -- is deliberate: a `util.ts` the tsconfig does not
+    // claim is never emitted, so it cannot clash with a hand-written
+    // `util.js`, and excluding it is the documented way out of that clash.
+    const { compile, warning: tsconfigWarning } = applyTsconfigCompileFilter({
+      serviceDir,
+      tsconfigPath: buildProperties.tsconfig,
+      compileFiles: sweptCompile,
+      handlerFiles,
+    })
+    if (tsconfigWarning) {
+      logger.warning(tsconfigWarning)
+    }
+
+    this._assertNoOutputCollisions(detectOutputCollisions(compile, copy))
+
+    const packageJsonTypeCache = new Map()
+    const partitions = new Map()
+    for (const file of compile) {
+      // The class a file belongs to is the module system its own name carries:
+      // `.mts`/`.mjs` are ESM, `.cts`/`.cjs` are CommonJS, and everything else
+      // defers to its directory. `outputPathFor` already encodes exactly that
+      // mapping. Deriving the class from it — rather than from the compilable
+      // extensions alone — is what keeps a `.mjs` or `.cjs` HANDLER in its own
+      // class: handlers are force-compiled whatever their extension, and
+      // treating one as `.js` emitted `handler.js` while everything downstream
+      // (`outputPathFor`, `builtArtifacts`, packaging) looked for
+      // `handler.mjs`, failing the build with ESBUILD_HANDLER_NOT_BUILT.
+      const sourceClass = path.posix.extname(outputPathFor(file))
+      let outputExtension
+      let format
+      if (sourceClass === '.mjs') {
+        outputExtension = '.mjs'
+        format = 'esm'
+      } else if (sourceClass === '.cjs') {
+        outputExtension = '.cjs'
+        format = 'cjs'
+      } else {
+        format =
+          explicitFormat ??
+          (nearestPackageJsonType(serviceDir, file, packageJsonTypeCache) ===
+          'module'
+            ? 'esm'
+            : 'cjs')
+        // `outExtension` is a `.js`-class setting: the other classes carry a
+        // module system in their name and renaming their output discards it.
+        outputExtension = this._outputExtension(buildProperties, format)
+      }
+
+      // Keyed by SOURCE class, not by the extension it ends up with: with
+      // `outExtension: { '.js': '.mjs' }` the `.js` and `.mjs` classes emit the
+      // same extension in the same format, yet only the `.js` one takes the
+      // user's `.js`-scoped options — and each still needs its own metafile.
+      const key = `${sourceClass}|${format}`
+      const partition = partitions.get(key)
+      if (partition) partition.entryFiles.push(file)
+      else {
+        partitions.set(key, {
+          sourceClass,
+          outputExtension,
+          format,
+          entryFiles: [file],
+        })
+      }
+    }
+
+    // `detectOutputCollisions` derives outputs from source extensions, so it
+    // cannot see a clash that exists only because `outExtension` moved the
+    // `.js` class onto `.mjs`/`.cjs`. Re-check against the resolved plan when
+    // that is in play.
+    if (buildProperties.outExtension?.['.js'] !== undefined) {
+      this._assertNoOutputCollisions(
+        this._detectPlannedOutputCollisions(partitions, copy),
+      )
+    }
+
+    const esbuildBase = {
+      ...buildProperties,
+      platform: 'node',
+      // Nothing is resolved into the output, so there is nothing to keep out
+      // of it either.
+      external: [],
+      logLevel: 'warning',
+    }
+    // Not valid esbuild properties, or set per partition below.
+    delete esbuildBase.exclude
+    delete esbuildBase.buildConcurrency
+    delete esbuildBase.configFile
+    delete esbuildBase.bundle
+    delete esbuildBase.format
+    delete esbuildBase.outExtension
+    // The bundling path builds one file at a time and may carry an `outfile`
+    // through from a configFile. esbuild rejects it alongside the `outdir` this
+    // path needs, and it would name a single output for a whole partition
+    // anyway.
+    delete esbuildBase.outfile
+    // A tsconfig the user named is theirs to apply, so esbuild gets it too,
+    // carried through by the spread above -- `_buildProperties` has already
+    // made it absolute. A tsconfig merely discovered is not forwarded:
+    // esbuild does its own per-file lookup, and pinning every file to the root
+    // config would override the nested ones that lookup exists to honor.
+    if (!buildProperties.tsconfig) {
+      delete esbuildBase.tsconfig
+    }
+
+    // Options the user aims at their handler's own module system. They are
+    // scoped to the `.js` class for the same reason `format` and `outExtension`
+    // are: a `createRequire(import.meta.url)` banner — the standard fix for an
+    // ESM build — is a syntax error in a CommonJS output, and the `.cts`/`.cjs`
+    // partitions exist precisely to stay CommonJS.
+    const jsClassOnlyProperties = {}
+    for (const property of ['banner', 'footer', 'inject']) {
+      if (esbuildBase[property] !== undefined) {
+        jsClassOnlyProperties[property] = esbuildBase[property]
+        delete esbuildBase[property]
+      }
+    }
+
+    // `buildConcurrency` caps the partition builds, the way it caps the
+    // per-handler builds on the bundling path. Partitions write disjoint files,
+    // so the default is to run them all at once.
+    const partitionLimit = pLimit(
+      buildProperties.buildConcurrency ?? Math.max(partitions.size, 1),
+    )
+
+    await Promise.all(
+      [...partitions.entries()].map(([key, partition]) =>
+        partitionLimit(async () => {
+          const result = await esbuild.build({
+            ...esbuildBase,
+            ...(partition.sourceClass === '.js' ? jsClassOnlyProperties : {}),
+            bundle: false,
+            format: partition.format,
+            entryPoints: partition.entryFiles.map((file) =>
+              path.join(serviceDir, file),
+            ),
+            // `outbase` is what preserves the layout: esbuild places each
+            // output at its entry point's path relative to it. Without it
+            // esbuild picks the lowest common ancestor of the partition's entry
+            // points, which differs per partition and would flatten or shift
+            // the tree.
+            outdir: this.buildDirPath,
+            outbase: serviceDir,
+            ...(partition.outputExtension !== '.js'
+              ? { outExtension: { '.js': partition.outputExtension } }
+              : {}),
+          })
+
+          // One metafile per partition. A single `meta.json`, as the bundling
+          // path writes, would be overwritten by each partition in turn and
+          // describe only the last one.
+          if (result.metafile) {
+            await writeFile(
+              path.join(
+                this.buildDirPath,
+                `meta.${key.replace(/[|.]/g, '')}.json`,
+              ),
+              JSON.stringify(result.metafile, null, 2),
+            )
+          }
+        }),
+      ),
+    )
+
+    // Every file this build just emitted, with the depth of scan its format
+    // warrants. Derived from the partition plan rather than from a walk of the
+    // build directory: the plan is the only thing that knows each output's
+    // format, and a walk would sweep up the sourcemaps, the metafiles and the
+    // verbatim copies alongside them — none of which this scan has anything to
+    // say about, and the first of which is a second copy of every emitted file.
+    const scanTargets = []
+    for (const partition of partitions.values()) {
+      // CommonJS output is scanned for `import()` only. esbuild rewrites the
+      // static forms into `require()`, which the CommonJS resolver happily
+      // completes with an extension — but it leaves `import()` verbatim, and
+      // Node routes `import()` through the ES module resolver even from inside
+      // a CommonJS file. So the dynamic form is unsafe in every format, and
+      // the static ones only where they survive as imports.
+      const dynamicOnly = partition.format !== 'esm'
+      for (const file of partition.entryFiles) {
+        const base = outputPathFor(file)
+        scanTargets.push({
+          output: base.endsWith('.js')
+            ? `${base.slice(0, -'.js'.length)}${partition.outputExtension}`
+            : base,
+          dynamicOnly,
+        })
+      }
+    }
+    await this._warnOnUnresolvableRelativeImports(scanTargets)
+
+    // Anything the sweep selected under a root the artifact walk skips by
+    // default got there through a positive pattern (the sweep's own
+    // exclusions cover those roots), so the walk has to keep it.
+    this._claimBuildPaths([
+      ...compile.map((file) =>
+        this._outputPathForSource(file, buildProperties),
+      ),
+      ...copy,
+    ])
+
+    // Raw copies, layout preserved. Directories first, deduplicated: a flat
+    // service of 10k files would otherwise issue 10k redundant `mkdir` calls.
+    const destinations = copy.map((file) => ({
+      from: path.join(serviceDir, file),
+      to: path.join(this.buildDirPath, file),
+    }))
+    for (const dir of new Set(
+      destinations.map((destination) => path.dirname(destination.to)),
+    )) {
+      await mkdir(dir, { recursive: true })
+    }
+    const copyLimit = pLimit(COPY_CONCURRENCY)
+    await Promise.all(
+      destinations.map((destination) =>
+        copyLimit(() => copyFile(destination.from, destination.to)),
+      ),
+    )
+
+    // Per-alias side effects, gated on the artifact actually being on disk:
+    // `write: false` in a configFile makes esbuild return its output in memory
+    // and touch nothing, and a function reported as built but with no file
+    // behind it sends dev mode and packaging at a path that is not there.
+    if (!this.serverless.builtFunctions) {
+      this.serverless.builtFunctions = new Set()
+    }
+    const shouldSetNodeOptions = this._shouldSetNodeOptions(buildProperties)
+    for (const [alias, handlerFile] of handlerFileByAlias) {
+      const outfile = this._outputPathForSource(handlerFile, buildProperties)
+      if (!existsSync(path.join(this.buildDirPath, outfile))) continue
+
+      this.serverless.builtFunctions.add(alias)
+      this.builtArtifacts.set(alias, {
+        outfile,
+        // `sourcemap: 'inline'`/`false` emit no map file.
+        mapfile: existsSync(path.join(this.buildDirPath, `${outfile}.map`))
+          ? `${outfile}.map`
+          : null,
+      })
+
+      if (shouldSetNodeOptions) {
+        const functionObject = this.serverless.service.getFunction(alias)
+        if (functionObject.environment?.NODE_OPTIONS) {
+          functionObject.environment.NODE_OPTIONS = `${functionObject.environment.NODE_OPTIONS} --enable-source-maps`
+        } else {
+          if (!functionObject.environment) {
+            functionObject.environment = {}
+          }
+          functionObject.environment.NODE_OPTIONS = '--enable-source-maps'
+        }
+      }
+    }
+  }
+
+  /**
+   * Say once, after the build, which emitted files import a relative path Node
+   * will not resolve.
+   *
+   * Bundling used to hide both of these: esbuild resolved the specifier itself
+   * and inlined the result. With bundling off the specifier survives into the
+   * artifact, and either Node's ES module resolver refuses it (it adds no
+   * extension and probes no `index.js`) or it names a source file the build
+   * emitted under a different name (`./util.ts` → `util.js`). Both fail on the
+   * first invocation of the deployed function, pointing at a file that is
+   * right there in the zip. Nothing before this point can catch it: esbuild
+   * does not resolve imports when it is not bundling, so it has no opinion to
+   * report.
+   *
+   * Each target is read once, scanned, and dropped — up to `COPY_CONCURRENCY`
+   * of them in flight at a time, so peak memory is bounded by that many files
+   * rather than by the size of the project. Only the hits are retained.
+   *
+   * @param {Array<{output: string, dynamicOnly: boolean}>} targets build-dir-
+   *   relative POSIX output paths, each with the scan depth its format warrants
+   */
+  async _warnOnUnresolvableRelativeImports(targets) {
+    // Indexed rather than appended: the reads are concurrent, and a warning
+    // whose first ten entries depend on I/O scheduling is a warning that reads
+    // differently on every run.
+    const perTarget = new Array(targets.length)
+    const limit = pLimit(COPY_CONCURRENCY)
+    await Promise.all(
+      targets.map((target, index) =>
+        limit(async () => {
+          let contents
+          try {
+            contents = await readFile(
+              path.join(this.buildDirPath, target.output),
+              'utf8',
+            )
+          } catch {
+            // Nothing on disk to scan. `write: false` carried in from a
+            // configFile is the ordinary way here, and it is not this
+            // function's business to complain about it.
+            return
+          }
+          const found = scanUnresolvableRelativeImports(contents, {
+            dynamicOnly: target.dynamicOnly,
+          })
+          // Only the hits are kept, and the contents go out of scope here.
+          if (
+            found.extensionless.length > 0 ||
+            found.sourceExtension.length > 0
+          )
+            perTarget[index] = found
+        }),
+      ),
+    )
+
+    let total = 0
+    const pairs = []
+    const record = (index, detail) => {
+      total += 1
+      if (pairs.length < ESM_SPECIFIER_WARNING_LIMIT) {
+        pairs.push(`${targets[index].output} → ${detail}`)
+      }
+    }
+    for (const [index, found] of perTarget.entries()) {
+      if (!found) continue
+      for (const specifier of found.extensionless) record(index, specifier)
+      for (const specifier of found.sourceExtension) {
+        // Naming the emitted file is the whole fix, so print it rather than
+        // making the reader work out what `.ts` compiles to.
+        record(index, `${specifier} (emitted as "${outputPathFor(specifier)}")`)
+      }
+    }
+    if (total === 0) {
+      return
+    }
+
+    const remainder =
+      total > pairs.length ? ` (and ${total - pairs.length} more)` : ''
+    logger.warning(
+      `Found ${total} relative import${total === 1 ? '' : 's'} in this build's output that Node will not resolve: ` +
+        `${pairs.join(', ')}${remainder}. ` +
+        `Node resolves ES module specifiers verbatim — it adds no file extension and looks for no "index" file, and "import()" uses ` +
+        `that resolver even inside CommonJS — so each of these fails at runtime with ERR_MODULE_NOT_FOUND even though the target is ` +
+        `in the package. Write relative imports with an explicit extension naming the EMITTED file, e.g. "./util.js", which is what ` +
+        `TypeScript's "module": "nodenext" requires.`,
+    )
+  }
+
+  /**
+   * Where a non-bundled build writes one source file, as a build-dir-relative
+   * POSIX path. `outputPathFor` knows the extension mapping; only the
+   * `.js`-class `outExtension` override has to be layered on top of it.
+   *
+   * @param {string} sourcePath - Service-relative POSIX source path
+   * @param {object} buildProperties - The merged esbuild build properties
+   * @returns {string}
+   */
+  _outputPathForSource(sourcePath, buildProperties) {
+    const defaultOutput = outputPathFor(sourcePath)
+    const configured = buildProperties.outExtension?.['.js']
+    if (!configured || !defaultOutput.endsWith('.js')) {
+      return defaultOutput
+    }
+    return `${defaultOutput.slice(0, -'.js'.length)}${configured}`
+  }
+
+  /**
+   * Output paths claimed by more than one source once the partition plan (and
+   * therefore any `outExtension` override) is known.
+   *
+   * @param {Map<string, {outputExtension: string, entryFiles: string[]}>} partitions
+   * @param {string[]} copyFiles
+   * @returns {Array<{ output: string, sources: string[] }>}
+   */
+  _detectPlannedOutputCollisions(partitions, copyFiles) {
+    const sourcesByOutput = new Map()
+    const record = (source, output) => {
+      if (!sourcesByOutput.has(output)) sourcesByOutput.set(output, new Set())
+      sourcesByOutput.get(output).add(source)
+    }
+    for (const partition of partitions.values()) {
+      for (const file of partition.entryFiles) {
+        const base = outputPathFor(file)
+        record(
+          file,
+          base.endsWith('.js')
+            ? `${base.slice(0, -'.js'.length)}${partition.outputExtension}`
+            : base,
+        )
+      }
+    }
+    for (const file of copyFiles) record(file, outputPathFor(file))
+    return [...sourcesByOutput.entries()]
+      .filter(([, sources]) => sources.size > 1)
+      .map(([output, sources]) => ({ output, sources: [...sources] }))
+  }
+
+  /**
+   * Two sources writing one output means one of them silently disappears from
+   * the artifact — a hand-written `util.js` next to a `util.ts`, most often
+   * left behind by a half-finished TypeScript migration. Report both names
+   * instead of shipping whichever esbuild happened to write last.
+   *
+   * @param {Array<{ output: string, sources: string[] }>} collisions
+   */
+  _assertNoOutputCollisions(collisions) {
+    if (collisions.length === 0) {
+      return
+    }
+
+    const details = collisions
+      .map(
+        (collision) =>
+          `"${collision.output}" would be produced by both ${collision.sources
+            .map((source) => `"${source}"`)
+            .join(' and ')}`,
+      )
+      .join('; ')
+
+    throw new ServerlessError(
+      `Multiple source files map to the same build output: ${details}. ` +
+        `With "bundle: false" every source file is emitted, so two of them ` +
+        `cannot share a name. Delete the stale file, exclude one side with a ` +
+        `"package.patterns" negation — for a handler file, negate the ` +
+        `TypeScript side, because handlers always compile whatever the ` +
+        `patterns say — point "build.esbuild.tsconfig" at a config that ` +
+        `excludes it, or remove "build.esbuild" if you precompile.`,
+      'ESBUILD_OUTPUT_COLLISION',
+    )
+  }
+
+  /**
+   * Report every function esbuild was asked to build that produced no
+   * artifact — an unresolvable handler file, or a build configured not to
+   * write one. Such functions used to be skipped in silence and shipped a zip
+   * with no handler in it (#12970): the deploy succeeded and the function
+   * failed at invocation time with `Cannot find module`.
+   *
+   * A handler does not always have to exist in the service directory though.
+   * Layer-provided wrappers — Datadog's
+   * `/opt/nodejs/node_modules/datadog-lambda-js/handler.datadog`, New Relic's
+   * `newrelic-lambda-wrapper.handler` — resolve inside a Lambda layer at
+   * runtime and are perfectly valid. So a function with layers in scope gets
+   * a warning; only a function with no layers at all is the typo case and
+   * fails the build.
+   *
+   * @param {Object} functionsToBuild - Functions approved by `_shouldBuildFunction`
+   * @param {string} handlerPropertyName - The handler property these were resolved from
+   */
+  _assertAllHandlersBuilt(functionsToBuild, handlerPropertyName) {
+    const missing = Object.keys(functionsToBuild).filter(
+      (alias) => !this.builtArtifacts.has(alias),
+    )
+
+    if (missing.length === 0) {
+      return
+    }
+
+    const providerLayers = this.serverless.service.provider?.layers
+    const serviceHasLayers =
+      Array.isArray(providerLayers) && providerLayers.length > 0
+
+    const describe = (alias) =>
+      `"${alias}" (handler: ${functionsToBuild[alias][handlerPropertyName]})`
+
+    const layerProvided = []
+    const unresolvable = []
+    for (const alias of missing) {
+      const functionLayers = functionsToBuild[alias].layers
+      const hasLayers =
+        serviceHasLayers ||
+        (Array.isArray(functionLayers) && functionLayers.length > 0)
+      ;(hasLayers ? layerProvided : unresolvable).push(alias)
+    }
+
+    // One aggregated warning, not one per function: a service wrapping every
+    // function in an observability layer would otherwise print a wall of them.
+    if (layerProvided.length > 0) {
+      logger.warning(
+        `Handler files for ${layerProvided
+          .map(describe)
+          .join(
+            ', ',
+          )} could not be found locally; assuming they are provided by a Lambda layer at runtime. ` +
+          `If that is not the case, fix the handler path — the deployed function will fail to start.`,
+      )
+    }
+
+    if (unresolvable.length > 0) {
+      throw new ServerlessError(
+        `The following functions are configured to be built by esbuild but their handler files could not be found: ${unresolvable
+          .map(describe)
+          .join(', ')}. Checked extensions: ${BUILDABLE_HANDLER_EXTENSIONS.join(
+          ', ',
+        )}. Fix the handler path, or set "build: false" on the function to exclude it from the build.`,
+        'ESBUILD_HANDLER_NOT_BUILT',
+      )
+    }
+  }
+
+  /**
+   * Every file the build directory holds, as archive entries ready to append.
+   *
+   * The build directory IS the artifact definition: `_resetBuildDir` clears it
+   * before every deploy build, `_build` writes the outputs into it, and the
+   * `esbuild-package` hook lets plugins add to it. Packaging therefore ships
+   * all of it rather than re-deriving a handpicked list of handler files, which
+   * is what dropped every plugin-emitted asset — templates, locale JSON, WASM,
+   * prisma engines, `.node` binaries — from the artifact (#13163).
+   *
+   * Order and metadata are pinned, not incidental: `check-for-changes` hashes
+   * the raw zip bytes, so identical content has to produce an identical
+   * archive. Entries come out byte-wise sorted by their POSIX archive path, and
+   * the caller stamps every one of them with `PINNED_ARTIFACT_DATE`. The mode
+   * is normalized the same way classic packaging normalizes it (see
+   * `lib/plugins/package/lib/zip-service.js`), so a file that differs only by a
+   * group-writable bit — a different umask on a CI box — still hashes the same.
+   *
+   * The `fs.Stats` are carried along rather than discarded because archiver
+   * needs them: see `_writeArchive`.
+   *
+   * @returns {Promise<Array<{ absPath: string, zipPath: string, mode: number, stats: import('fs').Stats }>>}
+   */
+  async _collectBuildDirEntries() {
+    const serviceDir = this.serverless.config.serviceDir
+    const entries = []
+    const claimed = this.patternClaimedBuildPaths ?? new Set()
+    const claimedUnder = (root) => {
+      for (const claimedPath of claimed) {
+        if (claimedPath.startsWith(`${root}/`)) return true
+      }
+      return false
+    }
+
+    // `onlyClaimed` is set while walking below one of the roots the artifact
+    // skips by default: only what a positive pattern put there is kept, the
+    // install residue beside it (a `.yarn/cache`, say) stays out.
+    const walk = async (dir, onlyClaimed = false) => {
+      for (const dirent of await readdir(dir, { withFileTypes: true })) {
+        const absPath = path.join(dir, dirent.name)
+        // Archive names are POSIX on every platform, and the sort, the pattern
+        // filters and the handler assertion all compare against this form.
+        const zipPath = path
+          .relative(this.buildDirPath, absPath)
+          .split(path.sep)
+          .join('/')
+
+        if (!onlyClaimed && BUILD_DIR_EXCLUDED_ROOT_ENTRIES.has(zipPath)) {
+          if (dirent.isDirectory()) {
+            if (claimedUnder(zipPath)) await walk(absPath, true)
+            continue
+          }
+          if (!claimed.has(zipPath)) continue
+        }
+        // Only build metadata the service does not own itself. Under
+        // `bundle: false` the project sweep copies the service's own files into
+        // this directory, so a `meta.json` here can be the service's rather
+        // than esbuild's.
+        if (
+          BUILD_METAFILE_RE.test(zipPath) &&
+          !existsSync(path.join(serviceDir, zipPath))
+        ) {
+          continue
+        }
+
+        if (dirent.isDirectory()) {
+          await walk(absPath, onlyClaimed)
+          continue
+        }
+        // Only regular files. Nothing writes a symlink, socket or device into
+        // the build directory — outputs are written by esbuild and assets are
+        // copied with `copyFile`, which follows links — and handing archiver a
+        // path it cannot stream would fail the deploy at finalize time.
+        if (!dirent.isFile()) continue
+        if (onlyClaimed && !claimed.has(zipPath)) continue
+
+        // Same fail-fast contract as every other entry lookup: a file that
+        // cannot be stat'ed fails packaging with a clean CANNOT_READ_FILE
+        // rather than an unwrapped errno bubbling out of the walk.
+        const stats = await statIncludeEntry(absPath)
+        entries.push({
+          absPath,
+          zipPath,
+          stats,
+          mode: normalizedEntryMode(stats),
+        })
+      }
+    }
+
+    if (existsSync(this.buildDirPath)) {
+      await walk(this.buildDirPath)
+    }
+
+    entries.sort((a, b) =>
+      a.zipPath < b.zipPath ? -1 : a.zipPath > b.zipPath ? 1 : 0,
+    )
+    return entries
+  }
+
+  /**
+   * Service-relative POSIX paths selected by a `package.patterns` list.
+   *
+   * Only the positive patterns are globbed — a negation removes, it never adds
+   * — but the ORDERED list still decides what survives, so a later `!`
+   * genuinely retracts an earlier match (`['assets/**', '!assets/secret.txt']`).
+   *
+   * The glob has already done the selecting, so the ordered pass runs with
+   * everything it returned INCLUDED and only ever retracts. Starting from
+   * excluded instead would re-test each path against the literal patterns and
+   * silently drop whatever the glob expanded rather than matched: globby
+   * resolves a bare directory (`patterns: ['assets']`) to the files beneath it,
+   * and `assets/logo.png` does not match the literal `assets`. That dropped the
+   * whole tree such a pattern is meant to ship — and counted every file as an
+   * exclusion, so the artifact also reported entries it had never been asked to
+   * remove.
+   *
+   * `excludedCount` is how many of the globbed paths a negation retracted, so
+   * the caller can fold additive-include exclusions into the same counters the
+   * node_modules entry filter reports through.
+   *
+   * @param {string[]} patterns - ordered `package.patterns` entries
+   * @returns {Promise<{ matches: string[], excludedCount: number }>}
+   */
+  async _resolvePatternFiles(patterns) {
+    const positives = patterns.filter(
+      (pattern) => typeof pattern === 'string' && !pattern.startsWith('!'),
+    )
+    if (positives.length === 0) return { matches: [], excludedCount: 0 }
+
+    const globbed = await globby(positives, {
+      cwd: this.serverless.config.serviceDir,
+      dot: true,
+      onlyFiles: true,
+      ignore: [...PATTERN_RESOLVE_IGNORE, ...this._packageDirectoryIgnores()],
+    })
+    const matches = filterPaths(compilePatterns(patterns), globbed, true)
+    return { matches, excludedCount: globbed.length - matches.length }
+  }
+
+  /**
+   * The configured package directory (`--package <dir>` or `package.path`) as
+   * a glob to hard-ignore, or nothing when there is no such directory inside
+   * the service.
+   *
+   * `serverless package --package ./dist` moves the whole of `.serverless/`
+   * — the artifact AND the open build directory — into `dist/`. Left in the
+   * sweep, the next run packages the previous zip plus a full copy of the
+   * previous build, and the artifact doubles with every run; a broad pattern
+   * (`**`) does the same on the bundled path. So the directory is treated
+   * exactly like `.serverless/**`: never swept, never selectable by a pattern.
+   *
+   * Only a directory strictly inside the service directory qualifies. `.`
+   * would exclude the whole service, and anything at or above it is not part
+   * of the sweep in the first place. The precedence mirrors the framework's
+   * own (`AwsDeploy.packagePath`): the flag wins over the config key.
+   *
+   * @returns {string[]} zero or one POSIX glob, service-relative
+   */
+  _packageDirectoryIgnores() {
+    const configured =
+      this.options.package || this.serverless.service.package?.path
+    if (typeof configured !== 'string' || configured === '') return []
+    const serviceDir = this.serverless.config.serviceDir
+    const relative = path.relative(
+      serviceDir,
+      path.resolve(serviceDir, configured),
+    )
+    if (
+      relative === '' ||
+      relative === '..' ||
+      relative.startsWith(`..${path.sep}`) ||
+      // Windows: a directory on another drive comes back absolute.
+      path.isAbsolute(relative)
+    ) {
+      return []
+    }
+    const glob = `${relative.split(path.sep).join('/')}/**`
+    logger.debug(
+      `Package directory ${relative} is inside the service directory: ignoring ${glob} when building and packaging`,
+    )
+    return [glob]
+  }
+
+  /**
+   * Remember which build-directory paths a positive pattern placed under a
+   * root the artifact walk skips by default, so `_collectBuildDirEntries`
+   * keeps them. Everything else is dropped here: the set only ever holds
+   * paths the walk would otherwise lose, never the whole tree.
+   *
+   * @param {string[]} zipPaths - build-directory-relative POSIX paths
+   */
+  _claimBuildPaths(zipPaths) {
+    for (const zipPath of zipPaths) {
+      const root = zipPath.split('/', 1)[0]
+      if (BUILD_DIR_EXCLUDED_ROOT_ENTRIES.has(root)) {
+        this.patternClaimedBuildPaths.add(zipPath)
+      }
+    }
+  }
+
+  /**
+   * Copy the files service-level `package.patterns` select into the build
+   * directory, overwriting whatever the build emitted at the same path.
+   *
+   * Patterns used to be added straight into the zip at packaging time. Copying
+   * them into the build directory instead is what keeps the artifact and the
+   * build directory the same tree: `invoke local`, dev mode and the deployed
+   * function then all load the identical file. It also settles who wins when
+   * both produce the same path — the patterns do, which is the behavior the
+   * zip-time add had, since it was appended last.
+   *
+   * Runs after `spawn('esbuild-package')` so a plugin's injections are in place
+   * first and the user's patterns still get the final word.
+   *
+   * Matches landing on the installed dependency tree are NOT copied — that
+   * would overwrite the install the pruned package.json produced, and
+   * `_resetBuildDir` would preserve the damage into every later deploy. They
+   * are handed back as archive entries instead, so the artifact still ships
+   * them (a vendored or patched dependency is a normal thing to name in a
+   * pattern) straight from the service directory.
+   *
+   * @returns {Promise<{ excludedCount: number, installedTreeEntries: Array<object> }>}
+   *   how many globbed paths the patterns retracted, and the archive entries
+   *   for the matches that may not be copied
+   */
+  async _copyPatternsIntoBuildDir() {
+    const serviceDir = this.serverless.config.serviceDir
+    const { matches, excludedCount } = await this._resolvePatternFiles(
+      this.serverless.service.package?.patterns ?? [],
+    )
+    // Matches above the service directory are placed by `archivePathFor`, so
+    // the installed-tree test and the copy destination both look at where the
+    // file lands, not where it came from: `../node_modules/hoisted/**` in a
+    // monorepo is an installed-tree match like any other.
+    const installedTreeEntries = await this._patternEntriesForPaths(
+      matches.filter((relativePath) =>
+        isInstalledDependencyPath(archivePathFor(relativePath)),
+      ),
+    )
+    const toCopy = matches.filter(
+      (relativePath) =>
+        !isInstalledDependencyPath(archivePathFor(relativePath)),
+    )
+    const relocated = matches.filter(
+      (relativePath) => archivePathFor(relativePath) !== relativePath,
+    )
+    if (relocated.length > 0) {
+      logger.debug(
+        `${relocated.length} "package.patterns" match(es) reach above the service directory and are packaged at the path that remains: ${relocated
+          .map(
+            (relativePath) =>
+              `${relativePath} -> ${archivePathFor(relativePath)}`,
+          )
+          .join(', ')}`,
+      )
+    }
+    this._claimBuildPaths(toCopy.map(archivePathFor))
+    if (toCopy.length === 0) return { excludedCount, installedTreeEntries }
+
+    let replacedDiffering = 0
+    const limit = pLimit(COPY_CONCURRENCY)
+
+    await Promise.all(
+      toCopy.map((relativePath) =>
+        limit(async () => {
+          const source = path.join(serviceDir, relativePath)
+          const destination = path.join(
+            this.buildDirPath,
+            archivePathFor(relativePath),
+          )
+
+          // A file can vanish between glob expansion and the copy. Probing it
+          // first turns that into the same clean CANNOT_READ_FILE the archive
+          // append path raises, instead of an unwrapped ENOENT from copyFile.
+          await statIncludeEntry(source)
+
+          if (existsSync(destination)) {
+            const [incoming, existing] = await Promise.all([
+              readFile(source),
+              readFile(destination),
+            ])
+            if (!incoming.equals(existing)) replacedDiffering += 1
+          }
+
+          await mkdir(path.dirname(destination), { recursive: true })
+          await copyFile(source, destination)
+        }),
+      ),
+    )
+
+    // One aggregated warning, not one per file: a pattern that shadows a whole
+    // generated directory would otherwise print a wall of them.
+    if (replacedDiffering > 0) {
+      logger.warning(
+        `${replacedDiffering} file(s) matched by "package.patterns" replaced esbuild build outputs with different content. ` +
+          `The copies from your source directory are what deploys.`,
+      )
+    }
+    return { excludedCount, installedTreeEntries }
+  }
+
+  /**
+   * Pattern-selected files as archive entries, for a zip that takes them
+   * directly rather than through the build directory (per-function patterns,
+   * which belong to one function's artifact only).
+   *
+   * @param {string[]} patterns - ordered `package.patterns` entries
+   * @returns {Promise<{ entries: Array<{ absPath: string, zipPath: string, mode: number, stats: import('fs').Stats }>, excludedCount: number }>}
+   */
+  async _patternEntries(patterns) {
+    const { matches, excludedCount } = await this._resolvePatternFiles(patterns)
+    return {
+      entries: await this._patternEntriesForPaths(matches),
+      excludedCount,
+    }
+  }
+
+  /**
+   * Service-relative POSIX paths as archive entries, stamped with the same
+   * normalized mode the build-directory walk stamps its own with. A path that
+   * reaches above the service directory is read from where it is and named
+   * by `archivePathFor`.
+   *
+   * @param {string[]} relativePaths
+   * @returns {Promise<Array<{ absPath: string, zipPath: string, mode: number, stats: import('fs').Stats }>>}
+   */
+  async _patternEntriesForPaths(relativePaths) {
+    const serviceDir = this.serverless.config.serviceDir
+    const limit = pLimit(COPY_CONCURRENCY)
+
+    return Promise.all(
+      relativePaths.map((relativePath) =>
+        limit(async () => {
+          const absPath = path.join(serviceDir, relativePath)
+          const stats = await statIncludeEntry(absPath)
+          return {
+            absPath,
+            zipPath: archivePathFor(relativePath),
+            stats,
+            mode: normalizedEntryMode(stats),
+          }
+        }),
+      ),
+    )
+  }
+
+  /**
+   * How many dependencies the package.json the artifact ships declares. Used to
+   * tell a deliberately dependency-free service from one whose dependencies
+   * were filtered out from under it.
+   *
+   * @returns {Promise<number>}
+   */
+  async _declaredDependencyCount() {
+    try {
+      const raw = await readFile(
+        path.join(this.buildDirPath, 'package.json'),
+        'utf8',
+      )
+      return Object.keys(JSON.parse(raw).dependencies ?? {}).length
+    } catch {
+      // No package.json, or one nothing can parse. Either way there is no
+      // dependency declaration to contradict an empty `node_modules`.
+      return 0
+    }
+  }
+
+  /**
+   * Report what `package.patterns` did to one artifact: an info line naming the
+   * artifact when anything was excluded, an unconditional debug trace of the
+   * patterns and the counters, and a once-per-invocation warning when the
+   * patterns leave no dependencies behind for a build that needs them in the
+   * artifact.
+   *
+   * Call this only after the artifact's zip promise settled — the counters are
+   * incremented from the node_modules entry filter and are not final before
+   * then.
+   *
+   * @param {object} params
+   * @param {string} params.zipName - Artifact file name, e.g. `my-service-fn1.zip`.
+   * @param {string} params.subject - What the debug trace is about: the function
+   *   alias when packaging individually, the service zip name otherwise.
+   * @param {Array<object>} params.compiledPatterns - Compiled ordered patterns.
+   * @param {number} params.excludedEntryCount - Entries the patterns removed.
+   * @param {number} params.excludedNodeModulesEntryCount - Of those, entries
+   *   removed from the node_modules walk rather than from additive includes or
+   *   the build-directory sweep.
+   * @param {number} params.excludedNodeModulesFileCount - Of those, the ones
+   *   that were files rather than directory entries. Only this can attest that
+   *   a dependency was actually lost, so it is what arms the warning.
+   * @param {number} params.includedNodeModulesFileCount - node_modules files kept.
+   * @param {object} params.buildProperties - The merged esbuild build properties.
+   * @param {number} [params.declaredDependencyCount] - Dependencies the
+   *   generated package.json shipping in the artifact declares — the precise
+   *   statement of what this artifact needs installed beside it at runtime.
+   */
+  _reportPatternFiltering({
+    zipName,
+    subject,
+    compiledPatterns,
+    excludedEntryCount,
+    excludedNodeModulesEntryCount,
+    excludedNodeModulesFileCount,
+    includedNodeModulesFileCount,
+    buildProperties,
+    declaredDependencyCount = 0,
+  }) {
+    if (excludedEntryCount > 0) {
+      logger.info(
+        `Excluded ${excludedEntryCount} entries from ${zipName} via package.patterns`,
+      )
+    }
+    logger.debug(
+      `package.patterns for ${subject}: ${JSON.stringify(
+        compiledPatterns,
+      )} (excluded ${excludedEntryCount}, node_modules entries excluded ${excludedNodeModulesEntryCount}, node_modules files kept ${includedNodeModulesFileCount})`,
+    )
+    // Keyed on the generated manifest rather than the config shape. The pruned
+    // `build/package.json` is the precise statement of "dependencies this
+    // artifact needs installed beside it at runtime": it already accounts for
+    // the aws-sdk exclusions and for bundling having inlined everything else,
+    // so a non-empty `dependencies` there means an emptied node_modules is
+    // MODULE_NOT_FOUND on the first invocation — whichever combination of
+    // `bundle`, `packages` and `external` produced it. Inferring from the
+    // config instead missed `bundle: true` with `external: [...]`, which ships
+    // exactly that manifest and had no arm of its own.
+    //
+    // `packages: 'external'` stays as a second arm: it declares the intent
+    // even when the manifest cannot (a service that declares no dependencies
+    // of its own still asked for nothing to be bundled).
+    const artifactNeedsDependencies =
+      declaredDependencyCount > 0 || buildProperties.packages === 'external'
+    // Scoped to node_modules FILES on purpose. Excluding only additive includes
+    // says nothing about dependencies, and warning there would make a false
+    // claim; so would counting the directory husks a pattern strips out of a
+    // node_modules that never held a file. This cannot miss a real case -- if
+    // node_modules held a file that the patterns stripped, the entry filter ran
+    // and counted it.
+    if (
+      includedNodeModulesFileCount === 0 &&
+      excludedNodeModulesFileCount > 0 &&
+      artifactNeedsDependencies &&
+      !this._nodeModulesExclusionWarned
+    ) {
+      this._nodeModulesExclusionWarned = true
+      logger.warning(
+        'package.patterns exclude everything under node_modules, but this build requires dependencies in the artifact ' +
+          '(packages: external, or a non-bundled build with declared dependencies). ' +
+          'If dependencies are provided another way (e.g. a Lambda layer) or this exclusion predates build.esbuild, review or remove these patterns.',
+      )
+    }
+  }
+
+  /**
+   * Append the collected entries, then the installed dependencies, and settle
+   * once the archive is on disk.
+   *
+   * The stream wiring is the delicate part. `zip.finalize()` resolving is not
+   * the same as the file being complete, so the promise settles on the output
+   * stream's `close`; both the stream and the archive get error listeners,
+   * because an unlistened archiver `error` event throws out of an internal
+   * callback where nothing can catch it, and every await inside the `open`
+   * handler is wrapped so a throw there rejects rather than leaving the promise
+   * pending forever.
+   *
+   * Each entry hands archiver the `fs.Stats` the walk already took. That is not
+   * an optimization: an entry appended WITHOUT stats goes through archiver's
+   * internal stat queue, which runs four at a time and re-injects each task as
+   * its stat resolves — so the archive order becomes the order the filesystem
+   * answered in, and identical content produces differently-ordered (and
+   * therefore differently-hashed) zips from one run to the next. With stats
+   * supplied, entries are queued synchronously, in the sorted order they were
+   * appended in.
+   *
+   * @param {object} options
+   * @param {string} options.zipPath - where to write the archive
+   * @param {Array<{absPath: string, zipPath: string, mode: number}>} options.entries
+   * @param {Array<object>} options.compiledPatterns - compiled ordered patterns
+   *   governing `node_modules`
+   * @returns {Promise<{ excludedEntryCount: number, excludedNodeModulesEntryCount: number, includedNodeModulesFileCount: number }>}
+   *   the node_modules walk's pattern counters
+   */
+  async _writeArchive({ zipPath, entries, compiledPatterns }) {
+    const nodeModulesPath = path.join(this.buildDirPath, 'node_modules')
+    const { filter: patternEntryFilter, counters } =
+      createNodeModulesEntryFilter(compiledPatterns)
+
+    // A `package.patterns` match on the installed tree is appended above, from
+    // the service directory, so the installed file at the same archive path
+    // must not be appended too. The pattern copy is the one that wins: naming a
+    // dependency file in a pattern means "ship MY copy". Without this dedup the
+    // archive carries both entries and extractors take whichever was written
+    // last — a race while entry order depended on archiver's stat queue, and
+    // the installed copy once the order became deterministic, which silently
+    // turned the pattern into a no-op.
+    const claimedByPatterns = new Set(
+      entries
+        .map((entry) => entry.zipPath)
+        .filter((entryZipPath) => isInstalledDependencyPath(entryZipPath)),
+    )
+    const nodeModulesEntryFilter =
+      claimedByPatterns.size === 0
+        ? patternEntryFilter
+        : (entry, stats) => {
+            if (!claimedByPatterns.has(`node_modules/${entry}`)) {
+              return patternEntryFilter(entry, stats)
+            }
+            // Skipped, but NOT excluded: the archive still carries this path,
+            // supplied by the pattern entry. It has to count as a dependency
+            // file kept, or a node_modules the patterns fully re-supplied looks
+            // emptied — `patterns: ['**', '!node_modules/**/*.md']` over a real
+            // install claims every file, and leaving them uncounted fired the
+            // emptied-node_modules warning on an artifact that ships every
+            // dependency. Counting happens here rather than through the shared
+            // filter so the pattern-exclusion counters stay untouched.
+            if (!stats.isDirectory()) {
+              counters.includedNodeModulesFileCount += 1
+            }
+            return false
+          }
+
+    const zip = new ZipArchive()
+    const output = createWriteStream(zipPath)
+
+    await new Promise((resolve, reject) => {
+      output.on('close', () => resolve(zipPath))
+      output.on('error', reject)
+      zip.on('error', reject)
+
+      output.on('open', async () => {
+        try {
+          zip.pipe(output)
+
+          for (const entry of entries) {
+            zip.file(entry.absPath, {
+              name: entry.zipPath,
+              date: PINNED_ARTIFACT_DATE,
+              mode: entry.mode,
+              stats: entry.stats,
+            })
+          }
+
+          // Expanded and appended in sorted order rather than handed to
+          // `zip.directory()`: archiver's own walk feeds entries in readdir
+          // order, which differs per filesystem, so the same unchanged tree
+          // hashed differently between machines. Skipped when absent — a
+          // service with no dependencies at all never gets one installed.
+          // Modes are normalized here because the tree comes from a package
+          // manager install whose permissions follow the local umask.
+          if (existsSync(nodeModulesPath)) {
+            await appendDirectoryEntries(
+              zip,
+              nodeModulesPath,
+              'node_modules',
+              nodeModulesEntryFilter,
+              true,
+            )
+          }
+
+          await zip.finalize()
+        } catch (err) {
+          reject(err)
+        }
+      })
+    })
+
+    return counters
+  }
+
+  /**
+   * The entry names a finished archive actually contains, read back out of its
+   * central directory.
+   *
+   * The handler assertion is worth nothing if it checks the list packaging
+   * MEANT to write: an entry archiver dropped, renamed while sanitizing, or
+   * never flushed would sail straight through. So it is read off the file on
+   * disk instead.
+   *
+   * Only the directory itself is read, never the archive body — a Lambda
+   * artifact runs to hundreds of megabytes and loading it into a buffer to
+   * answer "which names are in here" is not affordable. ZIP64 is handled
+   * because it is genuinely reachable: archiver switches to it above 65535
+   * entries, which a real `node_modules` passes easily.
+   *
+   * Returns `null` rather than throwing if the archive cannot be read as
+   * expected. The caller then falls back to the intended list: this check
+   * exists to catch a missing handler, and it must never be the thing that
+   * invents one.
+   *
+   * @param {string} zipPath
+   * @returns {Promise<Set<string>|null>}
+   */
+  async _readArchiveEntryNames(zipPath) {
+    let handle
+    try {
+      handle = await open(zipPath, 'r')
+      const { size } = await handle.stat()
+
+      // The end-of-central-directory record is last, but a trailing comment
+      // (up to 64KiB) can sit behind it, so scan back over that window.
+      const tailLength = Math.min(size, 22 + 0xffff)
+      const tail = Buffer.alloc(tailLength)
+      await handle.read(tail, 0, tailLength, size - tailLength)
+
+      let eocd = -1
+      for (let i = tail.length - 22; i >= 0; i -= 1) {
+        if (tail.readUInt32LE(i) === 0x06054b50) {
+          eocd = i
+          break
+        }
+      }
+      if (eocd === -1) return null
+
+      let entryCount = tail.readUInt16LE(eocd + 10)
+      let directorySize = tail.readUInt32LE(eocd + 12)
+      let directoryOffset = tail.readUInt32LE(eocd + 16)
+
+      // Any of the three saturated means the real values live in the ZIP64
+      // record, found through the locator that sits immediately before the
+      // classic one.
+      if (
+        entryCount === 0xffff ||
+        directorySize === 0xffffffff ||
+        directoryOffset === 0xffffffff
+      ) {
+        const locator = eocd - 20
+        if (locator < 0 || tail.readUInt32LE(locator) !== 0x07064b50)
+          return null
+        const zip64Offset = Number(tail.readBigUInt64LE(locator + 8))
+        const zip64 = Buffer.alloc(56)
+        await handle.read(zip64, 0, 56, zip64Offset)
+        if (zip64.readUInt32LE(0) !== 0x06064b50) return null
+        entryCount = Number(zip64.readBigUInt64LE(32))
+        directorySize = Number(zip64.readBigUInt64LE(40))
+        directoryOffset = Number(zip64.readBigUInt64LE(48))
+      }
+
+      // Every figure above comes off the file being read, so none of them can
+      // be trusted to be sane. The central directory lives inside the archive
+      // and each of its records is at least 46 bytes; anything else means the
+      // record was misread, and allocating on it would abort the whole CLI
+      // with an out-of-memory crash rather than fail this one check.
+      if (
+        directoryOffset < 0 ||
+        directorySize < 0 ||
+        directoryOffset + directorySize > size ||
+        entryCount < 0 ||
+        entryCount * 46 > directorySize
+      ) {
+        return null
+      }
+
+      const directory = Buffer.alloc(directorySize)
+      await handle.read(directory, 0, directorySize, directoryOffset)
+
+      const names = new Set()
+      let offset = 0
+      for (let i = 0; i < entryCount; i += 1) {
+        if (offset + 46 > directory.length) return null
+        if (directory.readUInt32LE(offset) !== 0x02014b50) return null
+        const nameLength = directory.readUInt16LE(offset + 28)
+        const extraLength = directory.readUInt16LE(offset + 30)
+        const commentLength = directory.readUInt16LE(offset + 32)
+        names.add(
+          directory.toString('utf8', offset + 46, offset + 46 + nameLength),
+        )
+        offset += 46 + nameLength + extraLength + commentLength
+      }
+      return names
+    } catch {
+      return null
+    } finally {
+      await handle?.close()
+    }
+  }
+
+  /**
+   * Every function's handler has to be in the artifact that ships it.
+   *
+   * The build records where it wrote each handler; packaging appends the build
+   * directory. If the two disagree the function is deployed with no handler in
+   * it and only fails when it is first invoked, so the disagreement is fatal
+   * here instead.
+   *
+   * Functions with no recorded artifact are exempt: `_assertAllHandlersBuilt`
+   * has already decided about them, and the ones it let through are
+   * layer-provided wrappers whose handler is not supposed to be in the zip.
+   *
+   * The names come from the finished archive's own central directory, so this
+   * asserts what shipped rather than what packaging intended to ship. The
+   * caller's intended list is only the fallback for an archive that cannot be
+   * read back (see `_readArchiveEntryNames`).
+   *
+   * @param {Object} functions - the functions this archive was built for
+   * @param {Set<string>} intendedZipPaths - archive paths packaging appended
+   * @param {string} zipPath - the archive to read back
+   */
+  async _assertHandlersInArtifact(functions, intendedZipPaths, zipPath) {
+    const builtArtifacts = this.builtArtifacts ?? new Map()
+    const appendedZipPaths =
+      (await this._readArchiveEntryNames(zipPath)) ?? intendedZipPaths
+    const missing = []
+
+    for (const alias of Object.keys(functions)) {
+      const artifact = builtArtifacts.get(alias)
+      if (!artifact) continue
+      if (!appendedZipPaths.has(artifact.outfile)) {
+        missing.push(`"${alias}" (${artifact.outfile})`)
+      }
+    }
+
+    if (missing.length > 0) {
+      throw new ServerlessError(
+        `The handler files for ${missing.join(', ')} are missing from the deployment artifact ${zipPath}. ` +
+          `A "package.patterns" exclusion, or something removing files from "${this.buildDirPath}" after the build, is the usual cause.`,
+        'ESBUILD_HANDLER_MISSING_FROM_ARTIFACT',
+      )
+    }
   }
 
   /**
@@ -977,7 +2644,6 @@ class Esbuild {
   async _package(handlerPropertyName = 'handler') {
     const functions = await this.functions(handlerPropertyName)
     const buildProperties = await this._buildProperties()
-    const outputExtension = this._outputExtension(buildProperties)
 
     if (Object.keys(functions).length === 0) {
       log.debug('No functions to package')
@@ -986,7 +2652,7 @@ class Esbuild {
 
     // If not packaging individually then package all functions together into a single zip
     if (!this.serverless?.service?.package?.individually) {
-      await this._packageAll(functions, handlerPropertyName)
+      await this._packageAll(functions)
       return
     }
 
@@ -996,11 +2662,35 @@ class Esbuild {
     const limit = pLimit(concurrency)
 
     await this.serverless.pluginManager.spawn('esbuild-package')
+    const { excludedCount: excludedServiceIncludeCount, installedTreeEntries } =
+      await this._copyPatternsIntoBuildDir()
 
-    const packageIncludes = await globby(
-      this.serverless.service.package?.patterns ?? [],
-      { cwd: this.serverless.serviceDir },
-    )
+    // Walked once and shared: every function's zip is a subset of the same
+    // build directory, plus the service-level pattern matches that could not be
+    // copied into it. Both are shared across the functions and both are
+    // narrowable by a function-level negation, so they travel together.
+    const buildDirEntries = [
+      ...(await this._collectBuildDirEntries()),
+      ...installedTreeEntries,
+    ]
+    const servicePatterns = this.serverless.service.package?.patterns ?? []
+    // Read once for the whole run: every artifact ships the same build-dir
+    // package.json, and it only gates the non-bundled arm of the warning.
+    const declaredDependencyCount = await this._declaredDependencyCount()
+
+    // Everything the build emitted for any function. With bundling on, each
+    // bundle already contains every dependency its own handler needs, so
+    // shipping the other functions' bundles in this function's zip is pure
+    // weight — that is the whole point of `package.individually`. With bundling
+    // off, the emitted files ARE the project and every function needs all of
+    // them.
+    const allArtifactPaths = new Set()
+    for (const { outfile, mapfile } of (
+      this.builtArtifacts ?? new Map()
+    ).values()) {
+      allArtifactPaths.add(outfile)
+      if (mapfile) allArtifactPaths.add(mapfile)
+    }
 
     const zipPromises = Object.entries(functions).map(
       ([functionAlias, functionObject]) => {
@@ -1012,148 +2702,101 @@ class Esbuild {
             zipName,
           )
 
+          const functionPatterns = functionObject.package?.patterns ?? []
+          const compiledFunctionPatterns = compilePatterns(functionPatterns)
           // Service- and function-level patterns merge in that order so that
           // a function can re-include (or further exclude) what the service
           // level decided; `last match wins` then falls out of the ordering.
-          const compiledPatterns = compilePatterns([
-            ...(this.serverless.service.package?.patterns ?? []),
-            ...(functionObject.package?.patterns ?? []),
-          ])
-          const { filter: nodeModulesEntryFilter, counters: patternCounters } =
-            createNodeModulesEntryFilter(compiledPatterns)
+          const mergedPatterns = [...servicePatterns, ...functionPatterns]
+          const compiledPatterns = compilePatterns(mergedPatterns)
 
-          const zip = new ZipArchive()
-          const output = createWriteStream(zipPath)
-
-          const zipPromise = new Promise(async (resolve, reject) => {
-            output.on('close', () => resolve(zipPath))
-            output.on('error', (err) => reject(err))
-            zip.on('error', (err) => reject(err))
-
-            // Failures anywhere in the append sequence must reject the
-            // archive promise — an escaped rejection in this listener would
-            // otherwise leave the promise pending forever.
-            output.on('open', async () => {
-              try {
-                const functionIncludes = await globby(
-                  functionObject.package?.patterns ?? [],
-                  { cwd: this.serverless.serviceDir },
-                )
-
-                // Sorted so the archive entry order doesn't depend on glob
-                // traversal order, which is filesystem-dependent.
-                const unionedIncludes = [
-                  ...new Set([...packageIncludes, ...functionIncludes]),
-                ].sort()
-                const includesToPackage = filterPaths(
-                  compiledPatterns,
-                  unionedIncludes,
-                )
-                patternCounters.excludedEntryCount +=
-                  unionedIncludes.length - includesToPackage.length
-
-                zip.pipe(output)
-                const handlerPath = stripHandlerExportSuffix(
-                  functionObject[handlerPropertyName],
-                )
-
-                const packageJsonPath = path.join(
-                  this.serverless.config.serviceDir,
-                  '.serverless',
-                  'build',
-                  'package.json',
-                )
-
-                if (existsSync(packageJsonPath)) {
-                  await appendFileEntry(zip, packageJsonPath, 'package.json')
-                }
-
-                // Add lockfiles if they exist
-                const lockFiles = {
-                  'package-lock.json': 'package-lock.json',
-                  'yarn.lock': 'yarn.lock',
-                  'pnpm-lock.yaml': 'pnpm-lock.yaml',
-                }
-
-                for (const [lockFile, destName] of Object.entries(lockFiles)) {
-                  const lockFilePath = path.join(
-                    this.serverless.config.serviceDir,
-                    '.serverless',
-                    'build',
-                    lockFile,
-                  )
-                  if (existsSync(lockFilePath)) {
-                    await appendFileEntry(zip, lockFilePath, destName)
-                  }
-                }
-
-                const handlerZipPath = path.join(
-                  this.serverless.config.serviceDir,
-                  '.serverless',
-                  'build',
-                  handlerPath + outputExtension,
-                )
-
-                await appendFileEntry(
-                  zip,
-                  handlerZipPath,
-                  `${handlerPath}${outputExtension}`,
-                )
-
-                if (existsSync(`${handlerZipPath}.map`)) {
-                  await appendFileEntry(
-                    zip,
-                    `${handlerZipPath}.map`,
-                    `${handlerPath}${outputExtension}.map`,
-                  )
-                }
-
-                for (const filePath of includesToPackage) {
-                  const absolutePath = path.join(
-                    this.serverless.config.serviceDir,
-                    filePath,
-                  )
-                  const stats = await statIncludeEntry(absolutePath)
-                  if (stats.isDirectory()) {
-                    // No pattern predicate on purpose: the patterns already
-                    // selected this include, and pattern resolution (globby with
-                    // its onlyFiles default) never yields a directory, so this
-                    // branch is defensive rather than reachable from config.
-                    await appendDirectoryEntries(zip, absolutePath, filePath)
-                  } else {
-                    await appendFileEntry(zip, absolutePath, filePath)
-                  }
-                }
-
-                await appendDirectoryEntries(
-                  zip,
-                  path.join(
-                    this.serverless.config.serviceDir,
-                    '.serverless',
-                    'build',
-                    'node_modules',
+          const own =
+            (this.builtArtifacts ?? new Map()).get(functionAlias) ?? {}
+          const excluded =
+            buildProperties.bundle === false
+              ? new Set()
+              : new Set(
+                  [...allArtifactPaths].filter(
+                    (artifactPath) =>
+                      artifactPath !== own.outfile &&
+                      artifactPath !== own.mapfile,
                   ),
-                  'node_modules',
-                  nodeModulesEntryFilter,
                 )
 
-                await zip.finalize()
-                functionObject.package = {
-                  artifact: zipPath,
-                }
-              } catch (err) {
-                reject(err)
+          // Per-function patterns are additive to THIS zip only, so they are
+          // appended here rather than copied into the shared build directory.
+          // When one names a path the build directory also holds, the pattern
+          // copy is the one that ships — the same precedence service-level
+          // patterns get from overwriting the build directory — and the
+          // build-dir entry is dropped so the archive never carries the name
+          // twice.
+          const {
+            entries: patternEntries,
+            excludedCount: excludedFunctionIncludeCount,
+          } = await this._patternEntries(functionPatterns)
+          const patternZipPaths = new Set(
+            patternEntries.map((entry) => entry.zipPath),
+          )
+
+          // Build-directory entries a function-level negation retracted count
+          // as pattern exclusions too, exactly like the ones the node_modules
+          // filter and the include lists contribute.
+          let excludedBuildDirEntryCount = 0
+          const entries = [
+            ...buildDirEntries.filter((entry) => {
+              if (
+                excluded.has(entry.zipPath) ||
+                patternZipPaths.has(entry.zipPath)
+              ) {
+                return false
               }
-            })
+              // Negations in the function's own pattern list are the classic
+              // per-function slimming escape hatch — over project files. The
+              // generated manifest and lockfile are not project files and
+              // always ship (see `ARTIFACT_MANIFEST_ENTRIES`).
+              if (
+                !ARTIFACT_MANIFEST_ENTRIES.has(entry.zipPath) &&
+                !isPathIncluded(compiledFunctionPatterns, entry.zipPath)
+              ) {
+                excludedBuildDirEntryCount += 1
+                return false
+              }
+              return true
+            }),
+            ...patternEntries,
+          ].sort((a, b) =>
+            a.zipPath < b.zipPath ? -1 : a.zipPath > b.zipPath ? 1 : 0,
+          )
+
+          const patternCounters = await this._writeArchive({
+            zipPath,
+            entries,
+            compiledPatterns,
           })
-          await zipPromise
-          // Counters are only final once the output stream closed.
+          patternCounters.excludedEntryCount +=
+            excludedServiceIncludeCount +
+            excludedFunctionIncludeCount +
+            excludedBuildDirEntryCount
+
+          await this._assertHandlersInArtifact(
+            { [functionAlias]: functionObject },
+            new Set(entries.map((entry) => entry.zipPath)),
+            zipPath,
+          )
+
+          functionObject.package = {
+            artifact: zipPath,
+          }
+
+          // Counters are only final once the output stream closed, which
+          // `_writeArchive` already awaited.
           this._reportPatternFiltering({
             zipName,
             subject: functionAlias,
             compiledPatterns,
             ...patternCounters,
             buildProperties,
+            declaredDependencyCount,
           })
         })
       },
@@ -1167,9 +2810,14 @@ class Esbuild {
     }
   }
 
-  async _packageAll(functions, handlerPropertyName = 'handler') {
+  /**
+   * Package every function into one archive: the whole build directory plus the
+   * installed dependencies.
+   *
+   * @param {Object} functions - the functions this artifact ships
+   */
+  async _packageAll(functions) {
     const buildProperties = await this._buildProperties()
-    const outputExtension = this._outputExtension(buildProperties)
     const zipName = `${this.serverless.service.service}.zip`
     const zipPath = path.join(
       this.serverless.config.serviceDir,
@@ -1178,222 +2826,54 @@ class Esbuild {
     )
 
     await this.serverless.pluginManager.spawn('esbuild-package')
+    const { excludedCount: excludedServiceIncludeCount, installedTreeEntries } =
+      await this._copyPatternsIntoBuildDir()
 
-    // Sorted so the archive entry order doesn't depend on glob traversal
-    // order, which is filesystem-dependent.
-    const packageIncludes = (
-      await globby(this.serverless.service.package.patterns ?? [], {
-        cwd: this.serverless.serviceDir,
-      })
-    ).sort()
-
+    // Sorted together, so the pattern-supplied dependency files take their
+    // place in the same byte-wise order the build-directory sweep produces.
+    const entries = [
+      ...(await this._collectBuildDirEntries()),
+      ...installedTreeEntries,
+    ].sort((a, b) =>
+      a.zipPath < b.zipPath ? -1 : a.zipPath > b.zipPath ? 1 : 0,
+    )
     // Only service-level patterns apply here: a single shared zip has no
     // per-function view to narrow, so function-level patterns are ignored
     // without `individually` — same as classic packaging.
-    const compiledPatterns = compilePatterns(
-      this.serverless.service.package.patterns ?? [],
-    )
-    const { filter: nodeModulesEntryFilter, counters: patternCounters } =
-      createNodeModulesEntryFilter(compiledPatterns)
+    const patterns = this.serverless.service.package?.patterns ?? []
+    const compiledPatterns = compilePatterns(patterns)
 
-    const includesToPackage = filterPaths(compiledPatterns, packageIncludes)
-    patternCounters.excludedEntryCount +=
-      packageIncludes.length - includesToPackage.length
-
-    const zip = new ZipArchive()
-    const output = createWriteStream(zipPath)
-    const addedFiles = new Set()
-
-    const zipPromise = new Promise(async (resolve, reject) => {
-      output.on('close', () => resolve(zipPath))
-      output.on('error', (err) => reject(err))
-      zip.on('error', (err) => reject(err))
-
-      // Failures anywhere in the append sequence must reject the archive
-      // promise — an escaped rejection in this listener would otherwise
-      // leave the promise pending forever.
-      output.on('open', async () => {
-        try {
-          zip.pipe(output)
-
-          for (const [, functionObject] of Object.entries(functions)) {
-            const handlerPath = stripHandlerExportSuffix(
-              functionObject[handlerPropertyName],
-            )
-
-            const packageJsonPath = path.join(
-              this.serverless.config.serviceDir,
-              '.serverless',
-              'build',
-              'package.json',
-            )
-
-            if (
-              existsSync(packageJsonPath) &&
-              !addedFiles.has(packageJsonPath)
-            ) {
-              await appendFileEntry(zip, packageJsonPath, 'package.json')
-              addedFiles.add(packageJsonPath)
-            }
-
-            // Add lockfiles if they exist
-            const lockFiles = {
-              'package-lock.json': 'package-lock.json',
-              'yarn.lock': 'yarn.lock',
-              'pnpm-lock.yaml': 'pnpm-lock.yaml',
-            }
-
-            for (const [lockFile, destName] of Object.entries(lockFiles)) {
-              const lockFilePath = path.join(
-                this.serverless.config.serviceDir,
-                '.serverless',
-                'build',
-                lockFile,
-              )
-              if (existsSync(lockFilePath) && !addedFiles.has(lockFilePath)) {
-                await appendFileEntry(zip, lockFilePath, destName)
-                addedFiles.add(lockFilePath)
-              }
-            }
-
-            const handlerZipPath = path.join(
-              this.serverless.config.serviceDir,
-              '.serverless',
-              'build',
-              handlerPath + outputExtension,
-            )
-
-            if (!addedFiles.has(handlerZipPath)) {
-              await appendFileEntry(
-                zip,
-                handlerZipPath,
-                `${handlerPath}${outputExtension}`,
-              )
-              addedFiles.add(handlerZipPath)
-            }
-
-            if (
-              existsSync(`${handlerZipPath}.map`) &&
-              !addedFiles.has(`${handlerZipPath}.map`)
-            ) {
-              await appendFileEntry(
-                zip,
-                `${handlerZipPath}.map`,
-                `${handlerPath}${outputExtension}.map`,
-              )
-
-              addedFiles.add(`${handlerZipPath}.map`)
-            }
-          }
-
-          for (const filePath of includesToPackage) {
-            const absolutePath = path.join(this.serverless.serviceDir, filePath)
-            const stats = await statIncludeEntry(absolutePath)
-            if (stats.isDirectory()) {
-              // No pattern predicate on purpose: the patterns already selected
-              // this include, and pattern resolution (globby with its onlyFiles
-              // default) never yields a directory, so this branch is defensive
-              // rather than reachable from config.
-              await appendDirectoryEntries(zip, absolutePath, filePath)
-            } else if (!addedFiles.has(absolutePath)) {
-              await appendFileEntry(zip, absolutePath, filePath)
-              addedFiles.add(absolutePath)
-            }
-          }
-
-          await appendDirectoryEntries(
-            zip,
-            path.join(
-              this.serverless.config.serviceDir,
-              '.serverless',
-              'build',
-              'node_modules',
-            ),
-            'node_modules',
-            nodeModulesEntryFilter,
-          )
-
-          await zip.finalize()
-          this.serverless.service.package.artifact = zipPath
-        } catch (err) {
-          reject(err)
-        }
-      })
-    })
-
+    let patternCounters
     try {
-      await zipPromise
+      patternCounters = await this._writeArchive({
+        zipPath,
+        entries,
+        compiledPatterns,
+      })
     } catch (err) {
       if (err instanceof ServerlessError) throw err
       throw new ServerlessError(err.message, 'ESBULD_PACKAGE_ALL_ERROR')
     }
+    patternCounters.excludedEntryCount += excludedServiceIncludeCount
 
-    // Counters are only final once the output stream closed.
+    this.serverless.service.package.artifact = zipPath
+
+    // Counters are only final once the output stream closed, which
+    // `_writeArchive` already awaited.
     this._reportPatternFiltering({
       zipName,
       subject: zipName,
       compiledPatterns,
       ...patternCounters,
       buildProperties,
+      declaredDependencyCount: await this._declaredDependencyCount(),
     })
-  }
 
-  /**
-   * Report what `package.patterns` did to one artifact: an info line naming the
-   * artifact when anything was excluded, an unconditional debug trace of the
-   * patterns and the counters, and a once-per-invocation warning when the
-   * patterns leave no dependencies behind for `packages: external`.
-   *
-   * Call this only after the artifact's zip promise settled — the counters are
-   * incremented from the node_modules entry filter and are not final before
-   * then.
-   *
-   * @param {object} params
-   * @param {string} params.zipName - Artifact file name, e.g. `my-service-fn1.zip`.
-   * @param {string} params.subject - What the debug trace is about: the function
-   *   alias when packaging individually, the service zip name otherwise.
-   * @param {Array<object>} params.compiledPatterns - Compiled ordered patterns.
-   * @param {number} params.excludedEntryCount - Entries the patterns removed.
-   * @param {number} params.excludedNodeModulesEntryCount - Of those, entries
-   *   removed from the node_modules walk rather than from additive includes.
-   * @param {number} params.includedNodeModulesFileCount - node_modules files kept.
-   * @param {object} params.buildProperties - The merged esbuild build properties.
-   */
-  _reportPatternFiltering({
-    zipName,
-    subject,
-    compiledPatterns,
-    excludedEntryCount,
-    excludedNodeModulesEntryCount,
-    includedNodeModulesFileCount,
-    buildProperties,
-  }) {
-    if (excludedEntryCount > 0) {
-      logger.info(
-        `Excluded ${excludedEntryCount} entries from ${zipName} via package.patterns`,
-      )
-    }
-    logger.debug(
-      `package.patterns for ${subject}: ${JSON.stringify(
-        compiledPatterns,
-      )} (excluded ${excludedEntryCount}, node_modules entries excluded ${excludedNodeModulesEntryCount}, node_modules files kept ${includedNodeModulesFileCount})`,
+    await this._assertHandlersInArtifact(
+      functions,
+      new Set(entries.map((entry) => entry.zipPath)),
+      zipPath,
     )
-    // Scoped to the node_modules walk on purpose: excluding only additive
-    // includes says nothing about dependencies, and warning there would make a
-    // false claim. This cannot miss a real case -- if node_modules held
-    // anything that the patterns stripped, the entry filter ran and counted it.
-    if (
-      includedNodeModulesFileCount === 0 &&
-      excludedNodeModulesEntryCount > 0 &&
-      buildProperties.packages === 'external' &&
-      !this._nodeModulesExclusionWarned
-    ) {
-      this._nodeModulesExclusionWarned = true
-      logger.warning(
-        'package.patterns exclude everything under node_modules, but "packages: external" requires dependencies in the artifact. ' +
-          'If dependencies are provided another way (e.g. a Lambda layer) or this exclusion predates build.esbuild, review or remove these patterns.',
-      )
-    }
   }
 
   /**
@@ -1503,6 +2983,11 @@ class Esbuild {
       '.serverless',
       'build',
     )
+
+    // The writer guarantees its own directory. `_build` creates it on every
+    // path that reaches here, but a caller ordering that ever changed would
+    // fail with a raw ENOENT from `writeFile` rather than anything actionable.
+    await mkdir(buildDir, { recursive: true })
 
     // Copy package.json
     await writeFile(
@@ -1614,19 +3099,41 @@ class Esbuild {
   }
 
   /**
-   * Cleanup, mainly removing build files and directories
+   * Clears previous build outputs so the packaging step can treat the build
+   * directory as the complete artifact definition. `node_modules` and
+   * lockfiles are preserved: they are not esbuild outputs, are regenerated
+   * from package.json by the install step, and re-creating them cold on
+   * every deploy is a measured multi-second regression.
+   *
+   * The wipe MUST stay in `_build`, before `spawn('esbuild-package')` runs.
+   * `before:esbuild-package` is the supported injection point for plugins that
+   * add files to the build directory, and the zip has to include what they
+   * wrote -- moving the reset into `_package` would delete those files right
+   * before packaging.
    */
-  async _cleanUp() {
+  async _resetBuildDir() {
+    const preserved = new Set([
+      'node_modules',
+      'package-lock.json',
+      'yarn.lock',
+      'pnpm-lock.yaml',
+    ])
     try {
-      await rm(
-        path.join(this.serverless.config.serviceDir, '.serverless', 'build'),
-        {
-          recursive: true,
-          force: true,
-        },
-      )
+      if (existsSync(this.buildDirPath)) {
+        for (const entry of await readdir(this.buildDirPath)) {
+          if (preserved.has(entry)) continue
+          await rm(path.join(this.buildDirPath, entry), {
+            recursive: true,
+            force: true,
+          })
+        }
+      }
+      await mkdir(this.buildDirPath, { recursive: true })
     } catch (err) {
-      // empty error
+      throw new ServerlessError(
+        `Failed to reset the esbuild output directory "${this.buildDirPath}": ${err.message}`,
+        'ESBUILD_BUILD_DIR_RESET_FAILED',
+      )
     }
   }
 }

--- a/packages/serverless/lib/plugins/esbuild/index.js
+++ b/packages/serverless/lib/plugins/esbuild/index.js
@@ -112,7 +112,8 @@ const BUILD_DIR_EXCLUDED_ROOT_ENTRIES = new Set([
   '.pnp.loader.mjs',
   // Copied in by `_preparePackageJson` so that a pnpm install run inside the
   // build directory puts node_modules there. It is the install's scaffolding,
-  // not the function's, and no earlier release packaged it.
+  // not the function's, and no earlier release packaged it; the sweep keeps
+  // the project's own copy out by default for the same reason.
   'pnpm-workspace.yaml',
   'pnpm-workspace.yml',
 ])

--- a/packages/serverless/lib/plugins/esbuild/project-sweep.js
+++ b/packages/serverless/lib/plugins/esbuild/project-sweep.js
@@ -232,6 +232,12 @@ export async function sweepProjectFiles({
     '.yarn/**',
     '.pnp.cjs',
     '.pnp.loader.mjs',
+    // pnpm's workspace manifest describes the developer's monorepo layout, not
+    // the function; `_preparePackageJson` copies it into the build directory
+    // for the install, and the artifact walk skips that copy for the same
+    // reason.
+    'pnpm-workspace.yaml',
+    'pnpm-workspace.yml',
     // Caller-supplied, and last so a caller can never be shadowed by a rule
     // above -- they still precede `patterns`, so user patterns keep the final
     // word.

--- a/packages/serverless/lib/plugins/esbuild/project-sweep.js
+++ b/packages/serverless/lib/plugins/esbuild/project-sweep.js
@@ -238,6 +238,13 @@ export async function sweepProjectFiles({
     // reason.
     'pnpm-workspace.yaml',
     'pnpm-workspace.yml',
+    // Package-manager configuration is where registry credentials live
+    // (`_authToken` lines, `npmAuthToken`), and nothing reads it at runtime.
+    // Any depth: a nested package's copy is the same hazard. Classic packaging
+    // ships these; that parity is not worth a leaked token.
+    '**/.npmrc',
+    '**/.yarnrc',
+    '**/.yarnrc.yml',
     // Caller-supplied, and last so a caller can never be shadowed by a rule
     // above -- they still precede `patterns`, so user patterns keep the final
     // word.

--- a/packages/serverless/lib/plugins/esbuild/project-sweep.js
+++ b/packages/serverless/lib/plugins/esbuild/project-sweep.js
@@ -1,0 +1,607 @@
+import fs from 'fs'
+import path from 'path'
+import { globby } from 'globby'
+import { createFilesMatcher, getTsconfig } from 'get-tsconfig'
+import ServerlessError from '../../serverless-error.js'
+import { compilePatterns, filterPaths } from '../../utils/package-patterns.js'
+
+/**
+ * File selection for non-bundled (`bundle: false`) esbuild builds.
+ *
+ * With bundling off, the artifact is no longer "one file per handler": every
+ * source file the service ships has to be selected, transpiled or copied, and
+ * placed in the build directory. The selection has to match what classic
+ * packaging would have shipped for the same service, or turning bundling off
+ * silently changes the contents of the deployment package.
+ *
+ * Everything here is pure -- no `this`, no serverless instance -- so the
+ * selection rules can be pinned directly. Paths are POSIX throughout: globby
+ * returns POSIX-separated relative paths on every platform, and micromatch
+ * patterns are POSIX by definition, so no separator conversion happens (nor
+ * may be introduced) between the sweep and the pattern filters.
+ */
+
+/** Extensions esbuild has to transpile; everything else is copied verbatim. */
+export const COMPILE_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+  '.jsx',
+])
+
+/**
+ * The extensions a tsconfig has any authority over. A tsconfig describes a
+ * TypeScript program, so it decides which TypeScript files belong to the
+ * build and nothing else: `.jsx`, `.js`, and every copied asset are outside
+ * its remit even when `allowJs` would pull them into `tsc`.
+ */
+const TS_FAMILY_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts'])
+
+/**
+ * The file name a source file ends up under in the build directory. The
+ * module-system-carrying extensions have to survive transpilation -- `.mts`
+ * must stay ESM and `.cts` must stay CommonJS once Node resolves them -- while
+ * the rest collapse onto `.js`. Files that are copied rather than compiled keep
+ * their own name, which is why `.js`/`.mjs`/`.cjs` map to themselves: it is
+ * exactly that identity which makes a hand-written `util.js` and a compiled
+ * `util.ts` meet on the same output path.
+ */
+const OUTPUT_EXTENSION_BY_SOURCE = {
+  '.ts': '.js',
+  '.tsx': '.js',
+  '.jsx': '.js',
+  '.js': '.js',
+  '.mts': '.mjs',
+  '.mjs': '.mjs',
+  '.cts': '.cjs',
+  '.cjs': '.cjs',
+}
+
+/**
+ * Bring a caller-supplied path onto the same footing as globby's output:
+ * POSIX separators, no `./` prefix. Handler paths come from user configuration
+ * (`handler: ./src/handler.ts`) and from Windows path joins, and a path that
+ * only *looks* different from the swept one silently duplicates it in the
+ * compile set and hides genuine output collisions.
+ */
+export const toSweptPath = (filePath) =>
+  filePath.replace(/\\/g, '/').replace(/^(?:\.\/)+/, '')
+
+/**
+ * A path input worth turning into a glob. Bare names can be handed to
+ * `compilePatterns` blank and it drops them, but a blank name that has already
+ * been suffixed (`'' + '/**'`) is no longer empty and would survive as `/**`.
+ * That glob happens to match nothing today, so this guard is belt-and-braces
+ * rather than load-bearing -- it keeps a blank layer path from ever reaching
+ * micromatch as a pattern in the first place.
+ */
+const isUsablePathInput = (value) =>
+  typeof value === 'string' && value.trim() !== ''
+
+export function outputPathFor(sourcePath) {
+  const ext = path.posix.extname(sourcePath)
+  const mapped = OUTPUT_EXTENSION_BY_SOURCE[ext]
+  if (!mapped) return sourcePath
+  return sourcePath.slice(0, -ext.length) + mapped
+}
+
+/**
+ * The module system a file's own directory declares, resolved the way Node
+ * resolves it: the `type` of the nearest package.json at or above the file,
+ * defaulting to CommonJS when nothing declares one.
+ *
+ * A non-bundled build emits one output per source file, and Node decides how to
+ * load each of those outputs from exactly this rule. Compiling the whole
+ * project to a single service-wide format would drop `export` statements into a
+ * directory Node loads as CommonJS -- a monorepo package with its own
+ * `"type": "module"`, or a `legacy/` folder pinned back to CommonJS -- and the
+ * mistake only surfaces as a runtime `SyntaxError` on the deployed function.
+ *
+ * The walk stops at `serviceDir`: anything above it is the developer's machine,
+ * not the service, and its `type` has no say over what gets deployed.
+ *
+ * @param {string} serviceDir absolute path to the service directory
+ * @param {string} fileRelPath service-relative POSIX path of the source file
+ * @param {Map<string, 'module'|'commonjs'>} [cache] per-directory memo, shared
+ *   across the files of one build so each directory is stat'ed once
+ * @returns {'module'|'commonjs'}
+ */
+export function nearestPackageJsonType(
+  serviceDir,
+  fileRelPath,
+  cache = new Map(),
+) {
+  const resolveDir = (dir) => {
+    const cached = cache.get(dir)
+    if (cached !== undefined) return cached
+
+    let result
+    const pkgPath = path.join(
+      serviceDir,
+      ...(dir === '.' ? [] : dir.split('/')),
+      'package.json',
+    )
+    if (fs.existsSync(pkgPath)) {
+      try {
+        result =
+          JSON.parse(fs.readFileSync(pkgPath, 'utf8')).type === 'module'
+            ? 'module'
+            : 'commonjs'
+      } catch {
+        // A package.json the service cannot parse is the package manager's
+        // problem to report, not a reason to abort the build here. Node itself
+        // would throw on it at load time; assuming CommonJS keeps the build
+        // going and leaves the real error where it belongs.
+        result = 'commonjs'
+      }
+    } else if (dir === '.' || dir === '/' || dir === '') {
+      result = 'commonjs'
+    } else {
+      result = resolveDir(path.posix.dirname(dir))
+    }
+
+    cache.set(dir, result)
+    return result
+  }
+
+  return resolveDir(path.posix.dirname(fileRelPath))
+}
+
+/**
+ * Sweep the service directory the way classic packaging does: take everything,
+ * then run one ordered pattern pass in which the built-in exclusions come first
+ * as negations and the user's `package.patterns` come last.
+ *
+ * The ordering is the contract, not an implementation detail. Classic builds
+ * exactly this list in `resolveFilePathsFromPatterns()` (see
+ * `lib/plugins/package/lib/package-service.js`): its excludes are turned into
+ * leading `!` patterns and the user's includes are appended after them, so
+ * last-match-wins lets a service opt back into anything the defaults dropped --
+ * `patterns: ['serverless.yml']` really does ship the config file. Applying the
+ * exclusions as a pre-filter instead would make them unconditional and quietly
+ * break services that rely on re-inclusion.
+ *
+ * @param {object} options
+ * @param {string} options.serviceDir absolute path to the service directory
+ * @param {string[]} [options.patterns] ordered `package.patterns` entries
+ * @param {string[]} [options.configFileNames] resolved service-config file names
+ * @param {string[]} [options.layerPaths] layer source directories, service-relative
+ * @param {string|null} [options.localPluginPath] `plugins.localPath`, service-relative
+ * @param {string[]} [options.additionalExclusions] further globs to negate ahead
+ *   of the user patterns -- classic's `defaultExcludes` and the `useDotenv`
+ *   `.env*` rule, which are decided from the serverless instance and so cannot
+ *   be hard-coded here
+ * @param {string[]} [options.additionalIgnores] further globs that are never
+ *   swept and that no pattern can re-include -- the `--package` directory,
+ *   which holds the previous run's artifact and build directory the same way
+ *   `.serverless` does, and is likewise decided from the serverless instance
+ * @returns {Promise<string[]>} POSIX-relative file paths, in globby order
+ */
+export async function sweepProjectFiles({
+  serviceDir,
+  patterns = [],
+  configFileNames = [],
+  layerPaths = [],
+  localPluginPath = null,
+  additionalExclusions = [],
+  additionalIgnores = [],
+}) {
+  const all = await globby(['**'], {
+    cwd: serviceDir,
+    dot: true,
+    followSymbolicLinks: true,
+    onlyFiles: true,
+    // Dependencies are installed into the build directory separately, the build
+    // directory itself must never sweep itself back in, and `.git` is never
+    // part of a deployment artifact. globby evaluates these against the path it
+    // traversed, so a `node_modules` reached through a symlinked directory is
+    // matched here as well.
+    ignore: [
+      '**/node_modules/**',
+      '.serverless/**',
+      '.git/**',
+      ...additionalIgnores,
+    ],
+  })
+
+  const exclusionGlobs = [
+    // The service configuration is consumed by the CLI, not by the function.
+    // Blank names are left in deliberately: `compilePatterns` drops them, which
+    // is the one place that decision belongs.
+    ...configFileNames,
+    // Layer sources are packaged into their own layer artifacts.
+    ...layerPaths
+      .filter(isUsablePathInput)
+      .map((layerPath) => `${layerPath}/**`),
+    // Local plugins run on the developer machine, never in Lambda.
+    //
+    // This deliberately diverges from classic, which excludes the bare
+    // `localPath` with no `/**` suffix. Against a file list that carries no
+    // directory entries, that bare path matches nothing, so classic ships the
+    // plugin sources; the `/**` suffix here is the intended behavior rather
+    // than a bug worth reproducing.
+    ...(isUsablePathInput(localPluginPath) ? [`${localPluginPath}/**`] : []),
+    '.serverless_plugins/**',
+    // Type declarations carry no runtime code and cannot be transpiled into
+    // any, so shipping them only inflates the artifact.
+    '**/*.d.ts',
+    '**/*.d.mts',
+    '**/*.d.cts',
+    // Yarn PnP's runtime and cache belong to the developer's resolution setup.
+    '.yarn/**',
+    '.pnp.cjs',
+    '.pnp.loader.mjs',
+    // Caller-supplied, and last so a caller can never be shadowed by a rule
+    // above -- they still precede `patterns`, so user patterns keep the final
+    // word.
+    ...additionalExclusions,
+  ]
+  // One batched pass over the whole sweep: `filterPaths` matches each pattern
+  // against the full list once, rather than matching every file against every
+  // pattern. On a 50k-file service that is the difference between ~840ms and
+  // ~110ms.
+  //
+  // An exclusion already carrying a `!` prefix is inverted into a re-include
+  // rather than negated again, exactly as classic does with its exclude list
+  // (`resolveFilePathsFromPatterns`). Double negation is not a no-op here:
+  // `!!keep.js` compiles to the negated micromatch pattern `!keep.js`, which
+  // matches every path EXCEPT `keep.js` and would empty the whole sweep.
+  return filterPaths(
+    compilePatterns([
+      ...exclusionGlobs.map((glob) =>
+        glob.startsWith('!') ? glob.slice(1) : `!${glob}`,
+      ),
+      ...patterns,
+    ]),
+    all,
+  )
+}
+
+/**
+ * Partition swept files into the ones esbuild transpiles and the ones copied
+ * as-is.
+ *
+ * Handler paths are normalized onto the swept form (POSIX separators, no `./`
+ * prefix) before anything else happens, so `./src/handler.ts` and the swept
+ * `src/handler.ts` are recognized as one file rather than two.
+ *
+ * @param {string[]} files swept, service-relative POSIX paths
+ * @param {string[]} [handlerFiles] resolved handler source files
+ * @returns {{ compile: string[], copy: string[] }}
+ */
+export function splitCompileAndCopy(files, handlerFiles = []) {
+  const handlers = new Set(handlerFiles.map(toSweptPath))
+  const compile = []
+  const copy = []
+  for (const file of files) {
+    if (handlers.has(file)) continue // handlers are appended below, exactly once
+    if (COMPILE_EXTENSIONS.has(path.posix.extname(file))) compile.push(file)
+    else copy.push(file)
+  }
+  // Handlers always compile, whatever their extension and whether or not the
+  // sweep (or its negations) selected them -- a bad tsconfig or pattern must
+  // never be able to drop a handler.
+  for (const handler of handlers) compile.push(handler)
+  return { compile, copy }
+}
+
+/**
+ * Narrow the compile set to the TypeScript a tsconfig actually claims.
+ *
+ * The sweep selects everything the artifact ships, which is the right rule for
+ * assets and for JavaScript but too broad for TypeScript: a service routinely
+ * carries `.ts` files that are not part of the deployed program at all --
+ * test suites, CDK or Pulumi stacks, codegen scripts, a half-migrated
+ * `legacy/` tree -- and compiling them is at best wasted work and at worst a
+ * hard failure when one of them collides with a hand-written `.js` sibling.
+ * The project already states which TypeScript belongs to it, in its tsconfig,
+ * so that is what decides.
+ *
+ * The narrowing only ever removes. A file the sweep dropped (a
+ * `package.patterns` negation, a classic exclusion) stays dropped however
+ * enthusiastically the tsconfig includes it, and handlers are retained
+ * unconditionally -- a tsconfig that forgets one must not be able to ship an
+ * artifact with no handler in it.
+ *
+ * @param {object} options
+ * @param {string} options.serviceDir absolute path to the service directory
+ * @param {string} [options.tsconfigPath] `build.esbuild.tsconfig`, resolved
+ *   relative to `serviceDir`; when absent the service's own `tsconfig.json` is
+ *   used, if it has one
+ * @param {string[]} options.compileFiles service-relative POSIX paths, as
+ *   produced by `splitCompileAndCopy`
+ * @param {string[]} [options.handlerFiles] resolved handler source files
+ * @returns {{ compile: string[], warning: string|null }} the narrowed set, and
+ *   a message the caller logs once when the tsconfig turned out to select no
+ *   TypeScript at all
+ */
+export function applyTsconfigCompileFilter({
+  serviceDir,
+  tsconfigPath,
+  compileFiles,
+  handlerFiles = [],
+}) {
+  const explicit = Boolean(tsconfigPath)
+  const anchor = explicit
+    ? path.resolve(serviceDir, tsconfigPath)
+    : path.join(serviceDir, 'tsconfig.json')
+
+  // The anchor has to be a readable file at exactly that path, and it is
+  // checked here rather than left to `getTsconfig` for two reasons.
+  //
+  // Containment: `getTsconfig` searches by walking UP from where it starts, so
+  // without this it would happily answer with an ancestor's tsconfig -- a
+  // monorepo root's solution-style `files: []`, most often -- which was
+  // written for a different program and would drop this service's sources
+  // with nothing but a warning to show for it. Auto-discovery is the service's
+  // own `tsconfig.json` or nothing; anything else is named explicitly. It is
+  // anchored at the service directory and never at `process.cwd()`, because
+  // Compose runs every service in-process from the compose root.
+  //
+  // And `statSync` is what tells a file from a directory: `existsSync` is true
+  // for `tsconfig.json/`, which then dies inside the JSON parser instead of
+  // producing the error the user can act on.
+  let anchorIsFile = false
+  try {
+    anchorIsFile = fs.statSync(anchor).isFile()
+  } catch {
+    anchorIsFile = false
+  }
+
+  if (!anchorIsFile) {
+    if (explicit) {
+      throw new ServerlessError(
+        `The tsconfig specified at "build.esbuild.tsconfig" was not found: ${anchor}`,
+        'ESBUILD_TSCONFIG_NOT_FOUND',
+      )
+    }
+    // No tsconfig means no opinion, and the sweep governs on its own.
+    return { compile: compileFiles, warning: null }
+  }
+
+  // With the anchor pinned to an existing file, `getTsconfig` finds it on its
+  // first probe and the walk-up never happens; it is still the entry point
+  // because it is what resolves the `extends` chain.
+  let found
+  try {
+    found = getTsconfig(path.dirname(anchor), path.basename(anchor))
+  } catch (error) {
+    // An `extends` target that cannot be resolved. The overwhelmingly common
+    // cause is a shared base config (`@tsconfig/node20`, an internal preset)
+    // that lives in devDependencies and is simply not installed -- a CI box
+    // running `npm ci --omit=dev`, a Docker build stage. A config the user
+    // never asked us to read must not take the deploy down over that, so the
+    // discovered case says so once and compiles everything the sweep chose.
+    // A config the user DID name is theirs, and a broken one is an error.
+    if (explicit) {
+      throw new ServerlessError(
+        `The tsconfig specified at "build.esbuild.tsconfig" could not be read: ${anchor} (${error.message})`,
+        'ESBUILD_TSCONFIG_INVALID',
+      )
+    }
+    return {
+      compile: compileFiles,
+      warning:
+        `Your tsconfig at ${anchor} could not be resolved (${error.message}), so it is not narrowing what gets compiled: ` +
+        `every TypeScript file in the package will be. Install the missing config, or point "build.esbuild.tsconfig" at a build-specific config.`,
+    }
+  }
+
+  // A tsconfig that declares nothing at all narrows nothing at all -- its
+  // implicit `include` is `**/*`. Worth saying out loud, because this is also
+  // what an unparseable tsconfig looks like: the JSONC parser does not throw
+  // on malformed input, it returns an empty object, and the build would
+  // silently ignore the config the user believes is in charge.
+  const declaresNothing =
+    Object.keys(found.config).every((key) => key === 'compilerOptions') &&
+    Object.keys(found.config.compilerOptions ?? {}).length === 0
+  if (declaresNothing) {
+    return {
+      compile: compileFiles,
+      warning:
+        `Your tsconfig at ${found.path} declares no settings -- it is empty, or it could not be parsed -- so it is not narrowing ` +
+        `what gets compiled: every TypeScript file in the package will be. Check the file, or point "build.esbuild.tsconfig" at a build-specific config.`,
+    }
+  }
+
+  // The case sensitivity is stated rather than detected: left to itself
+  // `createFilesMatcher` probes the filesystem by writing a temp file into the
+  // current working directory, which is not ours to write to. Matching
+  // case-sensitively is also what Lambda does, so a selection that works
+  // locally on a case-insensitive macOS volume is the one that works deployed.
+  const matcher = createFilesMatcher(found, true)
+  const handlers = new Set(handlerFiles.map(toSweptPath))
+
+  let candidates = 0
+  let matched = 0
+  const compile = compileFiles.filter((file) => {
+    if (!TS_FAMILY_EXTENSIONS.has(path.posix.extname(file))) return true
+    candidates += 1
+    // `createFilesMatcher` requires an absolute path and compares it against
+    // patterns already resolved against the tsconfig's own directory, which is
+    // what makes an `extends` chain resolve the way `tsc` resolves it.
+    //
+    // Handlers are matched but never dropped. Exempting them from the match
+    // as well would make a service whose only in-scope TypeScript IS its
+    // handler look like a tsconfig that selects nothing.
+    if (matcher(path.resolve(serviceDir, file))) {
+      matched += 1
+      return true
+    }
+    return handlers.has(file)
+  })
+
+  // A tsconfig that claims none of the project's TypeScript is nearly always a
+  // solution-style root (`files: []` plus `references`) that was never meant
+  // to describe a program. The build still succeeds -- handlers compile
+  // regardless -- so silence here would ship an artifact missing every helper
+  // the handler imports. Say so once, and name the way out.
+  //
+  // A project with no TypeScript to select in the first place is not that
+  // case, and gets no warning.
+  const warning =
+    candidates > 0 && matched === 0
+      ? `Your tsconfig at ${found.path} selects no source files; only handler files will be compiled. ` +
+        `Point "build.esbuild.tsconfig" at a build-specific config to control compilation.`
+      : null
+
+  return { compile, warning }
+}
+
+/**
+ * Every relative specifier an ES module hands to the runtime: the static
+ * `import`/`export ... from` forms, the bare side-effect `import './x'`, and
+ * dynamic `import()`.
+ *
+ * `from` and `import` are the only tokens that can introduce one, and the
+ * quoted string has to follow immediately -- which is what keeps `const from =
+ * './util'` and `xs.from('./util')` out. The dynamic form is listed ahead of
+ * the bare one so `import('./x')` is consumed by it rather than failing on the
+ * parenthesis.
+ */
+const RELATIVE_SPECIFIER_RE =
+  /(?:\bfrom|\bimport\s*\(|\bimport)\s*['"](\.\.?\/[^'"]+)['"]/g
+
+/**
+ * Only the dynamic form. This is what CommonJS output is scanned with: esbuild
+ * rewrites every static `import` into `require()` on the way out, but it
+ * leaves `import()` exactly as written -- and Node routes `import()` through
+ * the ES module resolver even from inside a CommonJS file, so the dynamic form
+ * is unsafe in every output format while the static forms are only unsafe
+ * where they survive as imports.
+ *
+ * Both patterns anchor the specifier to a quote, so a template literal
+ * (`import(\`./p/${n}\`)`, which esbuild also preserves verbatim) matches
+ * neither and is silently left alone -- correctly, since its value is not
+ * knowable from the text.
+ */
+const DYNAMIC_RELATIVE_SPECIFIER_RE = /\bimport\s*\(\s*['"](\.\.?\/[^'"]+)['"]/g
+
+/**
+ * Sort a file's relative specifiers into the two ways a non-bundled build
+ * makes them unresolvable. One pass, because the caller runs this over every
+ * emitted file and both answers come from the same matches.
+ *
+ * @param {string} fileContent
+ * @param {boolean} dynamicOnly restrict to `import()`, for CommonJS output
+ * @returns {{ extensionless: string[], sourceExtension: string[] }}
+ */
+function classifyRelativeSpecifiers(fileContent, dynamicOnly) {
+  const extensionless = new Set()
+  const sourceExtension = new Set()
+  const pattern = dynamicOnly
+    ? DYNAMIC_RELATIVE_SPECIFIER_RE
+    : RELATIVE_SPECIFIER_RE
+
+  for (const match of fileContent.matchAll(pattern)) {
+    const specifier = match[1]
+    if (!specifier.split('/').pop().includes('.')) {
+      extensionless.add(specifier)
+    } else if (COMPILE_EXTENSIONS.has(path.posix.extname(specifier))) {
+      sourceExtension.add(specifier)
+    }
+  }
+
+  return {
+    extensionless: [...extensionless],
+    sourceExtension: [...sourceExtension],
+  }
+}
+
+/**
+ * Relative specifiers in emitted output that Node will not resolve.
+ *
+ * With bundling off the emitted file keeps whatever specifiers the source
+ * wrote, and there are two distinct ways that goes wrong:
+ *
+ * - **`extensionless`** -- Node's ES module resolver, unlike CommonJS's, adds
+ *   no extensions and probes no `index.js`: `./util` means a file named
+ *   exactly `util`. This is the single most common way a service that ran fine
+ *   bundled fails once it is not.
+ * - **`sourceExtension`** -- `./util.ts` names a file the build does not emit:
+ *   `util.ts` is compiled to `util.js`, so the specifier points at something
+ *   that is not in the artifact under that name. It looks extensioned, so the
+ *   dot heuristic below would otherwise wave it through, and it is guaranteed
+ *   broken rather than merely suspicious.
+ *
+ * Either way the failure is invisible until the function is invoked, so the
+ * build says it out loud.
+ *
+ * A specifier counts as extensionless when its LAST path segment carries no
+ * dot. That is a heuristic, and deliberately a cheap one:
+ *
+ * - It is a regex over text, not a parse, so a specifier inside a string
+ *   literal (or a comment, in the rare output that keeps one) is reported as
+ *   though it were live code.
+ * - A directory whose own name has a dot (`./lib.v2`) reads as extensioned and
+ *   is missed. Telling that from a file named `config.local` needs the
+ *   filesystem, which this never touches.
+ *
+ * Both are survivable in the sense that matters: the output is advice printed
+ * once, never a build failure, so a wrong line costs a reader ten seconds.
+ * These functions are pure and take text rather than a path precisely so the
+ * caller controls how much gets read into memory.
+ *
+ * @param {string} fileContent the emitted file's contents
+ * @param {object} [options]
+ * @param {boolean} [options.dynamicOnly] scan only `import()`, which is what
+ *   CommonJS output warrants -- see `DYNAMIC_RELATIVE_SPECIFIER_RE`
+ * @returns {{ extensionless: string[], sourceExtension: string[] }} distinct
+ *   specifiers, in order of first appearance
+ */
+export function scanUnresolvableRelativeImports(
+  fileContent,
+  { dynamicOnly = false } = {},
+) {
+  return classifyRelativeSpecifiers(fileContent, dynamicOnly)
+}
+
+/**
+ * The extensionless half of `scanUnresolvableRelativeImports`, on its own.
+ *
+ * Kept as its own export because it is the narrow question -- "which
+ * specifiers has Node no way to resolve" -- that the diagnostic was specified
+ * against, and it is the shape every rule of the heuristic is pinned by. The
+ * build itself calls the combined function so each emitted file is scanned
+ * once.
+ *
+ * @param {string} fileContent
+ * @param {object} [options]
+ * @param {boolean} [options.dynamicOnly]
+ * @returns {string[]}
+ */
+export function scanExtensionlessEsmImports(fileContent, options) {
+  return scanUnresolvableRelativeImports(fileContent, options).extensionless
+}
+
+/**
+ * Find output paths claimed by more than one source file. Two sources writing
+ * the same output means one silently overwrites the other in the build
+ * directory, so the caller can report it instead of shipping whichever won.
+ *
+ * A file that is both compiled and copied from the *same* source path (a
+ * handler that the sweep also selected) is not a collision: it is one file
+ * written once. Sources are therefore deduplicated per output before counting.
+ *
+ * @param {string[]} compileFiles
+ * @param {string[]} copyFiles
+ * @returns {Array<{ output: string, sources: string[] }>}
+ */
+export function detectOutputCollisions(compileFiles, copyFiles) {
+  const sourcesByOutput = new Map()
+  const record = (rawSource) => {
+    // Normalized here too: this function is also reachable directly, and an
+    // un-normalized source would compare unequal to its swept twin and hide
+    // the very clash it exists to find.
+    const source = toSweptPath(rawSource)
+    const output = outputPathFor(source)
+    if (!sourcesByOutput.has(output)) sourcesByOutput.set(output, new Set())
+    sourcesByOutput.get(output).add(source)
+  }
+  compileFiles.forEach(record)
+  copyFiles.forEach(record)
+  return [...sourcesByOutput.entries()]
+    .filter(([, sources]) => sources.size > 1)
+    .map(([output, sources]) => ({ output, sources: [...sources] }))
+}

--- a/packages/serverless/lib/plugins/esbuild/project-sweep.js
+++ b/packages/serverless/lib/plugins/esbuild/project-sweep.js
@@ -169,9 +169,10 @@ export function nearestPackageJsonType(
  * @param {string[]} [options.layerPaths] layer source directories, service-relative
  * @param {string|null} [options.localPluginPath] `plugins.localPath`, service-relative
  * @param {string[]} [options.additionalExclusions] further globs to negate ahead
- *   of the user patterns -- classic's `defaultExcludes` and the `useDotenv`
- *   `.env*` rule, which are decided from the serverless instance and so cannot
- *   be hard-coded here
+ *   of the user patterns -- classic's `defaultExcludes` and the `.env*` rule,
+ *   which are decided from the serverless instance and so cannot be hard-coded
+ *   here. Plain globs only: every entry is negated, so a `!`-prefixed entry
+ *   would double-negate and match everything but that path
  * @param {string[]} [options.additionalIgnores] further globs that are never
  *   swept and that no pattern can re-include -- the `--package` directory,
  *   which holds the previous run's artifact and build directory the same way
@@ -254,19 +255,8 @@ export async function sweepProjectFiles({
   // against the full list once, rather than matching every file against every
   // pattern. On a 50k-file service that is the difference between ~840ms and
   // ~110ms.
-  //
-  // An exclusion already carrying a `!` prefix is inverted into a re-include
-  // rather than negated again, exactly as classic does with its exclude list
-  // (`resolveFilePathsFromPatterns`). Double negation is not a no-op here:
-  // `!!keep.js` compiles to the negated micromatch pattern `!keep.js`, which
-  // matches every path EXCEPT `keep.js` and would empty the whole sweep.
   return filterPaths(
-    compilePatterns([
-      ...exclusionGlobs.map((glob) =>
-        glob.startsWith('!') ? glob.slice(1) : `!${glob}`,
-      ),
-      ...patterns,
-    ]),
+    compilePatterns([...exclusionGlobs.map((glob) => `!${glob}`), ...patterns]),
     all,
   )
 }

--- a/packages/serverless/lib/plugins/package/lib/package-service.js
+++ b/packages/serverless/lib/plugins/package/lib/package-service.js
@@ -35,7 +35,7 @@ const SERVERLESS_CONFIG_EXTENSIONS = [
  * and excludes those. If the value already carries an extension, it is used
  * verbatim.
  */
-function resolveServerlessConfigFileExcludes(serverless) {
+export function resolveServerlessConfigFileExcludes(serverless) {
   const base = serverless.configurationFilename
   if (!base) return []
 

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -71,6 +71,7 @@
     "filesize": "^11.0.22",
     "fs-extra": "^11.4.0",
     "get-stdin": "^9.0.0",
+    "get-tsconfig": "^4.14.1",
     "glob": "^13.0.6",
     "globby": "^14.1.0",
     "graphql": "^16.14.2",

--- a/packages/serverless/test/unit/lib/plugins/esbuild/build-dedup.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/build-dedup.test.js
@@ -82,7 +82,14 @@ describe('esbuild shared-handler build dedup', () => {
 
   beforeEach(() => {
     buildMock.mockReset()
-    buildMock.mockResolvedValue({})
+    // A successful esbuild call writes its outfile, and the plugin now records
+    // only artifacts that are actually on disk, so a mock that resolves
+    // without writing anything would misrepresent success.
+    buildMock.mockImplementation(async ({ outfile }) => {
+      fs.mkdirSync(path.dirname(outfile), { recursive: true })
+      fs.writeFileSync(outfile, '// built by the esbuild mock\n')
+      return {}
+    })
   })
 
   afterEach(() => {
@@ -214,7 +221,7 @@ describe('esbuild shared-handler build dedup', () => {
     expect([...plugin.serverless.builtFunctions]).toEqual(['getItems'])
   })
 
-  test('no buildable handler files resolves without throwing and does not build', async () => {
+  test('no buildable handler files fails with a diagnosable error and does not build', async () => {
     // Handler points at a file that doesn't exist on disk (e.g. missing file
     // or a typo'd path), so `_extensionForFunction` returns undefined for
     // every candidate and `buildGroups` ends up empty. Pre-fix, falling
@@ -222,14 +229,22 @@ describe('esbuild shared-handler build dedup', () => {
     // with `buildConcurrency` unset computed `pLimit(0)`, which throws
     // `TypeError: Expected concurrency to be a number from 1 and up` outside
     // the try/catch (bypassing both ESBULD_BUILD_ERROR wrapping and the
-    // dev-mode swallow). This should be a clean no-op instead.
+    // dev-mode swallow).
+    //
+    // It must still not reach `pLimit`/`esbuild.build`, but the outcome is no
+    // longer a silent no-op: skipping the function shipped a zip with no
+    // handler in it (#12970), so the empty-group case now raises the same
+    // named error as a build that leaves a function unbuilt.
     const serviceDir = makeServiceDir({})
     const functions = {
       missing: { handler: 'does/not/exist.handler' },
     }
     const plugin = makePlugin(serviceDir, functions)
 
-    await expect(plugin._build()).resolves.toBeUndefined()
+    await expect(plugin._build()).rejects.toMatchObject({
+      name: 'ServerlessError',
+      code: 'ESBUILD_HANDLER_NOT_BUILT',
+    })
 
     expect(buildMock).not.toHaveBeenCalled()
   })

--- a/packages/serverless/test/unit/lib/plugins/esbuild/build-dir-packaging.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/build-dir-packaging.test.js
@@ -1,0 +1,2312 @@
+/**
+ * `.serverless/build` is the authoritative source for the deployment artifact,
+ * so it must not accumulate outputs from earlier builds: a handler that was
+ * renamed or deleted would otherwise keep shipping forever.
+ *
+ * `_resetBuildDir` wipes the directory before each deploy/package build, with
+ * two deliberate exceptions:
+ *   - `node_modules` and the lockfiles are NOT esbuild outputs. They are
+ *     produced by the dependency install step and re-creating them cold on
+ *     every deploy is a multi-second regression.
+ *   - dev mode (`_build('originalHandler')`) must keep the last-good outputs
+ *     so a failed incremental rebuild doesn't leave the dev loop with nothing
+ *     to serve.
+ */
+
+import { jest } from '@jest/globals'
+import { ZipArchive } from 'archiver'
+import crypto from 'crypto'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import JsZip from 'jszip'
+import { log } from '@serverless/util'
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+// `log.get` is a memoized singleton, so this is the same logger instance the
+// plugin holds — spying here intercepts its calls.
+const esbuildLogger = log.get('esbuild')
+
+const createdServiceDirs = []
+
+afterAll(() => {
+  for (const dir of createdServiceDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+/**
+ * `realpathSync` because macOS resolves the temp dir through a symlink
+ * (`/var` -> `/private/var`), and esbuild reports real paths -- an unresolved
+ * prefix makes `outbase` fail to match the entry points, which collapses the
+ * built layout into the build root and breaks every path comparison downstream
+ * of a real build.
+ */
+function makeTempDir() {
+  const serviceDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-reset-')),
+  )
+  createdServiceDirs.push(serviceDir)
+  return serviceDir
+}
+
+function makeServiceDir() {
+  const serviceDir = makeTempDir()
+  const buildDir = path.join(serviceDir, '.serverless', 'build')
+  fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep'), { recursive: true })
+  fs.writeFileSync(path.join(buildDir, 'node_modules', 'dep', 'index.js'), 'x')
+  fs.writeFileSync(path.join(buildDir, 'stale-output.js'), 'stale')
+  fs.writeFileSync(path.join(buildDir, 'package-lock.json'), '{}')
+  return { serviceDir, buildDir }
+}
+
+// A service whose only source file is `src/handler.ts` exporting `hello`.
+function makeTsServiceDir() {
+  const serviceDir = makeTempDir()
+  fs.mkdirSync(path.join(serviceDir, 'src'), { recursive: true })
+  fs.writeFileSync(
+    path.join(serviceDir, 'src', 'handler.ts'),
+    'export const hello = async (): Promise<object> => ({ statusCode: 200 })\n',
+  )
+  return { serviceDir }
+}
+
+function makeServerless(serviceDir, fns = {}, esbuild = { bundle: false }) {
+  return {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'svc',
+      provider: { runtime: 'nodejs20.x' },
+      package: {},
+      build: { esbuild },
+      functions: fns,
+      getFunction: (n) => fns[n],
+      getAllFunctions: () => Object.keys(fns),
+    },
+    pluginManager: { spawn: async () => {} },
+  }
+}
+
+// Write `{ relativePath: contents }` under `root`, creating parent directories.
+function writeFiles(root, files) {
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const filePath = path.join(root, ...relativePath.split('/'))
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+}
+
+// A service directory whose `.serverless/build` already holds `buildFiles`,
+// as if `_build` + `_preparePackageJson` had just run.
+function seedBuildDir(buildFiles, serviceFiles = {}) {
+  const serviceDir = makeTempDir()
+  const buildDir = path.join(serviceDir, '.serverless', 'build')
+  fs.mkdirSync(buildDir, { recursive: true })
+  writeFiles(buildDir, buildFiles)
+  writeFiles(serviceDir, serviceFiles)
+  return { serviceDir, buildDir }
+}
+
+/**
+ * Entry names straight out of the zip central directory, in stored order and
+ * WITH duplicates. `JsZip.loadAsync` keys its `files` object by name, so a
+ * doubly-appended entry is invisible there — which is exactly what the
+ * node_modules double-add regression would look like.
+ */
+function centralDirectoryNames(artifactPath) {
+  const buffer = fs.readFileSync(artifactPath)
+  let eocd = buffer.length - 22
+  while (eocd >= 0 && buffer.readUInt32LE(eocd) !== 0x06054b50) eocd -= 1
+  if (eocd < 0) throw new Error('not a zip file')
+  const count = buffer.readUInt16LE(eocd + 10)
+  let offset = buffer.readUInt32LE(eocd + 16)
+  const names = []
+  for (let i = 0; i < count; i += 1) {
+    const nameLength = buffer.readUInt16LE(offset + 28)
+    const extraLength = buffer.readUInt16LE(offset + 30)
+    const commentLength = buffer.readUInt16LE(offset + 32)
+    names.push(buffer.toString('utf8', offset + 46, offset + 46 + nameLength))
+    offset += 46 + nameLength + extraLength + commentLength
+  }
+  return names
+}
+
+async function zipEntries(artifactPath) {
+  const zip = await JsZip.loadAsync(fs.readFileSync(artifactPath))
+  return zip.files
+}
+
+const sha256 = (filePath) =>
+  crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+
+const serviceArtifact = (serviceDir) =>
+  path.join(serviceDir, '.serverless', 'svc.zip')
+
+const functionArtifact = (serviceDir, alias) =>
+  path.join(serviceDir, '.serverless', `svc-${alias}.zip`)
+
+describe('_resetBuildDir', () => {
+  it('removes stale outputs but preserves node_modules and lockfiles', async () => {
+    const { serviceDir, buildDir } = makeServiceDir()
+    const plugin = new Esbuild(makeServerless(serviceDir), {})
+    await plugin._resetBuildDir()
+    expect(fs.existsSync(path.join(buildDir, 'stale-output.js'))).toBe(false)
+    expect(
+      fs.existsSync(path.join(buildDir, 'node_modules', 'dep', 'index.js')),
+    ).toBe(true)
+    expect(fs.existsSync(path.join(buildDir, 'package-lock.json'))).toBe(true)
+    expect(fs.existsSync(buildDir)).toBe(true) // dir recreated/kept
+  })
+
+  it('creates the build dir when absent', async () => {
+    const serviceDir = makeTempDir()
+    const plugin = new Esbuild(makeServerless(serviceDir), {})
+    await plugin._resetBuildDir()
+    expect(fs.existsSync(path.join(serviceDir, '.serverless', 'build'))).toBe(
+      true,
+    )
+  })
+
+  it('fails loudly when the build dir cannot be reset', async () => {
+    // The predecessor (`_cleanUp`) swallowed every error, so a build dir that
+    // could not be cleared silently shipped stale artifacts. Force a failure by
+    // making `.serverless` a regular FILE: `mkdir` of `.serverless/build` then
+    // fails with ENOTDIR on every platform, no fs mocking required.
+    const serviceDir = makeTempDir()
+    fs.writeFileSync(path.join(serviceDir, '.serverless'), 'not a directory')
+    const plugin = new Esbuild(makeServerless(serviceDir), {})
+
+    await expect(plugin._resetBuildDir()).rejects.toMatchObject({
+      name: 'ServerlessError',
+      code: 'ESBUILD_BUILD_DIR_RESET_FAILED',
+    })
+  })
+
+  it('constructs without a service dir', () => {
+    // The plugin is instantiated on every CLI invocation, including ones run
+    // outside a service (`serverless create`), where `config.serviceDir` is
+    // null. Capturing the build dir eagerly must not crash those.
+    const serverless = makeServerless(null)
+    expect(() => new Esbuild(serverless, {})).not.toThrow()
+  })
+})
+
+describe('_build resets the build dir only off the dev path', () => {
+  jest.setTimeout(30_000)
+
+  const handlerSource =
+    'export const hello = async () => ({ statusCode: 200 })\n'
+
+  it('wipes stale outputs on the deploy/package path', async () => {
+    const { serviceDir, buildDir } = makeServiceDir()
+    fs.writeFileSync(path.join(serviceDir, 'handler.js'), handlerSource)
+    const fns = { hello: { handler: 'handler.hello' } }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+    plugin.functions = async () => fns
+
+    await plugin._build()
+
+    expect(fs.existsSync(path.join(buildDir, 'stale-output.js'))).toBe(false)
+    expect(fs.existsSync(path.join(buildDir, 'handler.js'))).toBe(true)
+  })
+
+  it('keeps previous outputs on the dev-mode path', async () => {
+    const { serviceDir, buildDir } = makeServiceDir()
+    fs.writeFileSync(path.join(serviceDir, 'handler.js'), handlerSource)
+    const fns = { hello: { originalHandler: 'handler.hello' } }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+    plugin.functions = async () => fns
+
+    await plugin._build('originalHandler')
+
+    expect(fs.existsSync(path.join(buildDir, 'stale-output.js'))).toBe(true)
+    expect(fs.existsSync(path.join(buildDir, 'handler.js'))).toBe(true)
+  })
+})
+
+/**
+ * Packaging must never re-derive where a handler was emitted: the build knows
+ * the exact outfile, so it records it. And a function esbuild was asked to
+ * build but whose handler file it could not resolve used to be skipped in
+ * silence, shipping a zip with no handler in it (#12970) — it now fails the
+ * build.
+ */
+describe('_build bookkeeping', () => {
+  jest.setTimeout(30_000)
+
+  it('records emitted artifact paths per alias', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const fns = { hello: { handler: 'src/handler.hello' } }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._build()
+
+    expect(plugin.builtArtifacts.get('hello')).toEqual({
+      outfile: 'src/handler.js',
+      mapfile: 'src/handler.js.map',
+    })
+  })
+
+  it('records the same artifact for every alias sharing a handler file', async () => {
+    // The build is deduplicated per handler FILE, but the recording is
+    // per-alias: a group member that never had its own esbuild call must
+    // still be able to say where its artifact lives.
+    const { serviceDir } = makeTsServiceDir()
+    fs.appendFileSync(
+      path.join(serviceDir, 'src', 'handler.ts'),
+      'export const bye = async (): Promise<object> => ({ statusCode: 204 })\n',
+    )
+    const fns = {
+      hello: { handler: 'src/handler.hello' },
+      bye: { handler: 'src/handler.bye' },
+    }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._build()
+
+    expect(plugin.builtArtifacts.get('bye')).toEqual({
+      outfile: 'src/handler.js',
+      mapfile: 'src/handler.js.map',
+    })
+  })
+
+  it('records artifacts when bundling too', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const fns = { hello: { handler: 'src/handler.hello' } }
+    const plugin = new Esbuild(
+      makeServerless(serviceDir, fns, { bundle: true }),
+      {},
+    )
+
+    await plugin._build()
+
+    expect(plugin.builtArtifacts.get('hello')).toEqual({
+      outfile: 'src/handler.js',
+      mapfile: 'src/handler.js.map',
+    })
+  })
+
+  it('records a null mapfile when no sourcemap is emitted', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const fns = { hello: { handler: 'src/handler.hello' } }
+    const plugin = new Esbuild(
+      makeServerless(serviceDir, fns, { bundle: false, sourcemap: false }),
+      {},
+    )
+
+    await plugin._build()
+
+    expect(plugin.builtArtifacts.get('hello')).toEqual({
+      outfile: 'src/handler.js',
+      mapfile: null,
+    })
+  })
+
+  it('starts from a clean slate on every build', async () => {
+    // Dev mode rebuilds through the same instance; a Map that accumulated
+    // across builds would keep reporting artifacts for deleted functions.
+    const { serviceDir } = makeTsServiceDir()
+    const fns = { hello: { handler: 'src/handler.hello' } }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._build()
+    const first = plugin.builtArtifacts
+    await plugin._build()
+
+    expect(plugin.builtArtifacts).not.toBe(first)
+    expect([...plugin.builtArtifacts.keys()]).toEqual(['hello'])
+  })
+
+  it('throws ESBUILD_HANDLER_NOT_BUILT when an approved handler file does not exist', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const fns = { ghost: { handler: 'src/missing.handler' } }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(plugin._build()).rejects.toMatchObject({
+      name: 'ServerlessError',
+      code: 'ESBUILD_HANDLER_NOT_BUILT',
+    })
+  })
+
+  it('names only the unresolvable function when others build fine', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const fns = {
+      hello: { handler: 'src/handler.hello' },
+      ghost: { handler: 'src/missing.handler' },
+    }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    const error = await plugin._build().then(
+      () => undefined,
+      (err) => err,
+    )
+
+    expect(error?.code).toBe('ESBUILD_HANDLER_NOT_BUILT')
+    expect(error.message).toContain('"ghost" (handler: src/missing.handler)')
+    expect(error.message).not.toContain('"hello"')
+    // The message must name what was actually probed, or it sends people
+    // hunting for a file extension the plugin never looks for.
+    for (const extension of [
+      '.js',
+      '.ts',
+      '.cjs',
+      '.mjs',
+      '.cts',
+      '.mts',
+      '.jsx',
+      '.tsx',
+    ]) {
+      expect(error.message).toContain(extension)
+    }
+  })
+
+  it('ignores functions esbuild was never asked to build', async () => {
+    // Image/docker functions have no `handler` at all, and a function with a
+    // prebuilt `package.artifact` is packaged as-is. Neither is approved by
+    // `_shouldBuildFunction`, so neither may trip the assertion — note the
+    // artifact function deliberately points at a nonexistent handler file.
+    const { serviceDir } = makeTsServiceDir()
+    const fns = {
+      hello: { handler: 'src/handler.hello' },
+      docker: { image: 'account.dkr.ecr.us-east-1.amazonaws.com/repo:tag' },
+      prebuilt: {
+        handler: 'src/nowhere.handler',
+        package: { artifact: 'prebuilt.zip' },
+      },
+    }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect([...plugin.builtArtifacts.keys()]).toEqual(['hello'])
+  })
+
+  it('does not assert on the dev-mode path', async () => {
+    // Dev mode swallows build failures by design so the dev loop keeps
+    // serving; a missing handler there must not abort it either.
+    const { serviceDir } = makeTsServiceDir()
+    const fns = { ghost: { originalHandler: 'src/missing.handler' } }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(plugin._build('originalHandler')).resolves.toBeUndefined()
+  })
+
+  it('records nothing when esbuild is configured not to write the outfile', async () => {
+    // A configFile merging `write: false` makes esbuild return the output in
+    // memory and touch nothing on disk. Recording the path we asked for would
+    // hand packaging a phantom artifact that satisfies the assertion, so the
+    // outfile has to be probed, not assumed.
+    const { serviceDir } = makeTsServiceDir()
+    fs.writeFileSync(
+      path.join(serviceDir, 'esbuild.config.mjs'),
+      'export default () => ({ write: false })\n',
+    )
+    const fns = { hello: { handler: 'src/handler.hello' } }
+    const plugin = new Esbuild(
+      makeServerless(serviceDir, fns, {
+        bundle: false,
+        configFile: './esbuild.config.mjs',
+      }),
+      {},
+    )
+
+    await expect(plugin._build()).rejects.toMatchObject({
+      code: 'ESBUILD_HANDLER_NOT_BUILT',
+    })
+
+    expect(plugin.builtArtifacts.size).toBe(0)
+  })
+})
+
+/**
+ * A handler string does not have to point at a file in the service directory:
+ * the Datadog and New Relic wrappers point at a path inside a Lambda layer
+ * (`/opt/nodejs/node_modules/datadog-lambda-js/handler.datadog`) that only
+ * exists at runtime. Those configs deploy and work, so they must not be
+ * treated as the #12970 typo case.
+ */
+describe('_build unresolvable handlers with layers', () => {
+  jest.setTimeout(30_000)
+
+  let warnSpy
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(esbuildLogger, 'warning').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  const datadogHandler =
+    '/opt/nodejs/node_modules/datadog-lambda-js/handler.datadog'
+
+  it('warns instead of throwing when the function configures layers', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const fns = {
+      wrapped: {
+        handler: datadogHandler,
+        layers: [
+          'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node20-x:1',
+        ],
+      },
+    }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect(plugin.builtArtifacts.has('wrapped')).toBe(false)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toMatch(/provided by a Lambda layer/)
+    expect(warnSpy.mock.calls[0][0]).toContain('"wrapped"')
+  })
+
+  it('warns instead of throwing when only the provider configures layers', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const fns = { wrapped: { handler: datadogHandler } }
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.provider.layers = [
+      'arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node20-x:1',
+    ]
+    const plugin = new Esbuild(serverless, {})
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits a single aggregated warning for several layer-provided handlers', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const layers = ['arn:aws:lambda:us-east-1:1234567890:layer:wrapper:1']
+    const fns = {
+      hello: { handler: 'src/handler.hello', layers },
+      wrappedA: { handler: datadogHandler, layers },
+      wrappedB: { handler: 'newrelic-lambda-wrapper.handler', layers },
+    }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect([...plugin.builtArtifacts.keys()]).toEqual(['hello'])
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('"wrappedA"')
+    expect(warnSpy.mock.calls[0][0]).toContain('"wrappedB"')
+  })
+
+  it('still throws for a layerless function alongside a layer-provided one', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const fns = {
+      wrapped: {
+        handler: datadogHandler,
+        layers: ['arn:aws:lambda:us-east-1:1234567890:layer:wrapper:1'],
+      },
+      typo: { handler: 'src/hanlder.hello' },
+    }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    const error = await plugin._build().then(
+      () => undefined,
+      (err) => err,
+    )
+
+    expect(error?.code).toBe('ESBUILD_HANDLER_NOT_BUILT')
+    expect(error.message).toContain('"typo"')
+    expect(error.message).not.toContain('"wrapped"')
+    // The escape hatch the message advertises has to be a real one.
+    expect(error.message).toContain('build: false')
+    // The layer-provided function is still reported, just not fatally.
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('excludes a function with build: false entirely', async () => {
+    // Neither built nor asserted on nor warned about — the documented way out
+    // for a handler esbuild should keep its hands off.
+    const { serviceDir } = makeTsServiceDir()
+    const fns = {
+      hello: { handler: 'src/handler.hello' },
+      wrapped: { handler: datadogHandler, build: false },
+    }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect([...plugin.builtArtifacts.keys()]).toEqual(['hello'])
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('_shouldBuildFunction opt-outs', () => {
+  it('treats function-level build: false as an opt-out even when the provider enables esbuild', async () => {
+    // `false` is falsy, so it used to fall straight through the
+    // `functionBuildParam` checks into the provider-level default and build
+    // the function anyway — there was no per-function way out.
+    const { serviceDir } = makeTsServiceDir()
+    const plugin = new Esbuild(
+      makeServerless(serviceDir, {
+        optedOut: { handler: 'src/handler.hello', build: false },
+      }),
+      {},
+    )
+
+    expect(
+      await plugin._shouldBuildFunction({
+        handler: 'src/handler.hello',
+        build: false,
+      }),
+    ).toBe(false)
+    expect(await plugin.functions()).toEqual({})
+  })
+
+  it('still builds a function whose build is set to esbuild', async () => {
+    const { serviceDir } = makeTsServiceDir()
+    const plugin = new Esbuild(makeServerless(serviceDir, {}), {})
+
+    expect(
+      await plugin._shouldBuildFunction({
+        handler: 'src/handler.hello',
+        build: 'esbuild',
+      }),
+    ).toBe(true)
+  })
+})
+
+/**
+ * The build directory is the artifact definition: whatever `_build`,
+ * `_preparePackageJson` and any `esbuild-package` plugin leave in there is
+ * what deploys. The predecessor hand-picked a handler, its sourcemap, the
+ * package.json and the lockfiles, so anything an esbuild plugin emitted
+ * alongside the bundle — templates, locale JSON, WASM, native `.node` binaries
+ * — was silently dropped (#13163).
+ */
+describe('_packageAll build-dir sweep', () => {
+  jest.setTimeout(30_000)
+
+  const fns = { hello: { handler: 'src/handler.hello' } }
+
+  it('ships every build-dir file including plugin-emitted assets', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'export const hello = () => {}\n',
+      'src/handler.js.map': '{}\n',
+      'src/locales/en.json': '{"hi":"hi"}\n',
+      'package.json': '{"name":"svc"}\n',
+      'package-lock.json': '{}\n',
+      'node_modules/dep/index.js': 'module.exports = 1\n',
+    })
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._packageAll(fns)
+
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'src/handler.js',
+        'src/handler.js.map',
+        'src/locales/en.json',
+        'package.json',
+        'package-lock.json',
+        'node_modules/dep/index.js',
+      ]),
+    )
+  })
+
+  it('does not ship the pnpm workspace file copied in for the install', async () => {
+    // `_preparePackageJson` copies `pnpm-workspace.yaml` into the build
+    // directory so that the install puts node_modules there. It is the
+    // install's scaffolding, and no earlier release packaged it.
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'export const hello = () => {}\n',
+      'package.json': '{"name":"svc"}\n',
+      'pnpm-lock.yaml': 'lockfileVersion: 9\n',
+      'pnpm-workspace.yaml': 'packages: []\n',
+    })
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._packageAll(fns)
+
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names).toContain('pnpm-lock.yaml')
+    expect(names).not.toContain('pnpm-workspace.yaml')
+  })
+
+  it('ships the pnpm workspace file when a positive pattern names it', async () => {
+    // Package-manager internals are default exclusions, not a hard rule:
+    // like every other default exclusion a positive pattern gets the last
+    // word, on the service-level path as much as the per-function one.
+    const { serviceDir } = seedBuildDir(
+      {
+        'src/handler.js': 'export const hello = () => {}\n',
+        'package.json': '{"name":"svc"}\n',
+        'pnpm-workspace.yaml': 'packages: []\n',
+      },
+      { 'pnpm-workspace.yaml': 'packages: []\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['pnpm-workspace.yaml']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(centralDirectoryNames(serviceArtifact(serviceDir))).toContain(
+      'pnpm-workspace.yaml',
+    )
+  })
+
+  it('re-includes only the pattern-claimed files under an excluded root, not the install residue beside them', async () => {
+    // `.yarn/cache` is what a Yarn Berry install leaves in the build directory;
+    // `.yarn/releases/yarn.cjs` is a file the service deliberately ships. The
+    // pattern re-includes the latter and nothing else under `.yarn`.
+    const { serviceDir } = seedBuildDir(
+      {
+        'src/handler.js': 'export const hello = () => {}\n',
+        'package.json': '{"name":"svc"}\n',
+        '.yarn/cache/dep.zip': 'PK\n',
+      },
+      { '.yarn/releases/yarn.cjs': 'module.exports = 1\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['.yarn/releases/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names).toContain('.yarn/releases/yarn.cjs')
+    expect(names).not.toContain('.yarn/cache/dep.zip')
+  })
+
+  it('ships an asset an esbuild-package plugin emitted, after a real build', async () => {
+    // The regression in full: a real bundling build, then a plugin dropping an
+    // asset next to the bundle from the `esbuild-package` hook. The handpicked
+    // file list never looked at it.
+    const { serviceDir } = makeTsServiceDir()
+    const buildDir = path.join(serviceDir, '.serverless', 'build')
+    const realFns = { hello: { handler: 'src/handler.hello' } }
+    const serverless = makeServerless(serviceDir, realFns, { bundle: true })
+    serverless.pluginManager = {
+      spawn: async () => {
+        writeFiles(buildDir, { 'src/locales/en.json': '{"hi":"hi"}\n' })
+      },
+    }
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._build()
+    await plugin._package()
+
+    // The build really did record where it wrote the handler, so the post-zip
+    // assertion ran against real bookkeeping rather than a seeded map.
+    expect(plugin.builtArtifacts.get('hello').outfile).toBe('src/handler.js')
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names).toContain('src/handler.js')
+    expect(names).toContain('src/locales/en.json')
+  })
+
+  it('excludes build metadata and never double-adds node_modules', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'meta.json': '{}\n',
+      'meta.tscjs.json': '{}\n',
+      '.pnp.cjs': 'pnp\n',
+      '.pnp.loader.mjs': 'pnp\n',
+      '.yarn/cache/dep.zip': 'zip\n',
+      'node_modules/dep/index.js': 'module.exports = 1\n',
+    })
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._packageAll(fns)
+
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names.filter((n) => n.startsWith('meta.'))).toEqual([])
+    expect(names).not.toContain('.pnp.cjs')
+    expect(names).not.toContain('.pnp.loader.mjs')
+    expect(names.filter((n) => n.startsWith('.yarn'))).toEqual([])
+    expect(names.filter((n) => n === 'node_modules/dep/index.js')).toHaveLength(
+      1,
+    )
+  })
+
+  it('keeps a meta.json the service itself owns', async () => {
+    // `meta.*.json` at the build-dir root is esbuild's metafile. Under
+    // `bundle: false` the project sweep also copies the service's own files in,
+    // so the name is only build metadata when the service has no file of its
+    // own claiming it.
+    const { serviceDir } = seedBuildDir(
+      { 'src/handler.js': 'x\n', 'meta.json': '{"mine":true}\n' },
+      { 'meta.json': '{"mine":true}\n' },
+    )
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._packageAll(fns)
+
+    expect(centralDirectoryNames(serviceArtifact(serviceDir))).toContain(
+      'meta.json',
+    )
+  })
+
+  it('appends entries in byte-wise sorted order', async () => {
+    // Two independent traps, because either one alone lets a broken sort pass.
+    //
+    // Volume: more files than archiver's internal stat queue runs at once (4).
+    // An entry appended without its stats is re-queued when its stat resolves,
+    // so the stored order becomes whatever order the filesystem answered in.
+    //
+    // Shape: `a.txt` vs `a/b.txt`. Byte-wise `.` (0x2e) sorts before `/`
+    // (0x2f), so `a.txt` comes FIRST — but the walk is depth-first, so it can
+    // only ever emit `a/b.txt` before or after the whole `a.txt` entry
+    // depending on which way readdir happens to order `a` and `a.txt`. Whatever
+    // that order is, one of the two pairs here contradicts it, so an
+    // unsorted walk cannot accidentally match the expectation.
+    const buildFiles = {
+      'a.txt': 'a\n',
+      'a/b.txt': 'b\n',
+      'z.txt': 'z\n',
+      'z/deep.txt': 'deep\n',
+      'src/handler.js': 'x\n',
+      'package.json': '{}\n',
+    }
+    for (let i = 0; i < 80; i += 1) {
+      buildFiles[`assets/${String(i).padStart(3, '0')}.txt`] = `${i}\n`
+    }
+    const { serviceDir } = seedBuildDir(buildFiles)
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._packageAll(fns)
+
+    // The expectation is computed from the known file set, not from the
+    // archive's own output, so this compares the stored order against the
+    // contract rather than against itself.
+    const expected = Object.keys(buildFiles).sort()
+    const names = centralDirectoryNames(serviceArtifact(serviceDir)).filter(
+      (n) => !n.startsWith('node_modules'),
+    )
+    expect(names).toEqual(expected)
+  })
+
+  it('produces byte-identical zips across rebuilds with shuffled write order and differing file modes', async () => {
+    // `check-for-changes` hashes the raw zip bytes, so a reordered walk or a
+    // stray group-writable bit must not force a redeploy.
+    const files = {
+      'src/handler.js': 'export const hello = () => {}\n',
+      'assets/a.txt': 'a\n',
+      'assets/z.txt': 'z\n',
+      'package.json': '{"name":"svc"}\n',
+    }
+    const build = async (order, mode) => {
+      const { serviceDir, buildDir } = seedBuildDir({})
+      for (const name of order) writeFiles(buildDir, { [name]: files[name] })
+      fs.chmodSync(path.join(buildDir, 'assets', 'a.txt'), mode)
+      const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+      await plugin._packageAll(fns)
+      return sha256(serviceArtifact(serviceDir))
+    }
+
+    const forward = await build(Object.keys(files), 0o644)
+    const shuffled = await build([...Object.keys(files)].reverse(), 0o664)
+
+    expect(shuffled).toBe(forward)
+  })
+
+  it('forces 0644 on regular files and 0755 on executable ones', async () => {
+    const { serviceDir, buildDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'bin/tool.sh': '#!/bin/sh\n',
+    })
+    fs.chmodSync(path.join(buildDir, 'src', 'handler.js'), 0o664)
+    fs.chmodSync(path.join(buildDir, 'bin', 'tool.sh'), 0o755)
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._packageAll(fns)
+
+    const entries = await zipEntries(serviceArtifact(serviceDir))
+    // `unixPermissions` carries the file-type bits (S_IFREG) alongside the
+    // permission bits, so compare the permission bits only.
+    const expected = process.platform === 'win32' ? 0o755 : 0o644
+    expect(entries['src/handler.js'].unixPermissions & 0o777).toBe(expected)
+    expect(entries['bin/tool.sh'].unixPermissions & 0o777).toBe(0o755)
+  })
+
+  it('forces node_modules entry modes too, directories included', async () => {
+    // These entries come from the node_modules walk, which reads the mode off
+    // the filesystem — so without normalization the same dependency tree
+    // installed under a different umask hashes differently.
+    const { serviceDir, buildDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'node_modules/dep/index.js': 'module.exports = 1\n',
+    })
+    fs.chmodSync(path.join(buildDir, 'node_modules', 'dep', 'index.js'), 0o664)
+    fs.chmodSync(path.join(buildDir, 'node_modules', 'dep'), 0o775)
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._packageAll(fns)
+
+    const entries = await zipEntries(serviceArtifact(serviceDir))
+    const expected = process.platform === 'win32' ? 0o755 : 0o644
+    expect(entries['node_modules/dep/index.js'].unixPermissions & 0o777).toBe(
+      expected,
+    )
+    expect(entries['node_modules/dep/'].unixPermissions & 0o777).toBe(0o755)
+  })
+
+  it('writes a valid archive when nothing was built', async () => {
+    // Every function's handler lives in a Lambda layer, so the build emitted
+    // nothing. The zip must still be a zip.
+    const { serviceDir } = seedBuildDir({})
+    const plugin = new Esbuild(makeServerless(serviceDir, {}), {})
+
+    await plugin._packageAll({})
+
+    expect(centralDirectoryNames(serviceArtifact(serviceDir))).toEqual([])
+  })
+
+  it('lets service patterns slim node_modules', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'node_modules/keep/index.js': 'keep\n',
+      'node_modules/drop/index.js': 'drop\n',
+    })
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!node_modules/drop/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names).toContain('node_modules/keep/index.js')
+    expect(names.filter((n) => n.startsWith('node_modules/drop'))).toEqual([])
+  })
+
+  it('pins node_modules entry dates even behind a pattern filter', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'node_modules/keep/index.js': 'keep\n',
+    })
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!node_modules/drop/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    const entries = await zipEntries(serviceArtifact(serviceDir))
+    expect(entries['node_modules/keep/index.js'].date.getFullYear()).toBe(1980)
+  })
+
+  it('fails loudly when a built handler is missing from the artifact', async () => {
+    const { serviceDir } = seedBuildDir({ 'package.json': '{}\n' })
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+    plugin.builtArtifacts = new Map([
+      ['hello', { outfile: 'src/handler.js', mapfile: null }],
+    ])
+
+    await expect(plugin._packageAll(fns)).rejects.toMatchObject({
+      name: 'ServerlessError',
+      code: 'ESBUILD_HANDLER_MISSING_FROM_ARTIFACT',
+    })
+  })
+
+  it('exempts layer-provided functions from the handler assertion', async () => {
+    // `_assertAllHandlersBuilt` already warned about these and let the build
+    // through; they have no outfile, so there is nothing to assert.
+    const { serviceDir } = seedBuildDir({ 'src/handler.js': 'x\n' })
+    const withWrapper = {
+      hello: { handler: 'src/handler.hello' },
+      wrapped: { handler: '/opt/nodejs/wrapper.handler' },
+    }
+    const plugin = new Esbuild(makeServerless(serviceDir, withWrapper), {})
+    plugin.builtArtifacts = new Map([
+      ['hello', { outfile: 'src/handler.js', mapfile: null }],
+    ])
+
+    await expect(plugin._packageAll(withWrapper)).resolves.toBeUndefined()
+  })
+})
+
+/**
+ * The zip is the only thing that reaches Lambda, so the shapes that decide what
+ * a non-bundled artifact must carry are pinned against a real build followed by
+ * real packaging, not against a seeded build directory.
+ */
+describe('_packageAll after a real non-bundled build', () => {
+  jest.setTimeout(30_000)
+
+  it('ships the nested package.json that classes the handler', async () => {
+    // `src/handler.js` was emitted as ESM because `src/package.json` says
+    // `"type": "module"`. Node repeats that lookup inside Lambda, so dropping
+    // the nested package.json from the artifact turns the handler into a
+    // CommonJS file full of `import` statements.
+    const serviceDir = makeTempDir()
+    writeFiles(serviceDir, {
+      'package.json': '{"name":"svc"}',
+      'src/package.json': '{"type":"module"}',
+      'src/handler.ts':
+        "import { helper } from './util.js'\n" +
+        'export const hello = async () => ({ body: helper() })\n',
+      'src/util.js': "export const helper = () => 'helped'\n",
+    })
+    const fns = { hello: { handler: 'src/handler.hello' } }
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await plugin._build()
+    await plugin._packageAll(fns)
+
+    expect(centralDirectoryNames(serviceArtifact(serviceDir))).toEqual([
+      'package.json',
+      'src/handler.js',
+      'src/handler.js.map',
+      'src/package.json',
+      'src/util.js',
+    ])
+  })
+
+  it('ships only the precompiled tree when patterns drop the sources', async () => {
+    // The `tsc`-then-deploy shape: the handler names the compiled output in
+    // `dist`, and `!src/**` is what keeps the TypeScript it came from out of
+    // the artifact instead of shipping the same code twice.
+    const serviceDir = makeTempDir()
+    writeFiles(serviceDir, {
+      'package.json': '{"name":"svc"}',
+      'tsconfig.json': '{"include":["src"]}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/util.ts': 'export const helper = () => 1\n',
+      'dist/handler.js': 'exports.hello = async () => ({})\n',
+      'dist/util.js': 'exports.helper = () => 1\n',
+    })
+    const fns = { hello: { handler: 'dist/handler.hello' } }
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!src/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._build()
+    await plugin._packageAll(fns)
+
+    expect(plugin.builtArtifacts.get('hello').outfile).toBe('dist/handler.js')
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names).toContain('dist/handler.js')
+    expect(names.filter((name) => name.startsWith('src/'))).toEqual([])
+  })
+})
+
+describe('_package individually', () => {
+  jest.setTimeout(30_000)
+
+  function makeIndividualPlugin(serviceDir, fns, bundle) {
+    const serverless = makeServerless(serviceDir, fns, { bundle })
+    serverless.service.package.individually = true
+    const plugin = new Esbuild(serverless, {})
+    plugin.functions = async () => fns
+    plugin._buildProperties = async () => ({ bundle })
+    return plugin
+  }
+
+  it('bundle:true — own handler stays, sibling outfiles are excluded, shared assets stay', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/a.js': 'a\n',
+      'src/a.js.map': '{}\n',
+      'src/b.js': 'b\n',
+      'src/b.js.map': '{}\n',
+      'shared/asset.txt': 'shared\n',
+      'package.json': '{}\n',
+    })
+    const fns = {
+      a: { handler: 'src/a.handler' },
+      b: { handler: 'src/b.handler' },
+    }
+    const plugin = makeIndividualPlugin(serviceDir, fns, true)
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: 'src/a.js.map' }],
+      ['b', { outfile: 'src/b.js', mapfile: 'src/b.js.map' }],
+    ])
+
+    await plugin._package()
+
+    const names = centralDirectoryNames(functionArtifact(serviceDir, 'a'))
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'src/a.js',
+        'src/a.js.map',
+        'shared/asset.txt',
+        'package.json',
+      ]),
+    )
+    expect(names).not.toContain('src/b.js')
+    expect(names).not.toContain('src/b.js.map')
+  })
+
+  it('bundle:true — a function-level negation cannot drop the generated package.json or lockfile', async () => {
+    // `!**/*.json` is a classic slimming idiom. Every earlier release built the
+    // per-function archive from a handpicked list that always carried the
+    // manifest; for a `"type": "module"` service emitting `.js`, that manifest
+    // is the only thing telling Lambda to load the handler as ESM, so losing it
+    // deploys a function that fails at initialization with no build-time
+    // diagnostic. Project files the negation matches are still dropped.
+    const { serviceDir } = seedBuildDir({
+      'src/a.js': 'export const handler = () => {}\n',
+      'src/a.js.map': '{}\n',
+      'src/fixture.json': '{}\n',
+      'package.json': '{"type":"module"}\n',
+      'package-lock.json': '{}\n',
+    })
+    const fns = {
+      a: { handler: 'src/a.handler', package: { patterns: ['!**/*.json'] } },
+    }
+    const plugin = makeIndividualPlugin(serviceDir, fns, true)
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: 'src/a.js.map' }],
+    ])
+
+    await plugin._package()
+
+    const names = centralDirectoryNames(functionArtifact(serviceDir, 'a'))
+    expect(names).toContain('package.json')
+    expect(names).toContain('package-lock.json')
+    expect(names).toContain('src/a.js')
+    expect(names).not.toContain('src/fixture.json')
+  })
+
+  it('bundle:true — functions sharing one handler file both keep it', async () => {
+    const { serviceDir } = seedBuildDir({ 'src/api.js': 'api\n' })
+    const fns = {
+      a: { handler: 'src/api.one' },
+      b: { handler: 'src/api.two' },
+    }
+    const plugin = makeIndividualPlugin(serviceDir, fns, true)
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/api.js', mapfile: null }],
+      ['b', { outfile: 'src/api.js', mapfile: null }],
+    ])
+
+    await plugin._package()
+
+    expect(centralDirectoryNames(functionArtifact(serviceDir, 'a'))).toContain(
+      'src/api.js',
+    )
+    expect(centralDirectoryNames(functionArtifact(serviceDir, 'b'))).toContain(
+      'src/api.js',
+    )
+  })
+
+  it('bundle:false — whole tree in every zip, per-function negations narrow', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/a.js': 'a\n',
+      'src/b.js': 'b\n',
+      'src/b-only/x.js': 'x\n',
+    })
+    const fns = {
+      a: {
+        handler: 'src/a.handler',
+        package: { patterns: ['!src/b-only/**'] },
+      },
+      b: { handler: 'src/b.handler' },
+    }
+    const plugin = makeIndividualPlugin(serviceDir, fns, false)
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+      ['b', { outfile: 'src/b.js', mapfile: null }],
+    ])
+
+    await plugin._package()
+
+    const aNames = centralDirectoryNames(functionArtifact(serviceDir, 'a'))
+    const bNames = centralDirectoryNames(functionArtifact(serviceDir, 'b'))
+    // Nothing is excluded for a non-bundled build: every function needs the
+    // whole tree because its imports are resolved at runtime.
+    expect(aNames).toContain('src/b.js')
+    expect(aNames).not.toContain('src/b-only/x.js')
+    expect(bNames).toContain('src/b-only/x.js')
+  })
+
+  it('adds a function-level pattern file to that function only', async () => {
+    const { serviceDir } = seedBuildDir(
+      { 'src/a.js': 'a\n', 'src/b.js': 'b\n' },
+      { 'config/a.json': '{"fn":"a"}\n' },
+    )
+    const fns = {
+      a: { handler: 'src/a.handler', package: { patterns: ['config/a.json'] } },
+      b: { handler: 'src/b.handler' },
+    }
+    const plugin = makeIndividualPlugin(serviceDir, fns, false)
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+      ['b', { outfile: 'src/b.js', mapfile: null }],
+    ])
+
+    await plugin._package()
+
+    expect(centralDirectoryNames(functionArtifact(serviceDir, 'a'))).toContain(
+      'config/a.json',
+    )
+    expect(
+      centralDirectoryNames(functionArtifact(serviceDir, 'b')),
+    ).not.toContain('config/a.json')
+  })
+
+  it('lets a function-level pattern replace a build-dir file exactly once', async () => {
+    const { serviceDir } = seedBuildDir(
+      { 'src/a.js': 'a\n', 'config/app.json': '{"from":"build"}\n' },
+      { 'config/app.json': '{"from":"patterns"}\n' },
+    )
+    const fns = {
+      a: {
+        handler: 'src/a.handler',
+        package: { patterns: ['config/app.json'] },
+      },
+    }
+    const plugin = makeIndividualPlugin(serviceDir, fns, false)
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+    ])
+
+    await plugin._package()
+
+    const artifact = functionArtifact(serviceDir, 'a')
+    expect(
+      centralDirectoryNames(artifact).filter((n) => n === 'config/app.json'),
+    ).toHaveLength(1)
+    const entries = await zipEntries(artifact)
+    await expect(entries['config/app.json'].async('string')).resolves.toContain(
+      'patterns',
+    )
+  })
+
+  it('bundle:false — a .cjs handler ships under its own name, after a real build', async () => {
+    // The handler keeps its extension all the way through: `builtArtifacts`
+    // records `src/a.cjs`, packaging looks for `src/a.cjs`, and the archive
+    // assertion is satisfied by the file that is actually there. A packaging
+    // path that assumed `.js` would fail this function's zip outright.
+    const serviceDir = makeTempDir()
+    writeFiles(serviceDir, {
+      'package.json': '{"name":"svc","type":"module"}',
+      'src/a.cjs': 'exports.handler = async () => ({ statusCode: 200 })\n',
+      'src/b.ts': 'export const handler = async () => ({})\n',
+    })
+    const fns = {
+      a: { handler: 'src/a.handler' },
+      b: { handler: 'src/b.handler' },
+    }
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.individually = true
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._build()
+    await plugin._package()
+
+    expect(plugin.builtArtifacts.get('a').outfile).toBe('src/a.cjs')
+    const names = centralDirectoryNames(functionArtifact(serviceDir, 'a'))
+    expect(names).toContain('src/a.cjs')
+    expect(names).not.toContain('src/a.js')
+    // Non-bundled: the sibling function's output is part of the project every
+    // zip carries, so it is present here too.
+    expect(names).toContain('src/b.js')
+  })
+
+  it('gives a layer-provided function a valid zip of its own', async () => {
+    // Its handler resolves inside the Lambda at runtime, so the build recorded
+    // no artifact for it and the handler assertion has nothing to check. It
+    // still gets packaged: the layer wrapper needs the project to call into.
+    const { serviceDir } = seedBuildDir({
+      'src/a.js': 'a\n',
+      'package.json': '{}\n',
+    })
+    const fns = {
+      a: { handler: 'src/a.handler' },
+      wrapped: {
+        handler: '/opt/nodejs/node_modules/wrapper/handler.wrapped',
+        layers: ['arn:aws:lambda:us-east-1:1234567890:layer:wrapper:1'],
+      },
+    }
+    const plugin = makeIndividualPlugin(serviceDir, fns, false)
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+    ])
+
+    await expect(plugin._package()).resolves.toBeUndefined()
+
+    const names = centralDirectoryNames(functionArtifact(serviceDir, 'wrapped'))
+    expect(names).toEqual(['package.json', 'src/a.js'])
+    expect(fns.wrapped.package.artifact).toBe(
+      functionArtifact(serviceDir, 'wrapped'),
+    )
+  })
+
+  it('packages only the function `deploy function` named', async () => {
+    // `deploy function` narrows `functions()` to one alias. Packaging follows
+    // that subset -- one zip, for that function -- while the zip itself still
+    // holds the whole non-bundled project, because the deployed function
+    // resolves its imports out of that tree at runtime.
+    const { serviceDir } = seedBuildDir({
+      'src/a.js': 'a\n',
+      'src/b.js': 'b\n',
+      'package.json': '{}\n',
+    })
+    const fns = {
+      a: { handler: 'src/a.handler' },
+      b: { handler: 'src/b.handler' },
+    }
+    const serverless = makeServerless(serviceDir, fns, { bundle: false })
+    serverless.service.package.individually = true
+    // No `plugin.functions` override: the subset has to come from the real
+    // `functions()` path, which is where the `--function` option is read.
+    const plugin = new Esbuild(serverless, { function: 'a' })
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+      ['b', { outfile: 'src/b.js', mapfile: null }],
+    ])
+
+    await plugin._package()
+
+    expect(fs.existsSync(functionArtifact(serviceDir, 'a'))).toBe(true)
+    expect(fs.existsSync(functionArtifact(serviceDir, 'b'))).toBe(false)
+    expect(fns.b.package).toBeUndefined()
+    expect(centralDirectoryNames(functionArtifact(serviceDir, 'a'))).toEqual([
+      'package.json',
+      'src/a.js',
+      'src/b.js',
+    ])
+  })
+
+  it('throws when a handler outfile is missing from its archive', async () => {
+    const { serviceDir } = seedBuildDir({ 'src/b.js': 'b\n' })
+    const fns = { a: { handler: 'src/a.handler' } }
+    const plugin = makeIndividualPlugin(serviceDir, fns, true)
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+    ])
+
+    await expect(plugin._package()).rejects.toMatchObject({
+      name: 'ServerlessError',
+      code: 'ESBUILD_HANDLER_MISSING_FROM_ARTIFACT',
+    })
+  })
+
+  it('merges service and function patterns for the node_modules filter', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/a.js': 'a\n',
+      'node_modules/keep/index.js': 'keep\n',
+      'node_modules/svc-drop/index.js': 'drop\n',
+      'node_modules/fn-drop/index.js': 'drop\n',
+    })
+    const fns = {
+      a: {
+        handler: 'src/a.handler',
+        package: { patterns: ['!node_modules/fn-drop/**'] },
+      },
+    }
+    const plugin = makeIndividualPlugin(serviceDir, fns, true)
+    plugin.serverless.service.package.patterns = ['!node_modules/svc-drop/**']
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+    ])
+
+    await plugin._package()
+
+    const names = centralDirectoryNames(functionArtifact(serviceDir, 'a'))
+    expect(names).toContain('node_modules/keep/index.js')
+    expect(names.filter((n) => n.includes('-drop/'))).toEqual([])
+  })
+})
+
+describe('_copyPatternsIntoBuildDir', () => {
+  jest.setTimeout(30_000)
+
+  let warnSpy
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(esbuildLogger, 'warning').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  const fns = { hello: { handler: 'src/handler.hello' } }
+
+  it('overwrites emitted outputs and warns once per run about content changes', async () => {
+    const { serviceDir, buildDir } = seedBuildDir(
+      {
+        'src/handler.js': 'built\n',
+        'config/one.json': '{"from":"build"}\n',
+        'config/two.json': '{"from":"build"}\n',
+        'config/same.json': '{"same":true}\n',
+      },
+      {
+        'config/one.json': '{"from":"patterns"}\n',
+        'config/two.json': '{"from":"patterns"}\n',
+        'config/same.json': '{"same":true}\n',
+      },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['config/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(
+      fs.readFileSync(path.join(buildDir, 'config', 'one.json'), 'utf8'),
+    ).toContain('patterns')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toContain('2 file')
+  })
+
+  it('stays silent when the pattern copy matches what was emitted', async () => {
+    const { serviceDir } = seedBuildDir(
+      { 'src/handler.js': 'built\n', 'config/same.json': '{"same":true}\n' },
+      { 'config/same.json': '{"same":true}\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['config/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('ships the copied file and keeps the build dir in sync with it', async () => {
+    // Dev mode and `invoke local` run out of the build directory, so the file
+    // that deploys and the file those commands load have to be the same one.
+    const { serviceDir, buildDir } = seedBuildDir(
+      { 'src/handler.js': 'built\n' },
+      { 'assets/logo.txt': 'logo\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['assets/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    const entries = await zipEntries(serviceArtifact(serviceDir))
+    await expect(entries['assets/logo.txt'].async('string')).resolves.toBe(
+      fs.readFileSync(path.join(buildDir, 'assets', 'logo.txt'), 'utf8'),
+    )
+  })
+
+  it('honors a later negation retracting an earlier positive', async () => {
+    const { serviceDir, buildDir } = seedBuildDir(
+      { 'src/handler.js': 'built\n' },
+      { 'assets/keep.txt': 'keep\n', 'assets/secret.txt': 'secret\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['assets/**', '!assets/secret.txt']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(fs.existsSync(path.join(buildDir, 'assets', 'keep.txt'))).toBe(true)
+    expect(fs.existsSync(path.join(buildDir, 'assets', 'secret.txt'))).toBe(
+      false,
+    )
+  })
+
+  it('never copies the build directory into itself', async () => {
+    const { serviceDir, buildDir } = seedBuildDir(
+      { 'src/handler.js': 'built\n' },
+      { 'src/handler.ts': 'source\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(fs.existsSync(path.join(buildDir, '.serverless'))).toBe(false)
+    expect(centralDirectoryNames(serviceArtifact(serviceDir))).toContain(
+      'src/handler.ts',
+    )
+  })
+})
+
+/**
+ * A pattern that reaches above the service directory (`../shared/**`) has no
+ * parent directory to land in inside an archive. archiver strips the leading
+ * `../` from every entry name it is handed, so classic packaging and every
+ * esbuild release since patterns were supported shipped such files at the path
+ * that remains — a nested handler reading `../shared/x.json` found it at
+ * runtime. The build-directory copy has to place the file the same way, or a
+ * working monorepo setup stops working after a green deploy.
+ */
+describe('package.patterns reaching above the service directory', () => {
+  jest.setTimeout(30_000)
+
+  let warnSpy
+  let debugSpy
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(esbuildLogger, 'warning').mockImplementation(() => {})
+    debugSpy = jest.spyOn(esbuildLogger, 'debug').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    debugSpy.mockRestore()
+  })
+
+  // The service sits one level below the temp root so that `..` from it stays
+  // inside the directory the test owns.
+  function seedNestedService(buildFiles, siblingFiles) {
+    const root = makeTempDir()
+    const serviceDir = path.join(root, 'svc')
+    const buildDir = path.join(serviceDir, '.serverless', 'build')
+    fs.mkdirSync(buildDir, { recursive: true })
+    writeFiles(buildDir, buildFiles)
+    writeFiles(root, siblingFiles)
+    return { serviceDir, buildDir }
+  }
+
+  const fns = { hello: { handler: 'src/handler.hello' } }
+
+  it('packages the file at its path with the leading ../ removed, in the build dir and the zip', async () => {
+    const { serviceDir, buildDir } = seedNestedService(
+      { 'src/handler.js': 'built\n' },
+      { 'shared/x.json': '{"shared":true}\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['../shared/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(
+      fs.readFileSync(path.join(buildDir, 'shared', 'x.json'), 'utf8'),
+    ).toBe('{"shared":true}\n')
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names).toContain('shared/x.json')
+    expect(names.some((name) => name.includes('..'))).toBe(false)
+    const entries = await zipEntries(serviceArtifact(serviceDir))
+    await expect(entries['shared/x.json'].async('string')).resolves.toBe(
+      '{"shared":true}\n',
+    )
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(
+      debugSpy.mock.calls.some((call) =>
+        /\.\.\/shared\/x\.json -> shared\/x\.json/.test(call[0]),
+      ),
+    ).toBe(true)
+  })
+
+  it('treats a ../node_modules match as an installed-tree entry: shipped, never copied over the install', async () => {
+    const { serviceDir, buildDir } = seedNestedService(
+      {
+        'src/handler.js': 'built\n',
+        'node_modules/dep/index.js': 'installed\n',
+      },
+      { 'node_modules/hoisted/index.js': 'hoisted\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['../node_modules/hoisted/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(fs.existsSync(path.join(buildDir, 'node_modules', 'hoisted'))).toBe(
+      false,
+    )
+    const entries = await zipEntries(serviceArtifact(serviceDir))
+    await expect(
+      entries['node_modules/hoisted/index.js'].async('string'),
+    ).resolves.toBe('hoisted\n')
+    expect(entries['node_modules/dep/index.js']).toBeDefined()
+  })
+
+  it('does the same for a function-level pattern under package.individually', async () => {
+    const { serviceDir } = seedNestedService(
+      { 'src/a.js': 'a\n' },
+      { 'shared/x.json': '{"shared":true}\n' },
+    )
+    const individually = {
+      a: { handler: 'src/a.handler', package: { patterns: ['../shared/**'] } },
+    }
+    const serverless = makeServerless(serviceDir, individually, {
+      bundle: false,
+    })
+    serverless.service.package.individually = true
+    const plugin = new Esbuild(serverless, {})
+    plugin.functions = async () => individually
+    plugin._buildProperties = async () => ({ bundle: false })
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+    ])
+
+    await plugin._package()
+
+    const names = centralDirectoryNames(functionArtifact(serviceDir, 'a'))
+    expect(names).toContain('shared/x.json')
+    expect(names.some((name) => name.includes('..'))).toBe(false)
+    // archiver would sanitize the name on its own at write time; the plugin
+    // has to know the real entry name before that, because the collision dedup
+    // and the handler assertion compare against it.
+    const { entries } = await plugin._patternEntries(['../shared/**'])
+    expect(entries.map((entry) => entry.zipPath)).toEqual(['shared/x.json'])
+  })
+})
+
+/**
+ * `package.patterns` negations reach the installed dependencies as well as the
+ * source tree, and a classic slimming idiom aimed at the latter (`!**` plus a
+ * re-include) empties the former. The artifact still carries a package.json
+ * declaring those dependencies, so the function deploys clean and then throws
+ * MODULE_NOT_FOUND on its first invocation with nothing in the deploy output
+ * pointing at the cause.
+ */
+/**
+ * The "Excluded N entries ... via package.patterns" line is assembled from
+ * three independently-sourced terms: what the node_modules walk filtered, what
+ * a negation retracted from the additive includes, and what a function-level
+ * negation retracted from the build-directory sweep. Each term is pinned with
+ * an EXACT count on the path that produces it, so dropping one from the sum
+ * cannot pass unnoticed.
+ */
+describe('package.patterns exclusion count', () => {
+  jest.setTimeout(30_000)
+
+  let infoSpy
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(esbuildLogger, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    infoSpy.mockRestore()
+  })
+
+  const patternsInfo = () =>
+    infoSpy.mock.calls
+      .map((call) => call[0])
+      .filter((message) => message.includes('package.patterns'))
+
+  const fns = { hello: { handler: 'src/handler.hello' } }
+
+  it('_packageAll counts a service-level include the patterns retracted', async () => {
+    // Only term in play: the service additive includes. node_modules is
+    // untouched by these patterns, and _packageAll never filters the build
+    // directory, so the count is exactly the one retracted include.
+    const { serviceDir } = seedBuildDir(
+      { 'src/handler.js': 'x\n', 'node_modules/dep/index.js': 'dep\n' },
+      { 'assets/logo.png': 'png\n', 'assets/secret.txt': 'ssh\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['assets/**', '!assets/secret.txt']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(patternsInfo()).toEqual([
+      'Excluded 1 entries from svc.zip via package.patterns',
+    ])
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(names).toContain('assets/logo.png')
+    expect(names).not.toContain('assets/secret.txt')
+  })
+
+  it('_package counts a function-level include the patterns retracted', async () => {
+    // Only term in play: this function's own additive includes. The service
+    // list is empty, and nothing in the build directory matches the negation.
+    const { serviceDir } = seedBuildDir(
+      { 'src/handler.js': 'x\n', 'node_modules/dep/index.js': 'dep\n' },
+      { 'assets/logo.png': 'png\n', 'assets/secret.txt': 'ssh\n' },
+    )
+    const individualFns = {
+      hello: {
+        handler: 'src/handler.hello',
+        package: { patterns: ['assets/**', '!assets/secret.txt'] },
+      },
+    }
+    const serverless = makeServerless(serviceDir, individualFns)
+    serverless.service.package.individually = true
+    const plugin = new Esbuild(serverless, {})
+    plugin.functions = async () => individualFns
+    plugin._buildProperties = async () => ({ bundle: false })
+
+    await plugin._package()
+
+    expect(patternsInfo()).toEqual([
+      'Excluded 1 entries from svc-hello.zip via package.patterns',
+    ])
+    const names = centralDirectoryNames(functionArtifact(serviceDir, 'hello'))
+    expect(names).toContain('assets/logo.png')
+    expect(names).not.toContain('assets/secret.txt')
+  })
+
+  it('_package counts a build-directory entry a function negation retracted', async () => {
+    // Only term in play: the build-directory sweep. The service-level include
+    // puts the file in the build directory unretracted; the function-level
+    // negation is what removes it from this one artifact.
+    const { serviceDir } = seedBuildDir(
+      { 'src/handler.js': 'x\n', 'node_modules/dep/index.js': 'dep\n' },
+      { 'assets/logo.png': 'png\n', 'assets/secret.txt': 'ssh\n' },
+    )
+    const individualFns = {
+      hello: {
+        handler: 'src/handler.hello',
+        package: { patterns: ['!assets/secret.txt'] },
+      },
+    }
+    const serverless = makeServerless(serviceDir, individualFns)
+    serverless.service.package.individually = true
+    serverless.service.package.patterns = ['assets/**']
+    const plugin = new Esbuild(serverless, {})
+    plugin.functions = async () => individualFns
+    plugin._buildProperties = async () => ({ bundle: false })
+
+    await plugin._package()
+
+    expect(patternsInfo()).toEqual([
+      'Excluded 1 entries from svc-hello.zip via package.patterns',
+    ])
+    const names = centralDirectoryNames(functionArtifact(serviceDir, 'hello'))
+    expect(names).toContain('assets/logo.png')
+    expect(names).not.toContain('assets/secret.txt')
+  })
+})
+
+/**
+ * A positive `package.patterns` entry naming `node_modules/...` selects files
+ * from the SERVICE tree — a vendored dependency, a patched copy, a data file
+ * re-included after a broad negation. None of it is declared in package.json,
+ * so the install into the build directory never produces it, and dropping it
+ * ships an artifact that throws MODULE_NOT_FOUND on the first invocation with
+ * nothing in the deploy output pointing at the cause.
+ *
+ * These matches cannot be COPIED into the build directory — writing the
+ * service's tree over the install would corrupt it, and `_resetBuildDir`
+ * preserves node_modules into every later deploy, so the damage would persist.
+ * They are appended to the archive straight from the service directory
+ * instead, and they beat the installed file at the same archive path.
+ */
+describe('package.patterns naming the installed dependency tree', () => {
+  jest.setTimeout(30_000)
+
+  const fns = { hello: { handler: 'src/handler.hello' } }
+
+  const vendoredFixture = () =>
+    seedBuildDir(
+      {
+        'src/handler.js': 'x\n',
+        'package.json': '{"name":"svc"}\n',
+        'node_modules/installed/index.js': 'installed\n',
+      },
+      {
+        'node_modules/vendored-lib/index.js': 'vendored\n',
+        'node_modules/vendored-lib/package.json': '{"name":"vendored-lib"}\n',
+      },
+    )
+
+  it.each([
+    ['bundle: true', true],
+    ['bundle: false', false],
+  ])(
+    'ships a vendored dependency the install never produced (%s)',
+    async (_label, bundle) => {
+      const { serviceDir } = vendoredFixture()
+      const serverless = makeServerless(serviceDir, fns, { bundle })
+      serverless.service.package.patterns = ['node_modules/vendored-lib/**']
+      const plugin = new Esbuild(serverless, {})
+
+      await plugin._packageAll(fns)
+
+      const entries = await zipEntries(serviceArtifact(serviceDir))
+      await expect(
+        entries['node_modules/vendored-lib/index.js'].async('string'),
+      ).resolves.toBe('vendored\n')
+      expect(entries['node_modules/vendored-lib/package.json']).toBeDefined()
+      // The installed tree is still there alongside it.
+      expect(entries['node_modules/installed/index.js']).toBeDefined()
+    },
+  )
+
+  it('ships a vendored dependency named by a function-level pattern', async () => {
+    const { serviceDir } = vendoredFixture()
+    const individualFns = {
+      hello: {
+        handler: 'src/handler.hello',
+        package: { patterns: ['node_modules/vendored-lib/**'] },
+      },
+    }
+    const serverless = makeServerless(serviceDir, individualFns)
+    serverless.service.package.individually = true
+    const plugin = new Esbuild(serverless, {})
+    plugin.functions = async () => individualFns
+    plugin._buildProperties = async () => ({ bundle: false })
+
+    await plugin._package()
+
+    const entries = await zipEntries(functionArtifact(serviceDir, 'hello'))
+    await expect(
+      entries['node_modules/vendored-lib/index.js'].async('string'),
+    ).resolves.toBe('vendored\n')
+  })
+
+  it('lets a pattern file beat the installed file at the same archive path', async () => {
+    // The re-include idiom over a patched dependency. Both trees hold the same
+    // archive path with different bytes; the pattern is what the user asked
+    // for, so it is what ships — once, not twice.
+    const { serviceDir } = seedBuildDir(
+      {
+        'src/handler.js': 'x\n',
+        'node_modules/dep/index.js': 'installed\n',
+        'node_modules/dep/other.js': 'installed-other\n',
+      },
+      { 'node_modules/dep/index.js': 'patched\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['node_modules/dep/index.js']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    expect(
+      names.filter((name) => name === 'node_modules/dep/index.js'),
+    ).toHaveLength(1)
+    const entries = await zipEntries(serviceArtifact(serviceDir))
+    await expect(
+      entries['node_modules/dep/index.js'].async('string'),
+    ).resolves.toBe('patched\n')
+    // Only the claimed path is replaced; the rest of the install is untouched.
+    await expect(
+      entries['node_modules/dep/other.js'].async('string'),
+    ).resolves.toBe('installed-other\n')
+  })
+
+  it('never writes the pattern match into the build directory', async () => {
+    const { serviceDir, buildDir } = vendoredFixture()
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['node_modules/vendored-lib/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    // The install in the build directory is exactly what it was: overwriting it
+    // would survive into every later deploy through _resetBuildDir.
+    expect(
+      fs.existsSync(path.join(buildDir, 'node_modules', 'vendored-lib')),
+    ).toBe(false)
+    expect(fs.readdirSync(path.join(buildDir, 'node_modules')).sort()).toEqual([
+      'installed',
+    ])
+    // ...while the artifact ships it anyway.
+    expect(centralDirectoryNames(serviceArtifact(serviceDir))).toContain(
+      'node_modules/vendored-lib/index.js',
+    )
+  })
+
+  it('does not claim node_modules was emptied when patterns re-supplied it', async () => {
+    // `patterns: ['**']` over a real install claims every installed file, so
+    // every one of them is skipped in the walk in favour of the pattern copy.
+    // Counting those skips as "not kept" made a fully-supplied node_modules
+    // look emptied, and the `.md` negation supplied the non-zero exclusion the
+    // warning also needs — so a working configuration that ships every
+    // dependency got told its patterns had stripped them. No released version
+    // warns here.
+    const { serviceDir } = seedBuildDir(
+      {
+        'src/handler.js': 'x\n',
+        'package.json': '{"name":"svc","dependencies":{"ms":"^2.1.3"}}\n',
+        'node_modules/ms/index.js': 'module.exports = 1\n',
+        'node_modules/ms/package.json': '{"name":"ms"}\n',
+        'node_modules/ms/readme.md': '# ms\n',
+      },
+      {
+        'src/handler.js': 'x\n',
+        'node_modules/ms/index.js': 'module.exports = 1\n',
+        'node_modules/ms/package.json': '{"name":"ms"}\n',
+        'node_modules/ms/readme.md': '# ms\n',
+      },
+    )
+    const serverless = makeServerless(serviceDir, fns, { packages: 'external' })
+    serverless.service.package.patterns = ['**', '!node_modules/**/*.md']
+    const plugin = new Esbuild(serverless, {})
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+
+    try {
+      await plugin._packageAll(fns)
+
+      // Guard the premise: the dependency really did ship, and the negation
+      // really did exclude something from the walk.
+      const names = centralDirectoryNames(serviceArtifact(serviceDir))
+      expect(names).toContain('node_modules/ms/index.js')
+      expect(names).toContain('node_modules/ms/package.json')
+      expect(names).not.toContain('node_modules/ms/readme.md')
+      expect(
+        warnSpy.mock.calls
+          .map((call) => call[0])
+          .filter((message) => message.includes('node_modules')),
+      ).toEqual([])
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('still warns when the patterns really did empty node_modules', async () => {
+    // Same shape minus the pattern re-supply: nothing claims the installed
+    // files, so they are genuinely excluded and the artifact ships no
+    // dependency at all.
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'package.json': '{"name":"svc","dependencies":{"ms":"^2.1.3"}}\n',
+      'node_modules/ms/index.js': 'module.exports = 1\n',
+    })
+    const serverless = makeServerless(serviceDir, fns, { packages: 'external' })
+    serverless.service.package.patterns = ['!node_modules/**']
+    const plugin = new Esbuild(serverless, {})
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+
+    try {
+      await plugin._packageAll(fns)
+
+      expect(
+        centralDirectoryNames(serviceArtifact(serviceDir)).filter((name) =>
+          name.startsWith('node_modules/'),
+        ),
+      ).toEqual([])
+      expect(
+        warnSpy.mock.calls
+          .map((call) => call[0])
+          .filter((message) => message.includes('node_modules')),
+      ).toHaveLength(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('stays byte-identical across repeated runs', async () => {
+    // The pattern-supplied entries are sorted in with the build-directory sweep
+    // rather than appended wherever the copy finished, so the artifact hash
+    // check-for-changes reads cannot drift between runs.
+    const hash = async () => {
+      const { serviceDir } = vendoredFixture()
+      const serverless = makeServerless(serviceDir, fns)
+      serverless.service.package.patterns = [
+        'node_modules/vendored-lib/**',
+        '!node_modules/vendored-lib/package.json',
+      ]
+      const plugin = new Esbuild(serverless, {})
+      await plugin._packageAll(fns)
+      return sha256(serviceArtifact(serviceDir))
+    }
+
+    expect(await hash()).toBe(await hash())
+  })
+})
+
+describe('node_modules emptied by patterns', () => {
+  jest.setTimeout(30_000)
+
+  let warnSpy
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(esbuildLogger, 'warning').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  const fns = { hello: { handler: 'src/handler.hello' } }
+  const withDependency = {
+    'src/handler.js': 'x\n',
+    'package.json': '{"name":"svc","dependencies":{"dep":"^1.0.0"}}\n',
+    'node_modules/dep/index.js': 'module.exports = 1\n',
+  }
+
+  // The merged warning is emitted once per invocation and names neither the
+  // pattern list nor the affected aliases (see `_reportPatternFiltering`), so
+  // it is matched on the claim it makes rather than on those details.
+  const emptiedWarning = () =>
+    warnSpy.mock.calls.filter((call) =>
+      /requires dependencies in the artifact/.test(call[0]),
+    )
+
+  it('warns when the patterns excluded every dependency file', async () => {
+    const { serviceDir } = seedBuildDir(withDependency)
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!**', 'src/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(emptiedWarning()).toHaveLength(1)
+    expect(emptiedWarning()[0][0]).toContain('node_modules')
+  })
+
+  it('stays silent when node_modules is legitimately empty', async () => {
+    // Nothing was excluded — there was simply nothing installed.
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'package.json': '{"name":"svc","dependencies":{"dep":"^1.0.0"}}\n',
+    })
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!**', 'src/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(emptiedWarning()).toHaveLength(0)
+  })
+
+  it('stays silent when the package.json declares no dependencies', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'package.json': '{"name":"svc"}\n',
+      'node_modules/.package-lock.json': '{}\n',
+    })
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!**', 'src/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(emptiedWarning()).toHaveLength(0)
+  })
+
+  it('warns for bundle:true with externals, where no config-shape gate applied', async () => {
+    // `external: ['ms']` under bundling keeps that one dependency out of the
+    // bundle and installs it beside the handler, exactly like `packages:
+    // external` does for all of them — but it is neither `packages: external`
+    // nor a non-bundled build, so gating on the config shape left this
+    // combination with no arm at all and a legacy `!node_modules/**` silently
+    // shipped an artifact without its externals. The generated manifest says
+    // what the artifact needs, whichever setting produced it.
+    const { serviceDir } = seedBuildDir(withDependency)
+    const serverless = makeServerless(serviceDir, fns, {
+      bundle: true,
+      external: ['dep'],
+    })
+    serverless.service.package.patterns = ['!node_modules/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    // Guard the premise: the dependency really was stripped.
+    expect(
+      centralDirectoryNames(serviceArtifact(serviceDir)).filter((name) =>
+        name.startsWith('node_modules/'),
+      ),
+    ).toEqual([])
+    expect(emptiedWarning()).toHaveLength(1)
+  })
+
+  it('stays silent for a bundled service whose manifest declares nothing', async () => {
+    // The modal service: everything inlined, so the generated manifest declares
+    // no dependencies and an excluded node_modules costs the artifact nothing.
+    // This is the false-positive guard for the widened gate — it must not start
+    // warning here.
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'package.json': '{"name":"svc"}\n',
+      'node_modules/leftover/index.js': 'module.exports = 1\n',
+    })
+    const serverless = makeServerless(serviceDir, fns, { bundle: true })
+    serverless.service.package.patterns = ['!node_modules/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    // Premise again: something really was excluded from the walk.
+    expect(
+      centralDirectoryNames(serviceArtifact(serviceDir)).filter((name) =>
+        name.startsWith('node_modules/'),
+      ),
+    ).toEqual([])
+    expect(emptiedWarning()).toHaveLength(0)
+  })
+
+  it('stays silent when dependencies survive the filter', async () => {
+    const { serviceDir } = seedBuildDir(withDependency)
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!node_modules/other/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(emptiedWarning()).toHaveLength(0)
+  })
+
+  it('warns once for the whole run when packaging individually', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/a.js': 'a\n',
+      'src/b.js': 'b\n',
+      'package.json': '{"name":"svc","dependencies":{"dep":"^1.0.0"}}\n',
+      'node_modules/dep/index.js': 'module.exports = 1\n',
+    })
+    const individualFns = {
+      a: { handler: 'src/a.handler' },
+      b: { handler: 'src/b.handler' },
+    }
+    const serverless = makeServerless(serviceDir, individualFns, {
+      bundle: false,
+    })
+    serverless.service.package.individually = true
+    serverless.service.package.patterns = ['!**', 'src/**']
+    const plugin = new Esbuild(serverless, {})
+    plugin.functions = async () => individualFns
+    plugin._buildProperties = async () => ({ bundle: false })
+
+    await plugin._package()
+
+    expect(emptiedWarning()).toHaveLength(1)
+  })
+})
+
+/**
+ * The handler assertion is only worth having if it inspects the artifact that
+ * exists on disk. Checking the list packaging MEANT to append would sail past
+ * an entry archiver dropped, renamed while sanitizing, or never flushed.
+ */
+describe('_readArchiveEntryNames', () => {
+  jest.setTimeout(30_000)
+
+  const fns = { hello: { handler: 'src/handler.hello' } }
+
+  it('catches a handler the archive lost even though packaging listed it', async () => {
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'package.json': '{}\n',
+    })
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+    plugin.builtArtifacts = new Map([
+      ['hello', { outfile: 'src/handler.js', mapfile: null }],
+    ])
+
+    // The archive silently loses the handler while the intended entry list
+    // still names it — what an archiver-side drop looks like from the outside.
+    const writeArchive = plugin._writeArchive.bind(plugin)
+    plugin._writeArchive = ({ zipPath, entries, patterns }) =>
+      writeArchive({
+        zipPath,
+        entries: entries.filter((entry) => entry.zipPath !== 'src/handler.js'),
+        patterns,
+      })
+
+    await expect(plugin._packageAll(fns)).rejects.toMatchObject({
+      name: 'ServerlessError',
+      code: 'ESBUILD_HANDLER_MISSING_FROM_ARTIFACT',
+    })
+  })
+
+  it('reads a ZIP64 archive', async () => {
+    // archiver switches to ZIP64 past 65535 entries, which a real node_modules
+    // clears easily. Getting that wrong would not lose an artifact — it would
+    // fail every large deploy with a bogus missing-handler error.
+    const { serviceDir, buildDir } = seedBuildDir({ 'src/handler.js': 'x\n' })
+    const zipPath = path.join(serviceDir, 'zip64.zip')
+    const zip = new ZipArchive({ forceZip64: true })
+    const output = fs.createWriteStream(zipPath)
+    await new Promise((resolve, reject) => {
+      output.on('close', resolve)
+      output.on('error', reject)
+      zip.pipe(output)
+      zip.file(path.join(buildDir, 'src', 'handler.js'), {
+        name: 'src/handler.js',
+      })
+      zip.finalize().catch(reject)
+    })
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(plugin._readArchiveEntryNames(zipPath)).resolves.toEqual(
+      new Set(['src/handler.js']),
+    )
+  })
+
+  it('returns null for something that is not an archive, and the assertion falls back', async () => {
+    // A read that cannot answer must never be the thing that invents a missing
+    // handler; the caller falls back to the list packaging appended.
+    const { serviceDir } = seedBuildDir({ 'src/handler.js': 'x\n' })
+    const notAZip = path.join(serviceDir, 'not-a-zip.bin')
+    fs.writeFileSync(notAZip, 'definitely not a zip file')
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(plugin._readArchiveEntryNames(notAZip)).resolves.toBeNull()
+    await expect(
+      plugin._assertHandlersInArtifact(
+        fns,
+        new Set(['src/handler.js']),
+        notAZip,
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  it('returns null for a file that does not exist', async () => {
+    const { serviceDir } = seedBuildDir({})
+    const plugin = new Esbuild(makeServerless(serviceDir, fns), {})
+
+    await expect(
+      plugin._readArchiveEntryNames(path.join(serviceDir, 'nope.zip')),
+    ).resolves.toBeNull()
+  })
+})
+
+/**
+ * `_copyPatternsIntoBuildDir` runs on both packaging paths. On the
+ * `package.individually` one it feeds every function's zip at once, because
+ * they are all subsets of the one build directory it copies into.
+ */
+describe('_copyPatternsIntoBuildDir on the individually path', () => {
+  jest.setTimeout(30_000)
+
+  let warnSpy
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(esbuildLogger, 'warning').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('supplies service-level pattern files to every function zip, warning once', async () => {
+    const { serviceDir } = seedBuildDir(
+      {
+        'src/a.js': 'a\n',
+        'src/b.js': 'b\n',
+        'config/app.json': '{"from":"build"}\n',
+      },
+      {
+        'assets/shared.txt': 'shared\n',
+        'config/app.json': '{"from":"patterns"}\n',
+      },
+    )
+    const fns = {
+      a: { handler: 'src/a.handler' },
+      b: { handler: 'src/b.handler' },
+    }
+    const serverless = makeServerless(serviceDir, fns, { bundle: false })
+    serverless.service.package.individually = true
+    serverless.service.package.patterns = ['assets/**', 'config/**']
+    const plugin = new Esbuild(serverless, {})
+    plugin.functions = async () => fns
+    plugin._buildProperties = async () => ({ bundle: false })
+    plugin.builtArtifacts = new Map([
+      ['a', { outfile: 'src/a.js', mapfile: null }],
+      ['b', { outfile: 'src/b.js', mapfile: null }],
+    ])
+
+    await plugin._package()
+
+    for (const alias of ['a', 'b']) {
+      const artifact = functionArtifact(serviceDir, alias)
+      const names = centralDirectoryNames(artifact)
+      expect(names).toContain('assets/shared.txt')
+      const entries = await zipEntries(artifact)
+      await expect(
+        entries['config/app.json'].async('string'),
+      ).resolves.toContain('patterns')
+    }
+    // The copy happens once per run, before any zip is written, so the
+    // overwrite warning must not be repeated per function.
+    const overwriteWarnings = warnSpy.mock.calls.filter((call) =>
+      /replaced esbuild build outputs/.test(call[0]),
+    )
+    expect(overwriteWarnings).toHaveLength(1)
+    expect(overwriteWarnings[0][0]).toContain('1 file')
+  })
+})
+
+/**
+ * The node_modules walk classifies entries by their lstat results, not by the
+ * entry name: a directory entry's name carries no trailing slash at the point
+ * the filter sees it. Calling every directory a file silently broke the
+ * emptied-node_modules accounting — directory husks counted as payload, so an
+ * artifact stripped of every dependency FILE still looked healthy.
+ */
+describe('node_modules directory entries are recognized as directories', () => {
+  jest.setTimeout(30_000)
+
+  let warnSpy
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(esbuildLogger, 'warning').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  const fns = { hello: { handler: 'src/handler.hello' } }
+  const emptiedWarning = () =>
+    warnSpy.mock.calls.filter((call) =>
+      /requires dependencies in the artifact/.test(call[0]),
+    )
+
+  it('warns when every dependency FILE is stripped and only directories remain', async () => {
+    // The shape that slipped through: the negations match files by extension,
+    // so every directory entry survives and an entry filter that counts
+    // directories as payload sees a healthy `included` count.
+    const { serviceDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'package.json': '{"name":"svc","dependencies":{"dep":"^1.0.0"}}\n',
+      'node_modules/dep/index.js': 'module.exports = 1\n',
+      'node_modules/dep/package.json': '{"name":"dep"}\n',
+      'node_modules/dep/lib/util.js': 'module.exports = 2\n',
+    })
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = [
+      '!node_modules/**/*.js',
+      '!node_modules/**/*.json',
+    ]
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    const names = centralDirectoryNames(serviceArtifact(serviceDir))
+    // Directory husks and nothing else.
+    expect(names.filter((n) => n.startsWith('node_modules/'))).toEqual(
+      expect.arrayContaining(['node_modules/dep/']),
+    )
+    expect(
+      names.filter((n) => n.startsWith('node_modules/') && !n.endsWith('/')),
+    ).toEqual([])
+    expect(emptiedWarning()).toHaveLength(1)
+  })
+
+  it('stays silent when node_modules holds nothing but empty directories', async () => {
+    // Nothing was excluded — there were no dependency files to begin with, so
+    // there is no pattern to blame.
+    const { serviceDir, buildDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'package.json': '{"name":"svc","dependencies":{"dep":"^1.0.0"}}\n',
+    })
+    fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep', 'lib'), {
+      recursive: true,
+    })
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!node_modules/**/*.js']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(emptiedWarning()).toHaveLength(0)
+  })
+
+  it('stays silent when the patterns strip only directory husks', async () => {
+    // Same empty node_modules, but now the negation DOES match the directory
+    // entries, so the walk-scoped exclusion count is non-zero while not one
+    // dependency file was lost. Counting entries rather than files here claims
+    // the patterns emptied node_modules when there was never anything in it.
+    const { serviceDir, buildDir } = seedBuildDir({
+      'src/handler.js': 'x\n',
+      'package.json': '{"name":"svc","dependencies":{"dep":"^1.0.0"}}\n',
+    })
+    fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep', 'lib'), {
+      recursive: true,
+    })
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.patterns = ['!node_modules/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    // Guard the premise: the husks really were stripped, so only the
+    // file-scoping of the counter can be what suppresses the warning.
+    expect(
+      centralDirectoryNames(serviceArtifact(serviceDir)).filter((name) =>
+        name.startsWith('node_modules/'),
+      ),
+    ).toEqual([])
+    expect(emptiedWarning()).toHaveLength(0)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/build-dir-packaging.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/build-dir-packaging.test.js
@@ -2075,11 +2075,12 @@ describe('_readArchiveEntryNames', () => {
     // The archive silently loses the handler while the intended entry list
     // still names it — what an archiver-side drop looks like from the outside.
     const writeArchive = plugin._writeArchive.bind(plugin)
-    plugin._writeArchive = ({ zipPath, entries, patterns }) =>
+    plugin._writeArchive = (args) =>
       writeArchive({
-        zipPath,
-        entries: entries.filter((entry) => entry.zipPath !== 'src/handler.js'),
-        patterns,
+        ...args,
+        entries: args.entries.filter(
+          (entry) => entry.zipPath !== 'src/handler.js',
+        ),
       })
 
     await expect(plugin._packageAll(fns)).rejects.toMatchObject({

--- a/packages/serverless/test/unit/lib/plugins/esbuild/build-dir-packaging.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/build-dir-packaging.test.js
@@ -654,6 +654,27 @@ describe('_packageAll build-dir sweep', () => {
     )
   })
 
+  it('does not let the legacy package.include add files on the pattern-copy path', async () => {
+    // The esbuild build reads `package.patterns` only, on every path patterns
+    // take; `_build` warns about the legacy keys, packaging just ignores them.
+    const { serviceDir } = seedBuildDir(
+      {
+        'src/handler.js': 'export const hello = () => {}\n',
+        'package.json': '{"name":"svc"}\n',
+      },
+      { 'lib/node_modules/inner/index.js': 'module.exports = "inner"\n' },
+    )
+    const serverless = makeServerless(serviceDir, fns)
+    serverless.service.package.include = ['lib/node_modules/**']
+    const plugin = new Esbuild(serverless, {})
+
+    await plugin._packageAll(fns)
+
+    expect(centralDirectoryNames(serviceArtifact(serviceDir))).not.toContain(
+      'lib/node_modules/inner/index.js',
+    )
+  })
+
   it('re-includes only the pattern-claimed files under an excluded root, not the install residue beside them', async () => {
     // `.yarn/cache` is what a Yarn Berry install leaves in the build directory;
     // `.yarn/releases/yarn.cjs` is a file the service deliberately ships. The

--- a/packages/serverless/test/unit/lib/plugins/esbuild/function-build-schema.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/function-build-schema.test.js
@@ -1,0 +1,107 @@
+/**
+ * `build: false` on a function is the documented way to keep esbuild's hands
+ * off a single handler — the escape hatch the ESBUILD_HANDLER_NOT_BUILT error
+ * points people at. An escape hatch the config schema rejects is not an escape
+ * hatch, so this suite validates it against the REAL schema.
+ *
+ * The value must also reach the plugin UNMUTATED: `_shouldBuildFunction`
+ * recognizes the opt-out with strict equality (`build === false`), while the
+ * schema is compiled with ajv's `coerceTypes: 'array'`. A `type: 'string'`
+ * branch ordered before the boolean one would silently rewrite `false` to the
+ * string "false" during validation.
+ */
+
+import { jest } from '@jest/globals'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+// The real `ConfigSchemaHandler` compiles the root schema into a standalone
+// ajv validator cached on disk, by default under the developer's
+// `~/.serverless/artifacts`. Point that at a throwaway directory via the
+// handler's own escape hatch (read per call inside `getCacheDir`, so setting
+// it in `beforeAll` is early enough). Derived from `os.tmpdir()` explicitly:
+// this repo's jest does not propagate a `TMPDIR` override to suites.
+let schemaCacheDir
+let previousSchemaCacheBaseDir
+
+beforeAll(() => {
+  schemaCacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-schema-cache-'))
+  previousSchemaCacheBaseDir = process.env.SLS_SCHEMA_CACHE_BASE_DIR
+  process.env.SLS_SCHEMA_CACHE_BASE_DIR = schemaCacheDir
+})
+
+afterAll(() => {
+  if (previousSchemaCacheBaseDir === undefined) {
+    delete process.env.SLS_SCHEMA_CACHE_BASE_DIR
+  } else {
+    process.env.SLS_SCHEMA_CACHE_BASE_DIR = previousSchemaCacheBaseDir
+  }
+  fs.rmSync(schemaCacheDir, { recursive: true, force: true })
+})
+
+const { default: Serverless } = await import('../../../../../lib/serverless.js')
+const { default: AwsProvider } =
+  await import('../../../../../lib/plugins/aws/provider.js')
+
+/**
+ * Validate a service configuration whose single function carries the given
+ * `build` value, against the real schema. Returns the validation message, or
+ * `null` when compliant, plus the (possibly coerced) post-validation value.
+ *
+ * `configValidationMode: 'error'` makes the handler throw rather than warn,
+ * and the service configuration is loaded before `AwsProvider` is constructed
+ * because `defineProvider` returns early unless `provider.name === 'aws'`.
+ */
+const validateFunctionBuild = async (build) => {
+  const functionConfig = { handler: 'src/handler.hello' }
+  if (build !== undefined) functionConfig.build = build
+
+  const configurationInput = {
+    service: 'acme',
+    configValidationMode: 'error',
+    provider: { name: 'aws', region: 'us-east-1', runtime: 'nodejs20.x' },
+    functions: { hello: functionConfig },
+  }
+
+  const serverless = new Serverless({
+    commands: [],
+    options: {},
+    servicePath: process.cwd(),
+    serviceConfigFileName: 'serverless.yml',
+    service: configurationInput,
+  })
+  serverless.credentialProviders = { aws: { getCredentials: jest.fn() } }
+  serverless.service.loadServiceFileParam()
+  serverless.setProvider(
+    'aws',
+    new AwsProvider(serverless, { stage: 'dev', region: 'us-east-1' }),
+  )
+
+  let message = null
+  try {
+    await serverless.configSchemaHandler.validateConfig(configurationInput)
+  } catch (error) {
+    message = error.message
+  }
+  return { message, value: configurationInput.functions.hello.build }
+}
+
+describe('function-level `build` schema', () => {
+  jest.setTimeout(60_000)
+
+  it('accepts `build: false` and leaves the boolean unmutated', async () => {
+    const { message, value } = await validateFunctionBuild(false)
+    expect(message).toBeNull()
+    // Not the string "false": the plugin compares with strict equality.
+    expect(value).toBe(false)
+  })
+
+  it("accepts `build: 'esbuild'`", async () => {
+    expect((await validateFunctionBuild('esbuild')).message).toBeNull()
+  })
+
+  it('accepts a function with no `build` at all', async () => {
+    expect((await validateFunctionBuild(undefined)).message).toBeNull()
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/layer-provided-build.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/layer-provided-build.test.js
@@ -1,0 +1,215 @@
+/**
+ * A service whose handlers ALL live in a Lambda layer — the manual Datadog /
+ * New Relic wrapper shape, `handler:
+ * /opt/nodejs/node_modules/datadog-lambda-js/handler.handler` plus a `layers`
+ * list — resolves no esbuild entry point at all. That is a normal, working
+ * configuration, and the build says so: it warns that the handlers are assumed
+ * to be layer-provided and carries on.
+ *
+ * Carrying on has to mean carrying on. The build directory is still the
+ * artifact definition for these functions, so it must exist and be clean by the
+ * time `_preparePackageJson` writes into it and packaging walks it. The
+ * no-entry-points path returned before resetting, so `.serverless/build` never
+ * existed and `_preparePackageJson` wrote into a directory that was not there —
+ * a raw ENOENT immediately after the plugin told the user it had handled the
+ * configuration.
+ *
+ * Clean matters as much as present: a service that switched a handler over to a
+ * layer-provided path still has that handler's outfile sitting in the build
+ * directory from the last deploy, and it must not ship.
+ *
+ * The packager install is stubbed; these tests are about the build directory
+ * and the artifact, not about a real `npm install`.
+ */
+
+import { jest } from '@jest/globals'
+import { EventEmitter } from 'events'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import JsZip from 'jszip'
+import { log } from '@serverless/util'
+
+const spawnMock = jest.fn(() => {
+  const child = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdout = new EventEmitter()
+  const promise = Promise.resolve()
+  promise.child = child
+  process.nextTick(() => child.emit('close', 0))
+  return promise
+})
+
+jest.unstable_mockModule('child-process-ext/spawn.js', () => ({
+  default: spawnMock,
+}))
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+const esbuildLogger = log.get('esbuild')
+const createdDirs = []
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+// `realpathSync` because macOS resolves the temp dir through a symlink
+// (`/var` -> `/private/var`) and esbuild reports real paths.
+function makeServiceDir(files = {}) {
+  const serviceDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-layer-')),
+  )
+  createdDirs.push(serviceDir)
+  for (const [name, contents] of Object.entries(files)) {
+    const filePath = path.join(serviceDir, ...name.split('/'))
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+  return serviceDir
+}
+
+const LAYER_HANDLER = {
+  handler: '/opt/nodejs/node_modules/datadog-lambda-js/handler.handler',
+  layers: ['arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node20-x:1'],
+}
+
+function makePlugin(serviceDir, fns) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    compose: { isWithinCompose: false },
+    service: {
+      service: 'svc',
+      provider: { runtime: 'nodejs20.x' },
+      package: {},
+      build: { esbuild: {} },
+      functions: fns,
+      getFunction: (name) => fns[name],
+      getAllFunctions: () => Object.keys(fns),
+    },
+    pluginManager: { spawn: async () => {} },
+  }
+  return new Esbuild(serverless, {})
+}
+
+const buildDirOf = (serviceDir) => path.join(serviceDir, '.serverless', 'build')
+
+async function zipNames(serviceDir) {
+  const zip = await JsZip.loadAsync(
+    fs.readFileSync(path.join(serviceDir, '.serverless', 'svc.zip')),
+  )
+  return Object.keys(zip.files).sort()
+}
+
+// A minimal service that declares nothing to install and carries a lockfile,
+// so `_preparePackageJson` exercises both the manifest write and the lockfile
+// copy without depending on what a real install would generate.
+const BASE_FILES = {
+  'package.json': '{"name":"svc","dependencies":{}}\n',
+  'package-lock.json': '{"lockfileVersion":3}\n',
+}
+
+describe('a service whose handlers are all layer-provided', () => {
+  jest.setTimeout(30_000)
+
+  let warnSpy
+
+  beforeEach(() => {
+    spawnMock.mockClear()
+    warnSpy = jest.spyOn(esbuildLogger, 'warning').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  const layerWarnings = () =>
+    warnSpy.mock.calls
+      .map((call) => call[0])
+      .filter((message) => message.includes('provided by a Lambda layer'))
+
+  it('builds, prepares and packages end to end', async () => {
+    const serviceDir = makeServiceDir(BASE_FILES)
+    const fns = { dd: LAYER_HANDLER }
+    const plugin = makePlugin(serviceDir, fns)
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    // The warning is the promise that this configuration was handled...
+    expect(layerWarnings()).toHaveLength(1)
+    // ...so the build directory it implies has to be there, and empty.
+    expect(fs.existsSync(buildDirOf(serviceDir))).toBe(true)
+    expect(fs.readdirSync(buildDirOf(serviceDir))).toEqual([])
+
+    await expect(plugin._preparePackageJson()).resolves.toBeUndefined()
+
+    // The post-zip handler assertion must not fire: a layer-provided function
+    // has no outfile, so there is nothing in the artifact to miss.
+    await expect(plugin._packageAll(fns)).resolves.toBeUndefined()
+
+    expect(await zipNames(serviceDir)).toEqual([
+      'package-lock.json',
+      'package.json',
+    ])
+  })
+
+  it('wipes an outfile left by a build made before the handler moved to a layer', async () => {
+    const serviceDir = makeServiceDir(BASE_FILES)
+    const stale = path.join(buildDirOf(serviceDir), 'src', 'handler.js')
+    fs.mkdirSync(path.dirname(stale), { recursive: true })
+    fs.writeFileSync(stale, 'module.exports.handler = "STALE"\n')
+    const fns = { dd: LAYER_HANDLER }
+    const plugin = makePlugin(serviceDir, fns)
+
+    await plugin._build()
+
+    expect(fs.existsSync(stale)).toBe(false)
+
+    await plugin._preparePackageJson()
+    await plugin._packageAll(fns)
+
+    expect(await zipNames(serviceDir)).not.toContain('src/handler.js')
+  })
+
+  it('leaves dev mode holding its last-good outputs', async () => {
+    // Dev mode never resets, on this path or any other — a failed incremental
+    // rebuild must not leave the dev loop with nothing to serve.
+    const serviceDir = makeServiceDir(BASE_FILES)
+    const previous = path.join(buildDirOf(serviceDir), 'src', 'handler.js')
+    fs.mkdirSync(path.dirname(previous), { recursive: true })
+    fs.writeFileSync(previous, 'last good\n')
+    const fns = { dd: { ...LAYER_HANDLER, originalHandler: '/opt/x.handler' } }
+    const plugin = makePlugin(serviceDir, fns)
+
+    await plugin._build('originalHandler')
+
+    expect(fs.readFileSync(previous, 'utf8')).toBe('last good\n')
+  })
+
+  it('still builds the buildable function in a mixed service', async () => {
+    const serviceDir = makeServiceDir({
+      ...BASE_FILES,
+      'src/api.ts':
+        'export const handler = async (): Promise<object> => ({ statusCode: 200 })\n',
+    })
+    const fns = { dd: LAYER_HANDLER, api: { handler: 'src/api.handler' } }
+    const plugin = makePlugin(serviceDir, fns)
+
+    await plugin._build()
+
+    // The layered function is still reported, and the buildable one is built.
+    expect(layerWarnings()).toHaveLength(1)
+    expect(plugin.builtArtifacts.get('api').outfile).toBe('src/api.js')
+    expect(plugin.builtArtifacts.get('dd')).toBeUndefined()
+
+    await plugin._preparePackageJson()
+    await plugin._packageAll(fns)
+
+    expect(await zipNames(serviceDir)).toEqual(
+      expect.arrayContaining(['package.json', 'src/api.js']),
+    )
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-build.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-build.test.js
@@ -1143,110 +1143,89 @@ describe('_build with bundle:false honors classic file selection', () => {
     expect(built).toContain('serverless.yml')
   })
 
-  it('honors the legacy package.exclude and lets patterns re-include from it', async () => {
-    const files = {
-      'package.json': '{"name":"svc"}',
-      'src/handler.ts': 'export const hello = async () => ({})\n',
-      'secrets/keys.txt': 'shh\n',
-      'secrets/keep.txt': 'fine\n',
+  it('ignores the legacy package.include and package.exclude keys and says so once', async () => {
+    // The esbuild build reads `package.patterns` only. The legacy pair is still
+    // schema-valid and still honored by classic packaging, so a service that
+    // never migrated must hear that its excludes remove nothing and its
+    // includes add nothing here -- once per process, dev mode rebuilds through
+    // the same instance.
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    try {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/other.ts': 'export const hello = async () => ({})\n',
+        'secrets/keys.txt': 'shh\n',
+        'lib/node_modules/inner/index.js': 'module.exports = "inner"\n',
+      })
+      const plugin = makePlugin(
+        serviceDir,
+        {
+          hello: { handler: 'src/handler.hello' },
+          other: {
+            handler: 'src/other.hello',
+            package: { include: ['lib/**'] },
+          },
+        },
+        {
+          packageConfig: {
+            exclude: ['secrets/**'],
+            include: ['lib/node_modules/**'],
+          },
+        },
+      )
+
+      await plugin._build()
+
+      const built = listBuild(serviceDir)
+      expect(built).toContain('secrets/keys.txt')
+      expect(built).not.toContain('lib/node_modules/inner/index.js')
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const [message] = warnSpy.mock.calls[0]
+      expect(message).toContain('"package.patterns" only')
+      expect(message).toContain(
+        'the service-level "package.include" and "package.exclude"',
+      )
+      expect(message).toContain('"package.include" on function "other"')
+      expect(message).toContain('prefixing excludes with "!"')
+
+      await plugin._build()
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
     }
-
-    const excluded = makeServiceDir(files)
-    await makePlugin(excluded, functions, {
-      packageConfig: { exclude: ['secrets/**'] },
-    })._build()
-    const built = listBuild(excluded)
-    expect(built).not.toContain('secrets/keys.txt')
-    expect(built).not.toContain('secrets/keep.txt')
-
-    // `exclude` rides in ahead of `patterns`, so last-match-wins still applies.
-    const reincluded = makeServiceDir(files)
-    await makePlugin(reincluded, functions, {
-      packageConfig: {
-        exclude: ['secrets/**'],
-        patterns: ['secrets/keep.txt'],
-      },
-    })._build()
-    const reincludedBuild = listBuild(reincluded)
-    expect(reincludedBuild).toContain('secrets/keep.txt')
-    expect(reincludedBuild).not.toContain('secrets/keys.txt')
   })
 
-  it('inverts a !-prefixed legacy package.exclude entry into a re-include, classic-style', async () => {
-    const serviceDir = makeServiceDir({
-      'package.json': '{"name":"svc"}',
-      'src/handler.ts': 'export const hello = async () => ({})\n',
-      'tmp/keep.js': 'module.exports = 1\n',
-      'tmp/other.js': 'module.exports = 2\n',
-      'assets/logo.txt': 'logo\n',
-    })
-    await makePlugin(serviceDir, functions, {
-      packageConfig: { exclude: ['tmp/**', '!tmp/keep.js'] },
-    })._build()
+  it('says nothing about legacy package keys when only patterns are configured', async () => {
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    try {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'secrets/keys.txt': 'shh\n',
+      })
+      await makePlugin(
+        serviceDir,
+        { hello: { handler: 'src/handler.hello' } },
+        {
+          packageConfig: {
+            patterns: ['!secrets/**'],
+            include: [],
+            exclude: [],
+          },
+        },
+      )._build()
 
-    const built = listBuild(serviceDir)
-    expect(built).toContain('tmp/keep.js')
-    expect(built).not.toContain('tmp/other.js')
-    // The exclude pair touches nothing outside tmp/.
-    expect(built).toContain('assets/logo.txt')
-    expect(built).toContain('src/handler.js')
-  })
-
-  it('keeps the project intact when package.exclude carries only a !-prefixed entry', async () => {
-    // A re-include of a file nothing excluded is a no-op in classic. A blanket
-    // `!${glob}` wrap turned it into `!!keep.js` -- a negation whose micromatch
-    // pattern matches everything EXCEPT keep.js -- and emptied the sweep.
-    const serviceDir = makeServiceDir({
-      'package.json': '{"name":"svc"}',
-      'src/handler.ts': 'export const hello = async () => ({})\n',
-      'keep.js': 'module.exports = 1\n',
-      'src/util.js': 'module.exports = 2\n',
-      'README.md': '# svc\n',
-    })
-    await makePlugin(serviceDir, functions, {
-      packageConfig: { exclude: ['!keep.js'] },
-    })._build()
-
-    expect(listBuild(serviceDir)).toEqual(
-      expect.arrayContaining([
-        'README.md',
-        'keep.js',
-        'src/handler.js',
-        'src/util.js',
-      ]),
-    )
-  })
-
-  it('honors the legacy package.include, after excludes and before patterns', async () => {
-    const files = {
-      'package.json': '{"name":"svc"}',
-      'src/handler.ts': 'export const hello = async () => ({})\n',
-      'lib/keep.js': 'module.exports = 1\n',
-      'lib/other.js': 'module.exports = 2\n',
+      expect(listBuild(serviceDir)).not.toContain('secrets/keys.txt')
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
     }
-
-    // The idiomatic legacy pair: exclude broad, re-include narrow.
-    const reincluded = makeServiceDir(files)
-    await makePlugin(reincluded, functions, {
-      packageConfig: { exclude: ['lib/**'], include: ['lib/keep.js'] },
-    })._build()
-    const reincludedBuild = listBuild(reincluded)
-    expect(reincludedBuild).toContain('lib/keep.js')
-    expect(reincludedBuild).not.toContain('lib/other.js')
-
-    // Classic appends `include` before `patterns`, so a patterns negation
-    // still gets the last word over an include.
-    const patternsWin = makeServiceDir(files)
-    await makePlugin(patternsWin, functions, {
-      packageConfig: {
-        exclude: ['lib/**'],
-        include: ['lib/**'],
-        patterns: ['!lib/other.js'],
-      },
-    })._build()
-    const patternsWinBuild = listBuild(patternsWin)
-    expect(patternsWinBuild).toContain('lib/keep.js')
-    expect(patternsWinBuild).not.toContain('lib/other.js')
   })
 
   it('builds the handler even when the patterns would have excluded it', async () => {

--- a/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-build.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-build.test.js
@@ -927,7 +927,7 @@ describe('_build with bundle:false honors classic file selection', () => {
     '.env': 'SECRET=1\n',
     '.env.production': 'SECRET=2\n',
     'src/.env': 'SECRET=3\n',
-    '.npmrc': 'registry=https://registry.npmjs.org/\n',
+    '.nvmrc': '24\n',
   }
 
   it.each([
@@ -947,7 +947,7 @@ describe('_build with bundle:false honors classic file selection', () => {
     expect(built).not.toContain('.env.production')
     expect(built).not.toContain('src/.env')
     // Scoped to env files: no other dotfile was swept up with them.
-    expect(built).toContain('.npmrc')
+    expect(built).toContain('.nvmrc')
     expect(built).toContain('src/handler.js')
 
     // And the artifact that actually deploys agrees with the build directory.
@@ -955,7 +955,63 @@ describe('_build with bundle:false honors classic file selection', () => {
     expect(packaged).not.toContain('.env')
     expect(packaged).not.toContain('.env.production')
     expect(packaged).not.toContain('src/.env')
+    expect(packaged).toContain('.nvmrc')
+  })
+
+  // Package-manager configuration is the other place credentials sit in a
+  // project tree (`//registry.npmjs.org/:_authToken=...`, `npmAuthToken`).
+  // Nothing reads it at runtime, so unlike classic packaging the sweep drops
+  // it at any depth. Other dotfiles are ordinary project files and ship.
+  const packageManagerConfigFiles = {
+    'package.json': '{"name":"svc"}',
+    'src/handler.ts': 'export const hello = async () => ({})\n',
+    '.npmrc': '//registry.npmjs.org/:_authToken=npm_secret\n',
+    '.yarnrc': 'registry "https://registry.yarnpkg.com"\n',
+    '.yarnrc.yml': 'npmAuthToken: secret\n',
+    'packages/lib/.npmrc': 'registry=https://registry.npmjs.org/\n',
+    '.nvmrc': '24\n',
+  }
+
+  it('never packages package-manager configuration files', async () => {
+    const serviceDir = makeServiceDir(packageManagerConfigFiles)
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).not.toContain('.npmrc')
+    expect(built).not.toContain('.yarnrc')
+    expect(built).not.toContain('.yarnrc.yml')
+    expect(built).not.toContain('packages/lib/.npmrc')
+    expect(built).toContain('.nvmrc')
+    expect(built).toContain('src/handler.js')
+
+    const packaged = await packagedNames(plugin, serviceDir)
+    expect(packaged).not.toContain('.npmrc')
+    expect(packaged).not.toContain('.yarnrc')
+    expect(packaged).not.toContain('.yarnrc.yml')
+    expect(packaged).not.toContain('packages/lib/.npmrc')
+    expect(packaged).toContain('.nvmrc')
+  })
+
+  it('re-includes a package-manager configuration file named by a positive pattern', async () => {
+    const serviceDir = makeServiceDir(packageManagerConfigFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      packageConfig: { patterns: ['.npmrc'] },
+    })
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).toContain('.npmrc')
+    // Only the one that was asked for.
+    expect(built).not.toContain('.yarnrc.yml')
+    expect(built).not.toContain('packages/lib/.npmrc')
+
+    const packaged = await packagedNames(plugin, serviceDir)
     expect(packaged).toContain('.npmrc')
+    expect(packaged).not.toContain('.yarnrc.yml')
+    expect(packaged).not.toContain('packages/lib/.npmrc')
   })
 
   it('re-includes an env file named by an explicit positive pattern', async () => {

--- a/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-build.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-build.test.js
@@ -1,0 +1,2232 @@
+/**
+ * With `bundle: false` a handler output is no longer self-contained: every
+ * `import` it makes is left as a runtime require/import, so each of those files
+ * has to exist in the deployment artifact too. Building only the handler files
+ * -- which is what the bundling path does -- ships a zip in which the handler
+ * immediately fails with `Cannot find module './util'`.
+ *
+ * So the non-bundled build compiles the WHOLE project: every file classic
+ * packaging would have shipped is either transpiled by esbuild (TS family, JSX)
+ * or copied verbatim, with the directory layout preserved exactly, because
+ * relative specifiers in unbundled output are resolved against that layout at
+ * runtime.
+ *
+ * These tests drive the real `_build` against real temp-directory services and
+ * inspect `.serverless/build`, rather than asserting on esbuild call arguments:
+ * the contract is what lands on disk.
+ */
+
+import { jest } from '@jest/globals'
+import { execFileSync, spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import JsZip from 'jszip'
+import { log } from '@serverless/util'
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+const esbuildLogger = log.get('esbuild')
+
+const createdServiceDirs = []
+
+afterAll(() => {
+  for (const dir of createdServiceDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+/**
+ * `realpathSync` because macOS resolves the temp dir through a symlink, and
+ * esbuild reports real paths -- an unresolved prefix makes `outbase` fail to
+ * match the entry points and collapses the whole layout into the build root.
+ */
+function makeServiceDir(files) {
+  const serviceDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-nobundle-')),
+  )
+  createdServiceDirs.push(serviceDir)
+  for (const [name, contents] of Object.entries(files)) {
+    const filePath = path.join(serviceDir, name)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+  return serviceDir
+}
+
+function makePlugin(
+  serviceDir,
+  functions,
+  {
+    esbuildConfig = { bundle: false },
+    packageConfig = {},
+    layers = {},
+    localPluginPath = null,
+    configurationFilename,
+    configurationInput,
+    options = {},
+  } = {},
+) {
+  const serverless = {
+    serviceDir,
+    configurationFilename,
+    configurationInput,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      provider: { runtime: 'nodejs20.x' },
+      package: packageConfig,
+      build: { esbuild: esbuildConfig },
+      functions,
+      getFunction: (alias) => functions[alias],
+      getAllFunctions: () => Object.keys(functions),
+      getAllLayers: () => Object.keys(layers),
+      getLayer: (name) => layers[name],
+    },
+    pluginManager: {
+      spawn: async () => {},
+      parsePluginsObject: () => ({ localPath: localPluginPath }),
+    },
+  }
+  const plugin = new Esbuild(serverless, options)
+  // Target `_build` directly: the selection/partitioning logic is what's under
+  // test, not the introspection in `functions()`.
+  plugin.functions = async () => functions
+  return plugin
+}
+
+const buildDirOf = (serviceDir) => path.join(serviceDir, '.serverless', 'build')
+
+const existsIn = (serviceDir, rel) =>
+  fs.existsSync(path.join(buildDirOf(serviceDir), rel))
+
+const readIn = (serviceDir, rel) =>
+  fs.readFileSync(path.join(buildDirOf(serviceDir), rel), 'utf8')
+
+/**
+ * Load a built handler in a real Node process and return whatever it resolved
+ * to. Reading the emitted syntax proves esbuild wrote what we asked for; only
+ * actually loading it proves Node agrees — which is the failure mode a wrong
+ * extension or format produces, and it produces it at invocation time.
+ */
+function loadBuiltHandler(serviceDir, rel, exportName) {
+  const target = path.join(buildDirOf(serviceDir), rel)
+  const script =
+    `import(${JSON.stringify(target)})` +
+    `.then((m) => (m.${exportName} ?? m.default?.${exportName})())` +
+    `.then((r) => console.log(JSON.stringify(r)))`
+  return JSON.parse(
+    execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' }),
+  )
+}
+
+/** Every file in the build dir, POSIX-relative and sorted. */
+// Entry names of the artifact `_packageAll` produces, so an assertion can be
+// made about what actually deploys rather than only about the build directory.
+async function packagedNames(plugin, serviceDir) {
+  await plugin._packageAll(await plugin.functions())
+  const zip = await JsZip.loadAsync(
+    fs.readFileSync(path.join(serviceDir, '.serverless', 'my-service.zip')),
+  )
+  return Object.keys(zip.files).sort()
+}
+
+function listBuild(serviceDir) {
+  const root = buildDirOf(serviceDir)
+  if (!fs.existsSync(root)) return []
+  const out = []
+  const walk = (dir, prefix) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name
+      if (entry.isDirectory()) walk(path.join(dir, entry.name), rel)
+      else out.push(rel)
+    }
+  }
+  walk(root, '')
+  return out.sort()
+}
+
+const HANDLER_TS =
+  "import { helper } from './util'\n" +
+  "import { legacy } from './legacy.js'\n" +
+  'export const hello = async () => ({\n' +
+  '  statusCode: 200,\n' +
+  '  body: `${helper()}${legacy()}`,\n' +
+  '})\n'
+
+const functions = { hello: { handler: 'src/handler.hello' } }
+
+describe('_build with bundle:false compiles the whole project', () => {
+  jest.setTimeout(60_000)
+
+  it('compiles TS helpers, copies JS helpers and assets, and preserves the layout', async () => {
+    const legacySource = 'exports.legacy = () => "legacy"\n'
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': HANDLER_TS,
+      'src/util.ts': "export const helper = () => 'helped'\n",
+      'src/legacy.js': legacySource,
+      'assets/data.json': '{"a":1}\n',
+      'deep/nested/dir/mod.ts': 'export const deep = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    // Compiled: the handler AND every other TS file in the project.
+    expect(existsIn(serviceDir, 'src/handler.js')).toBe(true)
+    expect(existsIn(serviceDir, 'src/util.js')).toBe(true)
+    // Nesting is preserved exactly -- relative specifiers depend on it.
+    expect(existsIn(serviceDir, 'deep/nested/dir/mod.js')).toBe(true)
+
+    // Copied: byte-for-byte, not re-emitted through esbuild.
+    expect(readIn(serviceDir, 'src/legacy.js')).toBe(legacySource)
+    expect(readIn(serviceDir, 'assets/data.json')).toBe('{"a":1}\n')
+
+    // A project with no `"type": "module"` loads `.js` as CommonJS, so the
+    // compiled output has to be CommonJS or Node rejects it at load time.
+    const handler = readIn(serviceDir, 'src/handler.js')
+    expect(handler).toMatch(/require\(/)
+    expect(handler).not.toMatch(/^import /m)
+  })
+
+  it('records the handler artifact and marks the function built', async () => {
+    const serviceDir = makeServiceDir({
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/util.ts': 'export const helper = () => 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(plugin.builtArtifacts.get('hello')).toEqual({
+      outfile: 'src/handler.js',
+      mapfile: 'src/handler.js.map',
+    })
+    expect([...plugin.serverless.builtFunctions]).toEqual(['hello'])
+    // A helper is not a handler: it is built, but it is nobody's artifact.
+    expect([...plugin.builtArtifacts.keys()]).toEqual(['hello'])
+  })
+
+  it('builds a handler written with a "./" prefix exactly once', async () => {
+    // The handler comes from user configuration and the sweep from globby, so
+    // the two spellings of one file have to be reconciled -- otherwise the file
+    // is compiled twice and reported as colliding with itself.
+    const serviceDir = makeServiceDir({
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, {
+      hello: { handler: './src/handler.hello' },
+    })
+
+    await plugin._build()
+
+    expect(plugin.builtArtifacts.get('hello').outfile).toBe('src/handler.js')
+    expect(listBuild(serviceDir)).toEqual([
+      'src/handler.js',
+      'src/handler.js.map',
+    ])
+  })
+})
+
+describe('_build with bundle:false picks a format per file', () => {
+  jest.setTimeout(60_000)
+
+  it('follows the nearest package.json, not the service root', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/esm/package.json': '{"type":"module"}',
+      'src/esm/mod.ts': 'export const esmOnly = 1\n',
+      'src/plain.ts': 'export const cjsOnly = 2\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'src/esm/mod.js')).toMatch(/export /)
+    expect(readIn(serviceDir, 'src/plain.js')).toMatch(
+      /module\.exports|exports\./,
+    )
+    // The nested package.json is what makes Node agree with that choice at
+    // runtime, so it has to be in the artifact too.
+    expect(readIn(serviceDir, 'src/esm/package.json')).toBe('{"type":"module"}')
+  })
+
+  it('classes the handler itself by the nearest package.json and ships it', async () => {
+    // The handler sits UNDER the nested `"type": "module"`, so the whole
+    // question is settled by a file the service root never mentions: the
+    // compiled handler has to be ESM, the `.js` helper beside it is already
+    // ESM and must arrive untouched, and `src/package.json` has to be in the
+    // artifact or Node re-runs this same lookup in Lambda, finds nothing, and
+    // loads both files as CommonJS.
+    const utilSource = "export const helper = () => 'helped'\n"
+    const nestedPackageJson = '{"type":"module"}'
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/package.json': nestedPackageJson,
+      'src/handler.ts':
+        "import { helper } from './util.js'\n" +
+        'export const hello = async () => ({ statusCode: 200, body: helper() })\n',
+      'src/util.js': utilSource,
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    const handler = readIn(serviceDir, 'src/handler.js')
+    expect(handler).toMatch(/^import /m)
+    expect(handler).toMatch(/^export /m)
+    expect(handler).not.toMatch(/module\.exports|exports\./)
+    // Swept, not compiled: an ESM `.js` re-emitted as CommonJS would break the
+    // `import` above.
+    expect(readIn(serviceDir, 'src/util.js')).toBe(utilSource)
+    expect(existsIn(serviceDir, 'src/util.js.map')).toBe(false)
+    expect(readIn(serviceDir, 'src/package.json')).toBe(nestedPackageJson)
+    // Only Node agreeing proves the three of them are consistent.
+    expect(loadBuiltHandler(serviceDir, 'src/handler.js', 'hello')).toEqual({
+      statusCode: 200,
+      body: 'helped',
+    })
+  })
+
+  it('emits ESM everywhere for a "type": "module" service', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/util.ts': 'export const helper = () => 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'src/util.js')).toMatch(/export /)
+    expect(readIn(serviceDir, 'src/handler.js')).not.toMatch(/module\.exports/)
+  })
+
+  it('lets a nested CommonJS package.json opt out of an ESM service', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'legacy/package.json': '{"type":"commonjs"}',
+      'legacy/old.ts': 'export const old = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'legacy/old.js')).toMatch(
+      /module\.exports|exports\./,
+    )
+  })
+
+  it('honors an explicit format for the .js class only', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/util.ts': 'export const helper = () => 1\n',
+      'src/tool.mts': 'export const tool = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, format: 'esm' },
+    })
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'src/util.js')).toMatch(/export /)
+    // `.mts` is ESM by definition and unaffected either way.
+    expect(readIn(serviceDir, 'src/tool.mjs')).toMatch(/export /)
+  })
+
+  it('maps .mts to .mjs and .cts to .cjs whatever the service format is', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/tool.mts': 'export const tool = 1\n',
+      'src/old.cts': 'export const old = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(existsIn(serviceDir, 'src/tool.mjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/old.cjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/tool.js')).toBe(false)
+    expect(existsIn(serviceDir, 'src/old.js')).toBe(false)
+    // `.cts` stays CommonJS even though the service is `"type": "module"` --
+    // that is the whole point of the extension.
+    expect(readIn(serviceDir, 'src/old.cjs')).toMatch(
+      /module\.exports|exports\./,
+    )
+    expect(readIn(serviceDir, 'src/tool.mjs')).toMatch(/export /)
+  })
+
+  it('compiles .jsx and .tsx onto .js', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/a.jsx': 'export const A = () => null\n',
+      'src/b.tsx': 'export const B = (): null => null\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(existsIn(serviceDir, 'src/a.js')).toBe(true)
+    expect(existsIn(serviceDir, 'src/b.js')).toBe(true)
+  })
+
+  it('copies .mjs with top-level await untouched', async () => {
+    // Transpiling an `.mjs` down to CommonJS would fail outright on top-level
+    // await; it is already a module Node can load, so it is copied.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/tla.mjs': 'await Promise.resolve()\nexport const ready = true\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect(readIn(serviceDir, 'src/tla.mjs')).toContain(
+      'await Promise.resolve()',
+    )
+  })
+
+  it('copies a .cjs helper untouched under a "type": "module" root', async () => {
+    // A `.cjs` helper is CommonJS by name and Node loads it that way whatever
+    // the root says, so the service-wide ESM format must not reach it and
+    // nothing has to be re-emitted: it is copied, byte for byte.
+    const legacySource =
+      "const os = require('os')\nmodule.exports.legacy = () => os.EOL\n"
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/legacy.cjs': legacySource,
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'src/legacy.cjs')).toBe(legacySource)
+    // A compiled file gets a sourcemap; a copied one does not.
+    expect(existsIn(serviceDir, 'src/legacy.cjs.map')).toBe(false)
+    expect(existsIn(serviceDir, 'src/legacy.js')).toBe(false)
+    expect(existsIn(serviceDir, 'src/legacy.mjs')).toBe(false)
+  })
+})
+
+/**
+ * `.js` is not one language. Projects carry JSX and Flow annotations in files
+ * named `.js`, and esbuild's default `js` loader parses neither. Those files
+ * are not compilable sources here -- they are payload the sweep copies -- so
+ * they have to reach the artifact exactly as written rather than failing the
+ * build of a service that never asked for them to be compiled.
+ */
+describe('_build with bundle:false copies .js dialects it cannot parse', () => {
+  jest.setTimeout(60_000)
+
+  it('copies JSX and Flow files verbatim instead of parsing them', async () => {
+    const jsxSource =
+      "const { createElement } = require('react')\n" +
+      'module.exports.App = () => <div className="app">hi</div>\n'
+    const flowSource =
+      '// @flow\n' +
+      'function add(a: number, b: number): number {\n' +
+      '  return a + b\n' +
+      '}\n' +
+      'module.exports = add\n'
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/web/App.js': jsxSource,
+      'src/typed.js': flowSource,
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    // Compiling either of these fails with a parse error; copying cannot.
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect(readIn(serviceDir, 'src/web/App.js')).toBe(jsxSource)
+    expect(readIn(serviceDir, 'src/typed.js')).toBe(flowSource)
+    expect(existsIn(serviceDir, 'src/web/App.js.map')).toBe(false)
+    expect(existsIn(serviceDir, 'src/typed.js.map')).toBe(false)
+  })
+})
+
+/**
+ * A handler is compiled whatever its extension, even one the sweep would have
+ * copied. Treating a `.mjs`/`.cjs` handler as part of the `.js` class emitted
+ * `handler.js` while `builtArtifacts` and packaging looked for `handler.mjs`,
+ * so the build failed with ESBUILD_HANDLER_NOT_BUILT — a service whose handler
+ * was a plain `.mjs` file could not be built at all with `bundle: false`.
+ */
+describe('_build with bundle:false keeps a handler in its own module class', () => {
+  jest.setTimeout(60_000)
+
+  it('builds a .mjs handler as ESM under its own name', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.mjs':
+        "const greeting = await Promise.resolve('mjs')\n" +
+        'export const hello = async () => ({ statusCode: 200, body: greeting })\n',
+    })
+    const plugin = makePlugin(serviceDir, {
+      hello: { handler: 'src/handler.hello' },
+    })
+
+    await plugin._build()
+
+    expect(existsIn(serviceDir, 'src/handler.mjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/handler.js')).toBe(false)
+    // Top-level await only survives an ESM output.
+    expect(readIn(serviceDir, 'src/handler.mjs')).toMatch(
+      /await Promise\.resolve/,
+    )
+    expect(plugin.builtArtifacts.get('hello')).toEqual({
+      outfile: 'src/handler.mjs',
+      mapfile: 'src/handler.mjs.map',
+    })
+    expect(loadBuiltHandler(serviceDir, 'src/handler.mjs', 'hello')).toEqual({
+      statusCode: 200,
+      body: 'mjs',
+    })
+  })
+
+  it('builds a .cjs handler as CommonJS under a "type": "module" root', async () => {
+    // The whole point of the extension: `.cjs` is CommonJS even where the
+    // service says otherwise, so the service-wide ESM format must not reach it.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.cjs':
+        "exports.hello = async () => ({ statusCode: 200, body: require('./legacy.cjs').name })\n",
+      'src/legacy.cjs': "exports.name = 'cjs'\n",
+    })
+    const plugin = makePlugin(serviceDir, {
+      hello: { handler: 'src/handler.hello' },
+    })
+
+    await plugin._build()
+
+    expect(existsIn(serviceDir, 'src/handler.cjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/handler.js')).toBe(false)
+    const built = readIn(serviceDir, 'src/handler.cjs')
+    expect(built).toMatch(/module\.exports|exports\./)
+    expect(built).not.toMatch(/^export /m)
+    expect(plugin.builtArtifacts.get('hello')).toEqual({
+      outfile: 'src/handler.cjs',
+      mapfile: 'src/handler.cjs.map',
+    })
+    expect(loadBuiltHandler(serviceDir, 'src/handler.cjs', 'hello')).toEqual({
+      statusCode: 200,
+      body: 'cjs',
+    })
+  })
+
+  it('gives the .mjs and .js classes separate metafiles when outExtension merges their names', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/tool.mts': 'export const tool = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: {
+        bundle: false,
+        metafile: true,
+        outExtension: { '.js': '.mjs' },
+      },
+    })
+
+    await plugin._build()
+
+    // Both classes emit `.mjs`/esm here, but they are still two partitions --
+    // keyed by source class -- so neither metafile overwrites the other.
+    expect(
+      listBuild(serviceDir)
+        .filter((f) => f.startsWith('meta.'))
+        .sort(),
+    ).toEqual(['meta.jsesm.json', 'meta.mjsesm.json'])
+  })
+})
+
+describe('_build with bundle:false rejects output collisions', () => {
+  jest.setTimeout(60_000)
+
+  it('hard-errors naming both sources', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/dup.ts': 'export const fromTs = 1\n',
+      'src/dup.js': 'exports.fromJs = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    const error = await plugin._build().then(
+      () => undefined,
+      (err) => err,
+    )
+
+    expect(error?.code).toBe('ESBUILD_OUTPUT_COLLISION')
+    expect(error.message).toContain('src/dup.ts')
+    expect(error.message).toContain('src/dup.js')
+    expect(error.message).toContain('src/dup.js"') // the shared output
+  })
+
+  it('still errors when the two outputs would be byte-identical', async () => {
+    // The check is on the output PATH, deliberately, and this is the case that
+    // proves it has to be: nothing downstream would ever notice this one.
+    // esbuild writes the compiled `.ts`, the copy phase then writes the `.js`
+    // over it with the same bytes, and the artifact looks perfect -- while the
+    // service is one edit away from the two files diverging and a build
+    // silently shipping whichever ran last.
+    //
+    // The identical-bytes premise is established here rather than asserted
+    // from a hand-written constant, so it cannot rot when esbuild changes its
+    // output preamble: build the `.ts` alone, take what it emitted, and use
+    // exactly those bytes as the sibling `.js`.
+    const duplicated = 'module.exports.value = 1\n'
+    const alone = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/dup.ts': duplicated,
+    })
+    await makePlugin(alone, functions)._build()
+    const emitted = readIn(alone, 'src/dup.js')
+
+    const both = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/dup.ts': duplicated,
+      'src/dup.js': emitted,
+    })
+    const error = await makePlugin(both, functions)
+      ._build()
+      .then(
+        () => undefined,
+        (err) => err,
+      )
+
+    expect(error?.code).toBe('ESBUILD_OUTPUT_COLLISION')
+    expect(error.message).toMatch(
+      /"src\/dup\.js" would be produced by both "src\/dup\.ts" and "src\/dup\.js"/,
+    )
+    expect(listBuild(both)).toEqual([])
+  })
+
+  it('does not flag a compiled file whose output name is simply free', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/a.ts': 'export const a = 1\n',
+      'src/a.mjs': 'export const b = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+  })
+
+  it('catches a collision that only outExtension creates', async () => {
+    // `src/a.ts` and `src/a.mjs` do not clash by default -- they clash only
+    // because `outExtension` moves the `.js` class onto `.mjs` too.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/a.ts': 'export const a = 1\n',
+      'src/a.mjs': 'export const b = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, outExtension: { '.js': '.mjs' } },
+    })
+
+    const error = await plugin._build().then(
+      () => undefined,
+      (err) => err,
+    )
+
+    expect(error?.code).toBe('ESBUILD_OUTPUT_COLLISION')
+    expect(error.message).toContain('src/a.ts')
+    expect(error.message).toContain('src/a.mjs')
+  })
+})
+
+/**
+ * A project that already runs `tsc` itself keeps compiled JavaScript in the
+ * tree alongside the TypeScript it came from. Bundling never looked at either
+ * one except through the handler, so the two could coexist; compiling the whole
+ * project cannot ignore them, and where they land on the same name the build
+ * has to say so rather than pick a winner at random.
+ */
+describe('_build with bundle:false and a tsc-precompiled tree', () => {
+  jest.setTimeout(60_000)
+
+  // `tsc` with no `outDir`: every emitted `.js` sits next to its `.ts`.
+  const inPlace = {
+    'package.json': '{"name":"svc"}',
+    'tsconfig.json': '{"include":["src"]}',
+    'src/handler.ts':
+      "import { helper } from './util.js'\n" +
+      'export const hello = async () => ({ body: helper() })\n',
+    'src/handler.js': 'exports.hello = async () => ({ body: "stale" })\n',
+    'src/util.ts': "export const helper = () => 'helped'\n",
+    'src/util.js': 'exports.helper = () => "stale"\n',
+  }
+
+  it('refuses a precompiled output sitting on its own source name', async () => {
+    const serviceDir = makeServiceDir(inPlace)
+    const plugin = makePlugin(serviceDir, functions)
+
+    const error = await plugin._build().then(
+      () => undefined,
+      (err) => err,
+    )
+
+    expect(error?.code).toBe('ESBUILD_OUTPUT_COLLISION')
+    // The PAIRING is the payload, for EVERY colliding pair -- naming one source
+    // per output would leave the user hunting for the other half, and the fix
+    // is a pattern list that has to cover all of them. Matched as whole
+    // clauses: the output name is itself one of the two source names here, so
+    // a substring check for it is satisfied by the wrong token.
+    expect(error.message).toMatch(
+      /"src\/handler\.js" would be produced by both "src\/handler\.ts" and "src\/handler\.js"/,
+    )
+    expect(error.message).toMatch(
+      /"src\/util\.js" would be produced by both "src\/util\.ts" and "src\/util\.js"/,
+    )
+    expect(listBuild(serviceDir)).toEqual([])
+  })
+
+  it('builds the precompiled output once the sources are excluded', async () => {
+    const serviceDir = makeServiceDir(inPlace)
+    const plugin = makePlugin(serviceDir, functions, {
+      packageConfig: { patterns: ['!src/**/*.ts'] },
+    })
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    // The handler resolves to the `.js` -- it is the file that exists under the
+    // configured handler path once the TypeScript is out of the sweep -- and
+    // the rest of the precompiled tree rides along as copied payload.
+    expect(plugin.builtArtifacts.get('hello').outfile).toBe('src/handler.js')
+    expect(listBuild(serviceDir)).toEqual([
+      'package.json',
+      'src/handler.js',
+      'src/handler.js.map',
+      'src/util.js',
+      'tsconfig.json',
+    ])
+  })
+
+  it('emits both trees when the precompiled output has its own directory', async () => {
+    // The `outDir` shape does NOT collide: `dist/handler.js` and
+    // `src/handler.ts` emit different names, so the build succeeds and the
+    // artifact carries the same code twice. Nothing is wrong with it, but the
+    // sources are dead weight -- `package.patterns` is what removes them.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'tsconfig.json':
+        '{"include":["src"],"compilerOptions":{"outDir":"dist"}}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'dist/handler.js': 'exports.hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, {
+      hello: { handler: 'dist/handler.hello' },
+    })
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect(plugin.builtArtifacts.get('hello').outfile).toBe('dist/handler.js')
+    expect(listBuild(serviceDir)).toEqual([
+      'dist/handler.js',
+      'dist/handler.js.map',
+      'package.json',
+      'src/handler.js',
+      'src/handler.js.map',
+      'tsconfig.json',
+    ])
+  })
+})
+
+describe('_build with bundle:false and outExtension', () => {
+  jest.setTimeout(60_000)
+
+  it('renames the .js class and leaves .mts/.cts alone', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/util.ts': 'export const helper = () => 1\n',
+      'src/tool.mts': 'export const tool = 1\n',
+      'src/old.cts': 'export const old = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, outExtension: { '.js': '.mjs' } },
+    })
+
+    await plugin._build()
+
+    expect(existsIn(serviceDir, 'src/handler.mjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/util.mjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/tool.mjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/old.cjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/handler.js')).toBe(false)
+    // Packaging reads the artifact record, so it has to carry the real name.
+    expect(plugin.builtArtifacts.get('hello')).toEqual({
+      outfile: 'src/handler.mjs',
+      mapfile: 'src/handler.mjs.map',
+    })
+  })
+
+  it('rejects an extension the resolved format cannot emit', async () => {
+    // No `"type": "module"`, so the `.js` class compiles to CommonJS — which
+    // Lambda would then be asked to load from an `.mjs` file.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, outExtension: { '.js': '.mjs' } },
+    })
+
+    await expect(plugin._build()).rejects.toMatchObject({
+      code: 'ESBUILD_OUT_EXTENSION_FORMAT_MISMATCH',
+    })
+  })
+
+  it('rejects an unsupported extension even with no .js-class file to apply it to', async () => {
+    // Every source here is `.mts`, so nothing ever reaches the `.js`-class
+    // partition. An `outExtension` Lambda cannot load is still wrong, and
+    // leaving it to that partition let it through in silence.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.mts': 'export const hello = async () => ({})\n',
+      'src/tool.mts': 'export const tool = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, outExtension: { '.js': '.weird' } },
+    })
+
+    await expect(plugin._build()).rejects.toMatchObject({
+      code: 'ESBUILD_OUT_EXTENSION_UNSUPPORTED',
+    })
+  })
+})
+
+/**
+ * `banner`, `footer` and `inject` are how a user patches their own module
+ * system — the canonical example being a `createRequire(import.meta.url)`
+ * banner to get `require` back in an ESM build. Injecting that into a CommonJS
+ * partition is a syntax error, so they are scoped exactly like `format` and
+ * `outExtension`: the `.js` class only.
+ */
+describe('_build with bundle:false scopes banner/footer/inject to the .js class', () => {
+  jest.setTimeout(60_000)
+
+  it('applies them to the .js class and to nothing else', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/tool.mts': 'export const tool = 1\n',
+      'src/old.cts': 'export const old = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: {
+        bundle: false,
+        banner: { js: '// SERVERLESS_BANNER' },
+        footer: { js: '// SERVERLESS_FOOTER' },
+      },
+    })
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'src/handler.js')).toContain(
+      '// SERVERLESS_BANNER',
+    )
+    expect(readIn(serviceDir, 'src/handler.js')).toContain(
+      '// SERVERLESS_FOOTER',
+    )
+    // The `.cjs` class is CommonJS by definition; an ESM-shaped banner there is
+    // at best dead weight and at worst a syntax error.
+    expect(readIn(serviceDir, 'src/old.cjs')).not.toContain(
+      '// SERVERLESS_BANNER',
+    )
+    expect(readIn(serviceDir, 'src/tool.mjs')).not.toContain(
+      '// SERVERLESS_BANNER',
+    )
+  })
+
+  it('keeps a createRequire banner out of the CommonJS partitions', async () => {
+    // The real-world case: the banner is valid ESM and invalid CJS, so a
+    // `.cts` output carrying it would not even parse.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({ ok: true })\n',
+      'src/old.cts': 'export const old = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: {
+        bundle: false,
+        banner: {
+          js: "import { createRequire } from 'module'\nconst require = createRequire(import.meta.url)\n",
+        },
+      },
+    })
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'src/old.cjs')).not.toContain('import.meta.url')
+    // And the ESM output it was meant for still loads.
+    expect(loadBuiltHandler(serviceDir, 'src/handler.js', 'hello')).toEqual({
+      ok: true,
+    })
+  })
+})
+
+describe('_build with bundle:false honors classic file selection', () => {
+  jest.setTimeout(60_000)
+
+  it('drops the files classic never ships', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'serverless.yml': 'service: my-service\n',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      '.gitignore': 'node_modules\n',
+      '.DS_Store': 'junk',
+      'npm-debug.log': 'noise',
+      'yarn-error.log': 'noise',
+      'types.d.ts': 'export {}\n',
+      'layerdir/lib.js': 'module.exports = 1\n',
+      'my-plugins/plugin.js': 'module.exports = {}\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      configurationFilename: 'serverless.yml',
+      layers: { shared: { path: 'layerdir' } },
+      localPluginPath: 'my-plugins',
+    })
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).not.toContain('serverless.yml')
+    expect(built).not.toContain('.gitignore')
+    expect(built).not.toContain('.DS_Store')
+    expect(built).not.toContain('npm-debug.log')
+    expect(built).not.toContain('yarn-error.log')
+    expect(built).not.toContain('types.d.ts')
+    expect(built).not.toContain('layerdir/lib.js')
+    expect(built).not.toContain('my-plugins/plugin.js')
+    expect(built).toContain('src/handler.js')
+    expect(built).toContain('package.json')
+  })
+
+  // Env files never reach an artifact, whatever `useDotenv` says and whatever
+  // depth they sit at. Deliberately stricter than classic packaging, which
+  // drops them only when `useDotenv` is set and only at the service root.
+  const dotenvFiles = {
+    'package.json': '{"name":"svc"}',
+    'src/handler.ts': 'export const hello = async () => ({})\n',
+    '.env': 'SECRET=1\n',
+    '.env.production': 'SECRET=2\n',
+    'src/.env': 'SECRET=3\n',
+    '.npmrc': 'registry=https://registry.npmjs.org/\n',
+  }
+
+  it.each([
+    ['unset', undefined],
+    ['true', { useDotenv: true }],
+    ['false', { useDotenv: false }],
+  ])('never packages .env files (useDotenv %s)', async (_label, input) => {
+    const serviceDir = makeServiceDir(dotenvFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      configurationInput: input,
+    })
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).not.toContain('.env')
+    expect(built).not.toContain('.env.production')
+    expect(built).not.toContain('src/.env')
+    // Scoped to env files: no other dotfile was swept up with them.
+    expect(built).toContain('.npmrc')
+    expect(built).toContain('src/handler.js')
+
+    // And the artifact that actually deploys agrees with the build directory.
+    const packaged = await packagedNames(plugin, serviceDir)
+    expect(packaged).not.toContain('.env')
+    expect(packaged).not.toContain('.env.production')
+    expect(packaged).not.toContain('src/.env')
+    expect(packaged).toContain('.npmrc')
+  })
+
+  it('re-includes an env file named by an explicit positive pattern', async () => {
+    // The documented opt-in for the runtime `dotenv` pattern. Exclusions are
+    // leading negations, so a positive pattern still gets the last word.
+    const serviceDir = makeServiceDir(dotenvFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      packageConfig: { patterns: ['.env'] },
+    })
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).toContain('.env')
+    // Only the one that was asked for.
+    expect(built).not.toContain('.env.production')
+    expect(built).not.toContain('src/.env')
+
+    const packaged = await packagedNames(plugin, serviceDir)
+    expect(packaged).toContain('.env')
+    expect(packaged).not.toContain('.env.production')
+    expect(packaged).not.toContain('src/.env')
+  })
+
+  /**
+   * `serverless package --package ./dist-pkg` moves `.serverless/` -- the zip
+   * AND the open build directory -- into `dist-pkg/`. The next run sweeps the
+   * service directory again, so without an exclusion it packages the previous
+   * artifact and a full copy of the previous build, and the artifact doubles
+   * on every run. The package directory is therefore hard-ignored the way
+   * `.serverless/**` is: no pattern, not even `**`, brings it back.
+   */
+  const packageDirFiles = {
+    'package.json': '{"name":"svc"}',
+    'src/handler.ts': 'export const hello = async () => ({})\n',
+    'dist-pkg/my-service.zip': 'PK-previous-artifact',
+    'dist-pkg/build/src/handler.js': 'previous build\n',
+    'dist-pkg/build/node_modules/dep/index.js': 'previous install\n',
+  }
+
+  it.each([
+    ['--package', { options: { package: 'dist-pkg' } }],
+    [
+      '--package with ./ and a trailing slash',
+      { options: { package: './dist-pkg/' } },
+    ],
+    ['package.path', { packageConfig: { path: 'dist-pkg' } }],
+  ])(
+    'keeps the configured package directory out of the build and the artifact (%s)',
+    async (_label, config) => {
+      const serviceDir = makeServiceDir(packageDirFiles)
+      const plugin = makePlugin(serviceDir, functions, {
+        ...config,
+        packageConfig: { ...(config.packageConfig ?? {}), patterns: ['**'] },
+      })
+
+      await plugin._build()
+
+      const built = listBuild(serviceDir)
+      expect(built).toContain('src/handler.js')
+      expect(built.some((rel) => rel.startsWith('dist-pkg/'))).toBe(false)
+
+      const packaged = await packagedNames(plugin, serviceDir)
+      expect(packaged).toContain('src/handler.js')
+      expect(packaged.some((rel) => rel.startsWith('dist-pkg/'))).toBe(false)
+    },
+  )
+
+  it('keeps an absolute package path inside the service directory out as well', async () => {
+    const serviceDir = makeServiceDir(packageDirFiles)
+    const plugin = makePlugin(serviceDir, functions, {
+      options: { package: path.join(serviceDir, 'dist-pkg') },
+      packageConfig: { patterns: ['**'] },
+    })
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).toContain('src/handler.js')
+    expect(built.some((rel) => rel.startsWith('dist-pkg/'))).toBe(false)
+  })
+
+  it.each([
+    ['the service directory itself', '.'],
+    ['the parent directory', '..'],
+    ['a sibling directory', '../out'],
+  ])(
+    'excludes nothing when the package directory is %s',
+    async (_label, packageDir) => {
+      // Only a directory strictly inside the service directory can be swept
+      // back in. `.` would otherwise exclude the whole service, and anything
+      // above it is not part of the sweep to begin with.
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'assets/logo.txt': 'logo\n',
+      })
+      const plugin = makePlugin(serviceDir, functions, {
+        options: { package: packageDir },
+      })
+
+      expect(plugin._packageDirectoryIgnores()).toEqual([])
+
+      await plugin._build()
+
+      const built = listBuild(serviceDir)
+      expect(built).toContain('src/handler.js')
+      expect(built).toContain('assets/logo.txt')
+    },
+  )
+
+  it('resolves the package directory to a service-relative POSIX glob', () => {
+    const serviceDir = makeServiceDir({ 'package.json': '{"name":"svc"}' })
+    const ignoresFor = (options, packageConfig = {}) =>
+      makePlugin(serviceDir, functions, {
+        options,
+        packageConfig,
+      })._packageDirectoryIgnores()
+
+    expect(ignoresFor({})).toEqual([])
+    expect(ignoresFor({ package: 'dist-pkg' })).toEqual(['dist-pkg/**'])
+    expect(ignoresFor({ package: './out/pkg/' })).toEqual(['out/pkg/**'])
+    expect(ignoresFor({ package: path.join(serviceDir, 'abs') })).toEqual([
+      'abs/**',
+    ])
+    // A directory whose NAME starts with dots is still inside the service.
+    expect(ignoresFor({ package: '..dots' })).toEqual(['..dots/**'])
+    // `--package` wins over `package.path`, as it does for the framework.
+    expect(ignoresFor({ package: 'flag' }, { path: 'config' })).toEqual([
+      'flag/**',
+    ])
+    expect(ignoresFor({}, { path: 'config' })).toEqual(['config/**'])
+    expect(ignoresFor({ package: '/' })).toEqual([])
+    expect(ignoresFor({ package: '.' })).toEqual([])
+    expect(ignoresFor({ package: '..' })).toEqual([])
+    expect(ignoresFor({ package: '../out' })).toEqual([])
+    expect(ignoresFor({ package: '' })).toEqual([])
+  })
+
+  it('re-includes a package-manager internal the sweep dropped when a pattern names it', async () => {
+    // Yarn PnP files are default exclusions of the sweep. A positive pattern
+    // brings the named file back — into the build directory AND the artifact,
+    // which walks the build directory with these roots skipped unless a
+    // pattern claimed something under them.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      '.pnp.cjs': 'module.exports = {}\n',
+      '.yarn/cache/dep.zip': 'PK\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      packageConfig: { patterns: ['.pnp.cjs'] },
+    })
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).toContain('.pnp.cjs')
+    expect(built).not.toContain('.yarn/cache/dep.zip')
+
+    const packaged = await packagedNames(plugin, serviceDir)
+    expect(packaged).toContain('.pnp.cjs')
+    expect(packaged).not.toContain('.yarn/cache/dep.zip')
+  })
+
+  it('lets package.patterns exclude project files and re-include excluded ones', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'serverless.yml': 'service: my-service\n',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'tests/handler.test.ts': 'export const t = 1\n',
+      'docs/readme.md': '# docs\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      packageConfig: { patterns: ['!tests/**', '!docs/**', 'serverless.yml'] },
+      configurationFilename: 'serverless.yml',
+    })
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).not.toContain('tests/handler.test.js')
+    expect(built).not.toContain('docs/readme.md')
+    // Last match wins, exactly as in classic packaging.
+    expect(built).toContain('serverless.yml')
+  })
+
+  it('honors the legacy package.exclude and lets patterns re-include from it', async () => {
+    const files = {
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'secrets/keys.txt': 'shh\n',
+      'secrets/keep.txt': 'fine\n',
+    }
+
+    const excluded = makeServiceDir(files)
+    await makePlugin(excluded, functions, {
+      packageConfig: { exclude: ['secrets/**'] },
+    })._build()
+    const built = listBuild(excluded)
+    expect(built).not.toContain('secrets/keys.txt')
+    expect(built).not.toContain('secrets/keep.txt')
+
+    // `exclude` rides in ahead of `patterns`, so last-match-wins still applies.
+    const reincluded = makeServiceDir(files)
+    await makePlugin(reincluded, functions, {
+      packageConfig: {
+        exclude: ['secrets/**'],
+        patterns: ['secrets/keep.txt'],
+      },
+    })._build()
+    const reincludedBuild = listBuild(reincluded)
+    expect(reincludedBuild).toContain('secrets/keep.txt')
+    expect(reincludedBuild).not.toContain('secrets/keys.txt')
+  })
+
+  it('inverts a !-prefixed legacy package.exclude entry into a re-include, classic-style', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'tmp/keep.js': 'module.exports = 1\n',
+      'tmp/other.js': 'module.exports = 2\n',
+      'assets/logo.txt': 'logo\n',
+    })
+    await makePlugin(serviceDir, functions, {
+      packageConfig: { exclude: ['tmp/**', '!tmp/keep.js'] },
+    })._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).toContain('tmp/keep.js')
+    expect(built).not.toContain('tmp/other.js')
+    // The exclude pair touches nothing outside tmp/.
+    expect(built).toContain('assets/logo.txt')
+    expect(built).toContain('src/handler.js')
+  })
+
+  it('keeps the project intact when package.exclude carries only a !-prefixed entry', async () => {
+    // A re-include of a file nothing excluded is a no-op in classic. A blanket
+    // `!${glob}` wrap turned it into `!!keep.js` -- a negation whose micromatch
+    // pattern matches everything EXCEPT keep.js -- and emptied the sweep.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'keep.js': 'module.exports = 1\n',
+      'src/util.js': 'module.exports = 2\n',
+      'README.md': '# svc\n',
+    })
+    await makePlugin(serviceDir, functions, {
+      packageConfig: { exclude: ['!keep.js'] },
+    })._build()
+
+    expect(listBuild(serviceDir)).toEqual(
+      expect.arrayContaining([
+        'README.md',
+        'keep.js',
+        'src/handler.js',
+        'src/util.js',
+      ]),
+    )
+  })
+
+  it('honors the legacy package.include, after excludes and before patterns', async () => {
+    const files = {
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'lib/keep.js': 'module.exports = 1\n',
+      'lib/other.js': 'module.exports = 2\n',
+    }
+
+    // The idiomatic legacy pair: exclude broad, re-include narrow.
+    const reincluded = makeServiceDir(files)
+    await makePlugin(reincluded, functions, {
+      packageConfig: { exclude: ['lib/**'], include: ['lib/keep.js'] },
+    })._build()
+    const reincludedBuild = listBuild(reincluded)
+    expect(reincludedBuild).toContain('lib/keep.js')
+    expect(reincludedBuild).not.toContain('lib/other.js')
+
+    // Classic appends `include` before `patterns`, so a patterns negation
+    // still gets the last word over an include.
+    const patternsWin = makeServiceDir(files)
+    await makePlugin(patternsWin, functions, {
+      packageConfig: {
+        exclude: ['lib/**'],
+        include: ['lib/**'],
+        patterns: ['!lib/other.js'],
+      },
+    })._build()
+    const patternsWinBuild = listBuild(patternsWin)
+    expect(patternsWinBuild).toContain('lib/keep.js')
+    expect(patternsWinBuild).not.toContain('lib/other.js')
+  })
+
+  it('builds the handler even when the patterns would have excluded it', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      packageConfig: { patterns: ['!src/**'] },
+    })
+
+    await plugin._build()
+
+    expect(existsIn(serviceDir, 'src/handler.js')).toBe(true)
+  })
+
+  it('lets a patterns negation keep an unparsable file out of the build', async () => {
+    // Compiling the whole project means compiling files the bundling path
+    // never touched, so a test fixture that was never meant to be valid
+    // TypeScript now fails the build. `package.patterns` is the way out, and
+    // it has to work: the negation must be applied BEFORE the compile set is
+    // handed to esbuild, not just before packaging.
+    const files = {
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'tests/broken.fixture.ts': 'export const broken = ((((\n',
+    }
+
+    const negated = makeServiceDir(files)
+    await expect(
+      makePlugin(negated, functions, {
+        packageConfig: { patterns: ['!tests/**'] },
+      })._build(),
+    ).resolves.toBeUndefined()
+    expect(existsIn(negated, 'src/handler.js')).toBe(true)
+    expect(listBuild(negated)).not.toContain('tests/broken.fixture.js')
+
+    // Without the negation the parse error is the build's outcome, and it
+    // names the file so the negation can be written.
+    const swept = makeServiceDir(files)
+    const error = await makePlugin(swept, functions)
+      ._build()
+      .then(
+        () => undefined,
+        (err) => err,
+      )
+    expect(error?.code).toBe('ESBULD_BUILD_ERROR')
+    expect(error.message).toContain('tests/broken.fixture.ts')
+  })
+
+  it('never sweeps its own output back in', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+    const first = listBuild(serviceDir)
+    await plugin._build()
+
+    expect(listBuild(serviceDir)).toEqual(first)
+    expect(first).not.toContain('.serverless/build/src/handler.js')
+  })
+})
+
+describe('_build with bundle:false keeps its bookkeeping honest', () => {
+  jest.setTimeout(60_000)
+
+  it('marks nothing built when esbuild is configured not to write', async () => {
+    // A configFile merging `write: false` leaves the build dir empty. Reporting
+    // the function as built would route dev mode at a file that is not there.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'esbuild.config.mjs': 'export default () => ({ write: false })\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, configFile: './esbuild.config.mjs' },
+    })
+
+    await expect(plugin._build()).rejects.toMatchObject({
+      code: 'ESBUILD_HANDLER_NOT_BUILT',
+    })
+
+    expect(plugin.builtArtifacts.size).toBe(0)
+    expect(plugin.serverless.builtFunctions ?? new Set()).toEqual(new Set())
+  })
+
+  it('sets NODE_OPTIONS for source maps on the built functions', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const fns = { hello: { handler: 'src/handler.hello' } }
+    const plugin = makePlugin(serviceDir, fns, {
+      esbuildConfig: { bundle: false, sourcemap: { setNodeOptions: true } },
+    })
+
+    await plugin._build()
+
+    expect(fns.hello.environment.NODE_OPTIONS).toBe('--enable-source-maps')
+  })
+
+  it('records a null mapfile when no sourcemap is emitted', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, sourcemap: false },
+    })
+
+    await plugin._build()
+
+    expect(plugin.builtArtifacts.get('hello')).toEqual({
+      outfile: 'src/handler.js',
+      mapfile: null,
+    })
+  })
+
+  it('still compiles the project when a handler lives in a layer', async () => {
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    try {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/util.ts': 'export const helper = () => 1\n',
+      })
+      const plugin = makePlugin(serviceDir, {
+        wrapped: {
+          handler: '/opt/nodejs/node_modules/datadog-lambda-js/handler.datadog',
+          layers: ['arn:aws:lambda:us-east-1:1234567890:layer:dd:1'],
+        },
+      })
+
+      await expect(plugin._build()).resolves.toBeUndefined()
+
+      // The unresolvable handler is the assertion's business; the project
+      // still has to be built, or the layer wrapper has nothing to call into.
+      expect(existsIn(serviceDir, 'src/util.js')).toBe(true)
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('builds every partition under a buildConcurrency of 1', async () => {
+    // `buildConcurrency` now caps the partition builds the way it caps the
+    // per-handler builds on the bundling path; serializing them must not lose
+    // any partition.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/tool.mts': 'export const tool = 1\n',
+      'src/old.cts': 'export const old = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, buildConcurrency: 1 },
+    })
+
+    await plugin._build()
+
+    expect(existsIn(serviceDir, 'src/handler.js')).toBe(true)
+    expect(existsIn(serviceDir, 'src/tool.mjs')).toBe(true)
+    expect(existsIn(serviceDir, 'src/old.cjs')).toBe(true)
+  })
+
+  it('writes a metafile per partition when asked', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/tool.mts': 'export const tool = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, metafile: true },
+    })
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    // One per (output extension, format) partition, never a single `meta.json`
+    // that each partition would overwrite in turn.
+    expect(built.filter((f) => f.startsWith('meta.')).sort()).toEqual([
+      'meta.jscjs.json',
+      'meta.mjsesm.json',
+    ])
+  })
+})
+
+describe('_build with bundle:false scopes TypeScript with tsconfig', () => {
+  jest.setTimeout(60_000)
+
+  it('compiles only the TypeScript the discovered tsconfig selects', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'tsconfig.json': JSON.stringify({
+        include: ['src'],
+        exclude: ['src/skip'],
+      }),
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/util.ts': 'export const helper = () => 1\n',
+      'src/skip/scratch.ts': 'export const scratch = 1\n',
+      'scripts/seed.ts': 'export const seed = 1\n',
+      // Not TypeScript, so the tsconfig has no say over it either way.
+      'scripts/legacy.js': 'exports.legacy = 1\n',
+      'assets/data.json': '{"a":1}\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    const built = listBuild(serviceDir)
+    expect(built).toContain('src/handler.js')
+    expect(built).toContain('src/util.js')
+    expect(built).not.toContain('src/skip/scratch.js')
+    expect(built).not.toContain('scripts/seed.js')
+    expect(built).toContain('scripts/legacy.js')
+    expect(built).toContain('assets/data.json')
+  })
+
+  it('compiles a handler the tsconfig excludes', async () => {
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    try {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'tsconfig.json': JSON.stringify({ include: ['lib'] }),
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(existsIn(serviceDir, 'src/handler.js')).toBe(true)
+      // Nothing at all was selected, handler included, so the build says so.
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('stays quiet when the tsconfig claims the handler and nothing else', async () => {
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    try {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'tsconfig.json': JSON.stringify({ include: ['src'] }),
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'scripts/seed.ts': 'export const seed = 1\n',
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(existsIn(serviceDir, 'src/handler.js')).toBe(true)
+      expect(existsIn(serviceDir, 'scripts/seed.js')).toBe(false)
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('warns once when a solution-style tsconfig selects nothing', async () => {
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    try {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'tsconfig.json': JSON.stringify({
+          files: [],
+          references: [{ path: './src' }],
+        }),
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/util.ts': 'export const helper = () => 1\n',
+        'src/other.ts': 'export const other = 1\n',
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      const built = listBuild(serviceDir)
+      expect(built).toContain('src/handler.js')
+      expect(built).not.toContain('src/util.js')
+      expect(built).not.toContain('src/other.js')
+      // One aggregated warning for the whole build, not one per dropped file.
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('build.esbuild.tsconfig')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('rejects an explicit tsconfig that is not there', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, tsconfig: './missing.json' },
+    })
+
+    await expect(plugin._build()).rejects.toMatchObject({
+      code: 'ESBUILD_TSCONFIG_NOT_FOUND',
+    })
+  })
+
+  it('hands an explicit tsconfig to esbuild as well as to the selection', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      // A name esbuild would never discover on its own, so a `jsxFactory` in
+      // the emitted output can only have come from the option being forwarded.
+      'tsconfig.build.json': JSON.stringify({
+        include: ['src'],
+        compilerOptions: { jsxFactory: 'buildFactory' },
+      }),
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/widget.jsx': 'export const widget = () => <div />\n',
+      'scripts/seed.ts': 'export const seed = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, tsconfig: './tsconfig.build.json' },
+    })
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'src/widget.js')).toContain('buildFactory')
+    // Same config, same build: it governs selection too.
+    expect(existsIn(serviceDir, 'scripts/seed.js')).toBe(false)
+  })
+
+  it('never hands a discovered tsconfig to esbuild', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'tsconfig.json': JSON.stringify({
+        include: ['src'],
+        compilerOptions: { jsxFactory: 'rootFactory' },
+      }),
+      // esbuild resolves compilerOptions per file. Forwarding the discovered
+      // root config as esbuild's `tsconfig` would pin every file to it and
+      // silently override the nested one Node's own tooling would apply.
+      'src/nested/tsconfig.json': JSON.stringify({
+        compilerOptions: { jsxFactory: 'nestedFactory' },
+      }),
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/nested/widget.jsx': 'export const widget = () => <div />\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await plugin._build()
+
+    expect(readIn(serviceDir, 'src/nested/widget.js')).toContain(
+      'nestedFactory',
+    )
+  })
+
+  it('builds on when a discovered tsconfig cannot resolve its extends chain', async () => {
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    try {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        // The devDependency base config is not installed -- `npm ci --omit=dev`
+        // on CI, or a slim Docker build stage.
+        'tsconfig.json': '{"extends":"@tsconfig/node20/tsconfig.json"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/util.ts': 'export const helper = () => 1\n',
+        'scripts/seed.ts': 'export const seed = 1\n',
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await expect(plugin._build()).resolves.toBeUndefined()
+
+      // No narrowing at all: an unreadable config nobody pointed us at must
+      // not be able to strip files out of the artifact.
+      const built = listBuild(serviceDir)
+      expect(built).toContain('src/handler.js')
+      expect(built).toContain('src/util.js')
+      expect(built).toContain('scripts/seed.js')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('@tsconfig/node20')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('rejects an explicit tsconfig that cannot resolve its extends chain', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'tsconfig.build.json': '{"extends":"@tsconfig/node20/tsconfig.json"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: false, tsconfig: './tsconfig.build.json' },
+    })
+
+    await expect(plugin._build()).rejects.toMatchObject({
+      code: 'ESBUILD_TSCONFIG_INVALID',
+    })
+  })
+
+  it('lets package.patterns drop a file the tsconfig would have selected', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'tsconfig.json': JSON.stringify({ include: ['src'] }),
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      'src/secret.ts': 'export const secret = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      packageConfig: { patterns: ['!src/secret.ts'] },
+    })
+
+    await plugin._build()
+
+    // The tsconfig narrows what the sweep selected; it can never widen it.
+    expect(existsIn(serviceDir, 'src/secret.js')).toBe(false)
+    expect(existsIn(serviceDir, 'src/handler.js')).toBe(true)
+  })
+
+  it('resolves a collision by leaving the excluded TypeScript out of the build', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'tsconfig.json': JSON.stringify({ include: ['src'] }),
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      // A half-finished migration parked outside the tsconfig: `legacy.ts` is
+      // not compiled, so it cannot claim `legacy/legacy.js` any more.
+      'legacy/legacy.ts': 'export const legacy = 1\n',
+      'legacy/legacy.js': 'exports.legacy = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    await expect(plugin._build()).resolves.toBeUndefined()
+
+    expect(readIn(serviceDir, 'legacy/legacy.js')).toContain('exports.legacy')
+  })
+})
+
+describe('_buildProperties resolves tsconfig against the service directory', () => {
+  jest.setTimeout(60_000)
+
+  it('makes a relative tsconfig absolute even when the cwd is elsewhere', async () => {
+    // Compose runs every service in-process from the compose root, so the
+    // process cwd is not the service directory. esbuild resolves a relative
+    // `tsconfig` against its own working directory, so leaving it relative
+    // fails the bundling build with `Cannot find tsconfig file`.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'tsconfig.build.json': '{"include":["src"]}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const composeRoot = makeServiceDir({ 'compose.yml': 'services: {}\n' })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: true, tsconfig: './tsconfig.build.json' },
+    })
+
+    const originalCwd = process.cwd()
+    process.chdir(composeRoot)
+    let buildProperties
+    try {
+      buildProperties = await plugin._buildProperties()
+    } finally {
+      process.chdir(originalCwd)
+    }
+
+    expect(path.isAbsolute(buildProperties.tsconfig)).toBe(true)
+    expect(buildProperties.tsconfig).toBe(
+      path.join(serviceDir, 'tsconfig.build.json'),
+    )
+  })
+
+  it('leaves tsconfig unset when the service never set one', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+    })
+    const plugin = makePlugin(serviceDir, functions)
+
+    expect((await plugin._buildProperties()).tsconfig).toBeUndefined()
+  })
+})
+
+describe('_build with bundle:true is unaffected', () => {
+  jest.setTimeout(60_000)
+
+  it('still emits only the handler bundle', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': HANDLER_TS,
+      'src/util.ts': "export const helper = () => 'helped'\n",
+      'src/legacy.js': 'exports.legacy = () => "legacy"\n',
+      'assets/data.json': '{"a":1}\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: { bundle: true },
+    })
+
+    await plugin._build()
+
+    expect(listBuild(serviceDir)).toEqual([
+      'src/handler.js',
+      'src/handler.js.map',
+    ])
+  })
+
+  it('still emits only the handler bundle when bundling is left at its default', async () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts': HANDLER_TS,
+      'src/util.ts': "export const helper = () => 'helped'\n",
+      'src/legacy.js': 'exports.legacy = () => "legacy"\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, { esbuildConfig: {} })
+
+    await plugin._build()
+
+    expect(listBuild(serviceDir)).toEqual([
+      'src/handler.js',
+      'src/handler.js.map',
+    ])
+  })
+})
+
+/**
+ * The failure this warns about is invisible until the deployed function is
+ * invoked: Node's ES module resolver adds no extensions and probes no
+ * `index.js`, so an `import './util'` that bundling used to resolve at build
+ * time becomes `ERR_MODULE_NOT_FOUND` at runtime. CommonJS output is left
+ * alone -- `require('./util')` still resolves the way it always did.
+ */
+describe('_build with bundle:false warns about extensionless ESM imports', () => {
+  jest.setTimeout(60_000)
+
+  const withWarnSpy = async (body) => {
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    try {
+      return await body(warnSpy)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  }
+
+  it('names the emitted file and the specifier, once, for a "type": "module" service', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"type":"module"}',
+        'src/handler.ts':
+          "import { helper } from './util'\n" +
+          "import { fine } from './other.js'\n" +
+          'export const hello = async () => ({ body: `${helper()}${fine()}` })\n',
+        'src/util.ts': "export const helper = () => 'helped'\n",
+        'src/other.ts': "export const fine = () => 'fine'\n",
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const message = warnSpy.mock.calls[0][0]
+      expect(message).toContain(
+        "Found 1 relative import in this build's output",
+      )
+      expect(message).toContain('src/handler.js → ./util')
+      // The specifier that already carries an extension is not in the list.
+      expect(message).not.toContain('./other.js')
+      // And the way out is named, in the terms tsc uses for the same rule.
+      expect(message).toContain('nodenext')
+      expect(message).toContain('./util.js')
+    })
+  })
+
+  it('stays quiet when every relative import carries an extension', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"type":"module"}',
+        'src/handler.ts':
+          "import { helper } from './util.js'\n" +
+          'export const hello = async () => ({ body: helper() })\n',
+        'src/util.ts': "export const helper = () => 'helped'\n",
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  it('never warns about CommonJS output, where the specifier still resolves', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/handler.ts':
+          "import { helper } from './util'\n" +
+          'export const hello = async () => ({ body: helper() })\n',
+        'src/util.ts': "export const helper = () => 'helped'\n",
+        'src/old.cts':
+          "import { helper } from './util'\nexport const old = () => helper()\n",
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      // `require('./util')` is resolved by the CommonJS loader, which does try
+      // extensions -- there is nothing to warn about.
+      expect(readIn(serviceDir, 'src/handler.js')).toMatch(/require\(/)
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  it('warns about a .mjs-class output inside an otherwise CommonJS service', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/tool.mts':
+          "import { helper } from './util'\nexport const tool = () => helper()\n",
+        'src/util.ts': "export const helper = () => 'helped'\n",
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      // `.mts` is ESM by definition, so it is scanned even though the service
+      // as a whole is CommonJS -- and the CommonJS siblings are not.
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('src/tool.mjs → ./util')
+    })
+  })
+
+  it('catches a side-effect import and an `export * from`', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"type":"module"}',
+        'src/handler.ts':
+          "import './polyfill'\nexport const hello = async () => ({})\n",
+        'src/polyfill.ts': 'globalThis.patched = true\n',
+        'src/barrel.ts': "export * from './util'\n",
+        'src/util.ts': 'export const helper = () => 1\n',
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const message = warnSpy.mock.calls[0][0]
+      expect(message).toContain('src/handler.js → ./polyfill')
+      expect(message).toContain('src/barrel.js → ./util')
+    })
+  })
+
+  it('lists at most ten pairs and reports the true total', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const files = {
+        'package.json': '{"type":"module"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/target.ts': 'export const target = 1\n',
+      }
+      for (let index = 0; index < 12; index += 1) {
+        files[`src/m${index}.ts`] =
+          `import { target } from './target'\n` +
+          `export const m${index} = target\n`
+      }
+      const serviceDir = makeServiceDir(files)
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const message = warnSpy.mock.calls[0][0]
+      expect(message).toContain('Found 12 relative imports')
+      expect(message).toContain('and 2 more')
+      expect(message.match(/→/g)).toHaveLength(10)
+    })
+  })
+
+  it('warns about a dynamic import in CommonJS output, where import() still uses the ESM resolver', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/old.cts':
+          "export const load = async () => import('./dyn')\n" +
+          "export const fine = async () => import('./ok.js')\n",
+        'src/dyn.ts': 'export const dyn = 1\n',
+        'src/ok.ts': 'export const ok = 1\n',
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      // esbuild leaves `import()` exactly as written even when emitting
+      // CommonJS, and Node routes it through the ES module resolver whatever
+      // the calling file is -- so this is the same ERR_MODULE_NOT_FOUND as in
+      // an ESM file, in output that used to be skipped entirely.
+      expect(readIn(serviceDir, 'src/old.cjs')).toContain('import("./dyn")')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const message = warnSpy.mock.calls[0][0]
+      expect(message).toContain('src/old.cjs → ./dyn')
+      expect(message).not.toContain('./ok.js')
+    })
+  })
+
+  it('never warns about a STATIC import in CommonJS output, which esbuild rewrote to require()', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/old.cts':
+          "import { helper } from './util'\nexport const old = () => helper()\n",
+        'src/util.ts': "export const helper = () => 'helped'\n",
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      // The specifier survives only inside a `require()`, and the CommonJS
+      // resolver does try extensions -- so there is nothing wrong here.
+      expect(readIn(serviceDir, 'src/old.cjs')).toContain('require("./util")')
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  it('does not full-scan CommonJS output (mutation probe for the dynamicOnly narrowing)', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      // On genuine CommonJS output a full scan and a dynamic-only scan agree,
+      // because esbuild has already turned every static import into a
+      // `require()` that neither pattern matches. That is precisely why the
+      // narrowing is safe -- and precisely why the previous test cannot detect
+      // whether it is applied at all.
+      //
+      // A string literal is the one thing esbuild does preserve verbatim, so
+      // it is the only way to observe the boundary from the outside. This
+      // leans on the documented "regex over text, not a parse" limitation and
+      // uses it as an instrument: under a dynamic-only scan `./guide` is
+      // invisible, under a full scan it is reported.
+      const serviceDir = makeServiceDir({
+        'package.json': '{"name":"svc"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/old.cts': `export const doc = "see import { x } from './guide' for details"\n`,
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(readIn(serviceDir, 'src/old.cjs')).toContain(`from './guide'`)
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  it('warns about a specifier naming a source file the build renames', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      // `./util.ts` looks extensioned, so the dot heuristic waves it through,
+      // but `util.ts` is emitted as `util.js` -- the specifier names a file
+      // that is not in the artifact under that name. Guaranteed broken.
+      const serviceDir = makeServiceDir({
+        'package.json': '{"type":"module"}',
+        'src/handler.ts':
+          "import { helper } from './util.ts'\n" +
+          "import { tool } from './tool.mts'\n" +
+          'export const hello = async () => ({ body: `${helper()}${tool()}` })\n',
+        'src/util.ts': "export const helper = () => 'helped'\n",
+        'src/tool.mts': "export const tool = () => 'tooled'\n",
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(readIn(serviceDir, 'src/handler.js')).toContain('"./util.ts"')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      const message = warnSpy.mock.calls[0][0]
+      expect(message).toContain(
+        'src/handler.js → ./util.ts (emitted as "./util.js")',
+      )
+      // The rename is extension-specific: `.mts` becomes `.mjs`, not `.js`.
+      expect(message).toContain('./tool.mts (emitted as "./tool.mjs")')
+    })
+  })
+
+  it('says nothing about a template-literal dynamic import', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      // esbuild preserves it verbatim and its value is not knowable from the
+      // text, so the scan must neither crash on it nor invent an offender.
+      const serviceDir = makeServiceDir({
+        'package.json': '{"type":"module"}',
+        'src/handler.ts':
+          'export const hello = async (n) => import(`./p/${n}`)\n',
+        'src/p/a.ts': 'export const a = 1\n',
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(readIn(serviceDir, 'src/handler.js')).toContain('`./p/${n}`')
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  it('follows an outExtension rename to find the file it emitted', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      // The scan reads the plan, not the directory, so a `.js` class the user
+      // moved onto `.mjs` has to be looked for under its real name. Get this
+      // wrong and the read simply misses -- no error, no warning, and the
+      // diagnostic quietly stops working for every service that sets it.
+      const serviceDir = makeServiceDir({
+        'package.json': '{"type":"module"}',
+        'src/handler.ts':
+          "import { helper } from './util'\n" +
+          'export const hello = async () => ({ body: helper() })\n',
+        'src/util.ts': "export const helper = () => 'helped'\n",
+      })
+      const plugin = makePlugin(serviceDir, functions, {
+        esbuildConfig: { bundle: false, outExtension: { '.js': '.mjs' } },
+      })
+
+      await plugin._build()
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('src/handler.mjs → ./util')
+    })
+  })
+
+  it('says nothing, and throws nothing of its own, when esbuild wrote no files', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      // `write: false` from a configFile leaves the build dir empty, so every
+      // file the scan was told to read is missing. That is the configFile's
+      // business -- `_assertAllHandlersBuilt` is what reports it -- and a
+      // diagnostic must not turn it into a different, wronger error.
+      const serviceDir = makeServiceDir({
+        'package.json': '{"type":"module"}',
+        'src/handler.ts':
+          "import { helper } from './util'\n" +
+          'export const hello = async () => ({ body: helper() })\n',
+        'src/util.ts': "export const helper = () => 'helped'\n",
+        'esbuild.config.mjs': 'export default () => ({ write: false })\n',
+      })
+      const plugin = makePlugin(serviceDir, functions, {
+        esbuildConfig: { bundle: false, configFile: './esbuild.config.mjs' },
+      })
+
+      await expect(plugin._build()).rejects.toMatchObject({
+        code: 'ESBUILD_HANDLER_NOT_BUILT',
+      })
+
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  it('does not scan copied files, only compiled ESM output', async () => {
+    await withWarnSpy(async (warnSpy) => {
+      // A hand-written `.mjs`/`.js` helper is copied verbatim rather than
+      // compiled, so it is not a partition output and nothing reads it. The
+      // scan is deliberately scoped to what this build emitted; widening it to
+      // the copy set would mean re-deriving each copied file's module system.
+      const serviceDir = makeServiceDir({
+        'package.json': '{"type":"module"}',
+        'src/handler.ts': 'export const hello = async () => ({})\n',
+        'src/copied.mjs': "import './util'\nexport const copied = 1\n",
+      })
+      const plugin = makePlugin(serviceDir, functions)
+
+      await plugin._build()
+
+      expect(existsIn(serviceDir, 'src/copied.mjs')).toBe(true)
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+  })
+})
+
+/**
+ * Where esbuild's own diagnostics go.
+ *
+ * The non-bundled path runs esbuild at `logLevel: 'warning'` so its findings
+ * are not swallowed, and those findings do not come back through the JS API's
+ * return value alone: the esbuild service is a child process spawned with
+ * `stdio: ['pipe', 'pipe', 'inherit']`, so the formatted warning is written by
+ * the Go binary straight onto the Framework process's own stderr. Nothing in
+ * this process can intercept it -- not a `console` spy, not a
+ * `process.stderr.write` patch -- which is exactly why this test runs a real
+ * build in a child process and reads that child's stderr.
+ */
+describe('_build with bundle:false surfaces esbuild diagnostics', () => {
+  jest.setTimeout(60_000)
+
+  /** Run a real `_build` in a child node process and hand back its output. */
+  function buildInChildProcess(serviceDir) {
+    // The driver lives outside the service directory: anything inside it would
+    // be swept into the build and change what is under test.
+    const driverDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-driver-')),
+    )
+    createdServiceDirs.push(driverDir)
+    const driver = path.join(driverDir, 'build.mjs')
+    const pluginPath = new URL(
+      '../../../../../lib/plugins/esbuild/index.js',
+      import.meta.url,
+    ).href
+    fs.writeFileSync(
+      driver,
+      `import Esbuild from ${JSON.stringify(pluginPath)}\n` +
+        `const serviceDir = ${JSON.stringify(serviceDir)}\n` +
+        `const functions = ${JSON.stringify(functions)}\n` +
+        `const serverless = {\n` +
+        `  serviceDir,\n` +
+        `  config: { serviceDir },\n` +
+        `  service: {\n` +
+        `    service: 'my-service',\n` +
+        `    provider: { runtime: 'nodejs20.x' },\n` +
+        `    package: {},\n` +
+        `    build: { esbuild: { bundle: false } },\n` +
+        `    functions,\n` +
+        `    getFunction: (alias) => functions[alias],\n` +
+        `    getAllFunctions: () => Object.keys(functions),\n` +
+        `    getAllLayers: () => [],\n` +
+        `    getLayer: () => undefined,\n` +
+        `  },\n` +
+        `  pluginManager: {\n` +
+        `    spawn: async () => {},\n` +
+        `    parsePluginsObject: () => ({ localPath: null }),\n` +
+        `  },\n` +
+        `}\n` +
+        `const plugin = new Esbuild(serverless, {})\n` +
+        `plugin.functions = async () => functions\n` +
+        `await plugin._build()\n`,
+    )
+
+    // A bounded wait, well inside the suite's own 60s budget: an esbuild
+    // service that never answers would otherwise hang the jest worker until
+    // the whole run is killed, with nothing to show for it. On any failure the
+    // child's own output is what explains it, so it goes into the message
+    // rather than being thrown away with the process.
+    const result = spawnSync(process.execPath, [driver], {
+      encoding: 'utf8',
+      timeout: 45_000,
+      killSignal: 'SIGKILL',
+    })
+    if (result.error || result.status !== 0) {
+      throw new Error(
+        `Child build failed (status ${result.status}, signal ${result.signal}` +
+          `${result.error ? `, ${result.error.message}` : ''}).\n` +
+          `--- child stdout ---\n${result.stdout ?? ''}\n` +
+          `--- child stderr ---\n${result.stderr ?? ''}`,
+      )
+    }
+    return result
+  }
+
+  it('prints esbuild warnings to stderr, but has none to print for an unanalyzable require', () => {
+    const serviceDir = makeServiceDir({
+      'package.json': '{"name":"svc","type":"module"}',
+      'src/handler.ts': 'export const hello = async () => ({})\n',
+      // A require esbuild cannot follow, in a file that stays CommonJS.
+      'src/dynamic.cts':
+        'const name = process.env.MOD\nmodule.exports = { m: require(name) }\n',
+      // A genuine esbuild warning, to prove the channel is open at all.
+      'src/legacy.mts': 'module.exports = { legacy: 1 }\n',
+    })
+
+    const { stderr } = buildInChildProcess(serviceDir)
+
+    // The channel works: `logLevel: 'warning'` puts esbuild's findings in front
+    // of the user, on stderr, in esbuild's own formatting.
+    expect(stderr).toContain('[WARNING]')
+    expect(stderr).toContain('commonjs-variable-in-esm')
+    expect(stderr).toContain('src/legacy.mts')
+
+    // And the dynamic require is NOT among them. esbuild only reports a
+    // require it cannot follow when it was going to follow it -- that is, when
+    // bundling. With `bundle: false` it never resolves an import at all, so
+    // there is no such warning to surface at any log level. The call ships
+    // exactly as written and is resolved by Node at runtime, which is the
+    // correct outcome for an unbundled CommonJS file.
+    expect(stderr).not.toMatch(/will not be bundled/)
+    expect(readIn(serviceDir, 'src/dynamic.cjs')).toContain('require(name)')
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-partition-concurrency.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-partition-concurrency.test.js
@@ -1,0 +1,132 @@
+/**
+ * With `bundle: false` the unit of work is no longer the handler file but the
+ * partition -- one `esbuild.build()` per (source class, format) group covering
+ * the whole project. `buildConcurrency` has to keep capping that work, or a
+ * service that set it to stay inside a constrained CI box silently goes back to
+ * running every partition at once.
+ *
+ * Counting calls cannot show that: the cap is about OVERLAP. So `esbuild.build`
+ * is wrapped in a spy that records how many invocations are in flight at any
+ * moment and then delegates to the real bundler, and the assertion is on that
+ * high-water mark. The uncapped test is the control: it proves the probe can
+ * see overlap at all, so the capped expectation is not vacuous.
+ */
+
+import { jest } from '@jest/globals'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+
+let realBuild
+let inFlight = 0
+let peakInFlight = 0
+const buildMock = jest.fn(async (props) => {
+  inFlight += 1
+  peakInFlight = Math.max(peakInFlight, inFlight)
+  try {
+    return await realBuild(props)
+  } finally {
+    inFlight -= 1
+  }
+})
+
+jest.unstable_mockModule('esbuild', () => {
+  realBuild = jest.requireActual('esbuild').build
+  return { build: buildMock }
+})
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+const createdServiceDirs = []
+
+afterAll(() => {
+  for (const dir of createdServiceDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+beforeEach(() => {
+  buildMock.mockClear()
+  inFlight = 0
+  peakInFlight = 0
+})
+
+// Three source classes, so the build plans three partitions: `.ts` onto the
+// `.js` class, `.mts` onto `.mjs`, `.cts` onto `.cjs`.
+function makeThreePartitionService() {
+  const serviceDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-concurrency-')),
+  )
+  createdServiceDirs.push(serviceDir)
+  const files = {
+    'package.json': '{"name":"svc"}',
+    'src/handler.ts': 'export const hello = async () => ({})\n',
+    'src/tool.mts': 'export const tool = 1\n',
+    'src/old.cts': 'export const old = 1\n',
+  }
+  for (const [name, contents] of Object.entries(files)) {
+    const filePath = path.join(serviceDir, name)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+  return serviceDir
+}
+
+function makePlugin(serviceDir, esbuildConfig) {
+  const functions = { hello: { handler: 'src/handler.hello' } }
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      provider: { runtime: 'nodejs20.x' },
+      package: {},
+      build: { esbuild: esbuildConfig },
+      functions,
+      getFunction: (alias) => functions[alias],
+      getAllFunctions: () => Object.keys(functions),
+    },
+    pluginManager: { spawn: async () => {} },
+  }
+  const plugin = new Esbuild(serverless, {})
+  plugin.functions = async () => functions
+  return plugin
+}
+
+const buildDirOf = (serviceDir) => path.join(serviceDir, '.serverless', 'build')
+
+describe('buildConcurrency caps the partition builds', () => {
+  jest.setTimeout(60_000)
+
+  it('runs the partitions one at a time under a concurrency of 1', async () => {
+    const serviceDir = makeThreePartitionService()
+    const plugin = makePlugin(serviceDir, {
+      bundle: false,
+      buildConcurrency: 1,
+    })
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(3)
+    expect(peakInFlight).toBe(1)
+    // Serializing must not lose a partition.
+    for (const output of ['src/handler.js', 'src/tool.mjs', 'src/old.cjs']) {
+      expect(fs.existsSync(path.join(buildDirOf(serviceDir), output))).toBe(
+        true,
+      )
+    }
+  })
+
+  it('runs them all at once when nothing caps them', async () => {
+    // The control. Partitions write disjoint files, so the default is full
+    // parallelism -- and this is what the capped run above has to suppress.
+    const serviceDir = makeThreePartitionService()
+    const plugin = makePlugin(serviceDir, { bundle: false })
+
+    await plugin._build()
+
+    expect(buildMock).toHaveBeenCalledTimes(3)
+    expect(peakInFlight).toBe(3)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-runtime.e2e.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-runtime.e2e.test.js
@@ -1,0 +1,395 @@
+/**
+ * Does the non-bundled build dir actually run?
+ *
+ * Every other test in this directory reads the build dir: which files exist,
+ * what syntax they contain, which package.json sits beside them. None of that
+ * is the contract. The contract is that Node -- the Node inside Lambda, with
+ * nothing but the artifact and its own resolver -- loads the handler and calls
+ * it. A build dir can satisfy every structural assertion and still fail there,
+ * because the resolver is the arbiter of `.js` vs `.mjs`, of `"type": "module"`
+ * in the *nearest* package.json, and of whether `./util` names anything at all.
+ *
+ * So these tests spawn a real `node` with `cwd` set to the build dir and a
+ * runner file that requires or imports the built handler and prints its result.
+ *
+ * They may not do it in process. An `import()` evaluated inside jest goes
+ * through jest's module registry, not Node's ESM resolver, and that registry
+ * applies CommonJS-style extension probing: an emitted `import { x } from
+ * './util'` resolves happily under jest and fails with ERR_MODULE_NOT_FOUND on
+ * the deployed function. That divergence is measured, not assumed -- the same
+ * build dir that makes the negative control below exit non-zero was loaded
+ * in-process under this suite's own jest config and returned `{ statusCode:
+ * 200 }`. An in-process check here would therefore certify exactly the bug it
+ * exists to catch, which is why every assertion in this file goes through
+ * `spawnSync`.
+ *
+ * The runner is written into the build dir *after* `_build` has finished, so it
+ * never reaches the sweep and cannot influence what was compiled, and it is
+ * unlinked as soon as the child has been waited on -- including when the child
+ * times out or the assertions throw. The build directory IS the artifact
+ * definition (`_collectBuildDirEntries`), so leaving a runner behind would put
+ * it in the zip of any packaging run over the same tree; deleting it means
+ * these tests hand back a build dir byte-identical to the one `_build` wrote.
+ * The `__runner__.(c|m)js` name is the belt to that braces: unmistakably not a
+ * user file, and outside every fixture's own naming.
+ */
+
+import { jest } from '@jest/globals'
+import { spawnSync } from 'child_process'
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { log } from '@serverless/util'
+
+const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
+  .default
+
+const esbuildLogger = log.get('esbuild')
+
+const createdServiceDirs = []
+
+afterAll(() => {
+  for (const dir of createdServiceDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+/**
+ * `realpathSync` because macOS resolves the temp dir through a symlink, and
+ * esbuild reports real paths -- an unresolved prefix makes `outbase` fail to
+ * match the entry points and collapses the whole layout into the build root.
+ */
+function makeServiceDir(files) {
+  const serviceDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-runtime-')),
+  )
+  createdServiceDirs.push(serviceDir)
+  for (const [name, contents] of Object.entries(files)) {
+    const filePath = path.join(serviceDir, name)
+    fs.mkdirSync(path.dirname(filePath), { recursive: true })
+    fs.writeFileSync(filePath, contents)
+  }
+  return serviceDir
+}
+
+function makePlugin(serviceDir, functions) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      provider: { runtime: 'nodejs20.x' },
+      package: {},
+      build: { esbuild: { bundle: false } },
+      functions,
+      getFunction: (alias) => functions[alias],
+      getAllFunctions: () => Object.keys(functions),
+      getAllLayers: () => [],
+      getLayer: () => undefined,
+    },
+    pluginManager: {
+      spawn: async () => {},
+      parsePluginsObject: () => ({ localPath: null }),
+    },
+  }
+  const plugin = new Esbuild(serverless, {})
+  // Target `_build` directly: what is under test is the build dir it leaves
+  // behind, not the introspection in `functions()`.
+  plugin.functions = async () => functions
+  return plugin
+}
+
+const functions = { hello: { handler: 'src/handler.hello' } }
+
+const buildDirOf = (serviceDir) => path.join(serviceDir, '.serverless', 'build')
+
+/** Build a fixture service and hand back its build directory. */
+async function build(files) {
+  const serviceDir = makeServiceDir(files)
+  await makePlugin(serviceDir, functions)._build()
+  return buildDirOf(serviceDir)
+}
+
+/**
+ * Run `source` as a Node program whose working directory is the build dir.
+ *
+ * The child gets a scrubbed `NODE_OPTIONS`, and this is load-bearing rather
+ * than tidiness. A spawn inherits the jest worker's environment, and this
+ * suite's whole claim is that the child uses *Node's* resolver on *this*
+ * artifact:
+ *
+ *   - `NODE_OPTIONS` can carry `--experimental-loader` / `--import`. A resolve
+ *     hook in the ambient environment can make the negative control's
+ *     extensionless specifier resolve, so the artifact loads cleanly and the
+ *     test passes while asserting the opposite of the truth -- the identical
+ *     failure mode as running in process under jest, arriving by a different
+ *     door. It also carries this repo's own `--experimental-vm-modules`, which
+ *     the child has no use for.
+ *   - `NODE_NO_WARNINGS` is pinned on because the success cases assert an empty
+ *     stderr. Left to the ambient environment, an unrelated node warning turns
+ *     a correct artifact red, and an option that *emits* warnings turns most of
+ *     the file red at once.
+ *
+ * The timeout is a bounded wait well inside the suite budget: a child that
+ * never exits would otherwise hang the jest worker until the whole run is
+ * killed, with nothing to show for it. `SIGKILL` because a wedged loader will
+ * not honor anything gentler. Whatever the child said is carried back verbatim
+ * -- the assertions below put it in the failure message, since the child's own
+ * output is the only thing that explains a runtime load failure.
+ *
+ * The runner is removed as soon as the child has been waited on, so the build
+ * dir is left exactly as `_build` wrote it.
+ */
+function runNode(buildDir, runnerName, source) {
+  const runnerPath = path.join(buildDir, runnerName)
+  fs.writeFileSync(runnerPath, source)
+  let result
+  try {
+    result = spawnSync(process.execPath, [runnerName], {
+      cwd: buildDir,
+      encoding: 'utf8',
+      timeout: 45_000,
+      killSignal: 'SIGKILL',
+      env: { ...process.env, NODE_OPTIONS: '', NODE_NO_WARNINGS: '1' },
+    })
+  } finally {
+    fs.rmSync(runnerPath, { force: true })
+  }
+  return {
+    // `error` is the only account of a spawn that produced no status at all
+    // (timeout, SIGKILL, a missing binary), so it is folded into the reported
+    // stderr rather than dropped.
+    status: result.status,
+    signal: result.signal,
+    stdout: (result.stdout ?? '').trim(),
+    stderr: (
+      (result.stderr ?? '') + (result.error ? `\n${result.error.message}` : '')
+    ).trim(),
+  }
+}
+
+/**
+ * A clean load: exit 0, no diagnostics. Asserting the outcome and stderr
+ * together is what puts the child's stack trace in the jest diff -- a bare
+ * `expect(status).toBe(0)` would report `1 !== 0` and throw away the only
+ * information that identifies which module failed to resolve.
+ */
+const outcomeOf = ({ status, signal, stderr }) => ({ status, signal, stderr })
+const CLEAN_EXIT = { status: 0, signal: null, stderr: '' }
+
+const CJS_RUNNER = '__runner__.cjs'
+const ESM_RUNNER = '__runner__.mjs'
+
+/** Require the built handler from CommonJS and print what it returns. */
+const requireRunner = (target) =>
+  `const { hello } = require(${JSON.stringify(target)})\n` +
+  `hello().then((r) => console.log(JSON.stringify(r)))\n`
+
+/** Import the built handler as ESM and print what it returns. */
+const importRunner = (target) =>
+  `const { hello } = await import(${JSON.stringify(target)})\n` +
+  `console.log(JSON.stringify(await hello()))\n`
+
+describe('non-bundled build output loads in a real node process', () => {
+  jest.setTimeout(120_000)
+
+  it('loads a CommonJS service whose TS handler reaches a TS helper and a JS helper', async () => {
+    // The shape reported in #12744: a plain CommonJS service where the handler
+    // is TypeScript and pulls in both a compiled sibling and a hand-written
+    // one. Bundling made all three a single file; not bundling means the two
+    // helpers have to be in the artifact, at those paths, in a module format
+    // the CommonJS loader accepts.
+    const buildDir = await build({
+      'package.json': '{"name":"svc"}',
+      'src/handler.ts':
+        "import { helper } from './util'\n" +
+        "import { legacy } from './legacy.js'\n" +
+        'export const hello = async () => ({\n' +
+        '  statusCode: 200,\n' +
+        '  body: `${helper()}+${legacy()}`,\n' +
+        '})\n',
+      'src/util.ts': "export const helper = () => 'helped'\n",
+      'src/legacy.js': 'exports.legacy = () => "legacy"\n',
+    })
+
+    const result = runNode(
+      buildDir,
+      CJS_RUNNER,
+      requireRunner('./src/handler.js'),
+    )
+
+    expect(outcomeOf(result)).toEqual(CLEAN_EXIT)
+    expect(JSON.parse(result.stdout)).toEqual({
+      statusCode: 200,
+      body: 'helped+legacy',
+    })
+  })
+
+  it('loads a "type": "module" service whose sources name the emitted files', async () => {
+    // Extensioned specifiers written in the TypeScript source -- `./util.js`,
+    // naming the file esbuild will emit, which is what `"module": "nodenext"`
+    // requires. Nothing rewrites them, so this is the only spelling Node's ESM
+    // resolver accepts; the negative control below is the same fixture without
+    // the extension.
+    const buildDir = await build({
+      'package.json': '{"name":"svc","type":"module"}',
+      'src/handler.ts':
+        "import { helper } from './util.js'\n" +
+        'export const hello = async () => ({ statusCode: 200, body: helper() })\n',
+      'src/util.ts': "export const helper = () => 'helped'\n",
+    })
+
+    const result = runNode(
+      buildDir,
+      ESM_RUNNER,
+      importRunner('./src/handler.js'),
+    )
+
+    expect(outcomeOf(result)).toEqual(CLEAN_EXIT)
+    expect(JSON.parse(result.stdout)).toEqual({
+      statusCode: 200,
+      body: 'helped',
+    })
+  })
+
+  it('loads a handler under a nested "type": "module" that the service root never mentions', async () => {
+    // The root says CommonJS and `src/` says module, so the emitted format is
+    // decided by a file two levels away from the service manifest. Reading the
+    // root instead would emit `module.exports` into a directory Node parses as
+    // ESM, and the failure would be a ReferenceError at load time in Lambda.
+    // Shipping `src/package.json` is half of it; the other half is that the
+    // hand-written ESM `util.js` beside it is copied, not re-emitted.
+    const buildDir = await build({
+      'package.json': '{"name":"svc"}',
+      'src/package.json': '{"type":"module"}',
+      'src/handler.ts':
+        "import { helper } from './util.js'\n" +
+        'export const hello = async () => ({ statusCode: 200, body: helper() })\n',
+      'src/util.js': "export const helper = () => 'nested'\n",
+    })
+
+    const result = runNode(
+      buildDir,
+      ESM_RUNNER,
+      importRunner('./src/handler.js'),
+    )
+
+    expect(outcomeOf(result)).toEqual(CLEAN_EXIT)
+    expect(JSON.parse(result.stdout)).toEqual({
+      statusCode: 200,
+      body: 'nested',
+    })
+  })
+
+  it('loads an .mts handler from the .mjs it is emitted as, inside a CommonJS service', async () => {
+    // `.mts` is ESM by definition and keeps that identity through the extension
+    // mapping, so this handler is ESM in a service whose root package.json says
+    // nothing of the sort -- and Node agrees only because the emitted name ends
+    // in `.mjs`. Emitting `src/handler.js` here would be loaded as CommonJS and
+    // reject the `import` on its first line.
+    const buildDir = await build({
+      'package.json': '{"name":"svc"}',
+      'src/handler.mts':
+        "import { helper } from './util.mjs'\n" +
+        'export const hello = async () => ({ statusCode: 200, body: helper() })\n',
+      'src/util.mts': "export const helper = () => 'from-mts'\n",
+    })
+
+    const result = runNode(
+      buildDir,
+      ESM_RUNNER,
+      importRunner('./src/handler.mjs'),
+    )
+
+    expect(outcomeOf(result)).toEqual(CLEAN_EXIT)
+    expect(JSON.parse(result.stdout)).toEqual({
+      statusCode: 200,
+      body: 'from-mts',
+    })
+  })
+
+  it('loads a .cjs handler and its .cjs helper inside a "type": "module" service', async () => {
+    // The mirror image: CommonJS files that have to stay CommonJS under a root
+    // that declares the opposite. `require` between them is only legal because
+    // both names end in `.cjs` after the build.
+    const buildDir = await build({
+      'package.json': '{"name":"svc","type":"module"}',
+      'src/handler.cjs':
+        "const { helper } = require('./util.cjs')\n" +
+        'module.exports.hello = async () => ({ statusCode: 200, body: helper() })\n',
+      'src/util.cjs': "module.exports.helper = () => 'from-cjs'\n",
+    })
+
+    const result = runNode(
+      buildDir,
+      CJS_RUNNER,
+      requireRunner('./src/handler.cjs'),
+    )
+
+    expect(outcomeOf(result)).toEqual(CLEAN_EXIT)
+    expect(JSON.parse(result.stdout)).toEqual({
+      statusCode: 200,
+      body: 'from-cjs',
+    })
+  })
+})
+
+/**
+ * The honesty test for the extensionless-import warning.
+ *
+ * The build does not fail on an extensionless ESM specifier -- it warns and
+ * ships. That is only defensible if the warning describes something real, and
+ * "real" here means the artifact is genuinely unloadable. This runs the exact
+ * build the warning was emitted for and requires Node to refuse it. If the
+ * warning ever fires on output that loads, it is noise and should be deleted;
+ * if it stops firing on output that does not load, the diagnostic is gone. The
+ * two assertions are deliberately in one test so neither can drift alone.
+ */
+describe('the extensionless-import warning names a real runtime failure', () => {
+  jest.setTimeout(120_000)
+
+  it('warns at build time and then fails to load with ERR_MODULE_NOT_FOUND', async () => {
+    const warnSpy = jest
+      .spyOn(esbuildLogger, 'warning')
+      .mockImplementation(() => {})
+    let buildDir
+    try {
+      // Identical to the passing ESM case above, except the specifier omits the
+      // extension -- the one difference that decides whether this artifact
+      // works.
+      buildDir = await build({
+        'package.json': '{"name":"svc","type":"module"}',
+        'src/handler.ts':
+          "import { helper } from './util'\n" +
+          'export const hello = async () => ({ statusCode: 200, body: helper() })\n',
+        'src/util.ts': "export const helper = () => 'helped'\n",
+      })
+
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy.mock.calls[0][0]).toContain('src/handler.js → ./util')
+    } finally {
+      warnSpy.mockRestore()
+    }
+
+    // The build succeeded: the file the warning is about is on disk, and every
+    // file it needs is there too. Only the specifier is wrong.
+    expect(fs.existsSync(path.join(buildDir, 'src/handler.js'))).toBe(true)
+    expect(fs.existsSync(path.join(buildDir, 'src/util.js'))).toBe(true)
+
+    const result = runNode(
+      buildDir,
+      ESM_RUNNER,
+      importRunner('./src/handler.js'),
+    )
+
+    // Loud, not silent, and never reaching the handler body.
+    expect(result.status).not.toBe(0)
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toContain('ERR_MODULE_NOT_FOUND')
+    // Named precisely: the file the warned-about specifier resolves to and
+    // fails on -- `src/util`, extensionless, which is the whole complaint.
+    // Node renders it as an absolute path, hence the separator-agnostic tail
+    // match rather than a bare substring that `src/util.js` would satisfy too.
+    expect(result.stderr).toMatch(/Cannot find module '.*[/\\]src[/\\]util'/)
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/out-extension.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/out-extension.test.js
@@ -77,7 +77,14 @@ describe('esbuild outExtension support', () => {
 
   beforeEach(() => {
     buildMock.mockReset()
-    buildMock.mockResolvedValue({})
+    // A successful esbuild call writes its outfile, and the plugin now records
+    // only artifacts that are actually on disk, so a mock that resolves
+    // without writing anything would misrepresent success.
+    buildMock.mockImplementation(async ({ outfile }) => {
+      fs.mkdirSync(path.dirname(outfile), { recursive: true })
+      fs.writeFileSync(outfile, '// built by the esbuild mock\n')
+      return {}
+    })
   })
 
   afterEach(() => {
@@ -298,6 +305,28 @@ describe('esbuild packaging with outExtension', () => {
     expect(entries).toContain('handler.mjs')
     expect(entries).toContain('handler.mjs.map')
     expect(entries).not.toContain('handler.js')
+  })
+
+  test('the handler assertion accepts an outExtension-renamed outfile', async () => {
+    // The post-zip check compares `builtArtifacts` against the names actually
+    // appended. Both sides have to agree on the renamed extension, or an
+    // otherwise correct `.mjs` artifact would be rejected as handler-less.
+    const serviceDir = makeBuiltServiceDir('.mjs')
+    const plugin = makePackagingPlugin(serviceDir, {
+      esbuildConfig: { format: 'esm', outExtension: { '.js': '.mjs' } },
+      individually: true,
+    })
+    plugin.builtArtifacts = new Map([
+      ['hello', { outfile: 'handler.mjs', mapfile: 'handler.mjs.map' }],
+    ])
+
+    await expect(plugin._package()).resolves.toBeUndefined()
+
+    expect(
+      await zipEntryNames(
+        path.join(serviceDir, '.serverless', 'my-service-hello.zip'),
+      ),
+    ).toContain('handler.mjs')
   })
 
   test('without outExtension packaging still zips .js names', async () => {

--- a/packages/serverless/test/unit/lib/plugins/esbuild/out-extension.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/out-extension.test.js
@@ -194,6 +194,32 @@ describe('esbuild outExtension support', () => {
     expect(buildMock).not.toHaveBeenCalled()
   })
 
+  test("a CommonJS subtree under an ESM root names its file when '.mjs' cannot apply", async () => {
+    // `format: esm` on a `"type": "module"` root is the derived default, so
+    // nested package.json subtrees keep deciding their own module system. The
+    // mapping then fails on the first CommonJS file — and "set format: esm",
+    // which the user already did, must not be the advice.
+    const serviceDir = makeServiceDir({
+      'package.json': '{"type":"module"}\n',
+      ...handlerFiles,
+      'sub/package.json': '{"type":"commonjs"}\n',
+      'sub/util.ts': 'export const one = 1\n',
+    })
+    const plugin = makePlugin(serviceDir, functions, {
+      esbuildConfig: {
+        bundle: false,
+        format: 'esm',
+        outExtension: { '.js': '.mjs' },
+      },
+    })
+
+    await expect(plugin._build()).rejects.toThrow(
+      /"sub\/util\.ts" compiles as CommonJS because its nearest package\.json/,
+    )
+    await expect(plugin._build()).rejects.not.toThrow(/Set "format: esm"/)
+    expect(buildMock).not.toHaveBeenCalled()
+  })
+
   test('an unsupported extension value fails fast', async () => {
     const serviceDir = makeServiceDir(handlerFiles)
     const plugin = makePlugin(serviceDir, functions, {

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-determinism.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-determinism.test.js
@@ -206,3 +206,77 @@ describe('esbuild packaging determinism', () => {
     }
   })
 })
+
+/**
+ * Packaging now ships the whole build directory instead of a handpicked list
+ * of files. For the overwhelmingly common service — `bundle: true`, no
+ * patterns — the build directory holds exactly what that list named, so the
+ * artifact must come out with the same contents it always had.
+ */
+describe('bundle: true artifact contents are unchanged', () => {
+  jest.setTimeout(30_000)
+
+  // The exact shape a bundling build leaves behind: the pruned package.json,
+  // the lockfile copied beside it, one bundle per handler with its sourcemap,
+  // and the dependencies installed from that package.json.
+  function makeBundledBuildDir() {
+    const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
+    const buildDir = path.join(serviceDir, '.serverless', 'build')
+    fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep'), {
+      recursive: true,
+    })
+    fs.writeFileSync(
+      path.join(buildDir, 'node_modules', 'dep', 'index.js'),
+      'module.exports = 1\n',
+    )
+    fs.writeFileSync(path.join(buildDir, 'package.json'), '{"name":"svc"}\n')
+    fs.writeFileSync(path.join(buildDir, 'package-lock.json'), '{}\n')
+    fs.writeFileSync(
+      path.join(buildDir, 'handler.js'),
+      'export const hello = async () => ({ statusCode: 200 })\n',
+    )
+    fs.writeFileSync(path.join(buildDir, 'handler.js.map'), '{}\n')
+    return serviceDir
+  }
+
+  test('_packageAll ships exactly the files the handpicked list named, sorted', async () => {
+    const serviceDir = makeBundledBuildDir()
+    const plugin = makePlugin(serviceDir)
+    plugin.builtArtifacts = new Map([
+      ['hello', { outfile: 'handler.js', mapfile: 'handler.js.map' }],
+    ])
+
+    await plugin._packageAll(functions)
+
+    const zip = await JsZip.loadAsync(
+      fs.readFileSync(path.join(serviceDir, '.serverless', 'my-service.zip')),
+    )
+    const names = Object.keys(zip.files)
+    const fromBuildDir = names.filter((n) => !n.startsWith('node_modules'))
+    expect(fromBuildDir).toEqual([
+      'handler.js',
+      'handler.js.map',
+      'package-lock.json',
+      'package.json',
+    ])
+    expect(names).toContain('node_modules/dep/index.js')
+  })
+
+  test('rebuilding identical content produces byte-identical archives', async () => {
+    const hash = async () => {
+      const serviceDir = makeBundledBuildDir()
+      const plugin = makePlugin(serviceDir)
+      await plugin._packageAll(functions)
+      return crypto
+        .createHash('sha256')
+        .update(
+          fs.readFileSync(
+            path.join(serviceDir, '.serverless', 'my-service.zip'),
+          ),
+        )
+        .digest('hex')
+    }
+
+    expect(await hash()).toBe(await hash())
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-directory-include.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-directory-include.test.js
@@ -1,14 +1,29 @@
 /**
- * Package-pattern resolution (globby with its onlyFiles default) only ever
- * yields files, so the directory branch of the includes loop is defensive —
- * but if it fires it must reproduce the walk semantics that zip.directory()
- * historically gave that branch: directory entries recorded (including empty
- * directories), symlinks stored as symlinks (broken ones included), symlinked
- * directories not followed — while appending in sorted order so the archive
- * stays deterministic.
+ * A `package.patterns` entry that names a directory's contents is packaged
+ * with CLASSIC PACKAGING semantics, because that is what the rest of the
+ * esbuild packaging path is built to match: the include is resolved with
+ * symlinks followed and directories excluded (classic's `follow: true` +
+ * `nodir: true`), copied into the build directory, and shipped from there.
  *
- * The patterns lookup is mocked to return a directory; the expansion walk
- * itself runs against the real filesystem.
+ * Three consequences follow, and all three are the point of this file:
+ *
+ *   - A symlink inside the included directory ships DEREFERENCED — its target's
+ *     bytes under the symlink's own name, recorded as a regular file. The
+ *     deployed function reads a real file, not a link into a path that does not
+ *     exist inside a Lambda artifact.
+ *   - A symlinked DIRECTORY is walked through, and the files behind it ship as
+ *     regular files at their paths under the link.
+ *   - Empty directories produce nothing, and no directory entries are recorded
+ *     for the include at all. The artifact carries files; the runtime creates
+ *     the directories that hold them on extraction.
+ *
+ * A broken symlink resolves to nothing and is silently absent, which is also
+ * classic behavior — there is no target to package.
+ *
+ * This replaces the zip.directory()-based expansion, which recorded directory
+ * entries (empty ones included) and stored symlinks as symlink entries without
+ * following them. Nothing here is mocked: the walk, the copy and the archive
+ * all run against the real filesystem.
  */
 
 import { jest } from '@jest/globals'
@@ -16,21 +31,16 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import JsZip from 'jszip'
-
-const actualGlobbyModule = await import('globby')
-
-jest.unstable_mockModule('globby', () => ({
-  ...actualGlobbyModule,
-  globby: async (patterns, options) => {
-    if (Array.isArray(patterns) && patterns.includes('__DIR_INCLUDE__')) {
-      return ['assets']
-    }
-    return actualGlobbyModule.globby(patterns, options)
-  },
-}))
+import { log } from '@serverless/util'
 
 const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
   .default
+
+// The file-type bits of a zip entry's unix mode. S_IFREG (0o100000) is a
+// regular file; S_IFLNK (0o120000) is a stored symlink, which this path must
+// never produce.
+const S_IFMT = 0o170000
+const S_IFREG = 0o100000
 
 function makeServiceDir() {
   const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
@@ -52,7 +62,7 @@ function makeServiceDir() {
   fs.writeFileSync(path.join(assetsDir, 'sub', 'a.txt'), 'a\n')
 
   // Symlink creation needs privileges on some Windows setups; assert on
-  // symlink entries only when they could be created.
+  // symlink behavior only when they could be created.
   let symlinksCreated = false
   try {
     fs.symlinkSync(
@@ -71,13 +81,13 @@ function makeServiceDir() {
   return { serviceDir, symlinksCreated }
 }
 
-function makePlugin(serviceDir) {
+function makePlugin(serviceDir, patterns) {
   const serverless = {
     serviceDir,
     config: { serviceDir },
     service: {
       service: 'my-service',
-      package: { patterns: ['__DIR_INCLUDE__'] },
+      package: { patterns },
     },
     pluginManager: { spawn: async () => {} },
   }
@@ -86,35 +96,106 @@ function makePlugin(serviceDir) {
 
 const functions = { hello: { handler: 'handler.hello' } }
 
+async function packagedEntries(serviceDir, plugin) {
+  await plugin._packageAll(functions)
+  const zip = await JsZip.loadAsync(
+    fs.readFileSync(path.join(serviceDir, '.serverless', 'my-service.zip')),
+  )
+  return zip
+}
+
 describe('esbuild packaging with a directory include', () => {
   jest.setTimeout(30_000)
 
-  test('_packageAll walks the directory like zip.directory did', async () => {
+  test('_packageAll ships an included directory with classic packaging semantics', async () => {
     const { serviceDir, symlinksCreated } = makeServiceDir()
-    const plugin = makePlugin(serviceDir)
+    const plugin = makePlugin(serviceDir, ['assets/**'])
 
-    await plugin._packageAll(functions)
+    const zip = await packagedEntries(serviceDir, plugin)
+    const names = Object.values(zip.files).map((entry) => entry.name)
 
-    const zip = await JsZip.loadAsync(
-      fs.readFileSync(path.join(serviceDir, '.serverless', 'my-service.zip')),
-    )
+    // Files land at their paths under the included directory.
+    expect(names).toContain('assets/file.txt')
+    expect(names).toContain('assets/sub/a.txt')
+
+    // No directory entries for the include, empty directories included.
+    expect(names).not.toContain('assets/empty-dir/')
+    expect(
+      names.filter((name) => name.startsWith('assets/') && name.endsWith('/')),
+    ).toEqual([])
+
+    if (symlinksCreated) {
+      // A symlink to a file ships dereferenced: the target's bytes, stored
+      // under the link's own name, as a regular file.
+      expect(names).toContain('assets/link-to-file')
+      await expect(
+        zip.files['assets/link-to-file'].async('string'),
+      ).resolves.toBe('f\n')
+      expect(zip.files['assets/link-to-file'].unixPermissions & S_IFMT).toBe(
+        S_IFREG,
+      )
+
+      // A symlinked directory is walked through; what ships is the files
+      // behind it, as regular files, not the link.
+      expect(names).toContain('assets/link-to-sub/a.txt')
+      await expect(
+        zip.files['assets/link-to-sub/a.txt'].async('string'),
+      ).resolves.toBe('a\n')
+      expect(names).not.toContain('assets/link-to-sub')
+
+      // A broken symlink resolves to nothing, so there is nothing to package.
+      expect(names).not.toContain('assets/broken-link')
+    }
+  })
+
+  test('a bare directory name ships the whole tree it names', async () => {
+    // globby expands a pattern that resolves to a directory into the files
+    // beneath it, and those files are what the include selected — the ordered
+    // pattern pass only ever retracts from that set. Re-testing them against
+    // the literal pattern `assets` would match none of them and silently drop
+    // the entire tree the user asked to ship (and report every file as an
+    // exclusion while doing it).
+    const { serviceDir, symlinksCreated } = makeServiceDir()
+    const plugin = makePlugin(serviceDir, ['assets'])
+
+    const zip = await packagedEntries(serviceDir, plugin)
     const names = Object.values(zip.files).map((entry) => entry.name)
 
     expect(names).toContain('assets/file.txt')
-    expect(names).toContain('assets/sub/')
     expect(names).toContain('assets/sub/a.txt')
-    // Directory entries are preserved, including empty directories.
-    expect(names).toContain('assets/empty-dir/')
     if (symlinksCreated) {
-      // Symlinks are stored as entries (broken ones too), not followed.
+      // Same dereferencing contract as the explicit-glob form.
       expect(names).toContain('assets/link-to-file')
-      expect(names).toContain('assets/broken-link')
-      // A symlinked directory is stored as a symlink entry; its target's
-      // contents are not walked through the link.
-      expect(names).toContain('assets/link-to-sub')
-      expect(names.filter((n) => n.startsWith('assets/link-to-sub/'))).toEqual(
-        [],
+      await expect(
+        zip.files['assets/link-to-file'].async('string'),
+      ).resolves.toBe('f\n')
+      expect(zip.files['assets/link-to-file'].unixPermissions & S_IFMT).toBe(
+        S_IFREG,
       )
+    }
+    expect(names).toContain('handler.js')
+  })
+
+  test('a bare directory name reports no exclusions', async () => {
+    // The counter feeds the "Excluded N entries ... via package.patterns" line.
+    // Files the glob expanded rather than literally matched were being counted
+    // as exclusions, so a plain directory include announced that it had removed
+    // the very tree it shipped.
+    const { serviceDir } = makeServiceDir()
+    const plugin = makePlugin(serviceDir, ['assets'])
+    const infoSpy = jest
+      .spyOn(log.get('esbuild'), 'info')
+      .mockImplementation(() => {})
+
+    try {
+      await packagedEntries(serviceDir, plugin)
+      expect(
+        infoSpy.mock.calls
+          .map((call) => call[0])
+          .filter((message) => message.includes('package.patterns')),
+      ).toEqual([])
+    } finally {
+      infoSpy.mockRestore()
     }
   })
 })

--- a/packages/serverless/test/unit/lib/plugins/esbuild/packaging-vanished-include.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/packaging-vanished-include.test.js
@@ -4,15 +4,29 @@
  * an escaped rejection would bypass the archive promise: embedders hang on a
  * never-settling promise and the CLI aborts through the global
  * unhandledRejection handler. Worse, archiver's own stat queue silently drops
- * entries it cannot stat, which can ship an incomplete artifact (e.g. a zip
- * without its handler) that only fails at runtime.
+ * entries it cannot stat, which can ship an incomplete artifact that only
+ * fails at runtime.
  *
- * Packaging must instead fail fast with a clean CANNOT_READ_FILE error routed
- * through the archive promise — the same contract as the classic (non-esbuild)
- * packaging path.
+ * Packaging must instead fail fast, through the archive promise, with the same
+ * contract as the classic (non-esbuild) packaging path. Two distinct
+ * disappearances are pinned here, because packaging catches them in two
+ * different places:
  *
- * fs/promises is mocked so stat deterministically rejects for the marked
- * include while everything else uses the real filesystem.
+ *   - A `package.patterns` include that vanished. It is looked up by name on
+ *     the way into the build directory, so it fails with CANNOT_READ_FILE.
+ *     fs/promises is mocked so `stat` deterministically rejects for the marked
+ *     include while everything else uses the real filesystem.
+ *
+ *   - A handler bundle that vanished from the build directory after the build
+ *     wrote it. Packaging ships the build directory as a whole, so a missing
+ *     file is not a failed lookup — it is simply absent, and nothing about the
+ *     append sequence notices. What catches it is the post-zip assertion,
+ *     which reads the finished archive's central directory and compares it
+ *     against the outfiles `_build` recorded, raising
+ *     ESBUILD_HANDLER_MISSING_FROM_ARTIFACT. That check runs against real
+ *     build bookkeeping here — an actual build, then the emitted file deleted
+ *     — because seeding `builtArtifacts` by hand would prove nothing about
+ *     whether the bookkeeping and the assertion agree.
  */
 
 import { jest } from '@jest/globals'
@@ -38,7 +52,7 @@ jest.unstable_mockModule('fs/promises', () => {
 const Esbuild = (await import('../../../../../lib/plugins/esbuild/index.js'))
   .default
 
-function makeServiceDir({ withHandler = true } = {}) {
+function makeServiceDir() {
   const serviceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-'))
   const buildDir = path.join(serviceDir, '.serverless', 'build')
   fs.mkdirSync(path.join(buildDir, 'node_modules', 'dep'), { recursive: true })
@@ -46,12 +60,10 @@ function makeServiceDir({ withHandler = true } = {}) {
     path.join(buildDir, 'node_modules', 'dep', 'index.js'),
     'module.exports = 1\n',
   )
-  if (withHandler) {
-    fs.writeFileSync(
-      path.join(buildDir, 'handler.js'),
-      'export const hello = async () => ({ statusCode: 200 })\n',
-    )
-  }
+  fs.writeFileSync(
+    path.join(buildDir, 'handler.js'),
+    'export const hello = async () => ({ statusCode: 200 })\n',
+  )
   // Both exist at glob time; stat is mocked to reject for vanished.txt,
   // simulating a file deleted between glob expansion and packaging.
   fs.writeFileSync(path.join(serviceDir, 'kept.txt'), 'kept\n')
@@ -73,6 +85,43 @@ function makePlugin(serviceDir) {
 }
 
 const functions = { hello: { handler: 'handler.hello' } }
+
+/**
+ * A service that really builds: one TypeScript handler and nothing else.
+ * `realpathSync` because macOS resolves the temp dir through a symlink
+ * (`/var` -> `/private/var`) and esbuild reports real paths -- an unresolved
+ * prefix makes `outbase` fail to match the entry point, which collapses the
+ * built layout into the build root.
+ */
+function makeBuildableServiceDir() {
+  const serviceDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'sls-esbuild-build-')),
+  )
+  fs.mkdirSync(path.join(serviceDir, 'src'), { recursive: true })
+  fs.writeFileSync(
+    path.join(serviceDir, 'src', 'handler.ts'),
+    'export const hello = async (): Promise<object> => ({ statusCode: 200 })\n',
+  )
+  return serviceDir
+}
+
+function makeBuildablePlugin(serviceDir, fns) {
+  const serverless = {
+    serviceDir,
+    config: { serviceDir },
+    service: {
+      service: 'my-service',
+      provider: { runtime: 'nodejs20.x' },
+      package: {},
+      build: { esbuild: { bundle: true } },
+      functions: fns,
+      getFunction: (name) => fns[name],
+      getAllFunctions: () => Object.keys(fns),
+    },
+    pluginManager: { spawn: async () => {} },
+  }
+  return new Esbuild(serverless, {})
+}
 
 describe('esbuild packaging with a vanished file', () => {
   jest.setTimeout(30_000)
@@ -100,14 +149,33 @@ describe('esbuild packaging with a vanished file', () => {
     })
   })
 
-  test('_packageAll rejects with CANNOT_READ_FILE when the handler bundle is missing', async () => {
-    const serviceDir = makeServiceDir({ withHandler: false })
-    const plugin = makePlugin(serviceDir)
-    plugin.serverless.service.package.patterns = []
+  test('_packageAll rejects with ESBUILD_HANDLER_MISSING_FROM_ARTIFACT when the built handler vanished from the build directory', async () => {
+    const buildableFns = { hello: { handler: 'src/handler.hello' } }
+    const serviceDir = makeBuildableServiceDir()
+    const plugin = makeBuildablePlugin(serviceDir, buildableFns)
 
-    await expect(plugin._packageAll(functions)).rejects.toMatchObject({
-      code: 'CANNOT_READ_FILE',
-      message: expect.stringMatching(/handler\.js/),
+    await plugin._build()
+
+    // Real bookkeeping from a real build, not a seeded map: this is the
+    // recorded outfile the assertion will look for.
+    const { outfile } = plugin.builtArtifacts.get('hello')
+    expect(outfile).toBe('src/handler.js')
+
+    const emitted = path.join(
+      serviceDir,
+      '.serverless',
+      'build',
+      ...outfile.split('/'),
+    )
+    expect(fs.existsSync(emitted)).toBe(true)
+    fs.rmSync(emitted)
+
+    await expect(plugin._packageAll(buildableFns)).rejects.toMatchObject({
+      name: 'ServerlessError',
+      code: 'ESBUILD_HANDLER_MISSING_FROM_ARTIFACT',
+      // Naming the function and the file it lost is the whole point: the
+      // deploy output has to say which handler is missing and from where.
+      message: expect.stringContaining('"hello" (src/handler.js)'),
     })
   })
 })

--- a/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
@@ -1,0 +1,1217 @@
+/**
+ * `project-sweep.js` selects the files a non-bundled (`bundle: false`) esbuild
+ * build has to place in the deployment artifact, using the same selection rules
+ * classic packaging applies: sweep the whole service directory, drop the files
+ * classic never ships (the service config, layer sources, local plugins, type
+ * declarations, Yarn PnP runtime files), then let ordered `package.patterns`
+ * decide the rest with last-match-wins semantics.
+ *
+ * The module is deliberately free of `this` and of the serverless instance, so
+ * every rule below is pinned against a real temp-directory tree rather than
+ * through a plugin harness.
+ */
+
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  applyTsconfigCompileFilter,
+  sweepProjectFiles,
+  splitCompileAndCopy,
+  detectOutputCollisions,
+  nearestPackageJsonType,
+  outputPathFor,
+  scanExtensionlessEsmImports,
+  scanUnresolvableRelativeImports,
+  toSweptPath,
+} from '../../../../../lib/plugins/esbuild/project-sweep.js'
+
+const createdDirs = []
+
+const makeTree = (files) => {
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sweep-')))
+  createdDirs.push(root)
+  for (const rel of files) {
+    const p = path.join(root, rel)
+    fs.mkdirSync(path.dirname(p), { recursive: true })
+    fs.writeFileSync(p, '')
+  }
+  return root
+}
+
+/** Same, for fixtures whose file contents matter (package.json `type`). */
+const makeTreeWithContents = (files) => {
+  const root = makeTree([])
+  for (const [rel, contents] of Object.entries(files)) {
+    const p = path.join(root, rel)
+    fs.mkdirSync(path.dirname(p), { recursive: true })
+    fs.writeFileSync(p, contents)
+  }
+  return root
+}
+
+afterAll(() => {
+  for (const dir of createdDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('sweepProjectFiles', () => {
+  it('applies classic exclusions and pattern negations', async () => {
+    const dir = makeTree([
+      'serverless.yml',
+      'serverless.ts',
+      'src/util.ts',
+      'src/legacy.js',
+      'assets/logo.png',
+      'types.d.ts',
+      'tests/broken.ts',
+      '.serverless_plugins/p.js',
+      'layer/l.js',
+      'packages/a/node_modules/x.js',
+      '.env-template',
+    ])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      patterns: ['!tests/**'],
+      configFileNames: ['serverless.yml', 'serverless.ts'],
+      layerPaths: ['layer'],
+      localPluginPath: null,
+    })
+
+    expect(files.sort()).toEqual(
+      [
+        '.env-template',
+        'assets/logo.png',
+        'src/legacy.js',
+        'src/util.ts',
+      ].sort(),
+    )
+  })
+
+  it('drops declaration files at any depth, Yarn PnP runtime files and the local plugin path', async () => {
+    const dir = makeTree([
+      'index.js',
+      'types.d.ts',
+      'src/nested/types.d.ts',
+      'src/nested/types.d.mts',
+      'src/nested/types.d.cts',
+      '.yarn/cache/some-package.zip',
+      // Dotted segments below an excluded root only match when the exclusion
+      // globs are evaluated with `dot: true`.
+      '.yarn/.install-state.gz',
+      '.pnp.cjs',
+      '.pnp.loader.mjs',
+      'my-plugins/plugin.js',
+      'my-plugins/.eslintrc.json',
+    ])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      patterns: [],
+      configFileNames: [],
+      layerPaths: [],
+      localPluginPath: 'my-plugins',
+    })
+
+    expect(files).toEqual(['index.js'])
+  })
+
+  it('never sweeps the build output or the git directory', async () => {
+    const dir = makeTree([
+      'index.js',
+      '.serverless/build/index.js',
+      '.serverless/my-service.zip',
+      '.git/config',
+      '.git/objects/ab/cdef',
+      'node_modules/dep/index.js',
+    ])
+
+    const files = await sweepProjectFiles({ serviceDir: dir })
+
+    expect(files).toEqual(['index.js'])
+  })
+
+  it('hard-ignores caller-supplied directories: no positive pattern re-includes them', async () => {
+    // `--package <dir>` inside the service directory is the caller's case: it
+    // receives the previous run's artifact and build directory, so sweeping it
+    // would nest one artifact inside the next. Unlike `additionalExclusions`,
+    // these are not part of the pattern pass, so even `**` cannot bring them
+    // back -- exactly like `.serverless/**`.
+    const dir = makeTree([
+      'index.js',
+      'dist-pkg/my-service.zip',
+      'dist-pkg/build/index.js',
+      'dist-pkg/build/node_modules/dep/index.js',
+    ])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      patterns: ['**', 'dist-pkg/**'],
+      additionalIgnores: ['dist-pkg/**'],
+    })
+
+    expect(files).toEqual(['index.js'])
+  })
+
+  it('ignores node_modules reached through a symbolic link', async () => {
+    const dir = makeTree([
+      'packages/inner/keep.js',
+      'packages/inner/node_modules/dep/index.js',
+    ])
+    fs.symlinkSync(path.join(dir, 'packages', 'inner'), path.join(dir, 'link'))
+
+    const files = await sweepProjectFiles({ serviceDir: dir })
+
+    expect(files.sort()).toEqual(['link/keep.js', 'packages/inner/keep.js'])
+  })
+
+  it('includes every file when no patterns are given', async () => {
+    const dir = makeTree(['a.js', 'deep/b.ts', '.hidden'])
+
+    const files = await sweepProjectFiles({ serviceDir: dir })
+
+    expect(files.sort()).toEqual(['.hidden', 'a.js', 'deep/b.ts'])
+  })
+
+  it('treats empty and bare-negation patterns as inert instead of throwing', async () => {
+    const dir = makeTree(['a.js', 'b.js'])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      patterns: ['', '!'],
+    })
+
+    expect(files.sort()).toEqual(['a.js', 'b.js'])
+  })
+
+  it('resolves overlapping patterns with last-match-wins ordering', async () => {
+    const dir = makeTree(['src/keep.ts', 'src/drop.ts', 'other.ts'])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      patterns: ['!**', 'src/**', '!src/drop.ts'],
+    })
+
+    expect(files).toEqual(['src/keep.ts'])
+  })
+
+  it('lets a later positive pattern re-include a classic exclusion', async () => {
+    const dir = makeTree([
+      'serverless.yml',
+      'layer/l.js',
+      'types.d.ts',
+      'src/app.js',
+    ])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      // Classic turns its own exclusions into leading negated patterns and
+      // appends the user's patterns after them, so a user pattern always gets
+      // the last word.
+      patterns: ['serverless.yml', 'layer/**', '**/*.d.ts'],
+      configFileNames: ['serverless.yml'],
+      layerPaths: ['layer'],
+    })
+
+    expect(files.sort()).toEqual([
+      'layer/l.js',
+      'serverless.yml',
+      'src/app.js',
+      'types.d.ts',
+    ])
+  })
+
+  it('keeps classic exclusions when the user patterns do not mention them', async () => {
+    const dir = makeTree(['serverless.yml', 'layer/l.js', 'src/app.js'])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      patterns: ['src/**'],
+      configFileNames: ['serverless.yml'],
+      layerPaths: ['layer'],
+    })
+
+    expect(files).toEqual(['src/app.js'])
+  })
+
+  it('treats blank exclusion names as inert instead of excluding everything', async () => {
+    const dir = makeTree(['src/app.js', 'assets/logo.png', 'serverless.yml'])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      configFileNames: ['', 'serverless.yml'],
+      layerPaths: ['', '   '],
+      localPluginPath: '',
+    })
+
+    expect(files.sort()).toEqual(['assets/logo.png', 'src/app.js'])
+  })
+
+  it('excludes every configured layer path, not just the first', async () => {
+    const dir = makeTree([
+      'layers/one/handler.js',
+      'layers/two/handler.js',
+      'src/app.js',
+    ])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      layerPaths: ['layers/one', 'layers/two'],
+    })
+
+    expect(files).toEqual(['src/app.js'])
+  })
+
+  it('inverts a !-prefixed additionalExclusion into a re-include, classic-style', async () => {
+    const dir = makeTree(['tmp/keep.js', 'tmp/other.js', 'src/app.js'])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      // Classic's exclude list supports `!` re-include spellings by inverting
+      // them (package-service.js resolveFilePathsFromPatterns); the sweep has
+      // to do the same rather than blanket-negating every entry.
+      additionalExclusions: ['tmp/**', '!tmp/keep.js'],
+    })
+
+    expect(files.sort()).toEqual(['src/app.js', 'tmp/keep.js'])
+  })
+
+  it('treats a lone !-prefixed additionalExclusion as a no-op, not a sweep inversion', async () => {
+    const dir = makeTree(['keep.js', 'src/util.js', 'README.md'])
+
+    const files = await sweepProjectFiles({
+      serviceDir: dir,
+      // Blanket-wrapping this entry produced `!!keep.js` -- a negation whose
+      // micromatch pattern matches everything EXCEPT keep.js -- and emptied
+      // the whole sweep. Classic treats it as a re-include of a file nothing
+      // excluded: a no-op.
+      additionalExclusions: ['!keep.js'],
+    })
+
+    expect(files.sort()).toEqual(['README.md', 'keep.js', 'src/util.js'])
+  })
+})
+
+describe('splitCompileAndCopy', () => {
+  it('compiles TS-family + jsx + handlers, copies the rest', () => {
+    const { compile, copy } = splitCompileAndCopy(
+      [
+        'a.ts',
+        'b.tsx',
+        'c.mts',
+        'd.cts',
+        'e.jsx',
+        'f.js',
+        'g.mjs',
+        'h.cjs',
+        'i.png',
+      ],
+      ['f.js'],
+    )
+
+    expect(compile.sort()).toEqual([
+      'a.ts',
+      'b.tsx',
+      'c.mts',
+      'd.cts',
+      'e.jsx',
+      'f.js',
+    ])
+    expect(copy.sort()).toEqual(['g.mjs', 'h.cjs', 'i.png'])
+  })
+
+  it('compiles a handler the sweep never selected', () => {
+    const { compile, copy } = splitCompileAndCopy(
+      ['other.js'],
+      ['src/handler.js'],
+    )
+
+    expect(compile).toEqual(['src/handler.js'])
+    expect(copy).toEqual(['other.js'])
+  })
+
+  it('lists a repeated handler exactly once', () => {
+    const { compile } = splitCompileAndCopy(
+      ['src/handler.ts'],
+      ['src/handler.ts', 'src/handler.ts'],
+    )
+
+    expect(compile).toEqual(['src/handler.ts'])
+  })
+
+  it('normalizes handler paths so a "./"-prefixed handler is not duplicated', () => {
+    const { compile, copy } = splitCompileAndCopy(
+      ['src/handler.ts', 'src/handler.js'],
+      ['./src/handler.ts'],
+    )
+
+    expect(compile).toEqual(['src/handler.ts'])
+    expect(copy).toEqual(['src/handler.js'])
+    // Normalization is what lets the collision detector see the two files at
+    // all: an unnormalized './src/handler.ts' maps to './src/handler.js' and
+    // silently misses the clash with the copied 'src/handler.js'.
+    expect(detectOutputCollisions(compile, copy)).toEqual([
+      {
+        output: 'src/handler.js',
+        sources: ['src/handler.ts', 'src/handler.js'],
+      },
+    ])
+  })
+
+  it('normalizes backslash-separated handler paths to POSIX', () => {
+    const { compile, copy } = splitCompileAndCopy(
+      ['src/handler.ts'],
+      ['src\\handler.ts'],
+    )
+
+    expect(compile).toEqual(['src/handler.ts'])
+    expect(copy).toEqual([])
+  })
+
+  it('copies everything when there are no handlers and no compilable sources', () => {
+    const { compile, copy } = splitCompileAndCopy(['a.js', 'b.json'])
+
+    expect(compile).toEqual([])
+    expect(copy).toEqual(['a.js', 'b.json'])
+  })
+})
+
+describe('outputPathFor', () => {
+  it('maps source extensions onto their emitted extension', () => {
+    expect(outputPathFor('src/a.ts')).toBe('src/a.js')
+    expect(outputPathFor('src/a.tsx')).toBe('src/a.js')
+    expect(outputPathFor('src/a.jsx')).toBe('src/a.js')
+    expect(outputPathFor('src/a.mts')).toBe('src/a.mjs')
+    expect(outputPathFor('src/a.cts')).toBe('src/a.cjs')
+    expect(outputPathFor('src/a.js')).toBe('src/a.js')
+    expect(outputPathFor('src/a.mjs')).toBe('src/a.mjs')
+    expect(outputPathFor('src/a.cjs')).toBe('src/a.cjs')
+  })
+
+  it('leaves non-source files untouched', () => {
+    expect(outputPathFor('assets/logo.png')).toBe('assets/logo.png')
+    expect(outputPathFor('Makefile')).toBe('Makefile')
+    expect(outputPathFor('src/.env-template')).toBe('src/.env-template')
+  })
+})
+
+describe('detectOutputCollisions', () => {
+  it('flags distinct sources mapping to one output', () => {
+    const collisions = detectOutputCollisions(
+      ['util.ts', 'x.mts'],
+      ['util.js', 'x.mjs'],
+    )
+
+    expect(collisions).toEqual([
+      { output: 'util.js', sources: ['util.ts', 'util.js'] },
+      { output: 'x.mjs', sources: ['x.mts', 'x.mjs'] },
+    ])
+  })
+
+  it('does not flag a handler present in both sets from one source', () => {
+    expect(detectOutputCollisions(['f.js'], ['f.js'])).toEqual([])
+  })
+
+  it('reports every source of a three-way collision', () => {
+    expect(detectOutputCollisions(['a.ts', 'a.tsx', 'a.jsx'], [])).toEqual([
+      { output: 'a.js', sources: ['a.ts', 'a.tsx', 'a.jsx'] },
+    ])
+  })
+
+  it('keeps files whose outputs differ apart', () => {
+    expect(
+      detectOutputCollisions(['a.ts', 'b.mts'], ['a.mjs', 'c.js']),
+    ).toEqual([])
+  })
+
+  it('normalizes sources before grouping them', () => {
+    expect(detectOutputCollisions(['./util.ts'], ['util.js'])).toEqual([
+      { output: 'util.js', sources: ['util.ts', 'util.js'] },
+    ])
+  })
+
+  it('returns nothing for empty inputs', () => {
+    expect(detectOutputCollisions([], [])).toEqual([])
+  })
+})
+
+describe('toSweptPath', () => {
+  it('brings caller paths onto globby form', () => {
+    expect(toSweptPath('src/handler.ts')).toBe('src/handler.ts')
+    expect(toSweptPath('./src/handler.ts')).toBe('src/handler.ts')
+    expect(toSweptPath('.//src/handler.ts')).toBe('/src/handler.ts')
+    expect(toSweptPath('././src/handler.ts')).toBe('src/handler.ts')
+    expect(toSweptPath('src\\deep\\handler.ts')).toBe('src/deep/handler.ts')
+    expect(toSweptPath('.\\src\\handler.ts')).toBe('src/handler.ts')
+  })
+})
+
+/**
+ * Node decides whether a `.js` file is ESM or CommonJS from the `type` of the
+ * nearest package.json above it, so a non-bundled build has to compile each
+ * file to the format that file's own directory declares. A single service-wide
+ * format would emit `export` statements into a directory Node loads as
+ * CommonJS (or the reverse), and the failure only shows up at invocation time.
+ */
+describe('nearestPackageJsonType', () => {
+  it('defaults to commonjs when the service has no package.json at all', () => {
+    const dir = makeTree(['src/a.ts'])
+    expect(nearestPackageJsonType(dir, 'src/a.ts')).toBe('commonjs')
+  })
+
+  it('reads the root package.json for a root-level file', () => {
+    const dir = makeTreeWithContents({
+      'package.json': '{"type":"module"}',
+      'a.ts': '',
+    })
+    expect(nearestPackageJsonType(dir, 'a.ts')).toBe('module')
+  })
+
+  it('inherits the root type through directories that declare none', () => {
+    const dir = makeTreeWithContents({
+      'package.json': '{"type":"module"}',
+      'src/deep/nested/a.ts': '',
+    })
+    expect(nearestPackageJsonType(dir, 'src/deep/nested/a.ts')).toBe('module')
+  })
+
+  it('lets a nested package.json override the root', () => {
+    const dir = makeTreeWithContents({
+      'package.json': '{"type":"module"}',
+      'legacy/package.json': '{"type":"commonjs"}',
+      'legacy/a.ts': '',
+      'esm/a.ts': '',
+    })
+    expect(nearestPackageJsonType(dir, 'legacy/a.ts')).toBe('commonjs')
+    expect(nearestPackageJsonType(dir, 'esm/a.ts')).toBe('module')
+  })
+
+  it('lets a nested package.json opt into ESM under a CommonJS root', () => {
+    const dir = makeTreeWithContents({
+      'package.json': '{"name":"svc"}',
+      'src/esm/package.json': '{"type":"module"}',
+      'src/esm/mod.ts': '',
+      'src/plain.ts': '',
+    })
+    expect(nearestPackageJsonType(dir, 'src/esm/mod.ts')).toBe('module')
+    expect(nearestPackageJsonType(dir, 'src/plain.ts')).toBe('commonjs')
+  })
+
+  it('treats a package.json without a type as commonjs', () => {
+    const dir = makeTreeWithContents({
+      'package.json': '{"name":"svc"}',
+      'a.ts': '',
+    })
+    expect(nearestPackageJsonType(dir, 'a.ts')).toBe('commonjs')
+  })
+
+  it('treats an unparseable package.json as commonjs rather than failing the build', () => {
+    const dir = makeTreeWithContents({
+      'package.json': '{"type":"module"}',
+      'broken/package.json': 'not json at all',
+      'broken/a.ts': '',
+    })
+    expect(nearestPackageJsonType(dir, 'broken/a.ts')).toBe('commonjs')
+  })
+
+  it('never walks above the service directory', () => {
+    // The parent of a temp dir is the OS temp dir, which may well hold a
+    // package.json belonging to something else entirely.
+    const dir = makeTreeWithContents({ 'a.ts': '' })
+    fs.writeFileSync(
+      path.join(path.dirname(dir), 'package.json'),
+      '{"type":"module"}',
+    )
+    expect(nearestPackageJsonType(dir, 'a.ts')).toBe('commonjs')
+  })
+
+  it('reuses the cache across files instead of re-reading each directory', () => {
+    const dir = makeTreeWithContents({
+      'package.json': '{"type":"module"}',
+      'src/deep/a.ts': '',
+      'src/deep/b.ts': '',
+    })
+    const cache = new Map()
+    expect(nearestPackageJsonType(dir, 'src/deep/a.ts', cache)).toBe('module')
+    // Every directory on the walk is memoized, not just the one that answered.
+    expect([...cache.keys()].sort()).toEqual(['.', 'src', 'src/deep'])
+
+    // Delete the package.json the first call resolved through: a second call
+    // that still answers 'module' can only have come from the cache.
+    fs.rmSync(path.join(dir, 'package.json'))
+    expect(nearestPackageJsonType(dir, 'src/deep/b.ts', cache)).toBe('module')
+  })
+
+  it('accepts backslash-separated relative paths', () => {
+    const dir = makeTreeWithContents({
+      'src/esm/package.json': '{"type":"module"}',
+      'src/esm/a.ts': '',
+    })
+    expect(nearestPackageJsonType(dir, toSweptPath('src\\esm\\a.ts'))).toBe(
+      'module',
+    )
+  })
+})
+
+describe('applyTsconfigCompileFilter', () => {
+  const compileOf = (result) => result.compile.sort()
+
+  it('leaves the compile set alone when the service has no tsconfig', () => {
+    const dir = makeTreeWithContents({ 'src/a.ts': '' })
+    const compileFiles = ['src/a.ts', 'src/b.jsx']
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles,
+      handlerFiles: [],
+    })
+
+    expect(result.compile).toEqual(compileFiles)
+    expect(result.warning).toBeNull()
+  })
+
+  it('keeps the TypeScript the tsconfig selects and drops the rest', () => {
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({
+        include: ['src'],
+        exclude: ['src/skip'],
+      }),
+      'src/a.ts': '',
+      'src/skip/b.ts': '',
+      'lib/c.ts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['src/a.ts', 'src/skip/b.ts', 'lib/c.ts'],
+      handlerFiles: [],
+    })
+
+    expect(compileOf(result)).toEqual(['src/a.ts'])
+    expect(result.warning).toBeNull()
+  })
+
+  it('retains a handler the tsconfig does not select', () => {
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ include: ['src'] }),
+      'src/a.ts': '',
+      'lib/c.ts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['src/a.ts', 'lib/c.ts'],
+      handlerFiles: ['./lib/c.ts'],
+    })
+
+    // The handler is retained exactly once -- normalization has to recognize
+    // the `./`-prefixed handler as the swept `lib/c.ts`.
+    expect(compileOf(result)).toEqual(['lib/c.ts', 'src/a.ts'])
+  })
+
+  it('never filters JS-family sources, selected or not', () => {
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ include: ['src'] }),
+      'src/a.ts': '',
+      'src/legacy.js': '',
+      'lib/legacy.js': '',
+      'lib/widget.jsx': '',
+      'lib/mod.mjs': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: [
+        'src/a.ts',
+        'src/legacy.js',
+        'lib/legacy.js',
+        'lib/widget.jsx',
+        'lib/mod.mjs',
+      ],
+      handlerFiles: [],
+    })
+
+    expect(compileOf(result)).toEqual([
+      'lib/legacy.js',
+      'lib/mod.mjs',
+      'lib/widget.jsx',
+      'src/a.ts',
+      'src/legacy.js',
+    ])
+  })
+
+  it('filters every TypeScript flavor, not just .ts', () => {
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ include: ['src'] }),
+      'src/a.ts': '',
+      'lib/b.tsx': '',
+      'lib/c.mts': '',
+      'lib/d.cts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['src/a.ts', 'lib/b.tsx', 'lib/c.mts', 'lib/d.cts'],
+      handlerFiles: [],
+    })
+
+    expect(compileOf(result)).toEqual(['src/a.ts'])
+  })
+
+  it('warns when a solution-style tsconfig selects nothing', () => {
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({
+        files: [],
+        references: [{ path: './app' }],
+      }),
+      'src/a.ts': '',
+      'src/handler.ts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['src/a.ts', 'src/handler.ts'],
+      handlerFiles: ['src/handler.ts'],
+    })
+
+    expect(compileOf(result)).toEqual(['src/handler.ts'])
+    // get-tsconfig reports POSIX-separated paths on every platform.
+    expect(result.warning).toContain(
+      path.join(dir, 'tsconfig.json').replace(/\\/g, '/'),
+    )
+    expect(result.warning).toContain('build.esbuild.tsconfig')
+  })
+
+  it('counts a selected handler as a selection', () => {
+    // The whole TypeScript program is the handler, and the tsconfig does claim
+    // it. Exempting handlers from the match as well as from the drop would
+    // report this perfectly healthy service as selecting nothing.
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ include: ['src'] }),
+      'src/handler.ts': '',
+      'scripts/seed.ts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['src/handler.ts', 'scripts/seed.ts'],
+      handlerFiles: ['src/handler.ts'],
+    })
+
+    expect(compileOf(result)).toEqual(['src/handler.ts'])
+    expect(result.warning).toBeNull()
+  })
+
+  it('warns when even the handler falls outside the tsconfig', () => {
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ include: ['lib'] }),
+      'src/handler.ts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['src/handler.ts'],
+      handlerFiles: ['src/handler.ts'],
+    })
+
+    expect(result.compile).toEqual(['src/handler.ts'])
+    expect(result.warning).not.toBeNull()
+  })
+
+  it('matches include patterns case-sensitively, the way Lambda will', () => {
+    // `createFilesMatcher` is given an explicit case-sensitivity argument, and
+    // this is what discriminates it: left to detect for itself the library
+    // probes the filesystem -- and on a case-insensitive volume (macOS APFS by
+    // default) it would decide `include: ['SRC']` matches `src/a.ts`, which is
+    // exactly the selection that then breaks on Lambda's case-sensitive one.
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ include: ['SRC'] }),
+      'src/a.ts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['src/a.ts'],
+      handlerFiles: [],
+    })
+
+    expect(result.compile).toEqual([])
+    expect(result.warning).not.toBeNull()
+  })
+
+  it('stays silent when the project simply has no TypeScript to select', () => {
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ include: ['src'] }),
+      'lib/a.js': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['lib/a.js'],
+      handlerFiles: [],
+    })
+
+    expect(result.warning).toBeNull()
+  })
+
+  it('resolves an "extends" chain against the extended file own directory', () => {
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ extends: './configs/base.json' }),
+      // Relative to `configs/`, which is the only place `../src` resolves from.
+      'configs/base.json': JSON.stringify({
+        include: ['../src'],
+        exclude: ['../src/skip'],
+      }),
+      'src/a.ts': '',
+      'src/skip/b.ts': '',
+      'lib/c.ts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: dir,
+      tsconfigPath: undefined,
+      compileFiles: ['src/a.ts', 'src/skip/b.ts', 'lib/c.ts'],
+      handlerFiles: [],
+    })
+
+    expect(compileOf(result)).toEqual(['src/a.ts'])
+  })
+
+  it('ignores a tsconfig that lives above the service directory', () => {
+    // A monorepo root holding a solution-style tsconfig, with the service one
+    // directory down. Auto-discovery is the service's own tsconfig or nothing:
+    // a config written for a different project must never get to decide what
+    // this service ships.
+    const root = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ files: [] }),
+      'services/svc/src/a.ts': '',
+    })
+
+    const result = applyTsconfigCompileFilter({
+      serviceDir: path.join(root, 'services', 'svc'),
+      tsconfigPath: undefined,
+      compileFiles: ['src/a.ts'],
+      handlerFiles: [],
+    })
+
+    expect(result.compile).toEqual(['src/a.ts'])
+    expect(result.warning).toBeNull()
+  })
+
+  describe('when the tsconfig cannot be resolved', () => {
+    // A shared base config that lives in devDependencies and is simply not
+    // installed: `npm ci --omit=dev` on a CI box, a slim Docker build stage.
+    const brokenExtends = { 'tsconfig.json': '{"extends":"@tsconfig/node20"}' }
+
+    it('degrades to no narrowing, loudly, when it was only discovered', () => {
+      const dir = makeTreeWithContents({
+        ...brokenExtends,
+        'src/a.ts': '',
+        'scripts/seed.ts': '',
+      })
+
+      const result = applyTsconfigCompileFilter({
+        serviceDir: dir,
+        tsconfigPath: undefined,
+        compileFiles: ['src/a.ts', 'scripts/seed.ts'],
+        handlerFiles: [],
+      })
+
+      // Nothing is dropped: an unreadable config the user never pointed us at
+      // must not be able to strip files out of the artifact.
+      expect(result.compile).toEqual(['src/a.ts', 'scripts/seed.ts'])
+      expect(result.warning).toContain(
+        path.join(dir, 'tsconfig.json').replace(/\\/g, '/'),
+      )
+      expect(result.warning).toContain('@tsconfig/node20')
+      expect(result.warning).toContain('build.esbuild.tsconfig')
+    })
+
+    it('throws when the user named it', () => {
+      const dir = makeTreeWithContents({
+        ...brokenExtends,
+        'src/a.ts': '',
+      })
+
+      expect(() =>
+        applyTsconfigCompileFilter({
+          serviceDir: dir,
+          tsconfigPath: './tsconfig.json',
+          compileFiles: ['src/a.ts'],
+          handlerFiles: [],
+        }),
+      ).toThrow(
+        expect.objectContaining({
+          code: 'ESBUILD_TSCONFIG_INVALID',
+          message: expect.stringContaining('@tsconfig/node20'),
+        }),
+      )
+    })
+
+    it('warns rather than pretending an empty or unparseable tsconfig narrowed anything', () => {
+      // The JSONC parser does not throw on malformed input -- it returns an
+      // empty object -- so without this the config the user believes is in
+      // charge would be ignored in complete silence.
+      const dir = makeTreeWithContents({
+        'tsconfig.json': 'this is not a tsconfig at all',
+        'src/a.ts': '',
+        'scripts/seed.ts': '',
+      })
+
+      const result = applyTsconfigCompileFilter({
+        serviceDir: dir,
+        tsconfigPath: undefined,
+        compileFiles: ['src/a.ts', 'scripts/seed.ts'],
+        handlerFiles: [],
+      })
+
+      expect(result.compile).toEqual(['src/a.ts', 'scripts/seed.ts'])
+      expect(result.warning).toContain('build.esbuild.tsconfig')
+    })
+
+    it('leaves a tsconfig that carries only compilerOptions alone', () => {
+      // The common minimal config. It says nothing about file selection, so
+      // its implicit `include: ["**/*"]` applies and nothing is narrowed --
+      // but that is the user getting what they asked for, not a problem.
+      const dir = makeTreeWithContents({
+        'tsconfig.json': JSON.stringify({
+          compilerOptions: { target: 'es2022' },
+        }),
+        'src/a.ts': '',
+        'scripts/seed.ts': '',
+      })
+
+      const result = applyTsconfigCompileFilter({
+        serviceDir: dir,
+        tsconfigPath: undefined,
+        compileFiles: ['src/a.ts', 'scripts/seed.ts'],
+        handlerFiles: [],
+      })
+
+      expect(result.compile).toEqual(['src/a.ts', 'scripts/seed.ts'])
+      expect(result.warning).toBeNull()
+    })
+  })
+
+  describe('with an explicit build.esbuild.tsconfig', () => {
+    it('uses the named config rather than the service tsconfig.json', () => {
+      const dir = makeTreeWithContents({
+        // Decoy: the auto-discovered config would keep both files.
+        'tsconfig.json': JSON.stringify({ include: ['src'] }),
+        'tsconfig.build.json': JSON.stringify({ include: ['src/keep'] }),
+        'src/keep/a.ts': '',
+        'src/other/b.ts': '',
+      })
+
+      const result = applyTsconfigCompileFilter({
+        serviceDir: dir,
+        tsconfigPath: './tsconfig.build.json',
+        compileFiles: ['src/keep/a.ts', 'src/other/b.ts'],
+        handlerFiles: [],
+      })
+
+      expect(compileOf(result)).toEqual(['src/keep/a.ts'])
+    })
+
+    it('rejects a path that is a directory', () => {
+      const dir = makeTreeWithContents({ 'src/a.ts': '' })
+      fs.mkdirSync(path.join(dir, 'tsconfig.json'), { recursive: true })
+
+      expect(() =>
+        applyTsconfigCompileFilter({
+          serviceDir: dir,
+          tsconfigPath: './tsconfig.json',
+          compileFiles: ['src/a.ts'],
+          handlerFiles: [],
+        }),
+      ).toThrow(expect.objectContaining({ code: 'ESBUILD_TSCONFIG_NOT_FOUND' }))
+    })
+
+    it('rejects a path that is not there', () => {
+      const dir = makeTreeWithContents({
+        'tsconfig.json': JSON.stringify({ include: ['src'] }),
+        'src/a.ts': '',
+      })
+
+      expect(() =>
+        applyTsconfigCompileFilter({
+          serviceDir: dir,
+          tsconfigPath: './missing.json',
+          compileFiles: ['src/a.ts'],
+          handlerFiles: [],
+        }),
+      ).toThrow(expect.objectContaining({ code: 'ESBUILD_TSCONFIG_NOT_FOUND' }))
+    })
+
+    it('rejects rather than falling back to an ancestor tsconfig.json', () => {
+      const root = makeTreeWithContents({
+        'tsconfig.json': JSON.stringify({ include: ['services'] }),
+        'services/svc/src/a.ts': '',
+      })
+
+      expect(() =>
+        applyTsconfigCompileFilter({
+          serviceDir: path.join(root, 'services', 'svc'),
+          tsconfigPath: 'tsconfig.json',
+          compileFiles: ['src/a.ts'],
+          handlerFiles: [],
+        }),
+      ).toThrow(expect.objectContaining({ code: 'ESBUILD_TSCONFIG_NOT_FOUND' }))
+    })
+  })
+
+  it('anchors the search at the service directory, never the process cwd', () => {
+    // Compose runs every service in-process from the compose root, so
+    // `process.cwd()` is not the service directory. A tsconfig sitting in the
+    // cwd must have no say over what this service compiles -- and no probe
+    // file may be written there either, which is what an unspecified
+    // case-sensitivity argument to `createFilesMatcher` would do.
+    const decoyCwd = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ files: [] }),
+    })
+    const dir = makeTreeWithContents({
+      'tsconfig.json': JSON.stringify({ include: ['src'] }),
+      'src/a.ts': '',
+    })
+
+    const originalCwd = process.cwd()
+    process.chdir(decoyCwd)
+    try {
+      const result = applyTsconfigCompileFilter({
+        serviceDir: dir,
+        tsconfigPath: undefined,
+        compileFiles: ['src/a.ts'],
+        handlerFiles: [],
+      })
+
+      expect(result.compile).toEqual(['src/a.ts'])
+      expect(result.warning).toBeNull()
+      expect(fs.readdirSync(decoyCwd)).toEqual(['tsconfig.json'])
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+})
+
+/**
+ * Non-bundled ES module output keeps its specifiers verbatim, and Node's ESM
+ * resolver -- unlike CommonJS -- performs no extension guessing: `./util`
+ * resolves to a file literally named `util` and nothing else. The scan is a
+ * regex over emitted text rather than a parse, so its blind spots are pinned
+ * here alongside its hits: a warning that is merely noisy is survivable, a
+ * scanner whose limits are undocumented is not.
+ */
+describe('scanExtensionlessEsmImports', () => {
+  it.each([
+    [`import { x } from './util'`, ['./util']],
+    [`export { y } from '../lib/helpers'`, ['../lib/helpers']],
+    [`const m = await import('./dyn')`, ['./dyn']],
+    [`import { z } from './util.js'`, []],
+    [`import pkg from 'lodash'`, []],
+    [`import data from './data.json'`, []],
+  ])('%s → %j', (code, expected) => {
+    expect(scanExtensionlessEsmImports(code)).toEqual(expected)
+  })
+
+  it.each([
+    // A side-effect import has no `from` at all, and is exactly as broken.
+    [`import './polyfill'`, ['./polyfill']],
+    [`import"./minified"`, ['./minified']],
+    [`export * from './barrel'`, ['./barrel']],
+    [`export * as ns from '../ns'`, ['../ns']],
+    // The specifier sits on its own line in anything prettier has touched.
+    [`import {\n  a,\n  b,\n} from './util'`, ['./util']],
+    [`import(\n  './dyn'\n)`, ['./dyn']],
+    [`import x from "./double"`, ['./double']],
+    // Parent traversal, and a specifier that is nothing but traversal.
+    [`import x from '../../shared/log'`, ['../../shared/log']],
+    // Bare and absolute specifiers are resolved by Node's package/URL
+    // resolution, where extensions were never implied in the first place.
+    [`import x from '@scope/pkg/sub'`, []],
+    [`import x from 'node:fs'`, []],
+    [`await import('data:text/javascript,')`, []],
+    // An extension is an extension whether or not Node can execute it.
+    [`import './style.css'`, []],
+    [`import cfg from './config.yaml'`, []],
+    // `from` in any other role is not an import.
+    [`const from = './util'`, []],
+    [`const xs = ys.from('./util')`, []],
+  ])('%s → %j', (code, expected) => {
+    expect(scanExtensionlessEsmImports(code)).toEqual(expected)
+  })
+
+  it('reports each distinct specifier once however often it appears', () => {
+    const code =
+      `import { a } from './util'\n` +
+      `import { b } from './util'\n` +
+      `import { c } from './other'\n`
+
+    expect(scanExtensionlessEsmImports(code)).toEqual(['./util', './other'])
+  })
+
+  it('flags an extensionless file inside a directory whose name has a dot', () => {
+    // The last segment is what carries an extension, and `util` has none --
+    // the dot belongs to the directory, which Node never looks at.
+    expect(
+      scanExtensionlessEsmImports(`import x from './lib.v2/util'`),
+    ).toEqual(['./lib.v2/util'])
+  })
+
+  it('MISSES a directory import whose own name has a dot (known limitation)', () => {
+    // `./lib.v2` is a directory: Node resolves it by looking for a file named
+    // exactly `lib.v2`, fails, and never tries `lib.v2/index.js` -- so this is
+    // as broken as `./util`. The heuristic reads the trailing `.v2` as an
+    // extension and stays quiet. Pinned rather than fixed: telling a directory
+    // named `lib.v2` from a file named `config.local` needs the filesystem,
+    // and this scan deliberately never touches it.
+    expect(scanExtensionlessEsmImports(`import x from './lib.v2'`)).toEqual([])
+  })
+
+  it('FLAGS a specifier inside a comment or a string (known false positive)', () => {
+    // A regex over text cannot tell code from comment from string literal.
+    // Accepted deliberately: the alternative is tokenizing every emitted file,
+    // and the cost of being wrong here is one line of advice about a specifier
+    // that does not exist -- not a failed build.
+    //
+    // In practice the comment half rarely reaches this function, because
+    // esbuild strips ordinary comments from its output; string literals, which
+    // it preserves verbatim, are the case that actually occurs.
+    expect(
+      scanExtensionlessEsmImports(
+        `// import { x } from './commented'\n/* import './blocked' */\n`,
+      ),
+    ).toEqual(['./commented', './blocked'])
+    expect(
+      scanExtensionlessEsmImports(
+        `export const doc = "see import { x } from './guide' for details"\n`,
+      ),
+    ).toEqual(['./guide'])
+  })
+
+  it('ignores a template-literal dynamic import rather than guessing at it', () => {
+    // esbuild preserves `import(`./p/${n}`)` verbatim, and its value is not
+    // knowable from the text. Both patterns anchor the specifier to a quote,
+    // so it matches neither and no offender is invented for it.
+    const code =
+      'const tpl = async (n) => import(`./p/${n}`)\n' +
+      'const mixed = async () => import(`./static`)\n'
+
+    expect(scanUnresolvableRelativeImports(code)).toEqual({
+      extensionless: [],
+      sourceExtension: [],
+    })
+    expect(
+      scanUnresolvableRelativeImports(code, { dynamicOnly: true }),
+    ).toEqual({ extensionless: [], sourceExtension: [] })
+  })
+
+  it('returns nothing for output with no relative specifiers at all', () => {
+    expect(scanExtensionlessEsmImports('export const a = 1\n')).toEqual([])
+  })
+})
+
+/**
+ * The two ways a non-bundled build leaves a relative specifier unresolvable,
+ * and the one axis that decides how deep a given output is scanned.
+ *
+ * `dynamicOnly` is not a tuning knob: esbuild rewrites static imports into
+ * `require()` when it emits CommonJS, and the CommonJS resolver does try
+ * extensions -- so in CommonJS output only `import()`, which esbuild leaves
+ * verbatim and Node routes through the ES module resolver regardless, can
+ * still be broken.
+ */
+describe('scanUnresolvableRelativeImports', () => {
+  it('separates extensionless specifiers from ones naming a source file', () => {
+    const code =
+      `import { a } from './util'\n` +
+      `import { b } from './helpers.ts'\n` +
+      `import { c } from './widget.tsx'\n` +
+      `import { d } from './tool.mts'\n` +
+      `import { e } from './old.cts'\n` +
+      `import { f } from './view.jsx'\n` +
+      `import { g } from './fine.js'\n` +
+      `import data from './data.json'\n`
+
+    expect(scanUnresolvableRelativeImports(code)).toEqual({
+      extensionless: ['./util'],
+      // Every extension esbuild renames on the way out, and nothing else:
+      // `./fine.js` and `./data.json` are emitted under the names they name.
+      sourceExtension: [
+        './helpers.ts',
+        './widget.tsx',
+        './tool.mts',
+        './old.cts',
+        './view.jsx',
+      ],
+    })
+  })
+
+  it('leaves a dot-directory alone in both categories', () => {
+    // `.v2` is not an extension esbuild renames, and the dot heuristic already
+    // declines to call it extensionless. It belongs in neither bucket.
+    expect(scanUnresolvableRelativeImports(`import x from './lib.v2'`)).toEqual(
+      {
+        extensionless: [],
+        sourceExtension: [],
+      },
+    )
+  })
+
+  it.each([
+    // Static forms: seen in full scans, invisible to a dynamic-only scan.
+    [`import { x } from './util'`, ['./util'], []],
+    [`export { y } from './util'`, ['./util'], []],
+    [`export * from './util'`, ['./util'], []],
+    [`import './util'`, ['./util'], []],
+    // The dynamic form is seen by both.
+    [`const m = await import('./util')`, ['./util'], ['./util']],
+    [`import ( "./util" )`, ['./util'], ['./util']],
+  ])('%s → full %j, dynamicOnly %j', (code, full, dynamic) => {
+    expect(scanExtensionlessEsmImports(code)).toEqual(full)
+    expect(scanExtensionlessEsmImports(code, { dynamicOnly: true })).toEqual(
+      dynamic,
+    )
+  })
+
+  it('applies the source-extension rule in dynamic-only mode too', () => {
+    const code = `import { a } from './static.ts'\nconst m = await import('./dyn.ts')\n`
+
+    expect(scanUnresolvableRelativeImports(code).sourceExtension).toEqual([
+      './static.ts',
+      './dyn.ts',
+    ])
+    expect(
+      scanUnresolvableRelativeImports(code, { dynamicOnly: true })
+        .sourceExtension,
+    ).toEqual(['./dyn.ts'])
+  })
+
+  it('picks out the dynamic import from real emitted CommonJS output', () => {
+    // What esbuild actually writes for a `.cts` that had both forms: the
+    // static import is gone, rewritten to `require()`; the dynamic one is not.
+    const emitted =
+      `var import_util = require("./util");\n` +
+      `const dyn = async () => import("./dyn");\n` +
+      `const use = () => (0, import_util.h)();\n`
+
+    expect(scanExtensionlessEsmImports(emitted, { dynamicOnly: true })).toEqual(
+      ['./dyn'],
+    )
+    // And a full scan of the same text finds no more, because `require()` is
+    // not a form either pattern matches -- which is exactly why narrowing
+    // CommonJS output to the dynamic form costs nothing.
+    expect(scanExtensionlessEsmImports(emitted)).toEqual(['./dyn'])
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
@@ -90,9 +90,10 @@ describe('sweepProjectFiles', () => {
     )
   })
 
-  it('drops declaration files at any depth, package-manager internals and the local plugin path', async () => {
+  it('drops declaration files at any depth, package-manager internals and configuration, and the local plugin path', async () => {
     const dir = makeTree([
       'index.js',
+      '.nvmrc',
       'types.d.ts',
       'src/nested/types.d.ts',
       'src/nested/types.d.mts',
@@ -105,6 +106,11 @@ describe('sweepProjectFiles', () => {
       '.pnp.loader.mjs',
       'pnpm-workspace.yaml',
       'pnpm-workspace.yml',
+      // Registry credentials live here; excluded at any depth.
+      '.npmrc',
+      '.yarnrc',
+      '.yarnrc.yml',
+      'packages/lib/.npmrc',
       'my-plugins/plugin.js',
       'my-plugins/.eslintrc.json',
     ])
@@ -117,7 +123,8 @@ describe('sweepProjectFiles', () => {
       localPluginPath: 'my-plugins',
     })
 
-    expect(files).toEqual(['index.js'])
+    // Other dotfiles are ordinary project files and ship.
+    expect(files).toEqual(['.nvmrc', 'index.js'])
   })
 
   it('never sweeps the build output or the git directory', async () => {

--- a/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
@@ -272,35 +272,6 @@ describe('sweepProjectFiles', () => {
 
     expect(files).toEqual(['src/app.js'])
   })
-
-  it('inverts a !-prefixed additionalExclusion into a re-include, classic-style', async () => {
-    const dir = makeTree(['tmp/keep.js', 'tmp/other.js', 'src/app.js'])
-
-    const files = await sweepProjectFiles({
-      serviceDir: dir,
-      // Classic's exclude list supports `!` re-include spellings by inverting
-      // them (package-service.js resolveFilePathsFromPatterns); the sweep has
-      // to do the same rather than blanket-negating every entry.
-      additionalExclusions: ['tmp/**', '!tmp/keep.js'],
-    })
-
-    expect(files.sort()).toEqual(['src/app.js', 'tmp/keep.js'])
-  })
-
-  it('treats a lone !-prefixed additionalExclusion as a no-op, not a sweep inversion', async () => {
-    const dir = makeTree(['keep.js', 'src/util.js', 'README.md'])
-
-    const files = await sweepProjectFiles({
-      serviceDir: dir,
-      // Blanket-wrapping this entry produced `!!keep.js` -- a negation whose
-      // micromatch pattern matches everything EXCEPT keep.js -- and emptied
-      // the whole sweep. Classic treats it as a re-include of a file nothing
-      // excluded: a no-op.
-      additionalExclusions: ['!keep.js'],
-    })
-
-    expect(files.sort()).toEqual(['README.md', 'keep.js', 'src/util.js'])
-  })
 })
 
 describe('splitCompileAndCopy', () => {

--- a/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
@@ -90,7 +90,7 @@ describe('sweepProjectFiles', () => {
     )
   })
 
-  it('drops declaration files at any depth, Yarn PnP runtime files and the local plugin path', async () => {
+  it('drops declaration files at any depth, package-manager internals and the local plugin path', async () => {
     const dir = makeTree([
       'index.js',
       'types.d.ts',
@@ -103,6 +103,8 @@ describe('sweepProjectFiles', () => {
       '.yarn/.install-state.gz',
       '.pnp.cjs',
       '.pnp.loader.mjs',
+      'pnpm-workspace.yaml',
+      'pnpm-workspace.yml',
       'my-plugins/plugin.js',
       'my-plugins/.eslintrc.json',
     ])

--- a/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
@@ -517,13 +517,15 @@ describe('nearestPackageJsonType', () => {
   })
 
   it('never walks above the service directory', () => {
-    // The parent of a temp dir is the OS temp dir, which may well hold a
-    // package.json belonging to something else entirely.
-    const dir = makeTreeWithContents({ 'a.ts': '' })
-    fs.writeFileSync(
-      path.join(path.dirname(dir), 'package.json'),
-      '{"type":"module"}',
-    )
+    // The parent of a service dir may well hold a package.json belonging to
+    // something else entirely. The parent here is a directory this suite owns
+    // and deletes: writing into the OS temp dir itself would leave a
+    // `"type": "module"` marker behind for every other process using it.
+    const root = makeTreeWithContents({
+      'package.json': '{"type":"module"}',
+      'svc/a.ts': '',
+    })
+    const dir = path.join(root, 'svc')
     expect(nearestPackageJsonType(dir, 'a.ts')).toBe('commonjs')
   })
 


### PR DESCRIPTION
Closes: #12744
Closes: #13163
Addresses: #12970 (for services built with esbuild)

## Summary

> **`bundle: false` packages your service following classic packaging's rules, with TypeScript compiled in place.**

Previously, disabling bundling (`build.esbuild.bundle: false`) compiled and packaged only each function's handler file. Locally imported helpers were neither compiled nor included, and TypeScript helpers had no workaround (#12744). Files emitted by esbuild plugins into the build directory were not packaged either (#13163).

Now:

1. **Build** (`bundle: false` only): the service directory is swept with classic packaging's selection rules — its default excludes, the config/layer/plugin exclusions, and `package.patterns` including negations. TypeScript-family sources (`.ts`, `.tsx`, `.mts`, `.cts`, `.jsx`) are compiled per file; JavaScript and everything else is copied as-is; the project layout is preserved. Each compiled file is emitted in the module format Node.js will load it with, taken from the nearest `package.json` (`.mts` → `.mjs` and `.cts` → `.cjs` always). Compile scope is tsconfig-aware through the new `build.esbuild.tsconfig` option or an auto-discovered `tsconfig.json`.
2. **Packaging** (both bundle modes): the artifact is everything under `.serverless/build`, written in sorted order with normalized permissions so the same source produces the same archive on every machine. `package.patterns` matches are copied into the build directory (a pattern's copy wins over a build output at the same path); `node_modules` is appended through the existing deterministic walk and pattern filter.

Docs: new "Building Without Bundling" section and an expanded "Packaging Patterns" section in `docs/sf/providers/aws/guide/building.md`.

## New interface surface

- `build.esbuild.tsconfig` (string): tsconfig used for compile-set selection under `bundle: false` and forwarded to esbuild.
- Function-level `build: false` is accepted by the schema as a boolean (previously it passed only through type coercion to the string `"false"`) and is honored regardless of `configValidationMode`.
- Errors: `ESBUILD_HANDLER_NOT_BUILT`, `ESBUILD_OUTPUT_COLLISION`, `ESBUILD_HANDLER_MISSING_FROM_ARTIFACT`, `ESBUILD_TSCONFIG_NOT_FOUND`, `ESBUILD_TSCONFIG_INVALID`, `ESBUILD_BUILD_DIR_RESET_FAILED`.
- Warnings: relative import specifiers that Node's ESM resolver will not resolve at runtime (extensionless, or naming a `.ts` source); degenerate or unresolvable auto-discovered tsconfig; the existing patterns-emptied-`node_modules` warning now also fires when the artifact's generated `package.json` declares dependencies (covers `build.esbuild.external: [...]`); patterns replacing build outputs with different content.
- New runtime dependency: [`get-tsconfig`](https://www.npmjs.com/package/get-tsconfig) `^4.14.1` (MIT, one transitive dependency), used for tsconfig-scoped compile selection.

## Behavior changes

Everything below is described against the current behavior. The default `bundle: true` path is unchanged except where a line says "both modes".

**Explicit `bundle: false` — deliberate changes; artifacts change for every service using this mode**

- Artifacts contain the swept project instead of handler files only. Non-code files in the service directory now ship unless excluded with `package.patterns` negations — including other tools' output directories. `.env*` files are excluded by default at any depth, regardless of `useDotenv`; like every default exclusion, a positive pattern that matches them re-includes them (`patterns: ['.env']` by name, but also a glob such as `config/**`), so follow broad globs with `!**/.env*` where needed. Type declarations, nested `node_modules`, and the package-manager internals `.yarn/**`, `.pnp.cjs`, `.pnp.loader.mjs` and `pnpm-workspace.yaml` are excluded by default on the same terms, as are the package-manager configuration files `.npmrc`, `.yarnrc` and `.yarnrc.yml` at any depth: classic packaging ships them, but they can hold registry credentials and nothing reads them at runtime.
- The legacy `package.include` and `package.exclude` keys are not applied by the esbuild build, as before; a one-time warning now names them and points at `package.patterns`.
- Compiled output is emitted in the format the nearest `package.json` declares. Previously a TypeScript file written with `import`/`export` in a CommonJS project kept ESM syntax in its `.js` output, which Lambda's CommonJS loader rejects at initialization (verified on nodejs20.x, 22.x and 24.x); the new output loads on all three.
- `.mts` / `.cts` handlers emit `.mjs` / `.cjs` files; Lambda resolves either extension for a `handler.hello` string.
- The following configurations built successfully before and now fail the build with an actionable message:
  - Two source files that would produce the same output — typically `util.ts` next to a `util.js` left by an in-place `tsc` run — fail with `ESBUILD_OUTPUT_COLLISION`. Escape: exclude the TypeScript side with a negation such as `!**/*.ts`, or scope compilation with `build.esbuild.tsconfig`.
  - Any `.ts` file esbuild cannot parse (for example an intentionally broken test fixture) is now compiled and fails the build. Escape: a negation such as `!tests/**`, or `build.esbuild.tsconfig`.
  - Top-level `await` in a CommonJS-class TypeScript file fails the build (esbuild cannot emit CommonJS for it). Previously the artifact was produced and failed at initialization on Lambda. Escape: `"type": "module"` in `package.json`.
- A function whose handler path resolves to no file fails at build time with `ESBUILD_HANDLER_NOT_BUILT` naming the function and the probed extensions; previously these failed later, at package time, with `CANNOT_READ_FILE`. Functions with Lambda layers configured get a warning instead, so layer-provided handlers keep working; a mistyped handler path on such a function therefore surfaces at invocation rather than at build time. A handler file that a plugin injects into the build directory between build and packaging now needs function-level `build: false`.
- Change detection follows classic granularity: any change to a swept file changes the artifact. With `package.individually`, every function's archive contains the whole tree, narrowed by per-function negations.
- With `outExtension: { '.js': '.mjs' }` on a `"type": "module"` service that also contains a CommonJS `package.json` subtree, the build error names the CommonJS file and its package.json instead of advising `format: esm`.
- Build time scales with project size (about 1.3 s for a 2,000-file tree, versus 0.3 s when only handlers were compiled).

**Both bundle modes**

- Artifact hashes change once after upgrading, because the archive is now written in sorted order with normalized permissions; the first deploy after upgrading redeploys every esbuild-built function.
- `package.patterns` match dotfiles (classic parity). A glob such as `assets/**` or `**` now ships dotfiles it skipped before — including `.env*` files under a bundled build, which the default exclusion above does not cover when a glob matches them.
- Pattern-included symlinks ship as their target's content, and directory entries are not written (classic semantics).
- A positive `node_modules/...` pattern that collides with an installed file at the same archive path now wins deterministically, as a single entry; previously the installed copy won.
- Patterns reaching above the service directory (`../shared/**`) keep packaging their files at the path that remains once the leading `../` is removed, as classic packaging does; this is now explicit and tested rather than a side effect of archive-name sanitization.
- Packaging verifies that each function's built handler is present in its finalized archive (`ESBUILD_HANDLER_MISSING_FROM_ARTIFACT`).
- The directory given to `--package <dir>` (or `package.path`) is never packaged when it sits inside the service directory. `serverless package --package <dir>` moves the artifact and the build directory there, so a following run would otherwise sweep the previous archive and build tree into the new artifact; it is now ignored the way `.serverless` is, regardless of `package.patterns`. Under `bundle: true`, a broad glob such as `**` previously copied that directory into the artifact, so such artifacts shrink by the nested content.
- With `package.individually`, a function-level negation now also filters the build outputs in that function's archive (sourcemaps, plugin-emitted files), not only `node_modules` and pattern includes. The generated `package.json` and lockfile are exempt and always ship. A function-level negation that matches the function's own compiled handler (for example `!src/**` on a handler under `src/`) fails packaging with `ESBUILD_HANDLER_MISSING_FROM_ARTIFACT`; previously such a negation was ignored for the bundle.

## Also fixed

- A bundled service whose every handler is provided by a Lambda layer failed at packaging with `ENOENT` on `.serverless/build/package.json`; it now warns and packages.
- The patterns-emptied-`node_modules` warning stayed silent when dependencies reached the artifact through `build.esbuild.external: [...]`.
- Archive permission bits followed the local filesystem, so identical sources hashed differently across machines and operating systems.
- The zip central-directory reader used to verify archives is bounds-checked (a malformed archive could previously abort the process).
- Two esbuild test mocks never wrote output files, so two suites asserted on files that did not exist.

## Verification

- Unit: esbuild plugin suite 358 tests across 16 files (new suites for the sweep, the non-bundled build, build-directory packaging, runtime loading in a spawned Node process, layer-provided handlers, packaging determinism); full framework suite 4,123 tests. `npm run prettier`, `npm run lint` clean.
- Live on AWS Lambda: the #12744 reproduction (TypeScript + JavaScript helpers, CommonJS) deploys and both functions return 200; a `"type": "module"` variant with extensioned imports returns 200; a bundled service is byte-for-byte unchanged and returns 200. The previous `bundle: false` output for a CommonJS project fails at initialization on nodejs20.x, 22.x and 24.x; the new output returns 200 on all three.
- Compared against the current release on the same fixtures (both bundle modes, patterns and negations, dependencies, layers, dev mode, `invoke local`, `package.individually`, dotfiles, symlinks, non-ASCII paths): every difference is one listed above.
- Plugin interoperability: handler-rewriting observability plugins (Datadog, New Relic, Lumigo) run after build and packaging and are unaffected; files written into `.serverless/build` from the `before:esbuild-package` hook now ship.

## Review map

- `lib/plugins/esbuild/project-sweep.js` (new, pure functions): file selection, compile-vs-copy split, output-collision detection, per-file format classing, tsconfig filter, import-specifier scanner. Self-contained; start here.
- `lib/plugins/esbuild/index.js`: `_buildProject` (partitioned per-file build), `_resetBuildDir`, artifact bookkeeping and the layers-aware handler assertion, `_package` / `_packageAll` over the build directory, `_copyPatternsIntoBuildDir`, `_writeArchive` with the pattern-wins dedup, post-zip handler check.
- `lib/plugins/aws/provider.js`: function-level `build` schema accepts `false`.
- `lib/plugins/package/lib/package-service.js`: one export (`resolveServerlessConfigFileExcludes`) reused by the sweep.
- Tests: `test/unit/lib/plugins/esbuild/` — `project-sweep`, `nobundle-build`, `build-dir-packaging`, `nobundle-runtime.e2e`, `layer-provided-build`, `packaging-determinism`, plus adapted existing suites.
- Docs: `docs/sf/providers/aws/guide/building.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added non-bundled esbuild builds that preserve project structure while compiling and copying files.
  - Added support for excluding individual functions with `build: false`.
  - Added module-format and TypeScript configuration handling for non-bundled builds.
  - Improved packaging with file patterns, generated assets, collision detection, and deterministic archives.

- **Bug Fixes**
  - Builds now report clearer errors for unavailable or missing handlers.
  - Improved warnings for unresolved ESM imports and invalid configurations.
  - Package-manager configuration files are excluded from non-bundled artifacts.

- **Documentation**
  - Expanded guidance for packaging patterns and building without bundling.
  - Clarified that legacy packaging include/exclude settings are not applied to esbuild builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



