### PR TITLE
fix(mcp): confine docs tool reads to the resolved documentation directory

### DIFF
--- a/.github/workflows/ci-framework.yml
+++ b/.github/workflows/ci-framework.yml
@@ -127,6 +127,9 @@ jobs:
       - name: 'Test: Unit (serverless)'
         working-directory: ./packages/serverless
         run: npm run test:unit
+      - name: 'Test: Unit (mcp)'
+        working-directory: ./packages/mcp
+        run: npm run test:unit
       - name: 'Build: Minify Shim'
         run: |
           cd ../serverless/lib/plugins/aws/dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,8 @@ Gotchas:
 ```bash
 npm run test:unit -w @serverlessinc/sf-core     # jest over packages/sf-core/tests/unit/
 npm run test:unit -w @serverless/framework      # jest over packages/serverless/test/unit/
-npm test                                        # both unit suites
+npm run test:unit -w @serverless/mcp            # jest over packages/mcp/tests/ (excluding tests/e2e/)
+npm test                                        # all three unit suites
 ```
 
 Note the inconsistent directory naming: `tests/` in sf-core, `test/` in serverless — easy to misplace new tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Unit tests run locally without external dependencies:
 npm run test:unit -w @serverlessinc/sf-core
 npm run test:unit -w @serverless/framework
 npm test -w @serverless/engine
-npm test -w @serverless/mcp
+npm run test:unit -w @serverless/mcp
 ```
 
 ### Integration Tests

--- a/docs/sf/guides/mcp/tools.md
+++ b/docs/sf/guides/mcp/tools.md
@@ -59,11 +59,10 @@ The Serverless MCP Server provides a comprehensive set of tools for working with
 3. `service-summary`
    - Provides a comprehensive summary of your entire serverless service in a single API call
    - Inputs:
-     - `serviceType` (string): Cloud service provider ('aws', 'gcp', 'azure')
+     - `cloudProvider` (string): Cloud provider of the resources to analyze. Currently only "aws" is supported.
      - `resources` (array, optional): Array of resource objects with id and type. Not required if serviceWideAnalysis is true.
      - `serviceWideAnalysis` (boolean, optional): Set to true to automatically fetch and analyze ALL resources in the service
      - `serviceName` (string, optional): Required if serviceWideAnalysis is true. For Serverless Framework, use "serviceName-stageName" format. For CloudFormation, use the exact stack name.
-     - `cloudProvider` (string, optional): Required if serviceWideAnalysis is true. Specifies the cloud service provider ("aws")
      - `startTime` (string, optional): Start time for metrics and logs (ISO date or timestamp)
      - `endTime` (string, optional): End time for metrics and logs (ISO date or timestamp)
      - `period` (number, optional): Period for metrics in seconds (min 60, must be a multiple of 60, default 3600)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:fix": "eslint --fix",
     "prettier": "prettier -c .",
     "prettier:fix": "prettier -w .",
-    "test": "npm run test:unit -w @serverlessinc/sf-core -w @serverless/framework",
+    "test": "npm run test:unit -w @serverlessinc/sf-core -w @serverless/framework -w @serverless/mcp",
     "setup-dev-mode": "bash setup-dev-for-dev-mode.sh",
     "prepare": "husky"
   },

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -43,11 +43,10 @@ Provides a consolidated view of multiple cloud resources in a single request. Th
 
 **Inputs:**
 
-- `serviceType` (enum): Cloud provider ("aws", "gcp", "azure")
+- `cloudProvider` (enum): Cloud provider of the resources to analyze. Currently only "aws" is supported.
 - `resources` (optional object[]): Resources to analyze with their types and IDs. Not required if serviceWideAnalysis is true.
 - `serviceWideAnalysis` (optional boolean): Set to true to automatically fetch and analyze ALL resources in the specified service.
 - `serviceName` (optional string): Required if serviceWideAnalysis is true. For Serverless Framework, use "serviceName-stageName" format (e.g., "my-service-dev"). For CloudFormation, use the exact stack name.
-- `cloudProvider` (optional enum): Required if serviceWideAnalysis is true. Specifies the cloud service provider ("aws").
 - `startTime` (optional string): Start time for metrics. Can be an ISO date string or timestamp in milliseconds.
 - `endTime` (optional string): End time for metrics. Can be an ISO date string or timestamp in milliseconds.
 - `period` (optional number): Period for metrics in seconds

--- a/packages/mcp/src/lib/aws/errors-info-patterns.js
+++ b/packages/mcp/src/lib/aws/errors-info-patterns.js
@@ -386,13 +386,17 @@ async function fetchLambdaLogGroups(functionName, awsConfig) {
     // Get function configuration
     const functionDetails =
       await lambdaClient.getLambdaFunctionDetails(functionName)
+    // getLambdaFunctionDetails returns { status, function, policy, ... } with
+    // the GetFunction response under `function`, so the configuration lives
+    // at function.Configuration (same shape lambda-resource-info.js reads).
+    const configuration = functionDetails?.function?.Configuration
 
-    if (functionDetails && functionDetails.Configuration) {
+    if (configuration) {
       // Check if logging configuration is available
-      if (functionDetails.Configuration.LoggingConfig) {
+      if (configuration.LoggingConfig) {
         // Extract log group from LoggingConfig if available (newer Lambda versions)
-        if (functionDetails.Configuration.LoggingConfig.LogGroup) {
-          logGroups.push(functionDetails.Configuration.LoggingConfig.LogGroup)
+        if (configuration.LoggingConfig.LogGroup) {
+          logGroups.push(configuration.LoggingConfig.LogGroup)
         }
       }
 

--- a/packages/mcp/src/tools-definition.js
+++ b/packages/mcp/src/tools-definition.js
@@ -469,10 +469,10 @@ export function registerTools(server) {
     "Provides a consolidated view of multiple cloud resources in a single request. This tool is the FASTEST and MOST EFFICIENT way to get a complete overview of your entire serverless application in a single tool call. BEFORE USING THIS TOOL: Use the list-projects tool to identify all serverless projects in the workspace. If multiple projects are found, confirm with the user which project to use.\n\nUSE THIS TOOL WHEN:\n(1) You need a quick overview of an entire service\n(2) You need to analyze interactions between different resource types\n(3) You want to reduce the number of API calls for efficiency\n(4) You need a holistic view of a serverless application's components\n\nKEY FEATURES:\n• Service-wide analysis: Set serviceWideAnalysis=true to automatically fetch and analyze ALL resources in a service\n• Parallel processing: All resource information is fetched simultaneously for maximum efficiency\n• Comprehensive data: Returns the same detailed information as individual resource-specific tools\n\nSUPPORTED AWS RESOURCE TYPES:\n• lambda - AWS Lambda functions\n• iam - AWS IAM roles and policies\n• sqs - Amazon SQS queues\n• s3 - Amazon S3 buckets\n• restapigateway - AWS REST API Gateway\n• httpapigateway - AWS HTTP API Gateway\n• dynamodb - Amazon DynamoDB tables\n\nThis tool is MUCH MORE EFFICIENT than making individual calls to resource-specific tools. Use it as your first step when investigating service-wide issues or getting a complete picture of your application.\n\n" +
       AWS_CREDENTIALS_ERROR_HANDLING,
     {
-      serviceType: z
-        .enum(['aws', 'gcp', 'azure'])
+      cloudProvider: z
+        .enum(['aws'])
         .describe(
-          'The cloud service provider to use. Currently, only "aws" is fully supported.',
+          'Cloud provider of the resources to analyze. Currently only "aws" is supported.',
         ),
       resources: z
         .array(
@@ -498,19 +498,13 @@ export function registerTools(server) {
         .optional()
         .default(false)
         .describe(
-          'Set to true to automatically fetch and analyze ALL resources in the specified service. When true, serviceName and serviceType must be provided.',
+          'Set to true to automatically fetch and analyze ALL resources in the specified service. When true, serviceName must be provided.',
         ),
       serviceName: z
         .string()
         .optional()
         .describe(
           'Required if serviceWideAnalysis is true. For Serverless Framework, use "serviceName-stageName" format (e.g., "my-service-dev"). For CloudFormation, use the exact stack name.',
-        ),
-      cloudProvider: z
-        .enum(['aws'])
-        .optional()
-        .describe(
-          'Required if serviceWideAnalysis is true. Specifies the cloud service provider.',
         ),
       startTime: z
         .string()

--- a/packages/mcp/src/tools/docs.js
+++ b/packages/mcp/src/tools/docs.js
@@ -14,14 +14,51 @@ function normalizeDocPath(product, docPath) {
     : docPath
 }
 
-function resolvePathInBase(baseDir, relativePath) {
-  const resolvedPath = path.resolve(baseDir, relativePath)
-  const relativeToBase = path.relative(baseDir, resolvedPath)
-  const isWithinBase =
+function isWithin(baseDir, targetPath) {
+  const relativeToBase = path.relative(baseDir, targetPath)
+  return (
     relativeToBase === '' ||
     (!relativeToBase.startsWith('..') && !path.isAbsolute(relativeToBase))
+  )
+}
 
-  return { resolvedPath, isWithinBase }
+/**
+ * Resolves a requested doc path against its base directory and checks that it
+ * stays inside it, twice: lexically (rejects `..` and absolute escapes without
+ * touching the filesystem) and then on the real filesystem (rejects links
+ * whose target lies outside the base). The base is resolved too, so a docs
+ * directory that is itself reached through a link keeps working.
+ * @param {string} baseDir - Documentation base directory
+ * @param {string} relativePath - Requested path, relative to the base
+ * @returns {Promise<{resolvedPath: string, isWithinBase: boolean, exists: boolean}>}
+ *   isWithinBase=false → invalid path; isWithinBase=true, exists=false → not
+ *   found; both true → resolvedPath is the real path, safe to stat and read
+ */
+export async function resolveDocPath(baseDir, relativePath) {
+  const lexicalPath = path.resolve(baseDir, relativePath)
+  if (!isWithin(baseDir, lexicalPath)) {
+    return { resolvedPath: lexicalPath, isWithinBase: false, exists: false }
+  }
+
+  let realBase
+  let realTarget
+  try {
+    ;[realBase, realTarget] = await Promise.all([
+      fs.realpath(baseDir),
+      fs.realpath(lexicalPath),
+    ])
+  } catch (error) {
+    if (error.code === 'ENOENT' || error.code === 'ENOTDIR') {
+      return { resolvedPath: lexicalPath, isWithinBase: true, exists: false }
+    }
+    throw error
+  }
+
+  return {
+    resolvedPath: realTarget,
+    isWithinBase: isWithin(realBase, realTarget),
+    exists: true,
+  }
 }
 
 /**
@@ -65,13 +102,21 @@ async function readMarkdownContent(product, docPath) {
   }
 
   const normalizedPath = normalizeDocPath(product, docPath)
-  const { resolvedPath: fullPath, isWithinBase } = resolvePathInBase(
-    docsBaseDirs[product],
-    normalizedPath,
-  )
+  let resolved
+  try {
+    resolved = await resolveDocPath(docsBaseDirs[product], normalizedPath)
+  } catch {
+    // Any other filesystem failure (permissions, link loops) is reported the
+    // same way a missing path always has been.
+    throw new Error(`Path not found: ${product}/${docPath}`)
+  }
+  const { resolvedPath: fullPath, isWithinBase, exists } = resolved
 
   if (!isWithinBase) {
     throw new Error(`Invalid path: ${product}/${docPath}`)
+  }
+  if (!exists) {
+    throw new Error(`Path not found: ${product}/${docPath}`)
   }
 
   try {
@@ -127,12 +172,12 @@ async function findNearestDirectory(product, docPath, availablePaths) {
   }
 
   const normalizedPath = normalizeDocPath(product, docPath)
-  const { isWithinBase } = resolvePathInBase(
-    docsBaseDirs[product],
-    normalizedPath,
-  )
-
-  if (!isWithinBase) {
+  if (
+    !isWithin(
+      docsBaseDirs[product],
+      path.resolve(docsBaseDirs[product], normalizedPath),
+    )
+  ) {
     throw new Error(`Invalid path: ${product}/${docPath}`)
   }
 
@@ -142,10 +187,13 @@ async function findNearestDirectory(product, docPath, availablePaths) {
   while (parts.length > 0) {
     const testPath = parts.join('/')
     try {
-      const { resolvedPath: fullPath, isWithinBase: testWithinBase } =
-        resolvePathInBase(docsBaseDirs[product], testPath)
+      const {
+        resolvedPath: fullPath,
+        isWithinBase: testWithinBase,
+        exists,
+      } = await resolveDocPath(docsBaseDirs[product], testPath)
 
-      if (!testWithinBase) {
+      if (!testWithinBase || !exists) {
         parts.pop()
         continue
       }

--- a/packages/mcp/src/tools/service-summary.js
+++ b/packages/mcp/src/tools/service-summary.js
@@ -36,7 +36,7 @@ export const resourceTypeHandlers = {
  * @param {Array<Object>} [params.resources] - Array of resource objects with id and type properties
  * @param {boolean} [params.serviceWideAnalysis] - Boolean flag to analyze all resources for a service
  * @param {string} [params.serviceName] - Required if serviceWideAnalysis is true
- * @param {string} [params.cloudProvider] - The cloud service provider (aws, gcp, azure). Required if serviceWideAnalysis is true
+ * @param {string} params.cloudProvider - The cloud provider of the resources (currently only aws)
  * @param {string} [params.startTime] - Optional start time for metrics and logs (ISO string or timestamp)
  * @param {string} [params.endTime] - Optional end time for metrics and logs (ISO string or timestamp)
  * @param {number} [params.period] - Optional period for metrics in seconds (minimum 60, default 3600)

--- a/packages/mcp/tests/aws/aws-errors-info.test.js
+++ b/packages/mcp/tests/aws/aws-errors-info.test.js
@@ -332,13 +332,10 @@ describe('AWS Errors Info with Pattern Analytics', () => {
     // every logging resource in the stack: the default log group of each Lambda
     // function plus the REST API access log group.
     //
-    // KNOWN SOURCE DEFECT (see .reports/cluster-logs.md): the Lambda log groups
-    // are missing today because fetchLambdaLogGroups in
-    // src/lib/aws/errors-info-patterns.js:390 tests
-    // `functionDetails.Configuration` while the engine client returns
-    // `{ function: { Configuration } }` (compare
-    // src/lib/aws/lambda-resource-info.js:103), so the branch never runs and the
-    // function returns an empty list.
+    // fetchLambdaLogGroups reads the configuration from the engine's
+    // `{ function: { Configuration } }` response shape, the same way
+    // lambda-resource-info.js does; with no LoggingConfig set it falls back to
+    // the default /aws/lambda/<name> group for each function.
     expect(
       [
         ...mockExecutePatternAnalyticsQuery.mock.calls[0][0]

--- a/packages/mcp/tests/aws/aws-errors-info.test.js
+++ b/packages/mcp/tests/aws/aws-errors-info.test.js
@@ -1,79 +1,82 @@
 /**
- * E2E tests for the AWS Errors Info tool
+ * Unit tests for the AWS Errors Info pattern-analytics library
+ * (src/lib/aws/errors-info-patterns.js).
+ *
+ * Every engine AWS client the module (or the confirmation handler it uses) can
+ * construct is mocked, so no test in this file can reach AWS:
+ *  - cloudwatch.js     -> describeLogGroups (log group validation) and
+ *                         executePatternAnalyticsQuery (the Insights query)
+ *  - cloudformation.js -> describeStackResources (service-wide analysis)
+ *  - lambda.js         -> getLambdaFunctionDetails (log group discovery)
+ *  - restApiGateway.js / httpApiGateway.js -> getStages (log group discovery)
  */
 import { jest, expect, describe, test, beforeEach } from '@jest/globals'
 
-// Create mock functions
-const mockExecuteCloudWatchLogsQuery = jest.fn()
-const mockGetResourcesForService = jest.fn()
-const mockParseTimestamp = jest.fn((timestamp) => {
-  if (typeof timestamp === 'number') {
-    return timestamp
-  }
-  return new Date(timestamp).getTime()
-})
-
 // Mock AWS CloudWatch client
 const mockExecutePatternAnalyticsQuery = jest.fn()
-const mockAwsCloudWatchClient = {
-  startQuery: jest.fn(),
-  getQueryResults: jest.fn(),
-  stopQuery: jest.fn(),
-  executePatternAnalyticsQuery: mockExecutePatternAnalyticsQuery,
-}
+const mockDescribeLogGroups = jest.fn()
 
-// Mock the CloudWatch Logs Insights module
-await jest.unstable_mockModule(
-  '../../src/lib/aws/cloudwatch-logs-insights.js',
-  () => {
-    return {
-      executeCloudWatchLogsQuery: mockExecuteCloudWatchLogsQuery,
-      parseTimestamp: mockParseTimestamp,
-    }
-  },
-)
+// Mock AWS clients used while discovering log groups of a service
+const mockDescribeStackResources = jest.fn()
+const mockGetLambdaFunctionDetails = jest.fn()
+const mockGetRestApiStages = jest.fn()
+const mockGetHttpApiStages = jest.fn()
 
 // Mock the AWS CloudWatch client module
 await jest.unstable_mockModule(
   '@serverless/engine/src/lib/aws/cloudwatch.js',
   () => {
     return {
-      AwsCloudWatchClient: jest.fn(() => mockAwsCloudWatchClient),
+      AwsCloudWatchClient: jest.fn(() => ({
+        describeLogGroups: mockDescribeLogGroups,
+        executePatternAnalyticsQuery: mockExecutePatternAnalyticsQuery,
+      })),
     }
   },
 )
-
-// Mock the list-resources module
-await jest.unstable_mockModule('../../src/tools/list-resources.js', () => {
-  return {
-    getIacResources: mockGetResourcesForService,
-  }
-})
 
 // Mock the CloudFormation module
 await jest.unstable_mockModule(
   '@serverless/engine/src/lib/aws/cloudformation.js',
   () => {
     return {
-      AwsCloudformationService: class MockAwsCloudformationService {
-        constructor() {}
-        async describeStackResources() {
-          return [
-            {
-              ResourceType: 'AWS::Lambda::Function',
-              PhysicalResourceId: 'my-service-dev-function1',
-            },
-            {
-              ResourceType: 'AWS::Lambda::Function',
-              PhysicalResourceId: 'my-service-dev-function2',
-            },
-            {
-              ResourceType: 'AWS::ApiGateway::RestApi',
-              PhysicalResourceId: 'api1',
-            },
-          ]
-        }
-      },
+      AwsCloudformationService: jest.fn(() => ({
+        describeStackResources: mockDescribeStackResources,
+      })),
+    }
+  },
+)
+
+// Mock the Lambda client module
+await jest.unstable_mockModule(
+  '@serverless/engine/src/lib/aws/lambda.js',
+  () => {
+    return {
+      AwsLambdaClient: jest.fn(() => ({
+        getLambdaFunctionDetails: mockGetLambdaFunctionDetails,
+      })),
+    }
+  },
+)
+
+// Mock the API Gateway client modules (restApiGateway.js is a default export)
+await jest.unstable_mockModule(
+  '@serverless/engine/src/lib/aws/restApiGateway.js',
+  () => {
+    const AwsRestApiGatewayClient = jest.fn(() => ({
+      getStages: mockGetRestApiStages,
+    }))
+    return { AwsRestApiGatewayClient, default: AwsRestApiGatewayClient }
+  },
+)
+
+await jest.unstable_mockModule(
+  '@serverless/engine/src/lib/aws/httpApiGateway.js',
+  () => {
+    return {
+      AwsHttpApiGatewayClient: jest.fn(() => ({
+        getStages: mockGetHttpApiStages,
+      })),
     }
   },
 )
@@ -82,9 +85,22 @@ await jest.unstable_mockModule(
 const { getErrorsInfoWithPatterns } =
   await import('../../src/lib/aws/errors-info-patterns.js')
 
+const START_TIME = '2023-01-01T00:00:00Z'
+const END_TIME = '2023-01-01T01:00:00Z'
+
 describe('AWS Errors Info with Pattern Analytics', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+
+    // Every requested log group exists and is small enough (1 KiB) that the
+    // extended-timeframe cost confirmation is skipped.
+    mockDescribeLogGroups.mockImplementation(
+      async ({ logGroupNamePrefix }) => ({
+        logGroups: [{ logGroupName: logGroupNamePrefix, storedBytes: 1024 }],
+      }),
+    )
+    mockGetRestApiStages.mockResolvedValue([])
+    mockGetHttpApiStages.mockResolvedValue([])
   })
 
   test('should group similar errors correctly', async () => {
@@ -154,8 +170,8 @@ describe('AWS Errors Info with Pattern Analytics', () => {
 
     // Call the function
     const result = await getErrorsInfoWithPatterns({
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T01:00:00Z',
+      startTime: START_TIME,
+      endTime: END_TIME,
       logGroupIdentifiers: [
         '/aws/lambda/function1',
         '/aws/lambda/function2',
@@ -167,12 +183,32 @@ describe('AWS Errors Info with Pattern Analytics', () => {
     // Verify the results
     expect(result.summary.totalErrors).toBe(5)
     expect(result.summary.uniqueErrorGroups).toBe(3)
+    expect(result.summary.timeRange).toEqual({
+      start: new Date(Date.parse(START_TIME)).toISOString(),
+      end: new Date(Date.parse(END_TIME)).toISOString(),
+    })
+
+    // Only the log groups that exist are queried, and the query window is the
+    // requested one. maxResults is over-fetched by 3x to allow for grouping.
+    expect(mockExecutePatternAnalyticsQuery).toHaveBeenCalledWith({
+      logGroupIdentifiers: [
+        '/aws/lambda/function1',
+        '/aws/lambda/function2',
+        '/aws/lambda/function3',
+      ],
+      startTime: new Date(Date.parse(START_TIME)),
+      endTime: new Date(Date.parse(END_TIME)),
+      limit: 30,
+    })
 
     // Verify that the patterns were correctly processed
     const connectionTimeoutGroup = result.errorGroups.find((group) =>
       group.pattern.includes('Connection timeout to database'),
     )
     expect(connectionTimeoutGroup).toBeDefined()
+    expect(connectionTimeoutGroup.id).toBe(
+      'pattern-7ecb9e1506938875f66688ee60c510db',
+    )
     expect(connectionTimeoutGroup.count).toBe(2)
     expect(connectionTimeoutGroup.patternId).toBe(
       '7ecb9e1506938875f66688ee60c510db',
@@ -196,9 +232,23 @@ describe('AWS Errors Info with Pattern Analytics', () => {
     expect(typeErrorGroup.patternId).toBe('829d82345808dd14853884091c780f92')
   })
 
+  test('should require log groups when serviceWideAnalysis is false', async () => {
+    const result = await getErrorsInfoWithPatterns({
+      startTime: START_TIME,
+      endTime: END_TIME,
+      logGroupIdentifiers: [],
+    })
+
+    expect(result.error).toBe(
+      'logGroupIdentifiers is required when serviceWideAnalysis is false',
+    )
+    expect(result.errorGroups).toEqual([])
+    expect(mockExecutePatternAnalyticsQuery).not.toHaveBeenCalled()
+  })
+
   test('should handle service-wide analysis', async () => {
-    // Mock the list-resources response with CloudFormation resources format
-    mockGetResourcesForService.mockResolvedValue([
+    // CloudFormation stack resources of the analysed service
+    mockDescribeStackResources.mockResolvedValue([
       {
         ResourceType: 'AWS::Lambda::Function',
         PhysicalResourceId: 'my-service-dev-function1',
@@ -210,6 +260,29 @@ describe('AWS Errors Info with Pattern Analytics', () => {
       {
         ResourceType: 'AWS::ApiGateway::RestApi',
         PhysicalResourceId: 'api1',
+      },
+    ])
+
+    // Shape returned by AwsLambdaClient.getLambdaFunctionDetails
+    // (packages/engine/src/lib/aws/lambda.js): { status, function, ... } where
+    // `function` is the GetFunction response.
+    mockGetLambdaFunctionDetails.mockImplementation(async (functionName) => ({
+      status: 'success',
+      function: {
+        Configuration: {
+          FunctionName: functionName,
+        },
+      },
+    }))
+
+    // The REST API writes access logs to an explicit log group
+    mockGetRestApiStages.mockResolvedValue([
+      {
+        stageName: 'dev',
+        accessLogSettings: {
+          destinationArn:
+            'arn:aws:logs:us-east-1:123456789012:log-group:/aws/apigateway/api1-access-logs:*',
+        },
       },
     ])
 
@@ -234,37 +307,71 @@ describe('AWS Errors Info with Pattern Analytics', () => {
 
     // Call the function with serviceWideAnalysis
     const result = await getErrorsInfoWithPatterns({
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T01:00:00Z',
+      startTime: START_TIME,
+      endTime: END_TIME,
       serviceWideAnalysis: true,
       serviceName: 'my-service-dev',
       serviceType: 'serverless-framework',
     })
 
-    // With our new implementation, we're using AwsCloudformationService directly for CloudFormation-based services
-    // so getIacResources won't be called for serverless-framework type
-    // If we were testing a non-CloudFormation service type, we would expect this call:
-    // expect(mockGetResourcesForService).toHaveBeenCalledWith({
-    //   serviceName: 'my-service-dev',
-    //   serviceType: 'serverless-framework',
-    //   region: undefined,
-    //   profile: undefined,
-    // })
-
-    // Verify that executePatternAnalyticsQuery was called with the correct log groups
-    expect(mockExecutePatternAnalyticsQuery).toHaveBeenCalledWith(
-      expect.objectContaining({
-        logGroupIdentifiers: [
-          '/aws/lambda/my-service-dev-function1',
-          '/aws/lambda/my-service-dev-function2',
-          '/aws/apigateway/api1',
-        ],
-      }),
+    // Log groups are discovered from the CloudFormation stack resources
+    expect(mockDescribeStackResources).toHaveBeenCalledWith('my-service-dev')
+    expect(mockGetLambdaFunctionDetails).toHaveBeenCalledWith(
+      'my-service-dev-function1',
     )
+    expect(mockGetLambdaFunctionDetails).toHaveBeenCalledWith(
+      'my-service-dev-function2',
+    )
+    expect(mockGetRestApiStages).toHaveBeenCalledWith('api1')
 
     // Verify the results
     expect(result.summary.totalErrors).toBe(1)
     expect(result.errorGroups.length).toBe(1)
+
+    // Verify that executePatternAnalyticsQuery was called with the log groups of
+    // every logging resource in the stack: the default log group of each Lambda
+    // function plus the REST API access log group.
+    //
+    // KNOWN SOURCE DEFECT (see .reports/cluster-logs.md): the Lambda log groups
+    // are missing today because fetchLambdaLogGroups in
+    // src/lib/aws/errors-info-patterns.js:390 tests
+    // `functionDetails.Configuration` while the engine client returns
+    // `{ function: { Configuration } }` (compare
+    // src/lib/aws/lambda-resource-info.js:103), so the branch never runs and the
+    // function returns an empty list.
+    expect(
+      [
+        ...mockExecutePatternAnalyticsQuery.mock.calls[0][0]
+          .logGroupIdentifiers,
+      ].sort(),
+    ).toEqual([
+      '/aws/apigateway/api1-access-logs',
+      '/aws/lambda/my-service-dev-function1',
+      '/aws/lambda/my-service-dev-function2',
+    ])
+  })
+
+  test('should ask for confirmation before scanning large log groups over a long timeframe', async () => {
+    // 3 GiB of stored logs, queried over 6 hours: both cost guards apply
+    mockDescribeLogGroups.mockImplementation(
+      async ({ logGroupNamePrefix }) => ({
+        logGroups: [
+          { logGroupName: logGroupNamePrefix, storedBytes: 3 * 1024 ** 3 },
+        ],
+      }),
+    )
+
+    const result = await getErrorsInfoWithPatterns({
+      startTime: '2023-01-01T00:00:00Z',
+      endTime: '2023-01-01T06:00:00Z',
+      logGroupIdentifiers: ['/aws/lambda/function1'],
+    })
+
+    expect(result.content[0].text).toContain(
+      'CloudWatch Logs Insights queries incur costs',
+    )
+    expect(result.content[0].text).toContain('6.0 hours')
+    expect(mockExecutePatternAnalyticsQuery).not.toHaveBeenCalled()
   })
 
   test('should handle errors gracefully', async () => {
@@ -275,8 +382,8 @@ describe('AWS Errors Info with Pattern Analytics', () => {
 
     // Call the function
     const result = await getErrorsInfoWithPatterns({
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T01:00:00Z',
+      startTime: START_TIME,
+      endTime: END_TIME,
       logGroupIdentifiers: ['/aws/lambda/function1'],
     })
 
@@ -285,5 +392,24 @@ describe('AWS Errors Info with Pattern Analytics', () => {
     expect(result.errorGroups).toEqual([])
     expect(result.summary.totalErrors).toBe(0)
     expect(result.summary.uniqueErrorGroups).toBe(0)
+    expect(result.summary.nextSteps).toBe(
+      'Error occurred. No pattern analysis available.',
+    )
+    expect(result.statistics).toBeNull()
+  })
+
+  test('should report log group validation failures', async () => {
+    mockDescribeLogGroups.mockRejectedValue(new Error('Throttling'))
+
+    const result = await getErrorsInfoWithPatterns({
+      startTime: START_TIME,
+      endTime: END_TIME,
+      logGroupIdentifiers: ['/aws/lambda/function1'],
+    })
+
+    expect(result.message).toBe('Error validating log groups: Throttling')
+    expect(result.errorGroups).toEqual([])
+    expect(result.summary.totalErrors).toBe(0)
+    expect(mockExecutePatternAnalyticsQuery).not.toHaveBeenCalled()
   })
 })

--- a/packages/mcp/tests/aws/aws-logs-search.test.js
+++ b/packages/mcp/tests/aws/aws-logs-search.test.js
@@ -1,8 +1,15 @@
 /**
  * Jest tests for AWS Logs Search Tool
  *
- * This test file directly tests the getLogsSearch function, mocking the CloudWatch Logs Insights
- * functionality to avoid making actual AWS API calls during testing.
+ * These tests exercise getLogsSearch directly. Every module that
+ * src/tools/aws/aws-logs-search.js imports and that can reach AWS is mocked, so
+ * no test in this file can perform a network call:
+ *  - src/lib/aws/cloudwatch-logs-insights.js (executeCloudWatchLogsQuery builds
+ *    an AwsCloudWatchClient)
+ *  - src/lib/confirmation-handler.js (validateLogGroups calls
+ *    cloudWatchClient.describeLogGroups)
+ * src/lib/aws-credentials-error-handler.js is left unmocked on purpose: it is a
+ * pure message formatter with no AWS access.
  */
 
 import { jest, expect, describe, test, beforeEach } from '@jest/globals'
@@ -11,6 +18,29 @@ import { jest, expect, describe, test, beforeEach } from '@jest/globals'
 const mockExecuteCloudWatchLogsQuery = jest.fn()
 const mockBuildLogsSearchQuery = jest.fn()
 
+// Mirrors the real parseTimestamp contract in
+// src/lib/aws/cloudwatch-logs-insights.js: numbers pass through, ISO strings and
+// all-digit strings become epoch milliseconds, anything else throws.
+const mockParseTimestamp = jest.fn((timestamp) => {
+  if (typeof timestamp === 'number') {
+    return timestamp
+  }
+  if (typeof timestamp === 'string') {
+    const parsed = Date.parse(timestamp)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+    if (/^\d+$/.test(timestamp)) {
+      return Number.parseInt(timestamp, 10)
+    }
+  }
+  throw new Error(`Failed to parse timestamp: ${timestamp}`)
+})
+
+const mockHandleHistoricalConfirmation = jest.fn()
+const mockHandleExtendedTimeframeConfirmation = jest.fn()
+const mockValidateLogGroups = jest.fn()
+
 // Mock the CloudWatch Logs Insights module
 await jest.unstable_mockModule(
   '../../src/lib/aws/cloudwatch-logs-insights.js',
@@ -18,24 +48,54 @@ await jest.unstable_mockModule(
     return {
       executeCloudWatchLogsQuery: mockExecuteCloudWatchLogsQuery,
       buildLogsSearchQuery: mockBuildLogsSearchQuery,
+      parseTimestamp: mockParseTimestamp,
     }
   },
 )
 
+// Mock the confirmation handler module
+await jest.unstable_mockModule('../../src/lib/confirmation-handler.js', () => {
+  return {
+    handleHistoricalConfirmation: mockHandleHistoricalConfirmation,
+    handleExtendedTimeframeConfirmation:
+      mockHandleExtendedTimeframeConfirmation,
+    validateLogGroups: mockValidateLogGroups,
+  }
+})
+
 // Import the function after mocking dependencies
 const { getLogsSearch } = await import('../../src/tools/aws/aws-logs-search.js')
+
+// The aws-logs-search tool schema always supplies startTime/endTime (they
+// default to "3 hours ago"/"now" in src/tools-definition.js), so the tests pass
+// them explicitly, exactly as the registered tool does.
+const START_TIME = '2023-01-01T00:00:00.000Z'
+const END_TIME = '2023-01-01T03:00:00.000Z'
+const START_TIME_MS = Date.parse(START_TIME)
+const END_TIME_MS = Date.parse(END_TIME)
+
+const LOG_GROUPS_INFO = {
+  logGroups: ['/aws/lambda/function1'],
+  logGroupsWithSize: [{ name: '/aws/lambda/function1', storedBytes: 1024 }],
+  totalSizeBytes: 1024,
+  totalSizeGB: 1024 / 1024 ** 3,
+}
 
 describe('AWS Logs Search Tool', () => {
   beforeEach(() => {
     // Clear all mocks before each test
     jest.clearAllMocks()
 
-    // Default mock implementations
+    // Default mock implementations: no confirmation required, log groups valid
+    mockHandleHistoricalConfirmation.mockReturnValue(null)
+    mockHandleExtendedTimeframeConfirmation.mockReturnValue(null)
+    mockValidateLogGroups.mockResolvedValue(LOG_GROUPS_INFO)
+
     mockBuildLogsSearchQuery.mockImplementation(({ searchTerms, limit }) => {
       let query = 'fields @timestamp, @message | sort @timestamp asc'
 
       if (searchTerms) {
-        query += ` | filter @message like "${searchTerms}"`
+        query += ` | filter @message like "${searchTerms.join('|')}"`
       }
 
       if (limit) {
@@ -49,7 +109,9 @@ describe('AWS Logs Search Tool', () => {
   test('should validate input and return error for missing log groups', async () => {
     const result = await getLogsSearch({
       logGroupIdentifiers: [],
-      searchTerms: 'abc123',
+      searchTerms: ['abc123'],
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result).toBeDefined()
@@ -61,7 +123,8 @@ describe('AWS Logs Search Tool', () => {
       'Please provide at least one CloudWatch Log Group',
     )
 
-    // Verify that the CloudWatch Logs query was not executed
+    // Verify that neither log group validation nor the query were executed
+    expect(mockValidateLogGroups).not.toHaveBeenCalled()
     expect(mockExecuteCloudWatchLogsQuery).not.toHaveBeenCalled()
   })
 
@@ -84,8 +147,8 @@ describe('AWS Logs Search Tool', () => {
       ],
       errors: [],
       timeRange: {
-        start: '2023-01-01T11:00:00.000Z',
-        end: '2023-01-01T13:00:00.000Z',
+        start: START_TIME,
+        end: END_TIME,
       },
     })
 
@@ -95,7 +158,9 @@ describe('AWS Logs Search Tool', () => {
 
     const result = await getLogsSearch({
       logGroupIdentifiers: ['/aws/lambda/function1'],
-      searchTerms: 'abc123',
+      searchTerms: ['abc123'],
+      startTime: START_TIME,
+      endTime: END_TIME,
       limit: 50,
     })
 
@@ -103,6 +168,14 @@ describe('AWS Logs Search Tool', () => {
     expect(result.isError).toBeFalsy()
     expect(result.content.length).toBeGreaterThan(0)
     expect(result.content[0].type).toBe('text')
+
+    // The first content block is the summary of the search
+    const summary = JSON.parse(result.content[0].text)
+    expect(summary.title).toBe('Log Search Results')
+    expect(summary.logGroupsCount).toBe(1)
+    expect(summary.totalEvents).toBe(2)
+    expect(summary.errorsOnly).toBe('Showing all logs')
+    expect(summary.timeRange).toEqual({ start: START_TIME, end: END_TIME })
 
     // Check that we have the timeline data
     const timelineContent = result.content.find((item) => {
@@ -118,21 +191,59 @@ describe('AWS Logs Search Tool', () => {
     const parsedTimeline = JSON.parse(timelineContent.text)
     expect(parsedTimeline.timeline.events).toHaveLength(2)
 
+    // The tool also returns the raw results alongside the content blocks
+    expect(result.logGroups).toEqual(['/aws/lambda/function1'])
+    expect(result.timeRange).toEqual({ start: START_TIME, end: END_TIME })
+    expect(result.events).toHaveLength(2)
+    expect(result.errors).toBeUndefined()
+
+    // Log groups are validated (and sized) before the query runs
+    expect(mockValidateLogGroups).toHaveBeenCalledWith(
+      ['/aws/lambda/function1'],
+      { region: undefined, profile: undefined },
+    )
+
     // Verify that the query was built and executed with correct parameters
     expect(mockBuildLogsSearchQuery).toHaveBeenCalledWith({
-      searchTerms: 'abc123',
+      searchTerms: ['abc123'],
       limit: 50,
+      errorsOnly: false,
     })
 
     expect(mockExecuteCloudWatchLogsQuery).toHaveBeenCalledWith({
       logGroupIdentifiers: ['/aws/lambda/function1'],
       queryString: expectedQuery,
-      startTime: undefined,
-      endTime: undefined,
+      startTime: START_TIME_MS,
+      endTime: END_TIME_MS,
       limit: 50,
       region: undefined,
       profile: undefined,
     })
+  })
+
+  test('should forward errorsOnly to the query builder', async () => {
+    mockExecuteCloudWatchLogsQuery.mockResolvedValue({
+      events: [],
+      errors: [],
+      timeRange: { start: START_TIME, end: END_TIME },
+    })
+    mockBuildLogsSearchQuery.mockReturnValue('errors-only query')
+
+    const result = await getLogsSearch({
+      logGroupIdentifiers: ['/aws/lambda/function1'],
+      startTime: START_TIME,
+      endTime: END_TIME,
+      errorsOnly: true,
+    })
+
+    expect(mockBuildLogsSearchQuery).toHaveBeenCalledWith({
+      searchTerms: undefined,
+      limit: 100,
+      errorsOnly: true,
+    })
+    expect(JSON.parse(result.content[0].text).errorsOnly).toBe(
+      'Showing only error-related logs',
+    )
   })
 
   test('should handle query execution errors', async () => {
@@ -146,6 +257,8 @@ describe('AWS Logs Search Tool', () => {
 
     const result = await getLogsSearch({
       logGroupIdentifiers: ['/aws/lambda/function1'],
+      startTime: START_TIME,
+      endTime: END_TIME,
       region: 'us-east-1',
       profile: 'default',
     })
@@ -157,19 +270,18 @@ describe('AWS Logs Search Tool', () => {
 
     const parsedContent = JSON.parse(result.content[0].text)
     expect(parsedContent).toHaveProperty('error')
-    expect(parsedContent.error).toContain('Access denied')
+    expect(parsedContent.error).toBe('Error searching logs: Access denied')
 
-    // Check that error details are included
-    expect(result).toHaveProperty('errorDetails')
-    expect(result.errorDetails).toContain('Access denied')
+    // The failure response carries only the content blocks and the isError flag
+    expect(Object.keys(result).sort()).toEqual(['content', 'isError'])
 
     // Verify that the query was built and executed with correct parameters
     expect(mockBuildLogsSearchQuery).toHaveBeenCalled()
     expect(mockExecuteCloudWatchLogsQuery).toHaveBeenCalledWith({
       logGroupIdentifiers: ['/aws/lambda/function1'],
       queryString: 'fields @timestamp, @message | sort @timestamp asc',
-      startTime: undefined,
-      endTime: undefined,
+      startTime: START_TIME_MS,
+      endTime: END_TIME_MS,
       limit: 100,
       region: 'us-east-1',
       profile: 'default',
@@ -203,7 +315,7 @@ describe('AWS Logs Search Tool', () => {
 
     const result = await getLogsSearch({
       logGroupIdentifiers: ['/aws/lambda/function1', '/aws/lambda/function2'],
-      searchTerms: 'abc123 error',
+      searchTerms: ['abc123', 'error'],
       startTime,
       endTime,
     })
@@ -211,18 +323,21 @@ describe('AWS Logs Search Tool', () => {
     expect(result).toBeDefined()
     expect(result.isError).toBeFalsy()
     expect(result.content.length).toBeGreaterThan(0)
+    expect(JSON.parse(result.content[0].text).logGroupsCount).toBe(2)
 
     // Verify that the query was built and executed with correct parameters
     expect(mockBuildLogsSearchQuery).toHaveBeenCalledWith({
-      searchTerms: 'abc123 error',
+      searchTerms: ['abc123', 'error'],
       limit: 100,
+      errorsOnly: false,
     })
 
+    // The tool parses the ISO strings into epoch milliseconds before querying
     expect(mockExecuteCloudWatchLogsQuery).toHaveBeenCalledWith({
       logGroupIdentifiers: ['/aws/lambda/function1', '/aws/lambda/function2'],
       queryString: expectedQuery,
-      startTime,
-      endTime,
+      startTime: Date.parse(startTime),
+      endTime: Date.parse(endTime),
       limit: 100,
       region: undefined,
       profile: undefined,
@@ -235,8 +350,8 @@ describe('AWS Logs Search Tool', () => {
       events: [],
       errors: [],
       timeRange: {
-        start: '2023-01-01T00:00:00.000Z',
-        end: '2023-01-02T00:00:00.000Z',
+        start: START_TIME,
+        end: END_TIME,
       },
     })
 
@@ -246,7 +361,9 @@ describe('AWS Logs Search Tool', () => {
 
     const result = await getLogsSearch({
       logGroupIdentifiers: ['/aws/lambda/function1'],
-      searchTerms: 'nonexistent',
+      searchTerms: ['nonexistent'],
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result).toBeDefined()
@@ -273,5 +390,83 @@ describe('AWS Logs Search Tool', () => {
     // Verify that the query was built and executed
     expect(mockBuildLogsSearchQuery).toHaveBeenCalled()
     expect(mockExecuteCloudWatchLogsQuery).toHaveBeenCalled()
+  })
+
+  test('should surface query errors returned by the Insights query', async () => {
+    mockExecuteCloudWatchLogsQuery.mockResolvedValue({
+      events: [],
+      errors: ['Log group /aws/lambda/function1 does not exist'],
+      timeRange: { start: START_TIME, end: END_TIME },
+    })
+    mockBuildLogsSearchQuery.mockReturnValue('query')
+
+    const result = await getLogsSearch({
+      logGroupIdentifiers: ['/aws/lambda/function1'],
+      startTime: START_TIME,
+      endTime: END_TIME,
+    })
+
+    expect(result.isError).toBeFalsy()
+    expect(result.errors).toEqual([
+      'Log group /aws/lambda/function1 does not exist',
+    ])
+    expect(JSON.parse(result.content[1].text)).toEqual({
+      errors: ['Log group /aws/lambda/function1 does not exist'],
+    })
+  })
+
+  test('should return the historical confirmation prompt without querying', async () => {
+    const confirmationResponse = {
+      content: [{ type: 'text', text: 'confirm historical query' }],
+    }
+    mockHandleHistoricalConfirmation.mockReturnValue(confirmationResponse)
+
+    const result = await getLogsSearch({
+      logGroupIdentifiers: ['/aws/lambda/function1'],
+      startTime: START_TIME,
+      endTime: END_TIME,
+      confirmationToken: 'token-123',
+    })
+
+    expect(result).toBe(confirmationResponse)
+    expect(mockHandleHistoricalConfirmation).toHaveBeenCalledWith(
+      START_TIME_MS,
+      END_TIME_MS,
+      'token-123',
+    )
+
+    // Nothing is validated or queried until the confirmation is satisfied
+    expect(mockValidateLogGroups).not.toHaveBeenCalled()
+    expect(mockExecuteCloudWatchLogsQuery).not.toHaveBeenCalled()
+  })
+
+  test('should return the extended timeframe prompt with log group sizes', async () => {
+    const confirmationResponse = {
+      content: [{ type: 'text', text: 'confirm extended timeframe' }],
+    }
+    mockHandleExtendedTimeframeConfirmation.mockReturnValue(
+      confirmationResponse,
+    )
+
+    const result = await getLogsSearch({
+      logGroupIdentifiers: ['/aws/lambda/function1'],
+      startTime: START_TIME,
+      endTime: END_TIME,
+      region: 'us-east-1',
+      profile: 'dev',
+    })
+
+    expect(result).toBe(confirmationResponse)
+    expect(mockValidateLogGroups).toHaveBeenCalledWith(
+      ['/aws/lambda/function1'],
+      { region: 'us-east-1', profile: 'dev' },
+    )
+    expect(mockHandleExtendedTimeframeConfirmation).toHaveBeenCalledWith(
+      START_TIME_MS,
+      END_TIME_MS,
+      undefined,
+      LOG_GROUPS_INFO,
+    )
+    expect(mockExecuteCloudWatchLogsQuery).not.toHaveBeenCalled()
   })
 })

--- a/packages/mcp/tests/aws/dynamodb-info.test.js
+++ b/packages/mcp/tests/aws/dynamodb-info.test.js
@@ -124,10 +124,13 @@ describe('AWS DynamoDB Info Tool', () => {
       },
     })
 
+    const startTime = '2023-01-01T00:00:00Z'
+    const endTime = '2023-01-01T03:00:00Z'
+
     const result = await getDynamoDBInfo({
       tableNames: [tableName],
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime,
+      endTime,
     })
 
     expect(result.isError).toBeUndefined()
@@ -137,13 +140,20 @@ describe('AWS DynamoDB Info Tool', () => {
     expect(resultData[0].tableDetails).toBeDefined()
     expect(resultData[0].metrics).toBeDefined()
 
-    expect(mockGetDynamoDBResourceInfo).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceId: tableName,
-        startTime: '2023-01-01T00:00:00Z',
-        endTime: '2023-01-01T03:00:00Z',
-      }),
-    )
+    // The tool normalizes the time range through validateAndAdjustParameters
+    // before delegating, so the resource-info layer receives epoch
+    // milliseconds plus a derived CloudWatch period, not the raw ISO strings.
+    expect(mockGetDynamoDBResourceInfo).toHaveBeenCalledWith({
+      resourceId: tableName,
+      startTime: Date.parse(startTime),
+      endTime: Date.parse(endTime),
+      // No period was requested: the 3-hour window at the default 3600s
+      // granularity yields 3 data points, far below the 300-point cap, so
+      // calculateOptimalPeriod keeps the 1-hour default.
+      period: 3600,
+      region: undefined,
+      profile: undefined,
+    })
   })
 
   test('should get table details for multiple table names', async () => {

--- a/packages/mcp/tests/aws/lambda-info.test.js
+++ b/packages/mcp/tests/aws/lambda-info.test.js
@@ -511,9 +511,8 @@ describe('AWS Lambda Info Tool', () => {
     expect(parsedJson[0].functionName).toBe('my-function')
 
     // getErrorsInfoWithPatterns handles the failure itself and reports it in the
-    // summary, so the Lambda tool returns an empty pattern list. NOTE: the
-    // underlying error message is not propagated to errorLogs today - see
-    // .reports/cluster-logs.md.
+    // summary, so the Lambda tool returns an empty pattern list. The underlying
+    // error message is not propagated to errorLogs.
     const errorLogs = parsedJson[0].errorLogs
     expect(errorLogs.patterns).toEqual([])
     expect(errorLogs.summary.totalErrors).toBe(0)
@@ -552,7 +551,7 @@ describe('AWS Lambda Info Tool', () => {
     // (src/lib/parameter-validator.js:85-86) leaves them undefined and
     // calculateOptimalPeriod falls through to its widest bucket (1209600 = 2
     // weeks). Unreachable through the aws-lambda-info tool, whose schema always
-    // supplies startTime, endTime and period - see .reports/cluster-logs.md.
+    // supplies startTime, endTime and period.
     expect(mockGetMetricData).toHaveBeenCalledWith({
       functionNames: ['my-function'],
       startTime: expect.any(Number),

--- a/packages/mcp/tests/aws/lambda-info.test.js
+++ b/packages/mcp/tests/aws/lambda-info.test.js
@@ -1,8 +1,14 @@
 /**
  * Jest tests for AWS Lambda Info Tool
  *
- * This test file directly tests the getLambdaInfo function, mocking the AwsLambdaClient
- * to avoid making actual AWS API calls during testing.
+ * These tests exercise getLambdaInfo directly. The only AWS clients reachable
+ * from this code path are AwsLambdaClient (function details) and
+ * AwsCloudWatchClient (metrics, log group validation and the Insights pattern
+ * query used for the error-log summary); both engine modules are mocked with the
+ * same specifiers the sources import, so no test in this file can perform a
+ * network call. The other resource-info modules re-exported by
+ * src/lib/aws/resource-info.js only construct their clients inside functions
+ * that the Lambda tool never calls.
  */
 
 import { beforeEach, describe, expect, jest, test } from '@jest/globals'
@@ -10,25 +16,30 @@ import { beforeEach, describe, expect, jest, test } from '@jest/globals'
 // Create mock functions
 const mockGetLambdaFunctionDetails = jest.fn()
 const mockGetMetricData = jest.fn()
-const mockGetErrorLogs = jest.fn()
+const mockDescribeLogGroups = jest.fn()
+const mockExecutePatternAnalyticsQuery = jest.fn()
 
 // Mock the AWS Lambda client
-await jest.unstable_mockModule('../../../engine/src/lib/aws/lambda.js', () => {
-  return {
-    AwsLambdaClient: jest.fn(() => ({
-      getLambdaFunctionDetails: mockGetLambdaFunctionDetails,
-    })),
-  }
-})
+await jest.unstable_mockModule(
+  '@serverless/engine/src/lib/aws/lambda.js',
+  () => {
+    return {
+      AwsLambdaClient: jest.fn(() => ({
+        getLambdaFunctionDetails: mockGetLambdaFunctionDetails,
+      })),
+    }
+  },
+)
 
 // Mock the AWS CloudWatch client
 await jest.unstable_mockModule(
-  '../../../engine/src/lib/aws/cloudwatch.js',
+  '@serverless/engine/src/lib/aws/cloudwatch.js',
   () => {
     return {
       AwsCloudWatchClient: jest.fn(() => ({
         getMetricData: mockGetMetricData,
-        getErrorLogs: mockGetErrorLogs,
+        describeLogGroups: mockDescribeLogGroups,
+        executePatternAnalyticsQuery: mockExecutePatternAnalyticsQuery,
       })),
     }
   },
@@ -37,6 +48,22 @@ await jest.unstable_mockModule(
 // Import the function after mocking dependencies
 const { getLambdaInfo } = await import('../../src/tools/aws/lambda-info.js')
 
+const START_TIME = '2023-01-01T00:00:00Z'
+const END_TIME = '2023-01-01T03:00:00Z'
+const START_TIME_MS = Date.parse(START_TIME)
+const END_TIME_MS = Date.parse(END_TIME)
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+const successfulFunctionDetails = (functionName = 'my-function') => ({
+  status: 'success',
+  function: {
+    Configuration: {
+      FunctionName: functionName,
+      Runtime: 'nodejs18.x',
+    },
+  },
+})
+
 describe('AWS Lambda Info Tool', () => {
   beforeEach(() => {
     // Clear all mocks before each test
@@ -44,7 +71,17 @@ describe('AWS Lambda Info Tool', () => {
 
     // Reset mock implementations
     mockGetMetricData.mockReset()
-    mockGetErrorLogs.mockReset()
+    mockDescribeLogGroups.mockReset()
+    mockExecutePatternAnalyticsQuery.mockReset()
+
+    // Every log group the tool derives exists and is small enough (1 KiB) that
+    // the extended-timeframe cost confirmation is skipped.
+    mockDescribeLogGroups.mockImplementation(
+      async ({ logGroupNamePrefix }) => ({
+        logGroups: [{ logGroupName: logGroupNamePrefix, storedBytes: 1024 }],
+      }),
+    )
+    mockExecutePatternAnalyticsQuery.mockResolvedValue({ events: [] })
   })
 
   test('should validate input and return error for empty function names', async () => {
@@ -122,6 +159,8 @@ describe('AWS Lambda Info Tool', () => {
 
     const result = await getLambdaInfo({
       functionNames: ['my-function'],
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result).toBeDefined()
@@ -130,21 +169,17 @@ describe('AWS Lambda Info Tool', () => {
     const parsedJson = JSON.parse(result.content[0].text)
     expect(parsedJson).toHaveLength(1)
     expect(parsedJson[0].functionName).toBe('my-function')
+    expect(parsedJson[0].type).toBe('lambda')
     expect(parsedJson[0].status).toBe('success')
+    expect(parsedJson[0].policy).toEqual(mockFunctionDetails.policy)
+    expect(parsedJson[0].eventSourceMappings).toEqual(
+      mockFunctionDetails.eventSourceMappings,
+    )
     expect(mockGetLambdaFunctionDetails).toHaveBeenCalledWith('my-function')
   })
 
   test('should handle multiple Lambda functions', async () => {
-    const mockFunction1 = {
-      status: 'success',
-      function: {
-        Configuration: {
-          FunctionName: 'function-1',
-          Runtime: 'nodejs18.x',
-        },
-      },
-    }
-
+    const mockFunction1 = successfulFunctionDetails('function-1')
     const mockFunction2 = {
       status: 'success',
       function: {
@@ -161,6 +196,8 @@ describe('AWS Lambda Info Tool', () => {
 
     const result = await getLambdaInfo({
       functionNames: ['function-1', 'function-2'],
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result).toBeDefined()
@@ -182,6 +219,8 @@ describe('AWS Lambda Info Tool', () => {
 
     const result = await getLambdaInfo({
       functionNames: ['non-existent-function'],
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result).toBeDefined()
@@ -198,16 +237,6 @@ describe('AWS Lambda Info Tool', () => {
   })
 
   test('should fetch CloudWatch metrics when time range is provided', async () => {
-    const mockFunctionDetails = {
-      status: 'success',
-      function: {
-        Configuration: {
-          FunctionName: 'my-function',
-          Runtime: 'nodejs18.x',
-        },
-      },
-    }
-
     const mockMetrics = {
       'my-function': {
         Invocations: {
@@ -247,13 +276,13 @@ describe('AWS Lambda Info Tool', () => {
       },
     }
 
-    mockGetLambdaFunctionDetails.mockResolvedValue(mockFunctionDetails)
+    mockGetLambdaFunctionDetails.mockResolvedValue(successfulFunctionDetails())
     mockGetMetricData.mockResolvedValue(mockMetrics)
 
     const result = await getLambdaInfo({
       functionNames: ['my-function'],
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime: START_TIME,
+      endTime: END_TIME,
       period: 3600,
     })
 
@@ -264,40 +293,28 @@ describe('AWS Lambda Info Tool', () => {
     const parsedJson = JSON.parse(result.content[0].text)
     expect(parsedJson).toHaveLength(1)
     expect(parsedJson[0].functionName).toBe('my-function')
-    expect(parsedJson[0].metrics).toBeDefined()
-    expect(parsedJson[0].metrics.Invocations).toBeDefined()
-    expect(parsedJson[0].metrics.Errors).toBeDefined()
-    expect(parsedJson[0].metrics.Duration).toBeDefined()
-    expect(parsedJson[0].metrics.Duration.Average).toBeDefined()
-    expect(parsedJson[0].metrics.Duration.Maximum).toBeDefined()
+    expect(parsedJson[0].metrics).toEqual(mockMetrics['my-function'])
 
     expect(mockGetLambdaFunctionDetails).toHaveBeenCalledWith('my-function')
+
+    // The ISO strings are parsed to epoch milliseconds and the requested period
+    // is passed through unchanged.
     expect(mockGetMetricData).toHaveBeenCalledWith({
       functionNames: ['my-function'],
-      startTime: expect.any(Number),
-      endTime: expect.any(Number),
+      startTime: START_TIME_MS,
+      endTime: END_TIME_MS,
       period: 3600,
     })
   })
 
   test('should handle errors when fetching CloudWatch metrics', async () => {
-    const mockFunctionDetails = {
-      status: 'success',
-      function: {
-        Configuration: {
-          FunctionName: 'my-function',
-          Runtime: 'nodejs18.x',
-        },
-      },
-    }
-
-    mockGetLambdaFunctionDetails.mockResolvedValue(mockFunctionDetails)
+    mockGetLambdaFunctionDetails.mockResolvedValue(successfulFunctionDetails())
     mockGetMetricData.mockRejectedValue(new Error('Metrics not available'))
 
     const result = await getLambdaInfo({
       functionNames: ['my-function'],
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result).toBeDefined()
@@ -306,24 +323,13 @@ describe('AWS Lambda Info Tool', () => {
     const parsedJson = JSON.parse(result.content[0].text)
     expect(parsedJson).toHaveLength(1)
     expect(parsedJson[0].functionName).toBe('my-function')
-    expect(parsedJson[0].metrics).toBeDefined()
-    expect(parsedJson[0].metrics.error).toBe('Metrics not available')
+    expect(parsedJson[0].metrics).toEqual({ error: 'Metrics not available' })
 
     expect(mockGetLambdaFunctionDetails).toHaveBeenCalledWith('my-function')
     expect(mockGetMetricData).toHaveBeenCalled()
   })
 
   test('should handle function names with aliases when fetching metrics', async () => {
-    const mockFunctionDetails = {
-      status: 'success',
-      function: {
-        Configuration: {
-          FunctionName: 'my-function:prod',
-          Runtime: 'nodejs18.x',
-        },
-      },
-    }
-
     const mockMetrics = {
       'my-function': {
         Invocations: {
@@ -333,12 +339,14 @@ describe('AWS Lambda Info Tool', () => {
       },
     }
 
-    mockGetLambdaFunctionDetails.mockResolvedValue(mockFunctionDetails)
+    mockGetLambdaFunctionDetails.mockResolvedValue(
+      successfulFunctionDetails('my-function:prod'),
+    )
     mockGetMetricData.mockResolvedValue(mockMetrics)
 
     const result = await getLambdaInfo({
       functionNames: ['my-function:prod'],
-      startTime: '2023-01-01T00:00:00Z',
+      startTime: START_TIME,
       endTime: '2023-01-01T01:00:00Z',
     })
 
@@ -346,116 +354,175 @@ describe('AWS Lambda Info Tool', () => {
 
     const parsedJson = JSON.parse(result.content[0].text)
     expect(parsedJson[0].functionName).toBe('my-function:prod')
-    expect(parsedJson[0].metrics).toBeDefined()
+    expect(parsedJson[0].metrics).toEqual(mockMetrics['my-function'])
 
     // Verify that the function name was properly extracted for metrics
     expect(mockGetMetricData).toHaveBeenCalledWith({
       functionNames: ['my-function'],
-      startTime: expect.any(Number),
-      endTime: expect.any(Number),
+      startTime: START_TIME_MS,
+      endTime: Date.parse('2023-01-01T01:00:00Z'),
       period: 3600,
     })
+
+    // The alias is stripped for the log group name too
+    expect(
+      mockExecutePatternAnalyticsQuery.mock.calls[0][0].logGroupIdentifiers,
+    ).toEqual(['/aws/lambda/my-function'])
   })
 
-  test('should fetch error logs with specified time range', async () => {
-    const mockFunctionDetails = {
-      status: 'success',
-      function: {
-        Configuration: {
-          FunctionName: 'my-function',
-          Runtime: 'nodejs18.x',
+  test('should summarise error log patterns for the specified time range', async () => {
+    mockGetLambdaFunctionDetails.mockResolvedValue(successfulFunctionDetails())
+    mockGetMetricData.mockResolvedValue({})
+    mockExecutePatternAnalyticsQuery.mockResolvedValue({
+      events: [
+        {
+          pattern: 'Error: Connection timed out after <*>ms',
+          count: 2,
+          examples: ['Error: Connection timed out after 5000ms'],
+          patternId: 'aa11bb22cc33dd44ee55ff6677889900',
+          severityLabel: 'ERROR',
         },
-      },
-    }
-
-    const mockErrorLogs = {
-      'my-function': {
-        totalErrors: 3,
-        errorGroups: [
-          {
-            pattern: 'Error: Connection timed out',
-            count: 2,
-            sample: 'Error: Connection timed out after 5000ms',
-            timestamps: ['2023-01-01T02:00:00Z', '2023-01-01T01:30:00Z'],
-          },
-          {
-            pattern: 'TypeError: Cannot read property of undefined',
-            count: 1,
-            sample: "TypeError: Cannot read property 'id' of undefined",
-            timestamps: ['2023-01-01T01:00:00Z'],
-          },
-        ],
-      },
-    }
-
-    mockGetLambdaFunctionDetails.mockResolvedValue(mockFunctionDetails)
-    mockGetErrorLogs.mockResolvedValue(mockErrorLogs)
+        {
+          pattern: "TypeError: Cannot read property 'id' of undefined",
+          count: 1,
+          examples: ["TypeError: Cannot read property 'id' of undefined"],
+          patternId: '00998877665544ee33dd22cc11bbaa00',
+          severityLabel: 'ERROR',
+        },
+      ],
+    })
 
     const result = await getLambdaInfo({
       functionNames: ['my-function'],
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result).toBeDefined()
 
     const parsedJson = JSON.parse(result.content[0].text)
     expect(parsedJson[0].functionName).toBe('my-function')
-    expect(parsedJson[0].errorLogs).toBeDefined()
-    expect(parsedJson[0].errorLogs.totalErrors).toBe(3)
-    expect(parsedJson[0].errorLogs.errorGroups).toHaveLength(2)
-    expect(parsedJson[0].errorLogs.errorGroups[0].count).toBe(2)
 
-    // Verify that the error logs were fetched with the correct parameters
-    expect(mockGetErrorLogs).toHaveBeenCalledWith({
+    // Error logs are produced by the CloudWatch Logs Insights pattern analysis
+    // (src/lib/aws/errors-info-patterns.js), not by a per-function log fetch.
+    const errorLogs = parsedJson[0].errorLogs
+    expect(errorLogs.patterns).toHaveLength(2)
+    expect(errorLogs.patterns[0].count).toBe(2)
+    expect(errorLogs.patterns[0].pattern).toBe(
+      'Error: Connection timed out after <*>ms',
+    )
+    expect(errorLogs.summary.totalErrors).toBe(3)
+    expect(errorLogs.summary.uniqueErrorGroups).toBe(2)
+    expect(errorLogs.summary.logGroups).toEqual(['/aws/lambda/my-function'])
+    expect(errorLogs.timeframeLimited).toBe(false)
+    expect(errorLogs.agentNote).toBeUndefined()
+
+    // The default log group of the function is validated and then queried over
+    // the requested window. maxResults (100) is over-fetched 3x for grouping.
+    expect(mockDescribeLogGroups).toHaveBeenCalledWith({
+      logGroupNamePrefix: '/aws/lambda/my-function',
+      limit: 1,
+    })
+    expect(mockExecutePatternAnalyticsQuery).toHaveBeenCalledWith({
+      logGroupIdentifiers: ['/aws/lambda/my-function'],
+      startTime: new Date(START_TIME_MS),
+      endTime: new Date(END_TIME_MS),
+      limit: 300,
+    })
+  })
+
+  test('should use the log group from the function LoggingConfig when configured', async () => {
+    mockGetLambdaFunctionDetails.mockResolvedValue({
+      status: 'success',
+      function: {
+        Configuration: {
+          FunctionName: 'my-function',
+          Runtime: 'nodejs18.x',
+          LoggingConfig: {
+            LogGroup: '/custom/log/group',
+          },
+        },
+      },
+    })
+    mockGetMetricData.mockResolvedValue({})
+
+    await getLambdaInfo({
       functionNames: ['my-function'],
-      startTime: expect.any(Number),
-      endTime: expect.any(Number),
-      limit: 100,
+      startTime: START_TIME,
+      endTime: END_TIME,
+    })
+
+    expect(mockDescribeLogGroups).toHaveBeenCalledWith({
+      logGroupNamePrefix: '/custom/log/group',
+      limit: 1,
+    })
+    expect(
+      mockExecutePatternAnalyticsQuery.mock.calls[0][0].logGroupIdentifiers,
+    ).toEqual(['/custom/log/group'])
+  })
+
+  test('should limit error log analysis to the last 7 days of a longer window', async () => {
+    const longStartTime = '2023-01-01T00:00:00Z'
+    const longEndTime = '2023-01-31T00:00:00Z'
+
+    mockGetLambdaFunctionDetails.mockResolvedValue(successfulFunctionDetails())
+    mockGetMetricData.mockResolvedValue({})
+
+    const result = await getLambdaInfo({
+      functionNames: ['my-function'],
+      startTime: longStartTime,
+      endTime: longEndTime,
+    })
+
+    const errorLogs = JSON.parse(result.content[0].text)[0].errorLogs
+    expect(errorLogs.timeframeLimited).toBe(true)
+    expect(errorLogs.agentNote).toContain(
+      'limited to the last 7 days (ending at 2023-01-31T00:00:00.000Z)',
+    )
+
+    // Metrics still cover the full window, only the pattern query is shortened
+    expect(mockGetMetricData.mock.calls[0][0].startTime).toBe(
+      Date.parse(longStartTime),
+    )
+    expect(mockExecutePatternAnalyticsQuery).toHaveBeenCalledWith({
+      logGroupIdentifiers: ['/aws/lambda/my-function'],
+      startTime: new Date(Date.parse(longEndTime) - SEVEN_DAYS_MS),
+      endTime: new Date(Date.parse(longEndTime)),
+      limit: 300,
     })
   })
 
   test('should handle errors when fetching error logs', async () => {
-    const mockFunctionDetails = {
-      status: 'success',
-      function: {
-        Configuration: {
-          FunctionName: 'my-function',
-          Runtime: 'nodejs18.x',
-        },
-      },
-    }
-
-    mockGetLambdaFunctionDetails.mockResolvedValue(mockFunctionDetails)
-    mockGetErrorLogs.mockRejectedValue(new Error('Log group not found'))
+    mockGetLambdaFunctionDetails.mockResolvedValue(successfulFunctionDetails())
+    mockGetMetricData.mockResolvedValue({})
+    mockExecutePatternAnalyticsQuery.mockRejectedValue(
+      new Error('Log group not found'),
+    )
 
     const result = await getLambdaInfo({
       functionNames: ['my-function'],
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result).toBeDefined()
 
     const parsedJson = JSON.parse(result.content[0].text)
     expect(parsedJson[0].functionName).toBe('my-function')
-    expect(parsedJson[0].errorLogs).toBeDefined()
-    expect(parsedJson[0].errorLogs.error).toBe('Log group not found')
 
-    expect(mockGetErrorLogs).toHaveBeenCalled()
+    // getErrorsInfoWithPatterns handles the failure itself and reports it in the
+    // summary, so the Lambda tool returns an empty pattern list. NOTE: the
+    // underlying error message is not propagated to errorLogs today - see
+    // .reports/cluster-logs.md.
+    const errorLogs = parsedJson[0].errorLogs
+    expect(errorLogs.patterns).toEqual([])
+    expect(errorLogs.summary.totalErrors).toBe(0)
+    expect(errorLogs.summary.nextSteps).toBe(
+      'Error occurred. No pattern analysis available.',
+    )
   })
 
   test('should use default time range when not specified', async () => {
-    const mockFunctionDetails = {
-      status: 'success',
-      function: {
-        Configuration: {
-          FunctionName: 'my-function',
-          Runtime: 'nodejs18.x',
-        },
-      },
-    }
-
     const mockMetrics = {
       'my-function': {
         Invocations: {
@@ -465,23 +532,8 @@ describe('AWS Lambda Info Tool', () => {
       },
     }
 
-    const mockErrorLogs = {
-      'my-function': {
-        totalErrors: 1,
-        errorGroups: [
-          {
-            pattern: 'Error: Connection timed out',
-            count: 1,
-            sample: 'Error: Connection timed out after 5000ms',
-            timestamps: ['2023-01-01T00:00:00Z'],
-          },
-        ],
-      },
-    }
-
-    mockGetLambdaFunctionDetails.mockResolvedValue(mockFunctionDetails)
+    mockGetLambdaFunctionDetails.mockResolvedValue(successfulFunctionDetails())
     mockGetMetricData.mockResolvedValue(mockMetrics)
-    mockGetErrorLogs.mockResolvedValue(mockErrorLogs)
 
     const result = await getLambdaInfo({
       functionNames: ['my-function'],
@@ -491,22 +543,21 @@ describe('AWS Lambda Info Tool', () => {
 
     const parsedJson = JSON.parse(result.content[0].text)
     expect(parsedJson[0].functionName).toBe('my-function')
-    expect(parsedJson[0].metrics).toBeDefined()
+    expect(parsedJson[0].metrics).toEqual(mockMetrics['my-function'])
     expect(parsedJson[0].errorLogs).toBeDefined()
 
-    // Verify that the default time range was used (24 hours)
+    // With no timestamps, getLambdaResourceInfo falls back to "the last 24
+    // hours". The period is NOT the documented 3600 default: with both bounds
+    // undefined, validateTimeParameters
+    // (src/lib/parameter-validator.js:85-86) leaves them undefined and
+    // calculateOptimalPeriod falls through to its widest bucket (1209600 = 2
+    // weeks). Unreachable through the aws-lambda-info tool, whose schema always
+    // supplies startTime, endTime and period - see .reports/cluster-logs.md.
     expect(mockGetMetricData).toHaveBeenCalledWith({
       functionNames: ['my-function'],
       startTime: expect.any(Number),
       endTime: expect.any(Number),
-      period: 3600,
-    })
-
-    expect(mockGetErrorLogs).toHaveBeenCalledWith({
-      functionNames: ['my-function'],
-      startTime: expect.any(Number),
-      endTime: expect.any(Number),
-      limit: 100,
+      period: 1209600,
     })
 
     // Verify the time range is approximately 24 hours
@@ -518,5 +569,13 @@ describe('AWS Lambda Info Tool', () => {
     // Allow for a small margin of error in the test due to execution time
     expect(timeDiff).toBeGreaterThanOrEqual(oneDayInMs - 1000)
     expect(timeDiff).toBeLessThanOrEqual(oneDayInMs + 1000)
+
+    // The error log analysis uses the same default window
+    expect(mockExecutePatternAnalyticsQuery).toHaveBeenCalledWith({
+      logGroupIdentifiers: ['/aws/lambda/my-function'],
+      startTime: expect.any(Date),
+      endTime: expect.any(Date),
+      limit: 300,
+    })
   })
 })

--- a/packages/mcp/tests/aws/rest-api-gateway-info.test.js
+++ b/packages/mcp/tests/aws/rest-api-gateway-info.test.js
@@ -118,10 +118,13 @@ describe('REST API Gateway Info Tool', () => {
       },
     })
 
+    const startTime = '2023-01-01T00:00:00Z'
+    const endTime = '2023-01-01T03:00:00Z'
+
     const result = await getRestApiGatewayInfo({
       apiIds: [apiId],
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime,
+      endTime,
     })
 
     expect(result.isError).toBeUndefined()
@@ -134,14 +137,22 @@ describe('REST API Gateway Info Tool', () => {
     expect(jsonContent[0]).toHaveProperty('resourceId', apiId)
     expect(jsonContent[0]).toHaveProperty('type', 'restapigateway')
 
-    // Verify the resource info function was called with the correct parameters
-    expect(mockGetRestApiGatewayResourceInfo).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceId: apiId,
-        startTime: '2023-01-01T00:00:00Z',
-        endTime: '2023-01-01T03:00:00Z',
-      }),
-    )
+    // Verify the resource info function was called with the correct
+    // parameters. The tool normalizes the time range through
+    // validateAndAdjustParameters before delegating, so the resource-info
+    // layer receives epoch milliseconds plus a derived CloudWatch period,
+    // not the raw ISO strings.
+    expect(mockGetRestApiGatewayResourceInfo).toHaveBeenCalledWith({
+      resourceId: apiId,
+      startTime: Date.parse(startTime),
+      endTime: Date.parse(endTime),
+      // No period was requested: the 3-hour window at the default 3600s
+      // granularity yields 3 data points, far below the 300-point cap, so
+      // calculateOptimalPeriod keeps the 1-hour default.
+      period: 3600,
+      region: undefined,
+      profile: undefined,
+    })
   })
 
   test('should handle errors for individual APIs', async () => {

--- a/packages/mcp/tests/aws/rest-api-gateway-resource-info.test.js
+++ b/packages/mcp/tests/aws/rest-api-gateway-resource-info.test.js
@@ -252,8 +252,12 @@ describe('REST API Gateway Resource Info', () => {
     })
   })
 
-  test('should get list of all APIs when resourceId is not provided', async () => {
-    // Mock REST API Gateway client to return a list of APIs
+  test('should return an error when resourceId is not provided', async () => {
+    // An API ID is required: getRestApiGatewayResourceInfo short-circuits on a
+    // missing resourceId, matching its callers (the aws-rest-api-gateway-info
+    // tool requires at least one API ID in its schema and guards on an empty
+    // array). Listing every API is therefore not part of the contract, and no
+    // REST API Gateway request is issued.
     mockGetRestApis.mockResolvedValue([
       {
         id: 'api1',
@@ -261,40 +265,31 @@ describe('REST API Gateway Resource Info', () => {
         description: 'First test API',
         createdDate: new Date('2023-01-01T00:00:00Z'),
       },
-      {
-        id: 'api2',
-        name: 'API 2',
-        description: 'Second test API',
-        createdDate: new Date('2023-01-02T00:00:00Z'),
-      },
     ])
 
     const result = await getRestApiGatewayResourceInfo({})
 
-    // Verify the result contains a list of APIs
     expect(result).toEqual({
-      resourceId: 'all',
+      resourceId: undefined,
       type: 'restapigateway',
-      apis: expect.arrayContaining([
-        expect.objectContaining({
-          id: 'api1',
-          name: 'API 1',
-        }),
-        expect.objectContaining({
-          id: 'api2',
-          name: 'API 2',
-        }),
-      ]),
+      status: 'error',
+      error: 'Please provide a REST API Gateway API ID',
     })
 
-    // Verify REST API Gateway client calls
-    expect(mockGetRestApis).toHaveBeenCalled()
+    expect(mockGetRestApis).not.toHaveBeenCalled()
   })
 
   test('should handle errors when fetching REST API Gateway metrics', async () => {
     const apiId = 'abc123'
+    const apiName = 'Test API'
+    const startTime = '2023-01-01T00:00:00Z'
+    const endTime = '2023-01-01T03:00:00Z'
 
-    // Mock API Gateway client responses
+    // Mock API Gateway client responses. getRestApi must be re-stubbed here:
+    // jest.clearAllMocks() clears recorded calls but keeps implementations, so
+    // otherwise the rejection from the "API does not exist" test above leaks in
+    // and the API-not-found branch is taken before any metrics are fetched.
+    mockGetRestApi.mockResolvedValue({ id: apiId, name: apiName })
     mockGetStages.mockResolvedValue([{ stageName: 'dev' }])
     mockGetResources.mockResolvedValue([])
     mockGetDeployments.mockResolvedValue([])
@@ -304,21 +299,37 @@ describe('REST API Gateway Resource Info', () => {
 
     // Mock metrics to throw an error
     mockGetApiGatewayMetricData.mockRejectedValue(
-      new Error('Failed to fetch metrics'),
+      new Error('CloudWatch unavailable'),
     )
 
     const result = await getRestApiGatewayResourceInfo({
       resourceId: apiId,
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime,
+      endTime,
     })
 
-    // Verify the result contains error information for metrics
-    expect(result).toEqual({
+    // A metrics failure is reported inside the result rather than failing the
+    // whole lookup, so the API details are still returned.
+    expect(result).toMatchObject({
       resourceId: apiId,
       type: 'restapigateway',
-      error: expect.stringContaining('API not found'),
-      status: 'error',
+      id: apiId,
+      name: apiName,
+      metrics: {
+        error: 'Failed to fetch metrics: CloudWatch unavailable',
+      },
+    })
+    expect(result.status).toBeUndefined()
+
+    // The metrics request itself is made with the caller's time range: this
+    // layer forwards the values it was given (here, ISO strings) unchanged.
+    expect(mockGetApiGatewayMetricData).toHaveBeenCalledWith({
+      apiNames: [apiName],
+      stageNames: ['dev'],
+      startTime,
+      endTime,
+      // No period was requested, so the resource-info default is used.
+      period: 3600,
     })
   })
 })

--- a/packages/mcp/tests/aws/sqs-info.test.js
+++ b/packages/mcp/tests/aws/sqs-info.test.js
@@ -101,10 +101,13 @@ describe('AWS SQS Info Tool', () => {
       },
     })
 
+    const startTime = '2023-01-01T00:00:00Z'
+    const endTime = '2023-01-01T03:00:00Z'
+
     const result = await getSqsInfo({
       queueNames: [queueUrl],
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime,
+      endTime,
     })
 
     expect(result.isError).toBeUndefined()
@@ -115,13 +118,20 @@ describe('AWS SQS Info Tool', () => {
     expect(resultData[0].attributes).toBeDefined()
     expect(resultData[0].metrics).toBeDefined()
 
-    expect(mockGetSqsResourceInfo).toHaveBeenCalledWith(
-      expect.objectContaining({
-        resourceId: queueUrl,
-        startTime: '2023-01-01T00:00:00Z',
-        endTime: '2023-01-01T03:00:00Z',
-      }),
-    )
+    // The tool normalizes the time range through validateAndAdjustParameters
+    // before delegating, so the resource-info layer receives epoch
+    // milliseconds plus a derived CloudWatch period, not the raw ISO strings.
+    expect(mockGetSqsResourceInfo).toHaveBeenCalledWith({
+      resourceId: queueUrl,
+      startTime: Date.parse(startTime),
+      endTime: Date.parse(endTime),
+      // No period was requested: the 3-hour window at the default 3600s
+      // granularity yields 3 data points, far below the 300-point cap, so
+      // calculateOptimalPeriod keeps the 1-hour default.
+      period: 3600,
+      region: undefined,
+      profile: undefined,
+    })
   })
 
   test('should get queue details for a queue name', async () => {

--- a/packages/mcp/tests/deployment-history.test.js
+++ b/packages/mcp/tests/deployment-history.test.js
@@ -5,7 +5,14 @@
  * to avoid making actual AWS API calls during testing.
  */
 
-import { jest, expect, describe, test, beforeEach } from '@jest/globals'
+import {
+  jest,
+  expect,
+  describe,
+  test,
+  beforeEach,
+  afterEach,
+} from '@jest/globals'
 
 // Create mock functions
 const mockDescribeStackEvents = jest.fn()
@@ -27,11 +34,31 @@ const { getDeploymentHistory } =
   await import('../src/tools/deployment-history.js')
 const { AwsCloudformationService } =
   await import('@serverless/engine/src/lib/aws/cloudformation.js')
+const { formatDate } = await import('../src/utils/date-utils.js')
+
+/**
+ * The tool derives the window start from the end date with
+ * `start.setDate(start.getDate() - 7)`; expectations are derived the same way
+ * from the same input so the assertion holds in any local time zone.
+ */
+const sevenDaysBefore = (end) => {
+  const start = new Date(end)
+  start.setDate(start.getDate() - 7)
+  return start
+}
 
 describe('Deployment History Tool', () => {
+  let consoleErrorSpy
+
   beforeEach(() => {
     // Clear all mocks before each test
     jest.clearAllMocks()
+    // The error path logs through console.error; keep the suite output clean
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
   })
 
   test('should handle successful stack events retrieval', async () => {
@@ -65,11 +92,13 @@ describe('Deployment History Tool', () => {
       totalEvents: mockEvents.length,
     })
 
+    const endDate = '2023-01-03T00:00:00Z'
     const result = await getDeploymentHistory({
       serviceName: 'my-service-dev',
       serviceType: 'serverless-framework',
       region: 'us-east-1',
       profile: 'default',
+      endDate,
     })
 
     // Verify CloudFormation service was initialized with correct config
@@ -78,20 +107,98 @@ describe('Deployment History Tool', () => {
       profile: 'default',
     })
 
-    // Verify result structure
+    // Verify result structure: a single text entry carrying the JSON payload
     expect(result).toHaveProperty('content')
-    expect(result.content).toHaveLength(2)
+    expect(result.content).toHaveLength(1)
     expect(result.content[0].type).toBe('text')
-    expect(result.content[1].type).toBe('text')
+    expect(result.isError).toBeUndefined()
 
     // Parse the JSON string to verify data
-    const jsonData = JSON.parse(result.content[1].text)
+    const jsonData = JSON.parse(result.content[0].text)
     expect(jsonData.service).toBe('my-service-dev')
     expect(jsonData.serviceType).toBe('serverless-framework')
     expect(jsonData.region).toBe('us-east-1')
-    expect(jsonData).toHaveProperty('timeRange')
-    expect(jsonData).toHaveProperty('eventsByDay')
+    expect(jsonData.timeRange).toEqual({
+      start: formatDate(sevenDaysBefore(new Date(endDate))),
+      end: formatDate(new Date(endDate)),
+    })
     expect(jsonData.totalEvents).toBe(2)
+    // Events are grouped by the UTC date part of the formatted timestamp
+    expect(jsonData.eventsByDay).toEqual({
+      '2023-01-02': [
+        {
+          timestamp: '2023-01-02 10:00:00',
+          logicalId: 'MyLambdaFunction',
+          resourceType: 'AWS::Lambda::Function',
+          status: 'CREATE_COMPLETE',
+          statusReason: null,
+          physicalId: 'my-lambda-function',
+        },
+      ],
+      '2023-01-01': [
+        {
+          timestamp: '2023-01-01 09:00:00',
+          logicalId: 'MyS3Bucket',
+          resourceType: 'AWS::S3::Bucket',
+          status: 'UPDATE_COMPLETE',
+          statusReason: 'Resource update initiated',
+          physicalId: 'my-bucket',
+        },
+      ],
+    })
+  })
+
+  test('should default region and omit AWS config when region and profile are not given', async () => {
+    mockDescribeStackEvents.mockResolvedValue({ events: [] })
+
+    const result = await getDeploymentHistory({
+      serviceName: 'my-stack',
+      serviceType: 'cloudformation',
+    })
+
+    expect(AwsCloudformationService).toHaveBeenCalledWith({})
+
+    const jsonData = JSON.parse(result.content[0].text)
+    expect(jsonData.region).toBe('default')
+    expect(jsonData.eventsByDay).toEqual({})
+    expect(jsonData.totalEvents).toBe(0)
+  })
+
+  test('should tolerate a response without an events array', async () => {
+    mockDescribeStackEvents.mockResolvedValue(undefined)
+
+    const result = await getDeploymentHistory({
+      serviceName: 'my-stack',
+      serviceType: 'cloudformation',
+    })
+
+    expect(result.isError).toBeUndefined()
+    const jsonData = JSON.parse(result.content[0].text)
+    expect(jsonData.totalEvents).toBe(0)
+    expect(jsonData.eventsByDay).toEqual({})
+  })
+
+  test('should fall back to placeholders for incomplete events', async () => {
+    mockDescribeStackEvents.mockResolvedValue({
+      events: [{ Timestamp: new Date('2023-01-02T10:00:00Z') }],
+    })
+
+    const result = await getDeploymentHistory({
+      serviceName: 'my-stack',
+      serviceType: 'cloudformation',
+    })
+
+    const jsonData = JSON.parse(result.content[0].text)
+    expect(jsonData.eventsByDay['2023-01-02']).toEqual([
+      {
+        timestamp: '2023-01-02 10:00:00',
+        logicalId: 'Unknown',
+        resourceType: 'Unknown',
+        status: 'Unknown',
+        statusReason: null,
+        physicalId: null,
+      },
+    ])
   })
 
   test('should handle error during stack events retrieval', async () => {
@@ -106,85 +213,103 @@ describe('Deployment History Tool', () => {
       profile: 'default',
     })
 
-    // Verify error handling
+    // Verify error handling: a single text entry plus the isError flag
     expect(result).toHaveProperty('content')
-    expect(result.content).toHaveLength(3)
+    expect(result.content).toHaveLength(1)
     expect(result.content[0].type).toBe('text')
-    expect(result.content[0].text).toContain(
-      'Error retrieving deployment history',
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe(
+      'Error retrieving deployment history: Stack does not exist',
     )
-    expect(result.content[0].text).toContain('Stack does not exist')
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Deployment History Tool Error: Stack does not exist',
+    )
   })
 
-  test('should filter events by date range', async () => {
-    // Create events spanning multiple days
-    const now = new Date()
-    const yesterday = new Date(now)
-    yesterday.setDate(yesterday.getDate() - 1)
-    const twoDaysAgo = new Date(now)
-    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2)
-    const tenDaysAgo = new Date(now)
-    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10)
+  test('should map AWS credential errors to the guidance message', async () => {
+    mockDescribeStackEvents.mockRejectedValue(
+      new Error('ExpiredToken: the security token has expired'),
+    )
 
-    const mockEvents = [
-      {
-        StackId:
-          'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/abc123',
-        Timestamp: now,
-        LogicalResourceId: 'Resource1',
-        ResourceType: 'AWS::Lambda::Function',
-        ResourceStatus: 'UPDATE_COMPLETE',
-        PhysicalResourceId: 'resource-1',
-      },
-      {
-        StackId:
-          'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/abc123',
-        Timestamp: yesterday,
-        LogicalResourceId: 'Resource2',
-        ResourceType: 'AWS::S3::Bucket',
-        ResourceStatus: 'CREATE_COMPLETE',
-        PhysicalResourceId: 'resource-2',
-      },
-      {
-        StackId:
-          'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/abc123',
-        Timestamp: twoDaysAgo,
-        LogicalResourceId: 'Resource3',
-        ResourceType: 'AWS::DynamoDB::Table',
-        ResourceStatus: 'CREATE_COMPLETE',
-        PhysicalResourceId: 'resource-3',
-      },
-      {
-        StackId:
-          'arn:aws:cloudformation:us-east-1:123456789012:stack/my-stack/abc123',
-        Timestamp: tenDaysAgo,
-        LogicalResourceId: 'Resource4',
-        ResourceType: 'AWS::IAM::Role',
-        ResourceStatus: 'CREATE_COMPLETE',
-        PhysicalResourceId: 'resource-4',
-      },
-    ]
-
-    // Set up the mock to return events
-    mockDescribeStackEvents.mockResolvedValue({
-      events: mockEvents,
-      totalEvents: mockEvents.length,
+    const result = await getDeploymentHistory({
+      serviceName: 'my-service-dev',
+      serviceType: 'serverless-framework',
+      profile: 'my-profile',
     })
 
-    // Set endDate to 3 days ago, which should include only the first 3 events
-    const threeWeeksAgo = new Date(now)
-    threeWeeksAgo.setDate(threeWeeksAgo.getDate() - 3)
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toContain(
+      'This is an AWS credentials error.',
+    )
+    expect(result.content[0].text).toContain('Your credentials have expired.')
+    expect(result.content[0].text).toContain("Profile used: 'my-profile'.")
+  })
+
+  test('should query the seven days preceding the requested end date', async () => {
+    mockDescribeStackEvents.mockResolvedValue({ events: [] })
+
+    const endDate = '2023-01-10T12:00:00Z'
+    const result = await getDeploymentHistory({
+      serviceName: 'my-service-dev',
+      serviceType: 'serverless-framework',
+      region: 'us-east-1',
+      profile: 'default',
+      endDate,
+    })
+
+    const expectedEnd = new Date(endDate)
+    const expectedStart = sevenDaysBefore(expectedEnd)
+
+    // Date filtering is delegated to the CloudFormation service, which is
+    // asked only for completed deployments inside the derived window.
+    expect(mockDescribeStackEvents).toHaveBeenCalledWith({
+      stackName: 'my-service-dev',
+      startDate: expectedStart,
+      endDate: expectedEnd,
+      onlyCompletedDeployments: true,
+    })
+
+    const jsonData = JSON.parse(result.content[0].text)
+    expect(jsonData.timeRange).toEqual({
+      start: formatDate(expectedStart),
+      end: formatDate(expectedEnd),
+    })
+  })
+
+  test('should report every event returned by the service', async () => {
+    // The tool does not re-filter by date: whatever the CloudFormation
+    // service returns for the window is formatted and counted.
+    const timestamps = [
+      new Date('2023-01-09T10:00:00Z'),
+      new Date('2023-01-08T10:00:00Z'),
+      new Date('2023-01-07T10:00:00Z'),
+      new Date('2023-01-07T09:00:00Z'),
+    ]
+    mockDescribeStackEvents.mockResolvedValue({
+      events: timestamps.map((Timestamp, index) => ({
+        Timestamp,
+        LogicalResourceId: `Resource${index + 1}`,
+        ResourceType: 'AWS::Lambda::Function',
+        ResourceStatus: 'UPDATE_COMPLETE',
+        PhysicalResourceId: `resource-${index + 1}`,
+      })),
+    })
 
     const result = await getDeploymentHistory({
       serviceName: 'my-service-dev',
       serviceType: 'serverless-framework',
       region: 'us-east-1',
       profile: 'default',
-      endDate: threeWeeksAgo.toISOString(),
+      endDate: '2023-01-10T12:00:00Z',
     })
 
-    // Parse the JSON string to verify data
-    const jsonData = JSON.parse(result.content[1].text)
-    expect(jsonData.totalEvents).toBe(4) // Should include all events since we're using onlyCompletedDeployments
+    const jsonData = JSON.parse(result.content[0].text)
+    expect(jsonData.totalEvents).toBe(4)
+    expect(Object.keys(jsonData.eventsByDay)).toEqual([
+      '2023-01-09',
+      '2023-01-08',
+      '2023-01-07',
+    ])
+    expect(jsonData.eventsByDay['2023-01-07']).toHaveLength(2)
   })
 })

--- a/packages/mcp/tests/deployment-history.test.js
+++ b/packages/mcp/tests/deployment-history.test.js
@@ -278,12 +278,15 @@ describe('Deployment History Tool', () => {
 
   test('should report every event returned by the service', async () => {
     // The tool does not re-filter by date: whatever the CloudFormation
-    // service returns for the window is formatted and counted.
+    // service returns for the window is formatted and counted, including the
+    // last event, which lies before the derived seven-day window start
+    // (2023-01-03T12:00:00Z).
     const timestamps = [
       new Date('2023-01-09T10:00:00Z'),
       new Date('2023-01-08T10:00:00Z'),
       new Date('2023-01-07T10:00:00Z'),
       new Date('2023-01-07T09:00:00Z'),
+      new Date('2023-01-02T10:00:00Z'),
     ]
     mockDescribeStackEvents.mockResolvedValue({
       events: timestamps.map((Timestamp, index) => ({
@@ -304,12 +307,14 @@ describe('Deployment History Tool', () => {
     })
 
     const jsonData = JSON.parse(result.content[0].text)
-    expect(jsonData.totalEvents).toBe(4)
+    expect(jsonData.totalEvents).toBe(5)
     expect(Object.keys(jsonData.eventsByDay)).toEqual([
       '2023-01-09',
       '2023-01-08',
       '2023-01-07',
+      '2023-01-02',
     ])
     expect(jsonData.eventsByDay['2023-01-07']).toHaveLength(2)
+    expect(jsonData.eventsByDay['2023-01-02']).toHaveLength(1)
   })
 })

--- a/packages/mcp/tests/docs-resolve.test.js
+++ b/packages/mcp/tests/docs-resolve.test.js
@@ -1,0 +1,135 @@
+import { describe, test, expect, beforeAll, afterAll } from '@jest/globals'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { resolveDocPath } from '../src/tools/docs.js'
+
+// Exercises resolveDocPath against a real directory tree with real links.
+// The mocked suite in docs.test.js proves the tool wires the helper in; this
+// one proves the helper's containment property holds on the actual filesystem.
+//
+// Layout under a fresh temp directory:
+//   root/
+//     outside/secret.txt
+//     real-docs/            ← the real base
+//       guide.md
+//       alias.md            → guide.md            (link inside the base)
+//       leak.md             → ../outside/secret.txt (file link escaping)
+//       leak-dir            → ../outside           (directory link escaping)
+//     docs                  → real-docs           (the base reached via a link)
+
+let root
+let realDocs
+let linkedDocs
+let symlinksSupported = true
+
+async function trySymlink(target, linkPath, type) {
+  try {
+    await fs.symlink(target, linkPath, type)
+    return true
+  } catch (error) {
+    // Windows without Developer Mode refuses symlink creation with EPERM.
+    if (error.code === 'EPERM') {
+      console.warn(`Skipping symlink cases: ${error.message}`)
+      return false
+    }
+    throw error
+  }
+}
+
+beforeAll(async () => {
+  // Deliberately NOT realpath'd: on macOS os.tmpdir() is /var/... while the
+  // real path is /private/var/..., so passing the unresolved base exercises
+  // the requirement that the base itself is resolved before comparison.
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'sf-mcp-docs-resolve-'))
+  realDocs = path.join(root, 'real-docs')
+  linkedDocs = path.join(root, 'docs')
+  const outside = path.join(root, 'outside')
+
+  await fs.mkdir(realDocs)
+  await fs.mkdir(outside)
+  await fs.writeFile(path.join(realDocs, 'guide.md'), '# Guide\n')
+  await fs.writeFile(path.join(outside, 'secret.txt'), 'SECRET\n')
+
+  symlinksSupported =
+    (await trySymlink('guide.md', path.join(realDocs, 'alias.md'), 'file')) &&
+    (await trySymlink(
+      path.join('..', 'outside', 'secret.txt'),
+      path.join(realDocs, 'leak.md'),
+      'file',
+    )) &&
+    (await trySymlink(
+      path.join('..', 'outside'),
+      path.join(realDocs, 'leak-dir'),
+      'dir',
+    )) &&
+    (await trySymlink('real-docs', linkedDocs, 'dir'))
+})
+
+afterAll(async () => {
+  if (root) await fs.rm(root, { recursive: true, force: true })
+})
+
+describe('resolveDocPath on a real filesystem', () => {
+  test('serves a plain file inside the base', async () => {
+    const result = await resolveDocPath(realDocs, 'guide.md')
+    expect(result).toMatchObject({ isWithinBase: true, exists: true })
+    expect(result.resolvedPath).toBe(
+      await fs.realpath(path.join(realDocs, 'guide.md')),
+    )
+  })
+
+  test('reports a missing path as not existing but within the base', async () => {
+    const result = await resolveDocPath(realDocs, 'missing.md')
+    expect(result).toMatchObject({ isWithinBase: true, exists: false })
+  })
+
+  test('reports a file used as a directory as not existing', async () => {
+    const result = await resolveDocPath(realDocs, 'guide.md/nested.md')
+    expect(result).toMatchObject({ isWithinBase: true, exists: false })
+  })
+
+  test('rejects lexical escapes without touching the filesystem', async () => {
+    const result = await resolveDocPath(realDocs, '../outside/secret.txt')
+    expect(result).toMatchObject({ isWithinBase: false, exists: false })
+  })
+
+  test('rejects a file link whose target leaves the base', async () => {
+    if (!symlinksSupported) return
+    const result = await resolveDocPath(realDocs, 'leak.md')
+    expect(result).toMatchObject({ isWithinBase: false, exists: true })
+  })
+
+  test('rejects a directory link whose target leaves the base', async () => {
+    if (!symlinksSupported) return
+    const result = await resolveDocPath(realDocs, 'leak-dir')
+    expect(result).toMatchObject({ isWithinBase: false, exists: true })
+    const nested = await resolveDocPath(realDocs, 'leak-dir/secret.txt')
+    expect(nested).toMatchObject({ isWithinBase: false, exists: true })
+  })
+
+  test('allows a link whose target stays inside the base', async () => {
+    if (!symlinksSupported) return
+    const result = await resolveDocPath(realDocs, 'alias.md')
+    expect(result).toMatchObject({ isWithinBase: true, exists: true })
+    expect(result.resolvedPath).toBe(
+      await fs.realpath(path.join(realDocs, 'guide.md')),
+    )
+  })
+
+  test('allows a plain file when the base itself is reached through a link', async () => {
+    if (!symlinksSupported) return
+    const result = await resolveDocPath(linkedDocs, 'guide.md')
+    expect(result).toMatchObject({ isWithinBase: true, exists: true })
+    expect(result.resolvedPath).toBe(
+      await fs.realpath(path.join(realDocs, 'guide.md')),
+    )
+  })
+
+  test('still rejects an escaping link when the base is reached through a link', async () => {
+    if (!symlinksSupported) return
+    const result = await resolveDocPath(linkedDocs, 'leak.md')
+    expect(result).toMatchObject({ isWithinBase: false, exists: true })
+  })
+})

--- a/packages/mcp/tests/docs.test.js
+++ b/packages/mcp/tests/docs.test.js
@@ -1,23 +1,35 @@
 import { jest, describe, test, expect, beforeEach } from '@jest/globals'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const mockReaddir = jest.fn()
 const mockStat = jest.fn()
 const mockReadFile = jest.fn()
+const mockRealpath = jest.fn()
 
 await jest.unstable_mockModule('node:fs/promises', () => {
-  return {
+  const fsMock = {
     readdir: mockReaddir,
     stat: mockStat,
     readFile: mockReadFile,
+    realpath: mockRealpath,
   }
+  return { ...fsMock, default: fsMock }
 })
 
 const { getDocs } = await import('../src/tools/docs.js')
+
+// Same resolution the tool performs via fromRepoRoot('docs/sf'): this file
+// lives in packages/mcp/tests, three levels below the repo root.
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const docsBase = path.resolve(__dirname, '../../..', 'docs/sf')
 
 describe('Docs Tool', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockReaddir.mockResolvedValue([])
+    // Default: every path is already real.
+    mockRealpath.mockImplementation(async (p) => p)
   })
 
   test('should reject path traversal attempts', async () => {
@@ -31,5 +43,75 @@ describe('Docs Tool', () => {
       'Invalid path: sf/../../etc/passwd',
     )
     expect(mockStat).not.toHaveBeenCalled()
+    expect(mockRealpath).not.toHaveBeenCalled()
+  })
+
+  test('should reject a link whose target resolves outside the docs directory', async () => {
+    const requested = path.resolve(docsBase, 'leak.md')
+    const outside = path.resolve(docsBase, '..', '..', 'outside', 'secret.txt')
+    mockRealpath.mockImplementation(async (p) =>
+      p === requested ? outside : p,
+    )
+    mockStat.mockResolvedValue({ isDirectory: () => false })
+    mockReadFile.mockResolvedValue('SECRET')
+
+    const result = await getDocs({ product: 'sf', paths: ['leak.md'] })
+
+    expect(result.isError).toBe(false)
+    expect(result.content[0].text).toContain('Invalid path: sf/leak.md')
+    expect(result.content[0].text).not.toContain('SECRET')
+    expect(mockReadFile).not.toHaveBeenCalled()
+  })
+
+  test('should serve a file when the docs directory itself sits behind a link', async () => {
+    const realBase = path.resolve(docsBase, '..', '..', 'real-docs-location')
+    const requested = path.resolve(docsBase, 'guide.md')
+    const realRequested = path.resolve(realBase, 'guide.md')
+    mockRealpath.mockImplementation(async (p) => {
+      if (p === docsBase) return realBase
+      if (p === requested) return realRequested
+      return p
+    })
+    mockStat.mockResolvedValue({ isDirectory: () => false })
+    mockReadFile.mockResolvedValue('# Guide')
+
+    const result = await getDocs({ product: 'sf', paths: ['guide.md'] })
+
+    expect(result.isError).toBe(false)
+    expect(result.content[0].text).toContain('# Guide')
+    expect(mockStat).toHaveBeenCalledWith(realRequested)
+    expect(mockReadFile).toHaveBeenCalledWith(realRequested, 'utf-8')
+  })
+
+  test('should report other filesystem errors as not found, without the raw message', async () => {
+    const requested = path.resolve(docsBase, 'loop.md')
+    mockRealpath.mockImplementation(async (p) => {
+      if (p !== requested) return p
+      const error = new Error(`ELOOP: too many symbolic links, realpath '${p}'`)
+      error.code = 'ELOOP'
+      throw error
+    })
+
+    const result = await getDocs({ product: 'sf', paths: ['loop.md'] })
+
+    expect(result.isError).toBe(false)
+    expect(result.content[0].text).toContain('Path "sf/loop.md" not found.')
+    expect(result.content[0].text).not.toContain('ELOOP')
+    expect(mockReadFile).not.toHaveBeenCalled()
+  })
+
+  test('should fall back to suggestions when the path does not exist', async () => {
+    mockRealpath.mockImplementation(async (p) => {
+      if (p === docsBase) return p
+      const error = new Error(`ENOENT: no such file or directory, ${p}`)
+      error.code = 'ENOENT'
+      throw error
+    })
+
+    const result = await getDocs({ product: 'sf', paths: ['missing.md'] })
+
+    expect(result.isError).toBe(false)
+    expect(result.content[0].text).toContain('Path "sf/missing.md" not found.')
+    expect(mockReadFile).not.toHaveBeenCalled()
   })
 })

--- a/packages/mcp/tests/service-summary.test.js
+++ b/packages/mcp/tests/service-summary.test.js
@@ -7,6 +7,8 @@ const mockGetSqsResourceInfo = jest.fn()
 const mockGetS3ResourceInfo = jest.fn()
 const mockGetRestApiGatewayResourceInfo = jest.fn()
 const mockGetDynamoDBResourceInfo = jest.fn()
+const mockGetHttpApiGatewayResourceInfo = jest.fn()
+const mockDescribeStackResources = jest.fn()
 
 // Then mock the aws resource-info module
 jest.unstable_mockModule('../src/lib/aws/resource-info.js', () => {
@@ -20,8 +22,39 @@ jest.unstable_mockModule('../src/lib/aws/resource-info.js', () => {
   }
 })
 
+jest.unstable_mockModule(
+  '../src/lib/aws/http-api-gateway-resource-info.js',
+  () => {
+    return {
+      getHttpApiGatewayResourceInfo: mockGetHttpApiGatewayResourceInfo,
+    }
+  },
+)
+
+jest.unstable_mockModule(
+  '@serverless/engine/src/lib/aws/cloudformation.js',
+  () => {
+    return {
+      AwsCloudformationService: jest.fn(() => ({
+        describeStackResources: mockDescribeStackResources,
+      })),
+    }
+  },
+)
+
 // Import the module under test
 const { getServiceSummary } = await import('../src/tools/service-summary.js')
+const { AwsCloudformationService } =
+  await import('@serverless/engine/src/lib/aws/cloudformation.js')
+
+// Time bounds used by the tests. Expectations are derived from these same
+// inputs via Date.parse, because getServiceSummary forwards the parsed
+// millisecond values (validateAndAdjustParameters -> parseTimestamp) to the
+// per-resource handlers.
+const START_TIME = '2023-01-01T00:00:00Z'
+const END_TIME = '2023-01-01T03:00:00Z'
+const START_TIME_MS = Date.parse(START_TIME)
+const END_TIME_MS = Date.parse(END_TIME)
 
 describe('getServiceSummary', () => {
   beforeEach(() => {
@@ -29,32 +62,76 @@ describe('getServiceSummary', () => {
     jest.clearAllMocks()
   })
 
-  it('should validate input and return error for missing service type', async () => {
+  it('should validate input and return error for missing cloudProvider', async () => {
     const result = await getServiceSummary({
       resources: [{ id: 'test', type: 'lambda' }],
     })
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toContain('Please provide a service type')
+    expect(result.content).toHaveLength(1)
+    expect(result.content[0].type).toBe('text')
+    expect(result.content[0].text).toBe(
+      'Error: Please provide a cloud provider.',
+    )
+  })
+
+  // The registered tool contract (src/tools-definition.js) declares
+  // `serviceType` as the required provider enum and `cloudProvider` as
+  // optional, while the implementation reads only `cloudProvider`. This test
+  // pins what a schema-conformant call actually gets today; it is expected to
+  // change when that divergence is resolved.
+  it('should still require cloudProvider when only the registered serviceType is provided', async () => {
+    const result = await getServiceSummary({
+      serviceType: 'aws',
+      resources: [{ id: 'test', type: 'lambda' }],
+    })
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe(
+      'Error: Please provide a cloud provider.',
+    )
+    expect(mockGetLambdaResourceInfo).not.toHaveBeenCalled()
   })
 
   it('should validate input and return error for empty resources array', async () => {
     const result = await getServiceSummary({
-      serviceType: 'aws',
+      cloudProvider: 'aws',
       resources: [],
     })
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toContain(
-      'Please provide at least one resource',
+    expect(result.content[0].text).toBe(
+      'Error: Please provide at least one resource to get information about.',
     )
   })
 
-  it('should validate input and return error for unsupported service type', async () => {
+  it('should validate input and return error for omitted resources', async () => {
+    const result = await getServiceSummary({ cloudProvider: 'aws' })
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe(
+      'Error: Please provide at least one resource to get information about.',
+    )
+  })
+
+  it('should validate input and return error for unsupported cloud provider', async () => {
     const result = await getServiceSummary({
-      serviceType: 'unsupported',
+      cloudProvider: 'unsupported',
       resources: [{ id: 'test', type: 'lambda' }],
     })
     expect(result.isError).toBe(true)
-    expect(result.content[0].text).toContain('Unsupported service type')
+    expect(result.content[0].text).toBe(
+      'Error: Unsupported cloud provider: unsupported. Supported providers: aws, gcp, azure',
+    )
+    expect(mockGetLambdaResourceInfo).not.toHaveBeenCalled()
+  })
+
+  it('should require serviceName for serviceWideAnalysis', async () => {
+    const result = await getServiceSummary({
+      cloudProvider: 'aws',
+      serviceWideAnalysis: true,
+    })
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe(
+      'Error: serviceName and cloudProvider are required for serviceWideAnalysis.',
+    )
+    expect(AwsCloudformationService).not.toHaveBeenCalled()
   })
 
   it('should process multiple resources of different types', async () => {
@@ -73,30 +150,25 @@ describe('getServiceSummary', () => {
       type: 'sqs',
       queueUrl: 'https://sqs.region.amazonaws.com/account/queue1',
     })
-    mockGetS3ResourceInfo.mockResolvedValue({
-      resourceId: 'bucket1',
-      type: 's3',
-      bucketName: 'bucket1',
-      location: 'us-east-1',
-    })
-    mockGetRestApiGatewayResourceInfo.mockResolvedValue({
-      resourceId: 'api1',
-      type: 'restapigateway',
-      id: 'api1',
-      name: 'Test API',
-      stages: [{ name: 'dev' }],
-    })
 
     const result = await getServiceSummary({
-      serviceType: 'aws',
+      cloudProvider: 'aws',
       resources: [
         { id: 'lambda1', type: 'lambda' },
         { id: 'role1', type: 'iam' },
         { id: 'queue1', type: 'sqs' },
       ],
+      startTime: START_TIME,
+      endTime: END_TIME,
+      period: 3600,
+      region: 'us-east-1',
+      profile: 'default',
     })
 
     expect(result.isError).toBeUndefined()
+    expect(result.content).toHaveLength(1)
+    expect(result.content[0].type).toBe('text')
+    // Without serviceWideAnalysis the payload is the bare results array
     expect(JSON.parse(result.content[0].text)).toEqual([
       { resourceId: 'lambda1', type: 'lambda', status: 'active' },
       { resourceId: 'role1', type: 'iam', status: 'valid' },
@@ -106,29 +178,65 @@ describe('getServiceSummary', () => {
         queueUrl: 'https://sqs.region.amazonaws.com/account/queue1',
       },
     ])
+
+    const expectedHandlerArgs = {
+      startTime: START_TIME_MS,
+      endTime: END_TIME_MS,
+      period: 3600,
+      region: 'us-east-1',
+      profile: 'default',
+    }
     expect(mockGetLambdaResourceInfo).toHaveBeenCalledWith({
       resourceId: 'lambda1',
-      startTime: undefined,
-      endTime: undefined,
-      period: undefined,
+      ...expectedHandlerArgs,
     })
     expect(mockGetIamResourceInfo).toHaveBeenCalledWith({
       resourceId: 'role1',
-      startTime: undefined,
-      endTime: undefined,
-      period: undefined,
+      ...expectedHandlerArgs,
     })
     expect(mockGetSqsResourceInfo).toHaveBeenCalledWith({
       resourceId: 'queue1',
+      ...expectedHandlerArgs,
+    })
+  })
+
+  it('should forward undefined time bounds and the widest period when no timeframe is given', async () => {
+    mockGetS3ResourceInfo.mockResolvedValue({
+      resourceId: 'bucket1',
+      type: 's3',
+      bucketName: 'bucket1',
+      location: 'us-east-1',
+    })
+
+    const result = await getServiceSummary({
+      cloudProvider: 'aws',
+      resources: [{ id: 'bucket1', type: 's3' }],
+    })
+
+    expect(result.isError).toBeUndefined()
+    expect(JSON.parse(result.content[0].text)).toEqual([
+      {
+        resourceId: 'bucket1',
+        type: 's3',
+        bucketName: 'bucket1',
+        location: 'us-east-1',
+      },
+    ])
+    // With no startTime/endTime, parseTimestamp yields undefined bounds and
+    // calculateOptimalPeriod falls through every bucket to its 2-week default.
+    expect(mockGetS3ResourceInfo).toHaveBeenCalledWith({
+      resourceId: 'bucket1',
       startTime: undefined,
       endTime: undefined,
-      period: undefined,
+      period: 1209600,
+      region: undefined,
+      profile: undefined,
     })
   })
 
   it('should handle resources with missing id or type', async () => {
     const result = await getServiceSummary({
-      serviceType: 'aws',
+      cloudProvider: 'aws',
       resources: [
         { id: 'lambda1' }, // Missing type
         { type: 'lambda' }, // Missing id
@@ -140,6 +248,7 @@ describe('getServiceSummary', () => {
       { error: 'Resource must have both id and type properties' },
       { error: 'Resource must have both id and type properties' },
     ])
+    expect(mockGetLambdaResourceInfo).not.toHaveBeenCalled()
   })
 
   it('should handle DynamoDB resources', async () => {
@@ -178,10 +287,10 @@ describe('getServiceSummary', () => {
     })
 
     const result = await getServiceSummary({
-      serviceType: 'aws',
+      cloudProvider: 'aws',
       resources: [{ id: 'users-table', type: 'dynamodb' }],
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
+      startTime: START_TIME,
+      endTime: END_TIME,
     })
 
     expect(result.isError).toBeUndefined()
@@ -192,11 +301,15 @@ describe('getServiceSummary', () => {
     expect(resultData[0].tableDetails).toBeDefined()
     expect(resultData[0].metrics).toBeDefined()
 
+    // period is omitted by the caller, so calculateOptimalPeriod derives it
+    // from the 3-hour window: max(3600, ceil(10800 / 300)) === 3600.
     expect(mockGetDynamoDBResourceInfo).toHaveBeenCalledWith({
       resourceId: 'users-table',
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-01T03:00:00Z',
-      period: undefined,
+      startTime: START_TIME_MS,
+      endTime: END_TIME_MS,
+      period: 3600,
+      region: undefined,
+      profile: undefined,
     })
   })
 
@@ -213,7 +326,7 @@ describe('getServiceSummary', () => {
     })
 
     const result = await getServiceSummary({
-      serviceType: 'aws',
+      cloudProvider: 'aws',
       resources: [{ id: 'api1', type: 'restapigateway' }],
       startTime: '2023-01-01T00:00:00Z',
       endTime: '2023-01-02T00:00:00Z',
@@ -238,9 +351,11 @@ describe('getServiceSummary', () => {
 
     expect(mockGetRestApiGatewayResourceInfo).toHaveBeenCalledWith({
       resourceId: 'api1',
-      startTime: '2023-01-01T00:00:00Z',
-      endTime: '2023-01-02T00:00:00Z',
+      startTime: Date.parse('2023-01-01T00:00:00Z'),
+      endTime: Date.parse('2023-01-02T00:00:00Z'),
       period: 3600,
+      region: undefined,
+      profile: undefined,
     })
   })
 
@@ -252,7 +367,7 @@ describe('getServiceSummary', () => {
     })
 
     const result = await getServiceSummary({
-      serviceType: 'aws',
+      cloudProvider: 'aws',
       resources: [
         { id: 'queue1', type: 'sqs' },
         { id: 'resource1', type: 'unsupported' },
@@ -268,7 +383,7 @@ describe('getServiceSummary', () => {
     expect(JSON.parse(result.content[0].text)[1]).toEqual({
       id: 'resource1',
       type: 'unsupported',
-      error: 'Unsupported resource type: unsupported for service: aws',
+      error: 'Unsupported resource type: unsupported for cloud provider: aws',
     })
   })
 
@@ -276,7 +391,7 @@ describe('getServiceSummary', () => {
     mockGetLambdaResourceInfo.mockRejectedValue(new Error('Lambda error'))
 
     const result = await getServiceSummary({
-      serviceType: 'aws',
+      cloudProvider: 'aws',
       resources: [{ id: 'lambda1', type: 'lambda' }],
     })
 
@@ -285,6 +400,147 @@ describe('getServiceSummary', () => {
       id: 'lambda1',
       type: 'lambda',
       error: 'Lambda error',
+    })
+  })
+
+  it('should report parameter validation failures as a tool error', async () => {
+    const result = await getServiceSummary({
+      cloudProvider: 'aws',
+      resources: [{ id: 'lambda1', type: 'lambda' }],
+      startTime: START_TIME,
+      endTime: END_TIME,
+      period: 90, // not a multiple of 60
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.content[0].text).toBe(
+      'Error retrieving service summary: Invalid period: 90. Period must be a multiple of 60 seconds.',
+    )
+    expect(mockGetLambdaResourceInfo).not.toHaveBeenCalled()
+  })
+
+  describe('serviceWideAnalysis', () => {
+    it('should map supported stack resources and wrap results in metadata', async () => {
+      mockDescribeStackResources.mockResolvedValue([
+        {
+          ResourceType: 'AWS::Lambda::Function',
+          PhysicalResourceId: 'my-service-dev-hello',
+        },
+        {
+          ResourceType: 'AWS::DynamoDB::Table',
+          PhysicalResourceId: 'users-table',
+        },
+        // Unsupported CloudFormation type: filtered out before any handler runs
+        {
+          ResourceType: 'AWS::Logs::LogGroup',
+          PhysicalResourceId: 'log-group-hello',
+        },
+      ])
+      mockGetLambdaResourceInfo.mockResolvedValue({
+        resourceId: 'my-service-dev-hello',
+        type: 'lambda',
+      })
+      mockGetDynamoDBResourceInfo.mockResolvedValue({
+        resourceId: 'users-table',
+        type: 'dynamodb',
+      })
+
+      const result = await getServiceSummary({
+        cloudProvider: 'aws',
+        serviceWideAnalysis: true,
+        serviceName: 'my-service-dev',
+        region: 'us-east-1',
+        profile: 'default',
+        startTime: START_TIME,
+        endTime: END_TIME,
+        period: 3600,
+      })
+
+      expect(AwsCloudformationService).toHaveBeenCalledWith({
+        region: 'us-east-1',
+        profile: 'default',
+      })
+      expect(mockDescribeStackResources).toHaveBeenCalledWith('my-service-dev')
+
+      expect(result.isError).toBeUndefined()
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        metadata: {
+          serviceWideAnalysis: true,
+          serviceName: 'my-service-dev',
+          cloudProvider: 'aws',
+          resourceCount: 2,
+          resourceTypes: 'lambda, dynamodb',
+          message:
+            'Retrieved information for 2 resources of types: lambda, dynamodb',
+        },
+        resources: [
+          { resourceId: 'my-service-dev-hello', type: 'lambda' },
+          { resourceId: 'users-table', type: 'dynamodb' },
+        ],
+      })
+    })
+
+    it('should return the agent hint when the stack does not exist', async () => {
+      mockDescribeStackResources.mockResolvedValue({
+        error: 'Stack with id my-service-dev does not exist',
+      })
+
+      const result = await getServiceSummary({
+        cloudProvider: 'aws',
+        serviceWideAnalysis: true,
+        serviceName: 'my-service-dev',
+        profile: 'my-profile',
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content).toHaveLength(1)
+      expect(result.content[0].text).toContain(
+        "This is a 'Stack does not exist' error.",
+      )
+      expect(result.content[0].text).toContain(
+        "Stack 'my-service-dev' was not found. Original error: Stack with id my-service-dev does not exist",
+      )
+      expect(result.content[0].text).toContain(
+        "(Current profile: 'my-profile')",
+      )
+      expect(mockGetLambdaResourceInfo).not.toHaveBeenCalled()
+    })
+
+    it('should report no supported resources when the stack has none', async () => {
+      mockDescribeStackResources.mockResolvedValue([
+        {
+          ResourceType: 'AWS::Logs::LogGroup',
+          PhysicalResourceId: 'log-group-hello',
+        },
+      ])
+
+      const result = await getServiceSummary({
+        cloudProvider: 'aws',
+        serviceWideAnalysis: true,
+        serviceName: 'my-service-dev',
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toBe(
+        "No supported resources found for service 'my-service-dev'. Supported resource types: lambda, iam, sqs, s3, restapigateway, httpapigateway, dynamodb.",
+      )
+    })
+
+    it('should surface errors thrown while describing the stack', async () => {
+      mockDescribeStackResources.mockRejectedValue(
+        new Error('network unreachable'),
+      )
+
+      const result = await getServiceSummary({
+        cloudProvider: 'aws',
+        serviceWideAnalysis: true,
+        serviceName: 'my-service-dev',
+      })
+
+      expect(result.isError).toBe(true)
+      expect(result.content[0].text).toBe(
+        "Error retrieving resources for service 'my-service-dev': network unreachable",
+      )
     })
   })
 })

--- a/packages/mcp/tests/service-summary.test.js
+++ b/packages/mcp/tests/service-summary.test.js
@@ -74,12 +74,10 @@ describe('getServiceSummary', () => {
     )
   })
 
-  // The registered tool contract (src/tools-definition.js) declares
-  // `serviceType` as the required provider enum and `cloudProvider` as
-  // optional, while the implementation reads only `cloudProvider`. This test
-  // pins what a schema-conformant call actually gets today; it is expected to
-  // change when that divergence is resolved.
-  it('should still require cloudProvider when only the registered serviceType is provided', async () => {
+  it('should ignore unknown provider fields and still require cloudProvider', async () => {
+    // `serviceType` is not part of this tool's contract (in the other tools it
+    // names the infrastructure kind, not the provider); only cloudProvider
+    // selects the resource handlers, and the guard fires before any of them run.
     const result = await getServiceSummary({
       serviceType: 'aws',
       resources: [{ id: 'test', type: 'lambda' }],

--- a/packages/mcp/tests/tools-definition.test.js
+++ b/packages/mcp/tests/tools-definition.test.js
@@ -1,0 +1,37 @@
+import { jest, describe, test, expect, beforeAll } from '@jest/globals'
+
+import { registerTools } from '../src/tools-definition.js'
+
+// Pins the registered tool contracts that the implementations depend on, so
+// the schema advertised to MCP clients cannot drift from what the tool
+// handlers actually read.
+
+const registered = new Map()
+
+beforeAll(() => {
+  const server = {
+    tool: jest.fn((name, description, shape, handler) => {
+      registered.set(name, { description, shape, handler })
+    }),
+  }
+  registerTools(server)
+})
+
+describe('registered tool contracts', () => {
+  test('service-summary requires cloudProvider and does not declare serviceType', () => {
+    const { shape } = registered.get('service-summary')
+
+    expect(shape.serviceType).toBeUndefined()
+    expect(shape.cloudProvider.safeParse(undefined).success).toBe(false)
+    expect(shape.cloudProvider.safeParse('aws').success).toBe(true)
+    // Only providers with resource handlers are advertised.
+    expect(shape.cloudProvider.safeParse('gcp').success).toBe(false)
+  })
+
+  test('service-summary keeps serviceName optional for per-resource calls', () => {
+    const { shape } = registered.get('service-summary')
+
+    expect(shape.serviceName.safeParse(undefined).success).toBe(true)
+    expect(shape.serviceWideAnalysis.safeParse(undefined).success).toBe(true)
+  })
+})


### PR DESCRIPTION
Obvious bug fix plus test-suite maintenance; no corresponding issue.

## Summary

- The `docs` MCP tool now resolves the real path of the requested document and of the documentation directory before reading, and applies its containment check to the resolved pair. A link inside the documentation tree whose target lies elsewhere on disk is reported as `Invalid path: sf/<path>`, the same way a `..` escape already was. Links whose target stays inside the tree, and a documentation directory that is itself reached through a link, continue to work. Missing paths still produce the nearest-directory suggestions.
- The `packages/mcp` unit suite was not run by any workflow, and most of its suites had drifted from the sources they test. Every suite now asserts the current behavior, the framework CI job runs it next to the sf-core and serverless unit suites, the root `npm test` includes it, and the contributor docs list it.
- The `service-summary` tool's registered schema required a `serviceType` provider enum and marked `cloudProvider` optional, while the tool reads only `cloudProvider`, so a call that followed the schema was always rejected. The schema now declares `cloudProvider` as the single required provider field, matching the implementation and the other tools, where `serviceType` names the infrastructure kind. README and docs updated; a contract test pins the registered shape.
- Found by the rewritten tests: service-wide error analysis skipped every Lambda log group, because `packages/mcp/src/lib/aws/errors-info-patterns.js` read the function configuration from the top level of the engine response where the engine nests it under `function`. It now reads the nested field, matching `lambda-resource-info.js`.

## Root cause

- Docs tool: the path check was lexical only (`path.resolve` + `path.relative`), while the `fs.stat`, `fs.readdir` and `fs.readFile` calls that followed it follow links, so the check did not describe what was actually read.
- Unit suites: sources and tests arrived together in the package-integration commit already out of step (older contracts for metric time ranges, log-group lookups, the `service-summary` parameter name and the `deployment-history` response shape), and one mock lacked the default export the source imports, so the suite never loaded.
- Lambda log groups: the response shape of `getLambdaFunctionDetails` is `{ status, function, policy, eventSourceMappings }`; the guard checked `functionDetails.Configuration`, which is always undefined.

## Test plan

- [x] `npm run test:unit -w @serverless/mcp`: 19 suites, 128 tests passing (7 suites / 62 tests on `main`)
- [x] New `packages/mcp/tests/docs-resolve.test.js` exercises the resolver on a real temporary directory with real links: escaping file link and directory link rejected (including a nested path through the directory link), in-tree alias allowed, base reached through a linked parent allowed, missing path and file-as-directory reported as not found, lexical escape rejected; link cases skip with a logged reason where the runner cannot create links
- [x] `packages/mcp/tests/docs.test.js`: escaping link rejected with no read, base behind a link served, `ENOENT` yields suggestions, other filesystem errors are reported as not found without the raw message, existing `..` case unchanged
- [x] Drove the MCP server from source over stdio with an SDK client and called the `docs` tool against real links placed in `docs/sf`: normal file, in-tree alias, escaping file link, escaping directory link, nested path, `..`, missing path, mixed multi-path request and the tree listing all behave as described
- [x] `npm run lint` and `npm run prettier` clean on all touched files

## Notes

- Behavior changes: the `docs` tool rejects a link whose target lies outside the documentation directory; the `service-summary` tool's advertised input schema names the provider field `cloudProvider` (required) instead of `serviceType`. CLI, configuration schema and output are unchanged.
- Three commits kept on purpose: the docs-tool fix, the suite repair, and the review follow-up; squash-merge as usual.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * The `service-summary` tool now requires `cloudProvider` and currently supports AWS only; the `serviceType` input is no longer available.

* **Bug Fixes**
  * Improved Lambda log-group discovery.
  * Strengthened documentation path security and handling of missing or invalid paths.

* **Tests**
  * Added MCP unit tests to standard test commands and CI.
  * Expanded coverage for AWS tools, documentation paths, deployment history, and service summaries.

* **Documentation**
  * Updated contributor guidance and MCP tool documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->