### PR TITLE
feat(resolvers): fetch each Terraform state once per run across Compose services

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -81,6 +81,7 @@ The integration tests require specific AWS resources, including:
   - Versioning enabled
 - `terraform-s3-resolver-test-bucket`
   - Versioning enabled
+  - Holds the state written by `packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-setup/main.tf` at key `terraform-s3-resolver-test-state/tfstate` (`terraform init && terraform apply` in that directory); the suite expects the outputs `key-1-id` and `key-2-id`
 - `resolvers-integration-test`
   - File: `test.txt`
   - Content: `file content`

--- a/docs/sf/guides/variables/hashicorp/terraform.md
+++ b/docs/sf/guides/variables/hashicorp/terraform.md
@@ -75,9 +75,9 @@ The resolver reads the state file with the AWS credentials from the AWS SDK's de
 
 The `bucket` and `key` properties match the values in the terraform backend configuration in the Terraform configuration file.
 
-## Configuring the `remote` or `cloud` Backend
+## Configuring the `remote` Backend
 
-To use this resolver, you must declare the resolver with `type: terraform` and `backend: remote` under `stages.<stage>.resolvers.<key>` in the `serverless.yml`.
+To use this resolver, you must declare the resolver with `type: terraform` and `backend: remote` under `stages.<stage>.resolvers.<key>` in the `serverless.yml`. A Terraform configuration that uses the `cloud {}` block is read with `backend: remote` as well.
 
 ```yaml
 stages:

--- a/docs/sf/guides/variables/hashicorp/terraform.md
+++ b/docs/sf/guides/variables/hashicorp/terraform.md
@@ -17,17 +17,17 @@ It is a popular use case to use Terraform and Serverless Framework in conjunctio
 
 In this case, it is helpful to access the Terraform State Outputs from within your serverless.yml file so at deployment time it can look up details about the shared infrastructure, like the RDS connection string, or SQS Queue ARN.
 
-The Terraform Variable Resolver supports getting the Terraform State Outputs `s3`, `remote`,`cloud`, or `http` backend.
+The Terraform Variable Resolver supports reading Terraform state outputs from the `s3`, `remote` (including HCP Terraform, formerly Terraform Cloud), and `http` backends.
 
 ## Getting Terraform Outputs from Remote Backends
 
-Terraform supports using a remote backend to store the state of the infrastructure. The state can be stored in a number of support remote backends like AWS S3, Terraform HCP, or HTTP.
+Terraform supports using a remote backend to store the state of the infrastructure. The state can be stored in a number of support remote backends like AWS S3, HCP Terraform, or HTTP.
 
-The Terraform output variable resolver in Serverless Framework V.4 only supports the S3, Remote, and HTTP backends, therefore one of these four options must be used.
+The Terraform output variable resolver in Serverless Framework V.4 only supports the S3, Remote, and HTTP backends, therefore one of these three backends must be used.
 
 In all the examples we'll assume a Terraform configuration that creates a DynamoDB table and outputs the ARN of the table in the `users_table_arn` output.
 
-```
+```hcl
 # Configures the Terraform backend to store state in an S3 bucket
 terraform {
   # cloud {} - compatible with remote backend
@@ -69,9 +69,9 @@ In the `terraform` resolver supports the following configuration if the `backend
 
 - `bucket` - The name of the S3 bucket where the Terraform State Outputs are stored.
 - `key` - The key of the Terraform State Outputs file in the S3 bucket.
-- `region` - (optional) - The region of the S3 bucket where the Terraform State Outputs are stored. This is optional and if not provided the default region will be used.
+- `region` - (optional) - The region of the S3 bucket where the Terraform State Outputs are stored. If not provided, the region comes from the AWS SDK's default settings (the `AWS_REGION` environment variable or the `region` of the active AWS profile). The resolver does not use `provider.region`; if no region can be found, the resolver fails with `Region is missing`.
 
-The resolver uses the current AWS account credentials, the same ones being used for the deployment, so the S3 bucket containing the state must reside in that account. Support for pointing to a secondary AWS account is coming soon.
+The resolver reads the state file with the AWS credentials from the AWS SDK's default credential chain: environment variables, the `AWS_PROFILE` environment variable, or the default profile in `~/.aws`. It does not use `provider.profile`, an `aws` resolver's `profile`, or Serverless Dashboard provider credentials, so the identity that reads the state bucket can differ from the identity that deploys the service. Make sure the default credentials can read the bucket, or export the deployment profile as `AWS_PROFILE` for the run.
 
 The `bucket` and `key` properties match the values in the terraform backend configuration in the Terraform configuration file.
 
@@ -115,13 +115,23 @@ stages:
         backend: http
 ```
 
-In the `terraform` resolver supports the following configuration if the `backend` is `remote`:
+In the `terraform` resolver supports the following configuration if the `backend` is `http`:
 
 - `address` - (optional) The HTTP address of the Terraform http backend where the Terraform State Outputs are stored.
 - `username` - (optional) The username to use to access the Terraform State Outputs.
 - `password` - (optional) The password to use to access the Terraform State Outputs.
 
 While, `address`, `username`, and `password` are optional, you must provide an address either via the `address` configuration or the `TF_HTTP_ADDRESS` environment variable.
+
+## Requests and rate limits
+
+The Framework resolves all variables concurrently before a command runs, and reads each Terraform state once per run: a service that references twenty outputs of the same state reads it once, and services deployed together with Serverless Framework Compose share that read when they run in the same command. This applies to every backend (`s3`, `remote`, `http`).
+
+For the `s3` backend, a request that Amazon S3 throttles is retried with the AWS SDK's standard exponential backoff, up to 10 attempts by default. Run with `--verbose` to see each retry, and with `--debug` to see a summary of the requests made (`terraform: … state files, … GetObject calls`). If the retries are exhausted, the command fails with the `RESOLVER_AWS_RATE_EXCEEDED` error, which names the API, the number of attempts, and how many state files the run referenced. The retry settings follow the same precedence as in every AWS SDK and the AWS CLI: the `AWS_MAX_ATTEMPTS` and `AWS_RETRY_MODE` environment variables, then the `max_attempts` and `retry_mode` keys in `~/.aws/config`; the Framework default applies only when none of them is set. See [Retry behavior in the AWS SDKs and Tools Reference Guide](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html).
+
+A download that is interrupted by the network fails the command with `Error fetching Terraform outputs from S3: Error: aborted`; rerun the command. Because each state is read once per resolution pass rather than once per referenced output, such a failure can occur at most once per state file per pass.
+
+During `serverless dev`, the state read at startup is kept for the whole session. Restart the session after `terraform apply` to pick up new outputs.
 
 ## Resolvers in Serverless Framework V.4
 

--- a/packages/sf-core/src/lib/resolvers/providers/aws/clients.js
+++ b/packages/sf-core/src/lib/resolvers/providers/aws/clients.js
@@ -17,7 +17,8 @@ import {
 
 /**
  * Shared AWS SDK plumbing for the variable resolvers (`${cf:}`, `${ssm:}`,
- * `${s3:}`, `${aws:accountId}`).
+ * `${s3:}`, `${aws:accountId}`, and the Terraform resolver's `backend: s3`
+ * state reads).
  *
  * Every call gets its own SDK client (each client owns its retry budget, so a
  * burst of calls never shares one 500-token budget), but all clients share one
@@ -66,6 +67,18 @@ const SERVICES = {
     variable: '${s3:}',
     learnMore: RETRY_GUIDE_URL,
   },
+  terraform: {
+    Client: S3Client,
+    clientOptions: { followRegionRedirects: true },
+    label: 'terraform',
+    name: 'Amazon S3',
+    targetNoun: 'state files',
+    variable: '${terraform:outputs:}',
+    learnMore: RETRY_GUIDE_URL,
+    // The Terraform resolver memoizes the parsed state above this layer, so the
+    // request count here is the number of memo misses, not of placeholders.
+    summaryPlaceholders: false,
+  },
   sts: {
     Client: STSClient,
     label: 'aws:accountId',
@@ -98,7 +111,11 @@ const principalCache = new WeakMap()
  * rate-exceeded message sums the throttled region's scopes.
  */
 const counters = new Map()
-let summaryDirty = false
+/**
+ * `${service}:${api}` → the last line the debug summary printed for it, so an
+ * API whose numbers have not moved is not printed again.
+ */
+const lastPrintedLines = new Map()
 
 const getSharedHandler = () => {
   if (handlerOverride) return handlerOverride
@@ -111,7 +128,7 @@ const getSharedHandler = () => {
 /**
  * Build a new SDK client for one request.
  * @param {Object} params
- * @param {'cloudformation'|'ssm'|'s3'|'sts'} params.service
+ * @param {'cloudformation'|'ssm'|'s3'|'sts'|'terraform'} params.service
  * @param {Object|Function} params.credentials - static credentials or an SDK credential provider
  * @param {string} params.region
  */
@@ -215,7 +232,6 @@ const observeRetries = (client, { logger, api, counter, maxAttempts }) => {
         const isThrottled = errorInfo.errorType === 'THROTTLING'
         if (isThrottled) {
           counter.throttledAttempts += 1
-          summaryDirty = true
           if (failedAttempt < maxAttempts) {
             const { error } = errorInfo
             logger.info(
@@ -300,7 +316,7 @@ const toRateExceededError = (
  * Send one SDK command through a fresh client.
  *
  * @param {Object} params
- * @param {'cloudformation'|'ssm'|'s3'|'sts'} params.service
+ * @param {'cloudformation'|'ssm'|'s3'|'sts'|'terraform'} params.service
  * @param {Object|Function} params.credentials
  * @param {string} params.region
  * @param {{info: Function, debug: Function}} params.logger - the resolver's logger
@@ -337,7 +353,6 @@ export const sendAwsRequest = async ({
   const counter = counterFor(service, api, scope, region)
   counter.placeholders += 1
   counter.targets.add(target)
-  summaryDirty = true
 
   const send = async () => {
     const maxAttempts = await client.config.maxAttempts()
@@ -384,11 +399,15 @@ export const sendAwsRequest = async ({
  * regions counts as two stacks, while three Compose services reading the same
  * two stacks — each with its own temporary credentials, and so its own access
  * key id for the one account — still count as two.
- * Prints nothing when no request was recorded since the previous summary.
+ *
+ * A service whose `SERVICES` row sets `summaryPlaceholders: false` leaves the
+ * placeholder figure off its line; the counters still record it.
+ *
+ * A line prints when it first exists and again only when its numbers change, so
+ * a summary taken after another service's work does not repeat what is already
+ * on screen; the last line printed for a service is always its final total.
  */
 export const logAwsResolverSummary = (logger) => {
-  if (!summaryDirty) return
-  summaryDirty = false
   /** `${service}:${api}` → that API's totals across every scope, first seen first. */
   const totals = new Map()
   for (const counter of counters.values()) {
@@ -410,11 +429,16 @@ export const logAwsResolverSummary = (logger) => {
     total.throttledAttempts += counter.throttledAttempts
     totals.set(key, total)
   }
-  for (const total of totals.values()) {
+  for (const [key, total] of totals) {
     const definition = SERVICES[total.service]
-    logger.debug(
-      `${definition.label}: ${total.placeholders} placeholders, ${total.targets.size} ${definition.targetNoun}, ${total.calls} ${total.api} calls, ${total.throttledAttempts} throttled attempts`,
-    )
+    const placeholders =
+      definition.summaryPlaceholders === false
+        ? ''
+        : `${total.placeholders} placeholders, `
+    const line = `${definition.label}: ${placeholders}${total.targets.size} ${definition.targetNoun}, ${total.calls} ${total.api} calls, ${total.throttledAttempts} throttled attempts`
+    if (lastPrintedLines.get(key) === line) continue
+    logger.debug(line)
+    lastPrintedLines.set(key, line)
   }
 }
 
@@ -451,5 +475,5 @@ export const resetAwsResolverState = ({ requestHandler = null } = {}) => {
   handlerOverride = requestHandler
   responseCache.clear()
   counters.clear()
-  summaryDirty = false
+  lastPrintedLines.clear()
 }

--- a/packages/sf-core/src/lib/resolvers/providers/doppler/doppler.js
+++ b/packages/sf-core/src/lib/resolvers/providers/doppler/doppler.js
@@ -1,4 +1,4 @@
-import { AbstractProvider } from '../index.js'
+import { AbstractProvider, unrecognizedKeysMessage } from '../index.js'
 import { z } from 'zod'
 import DopplerSDK from '@dopplerhq/node-sdk'
 
@@ -9,16 +9,20 @@ export class Doppler extends AbstractProvider {
 
   static validateConfig(providerConfig) {
     const baseSchema = z
-      .object({
-        type: z.literal('doppler'),
-        token: z.string().optional(),
-        project: z.string().optional(),
-        config: z.string().optional(),
-      })
-      .strict({
-        message:
-          "Only 'token', 'project', and 'config' are allowed in the Doppler configuration",
-      })
+      .object(
+        {
+          type: z.literal('doppler'),
+          token: z.string().optional(),
+          project: z.string().optional(),
+          config: z.string().optional(),
+        },
+        {
+          error: unrecognizedKeysMessage(
+            "Only 'token', 'project', and 'config' are allowed in the Doppler configuration",
+          ),
+        },
+      )
+      .strict()
 
     try {
       baseSchema.parse(providerConfig)

--- a/packages/sf-core/src/lib/resolvers/providers/index.js
+++ b/packages/sf-core/src/lib/resolvers/providers/index.js
@@ -9,6 +9,19 @@
  */
 
 /**
+ * zod 4's `.strict()` takes no message, so the "only these keys are allowed"
+ * text has to be attached as the object schema's `error` for the
+ * `unrecognized_keys` issue. Field errors keep zod's own messages.
+ *
+ * @param {string} message - The allowed-keys text for this schema.
+ * @returns {Function} An error map for `z.object`'s second argument.
+ */
+export const unrecognizedKeysMessage = (message) => (issue) =>
+  issue.code === 'unrecognized_keys'
+    ? `${message} (unrecognized: ${issue.keys.map((key) => `'${key}'`).join(', ')})`
+    : undefined
+
+/**
  * AbstractProvider is a base class for all providers.
  * It provides common properties and methods that all providers can use.
  */

--- a/packages/sf-core/src/lib/resolvers/providers/service/service.js
+++ b/packages/sf-core/src/lib/resolvers/providers/service/service.js
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { ServerlessError, ServerlessErrorCodes } from '@serverless/util'
-import { AbstractProvider } from '../index.js'
+import { AbstractProvider, unrecognizedKeysMessage } from '../index.js'
 
 /**
  * The service name of a `<service>.<Output>` reference key, or `null` when the
@@ -62,16 +62,20 @@ export class Service extends AbstractProvider {
 
   static validateConfig(providerConfig) {
     const schema = z
-      .object({
-        type: z.literal('service'),
-        stage: z
-          .string({ message: "The 'stage' property must be a string" })
-          .optional(),
-      })
-      .strict({
-        message:
-          "Only 'type' and 'stage' are allowed in the service resolver configuration",
-      })
+      .object(
+        {
+          type: z.literal('service'),
+          stage: z
+            .string({ message: "The 'stage' property must be a string" })
+            .optional(),
+        },
+        {
+          error: unrecognizedKeysMessage(
+            "Only 'type' and 'stage' are allowed in the service resolver configuration",
+          ),
+        },
+      )
+      .strict()
 
     try {
       schema.parse(providerConfig)

--- a/packages/sf-core/src/lib/resolvers/providers/terraform/terraform.js
+++ b/packages/sf-core/src/lib/resolvers/providers/terraform/terraform.js
@@ -1,55 +1,130 @@
-import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
-import { addProxyToAwsClient } from '@serverless/util'
+import { GetObjectCommand } from '@aws-sdk/client-s3'
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers'
+import { ServerlessError } from '@serverless/util'
 import { text } from 'stream/consumers'
 import _ from 'lodash'
-import { AbstractProvider } from '../index.js'
+import { AbstractProvider, unrecognizedKeysMessage } from '../index.js'
+import { sendAwsRequest } from '../aws/clients.js'
 import { z } from 'zod'
 import path from 'path'
 import fs from 'fs'
+
+/**
+ * The S3 backend reads state with the AWS SDK's default credential chain
+ * (environment variables, AWS_PROFILE, the default profile), not with the
+ * deployment's credentials. Building that chain once per process, instead of
+ * once per client, means the credentials are resolved once rather than once
+ * per placeholder — with an SSO profile each resolution is a call to the SSO
+ * portal, which rate-limits a burst of them.
+ */
+let defaultCredentials = null
+const getDefaultCredentials = () => {
+  defaultCredentials ??= fromNodeProviderChain()
+  return defaultCredentials
+}
+
+/**
+ * Terraform state outputs, memoized for the life of the process.
+ *
+ * Every `${<resolver>:outputs:<name>}` placeholder used to fetch and parse the
+ * whole state document again, and Compose services never shared a fetch, so a
+ * project with many services reading the same state issued one download per
+ * placeholder per service. A state changes only when Terraform runs, never
+ * during a Framework command, so one fetch per state per process is safe.
+ *
+ * Keys name the state, not the credentials: the S3 backend always reads with
+ * the process's default credentials, and the other backends address one
+ * workspace or one URL. Two resolvers that declare different `token` or
+ * `password` values for the same remote workspace or the same http address
+ * therefore share the first fetch. A rejected fetch is evicted so a later
+ * placeholder, or a declared fallback, retries instead of inheriting the
+ * failure.
+ */
+const outputsCache = new Map()
+
+const memoizeOutputs = (cacheKey, fetchOutputs) => {
+  if (!outputsCache.has(cacheKey)) {
+    const pending = fetchOutputs()
+    outputsCache.set(cacheKey, pending)
+    pending.catch(() => {
+      if (outputsCache.get(cacheKey) === pending) outputsCache.delete(cacheKey)
+    })
+  }
+  return outputsCache.get(cacheKey)
+}
+
+/**
+ * Test seam: forget every memoized state and the shared credential provider.
+ * Production code never calls this.
+ */
+export const resetTerraformOutputsCache = () => {
+  outputsCache.clear()
+  defaultCredentials = null
+}
+
+const DEFAULT_TERRAFORM_API_URL = 'https://app.terraform.io/api/v2/'
 
 export class Terraform extends AbstractProvider {
   static type = 'terraform'
   static resolvers = ['outputs']
   static defaultResolver = 'outputs'
 
+  /**
+   * Runner hook (see AbstractProvider.invalidateCaches): a Compose service
+   * deploy or remove changes CloudFormation stacks, never a Terraform state
+   * file — only Terraform writes those — so the memoized outputs stay valid
+   * for the whole process and there is nothing to forget here.
+   */
+  static invalidateCaches() {}
+
   static validateConfig(providerConfig) {
     /**
      * The schema for the S3 backend configuration.
      */
     const s3ConfigSchema = z
-      .object({
-        type: z.literal('terraform'),
-        backend: z.literal('s3'),
-        bucket: z.string({
-          message: "The 'bucket' property is required and must be a string",
-        }),
-        key: z.string({
-          message: 'The `key` property is required and must be a string',
-        }),
-        region: z
-          .string({
-            message: "The 'region' property must be a string",
-          })
-          .optional(),
-      })
-      .strict(
-        "Only 'bucket', 'key', and 'region' are allowed in the remote backend configuration",
+      .object(
+        {
+          type: z.literal('terraform'),
+          backend: z.literal('s3'),
+          bucket: z.string({
+            message: "The 'bucket' property is required and must be a string",
+          }),
+          key: z.string({
+            message: 'The `key` property is required and must be a string',
+          }),
+          region: z
+            .string({
+              message: "The 'region' property must be a string",
+            })
+            .optional(),
+        },
+        {
+          error: unrecognizedKeysMessage(
+            "Only 'bucket', 'key', and 'region' are allowed in the s3 backend configuration",
+          ),
+        },
       )
+      .strict()
 
     /**
      * Schema for the http backend configuration.
      */
     const httpConfigSchema = z
-      .object({
-        type: z.literal('terraform'),
-        backend: z.literal('http'),
-        address: z.string().optional(),
-        username: z.string().optional(),
-        password: z.string().optional(),
-      })
-      .strict(
-        "Only 'address', 'username', and 'password' are allowed in the http backend configuration",
+      .object(
+        {
+          type: z.literal('terraform'),
+          backend: z.literal('http'),
+          address: z.string().optional(),
+          username: z.string().optional(),
+          password: z.string().optional(),
+        },
+        {
+          error: unrecognizedKeysMessage(
+            "Only 'address', 'username', and 'password' are allowed in the http backend configuration",
+          ),
+        },
       )
+      .strict()
 
     /**
      * The schema for the remote backend configuration.
@@ -71,18 +146,23 @@ export class Terraform extends AbstractProvider {
       }),
     })
     const remoteConfigSchema = z
-      .object({
-        type: z.literal('terraform'),
-        backend: z.literal('remote'),
-        token: z.string().optional(),
-        hostname: z.string().optional(),
-        workspaceId: z.string().optional(),
-        workspace: z.string().optional(),
-        organization: z.string().optional(),
-      })
-      .strict(
-        "Only 'token', 'hostname', 'workspaceId', 'workspace', and 'organization' are allowed in the remote backend configuration",
+      .object(
+        {
+          type: z.literal('terraform'),
+          backend: z.literal('remote'),
+          token: z.string().optional(),
+          hostname: z.string().optional(),
+          workspaceId: z.string().optional(),
+          workspace: z.string().optional(),
+          organization: z.string().optional(),
+        },
+        {
+          error: unrecognizedKeysMessage(
+            "Only 'token', 'hostname', 'workspaceId', 'workspace', and 'organization' are allowed in the remote backend configuration",
+          ),
+        },
       )
+      .strict()
       .refine(
         (data) => {
           /**
@@ -143,32 +223,59 @@ export class Terraform extends AbstractProvider {
     if (resolverType === 'outputs') {
       let terraformStateOutputs = {}
       if (this.config.backend === 's3') {
-        terraformStateOutputs = await resolveTerraformOutputsFromS3({
-          bucket: this.config.bucket,
-          key: this.config.key,
-          region: this.config.region,
-        })
+        const { bucket, key: objectKey, region } = this.config
+        terraformStateOutputs = await memoizeOutputs(
+          `s3|${region ?? ''}|${bucket}|${objectKey}`,
+          () =>
+            resolveTerraformOutputsFromS3({
+              bucket,
+              key: objectKey,
+              region,
+              logger: this.logger,
+            }),
+        )
       } else if (this.config.backend === 'remote') {
-        terraformStateOutputs = await resolveTerraformOutputsFromRemote({
-          hostname: this.config.hostname,
-          token: this.config.token,
-          organization: this.config.organization,
-          workspace: this.config.workspace,
-          workspaceId: this.config.workspaceId,
-        })
+        const { hostname, token, organization, workspace, workspaceId } =
+          this.config
+        const apiUrl = hostname || DEFAULT_TERRAFORM_API_URL
+        // The fetcher lets organization/workspace win: it overwrites
+        // workspaceId with the id it looks up. The key follows it, so a
+        // config carrying both is never served the other workspace's outputs.
+        const workspaceRef =
+          organization && workspace
+            ? `${organization}/${workspace}`
+            : workspaceId
+        terraformStateOutputs = await memoizeOutputs(
+          `remote|${apiUrl}|${workspaceRef}`,
+          () =>
+            resolveTerraformOutputsFromRemote({
+              hostname,
+              token,
+              organization,
+              workspace,
+              workspaceId,
+            }),
+        )
       } else if (this.config.backend === 'http') {
-        terraformStateOutputs = await resolveTerraformOutputsFromHttp({
-          address: this.config.address,
-          username: this.config.username,
-          password: this.config.password,
-        })
+        const { address, username, password } = this.config
+        const apiAddress = address || process.env.TF_HTTP_ADDRESS
+        const apiUsername = username || process.env.TF_HTTP_USERNAME || ''
+        terraformStateOutputs = await memoizeOutputs(
+          `http|${apiAddress}|${apiUsername}`,
+          () =>
+            resolveTerraformOutputsFromHttp({ address, username, password }),
+        )
       }
 
       /**
        * We use lodash get() instead of terraformStateOutputs[key] to allow for
-       * getting values from nested objects.
+       * getting values from nested objects. The value is deep-cloned because the
+       * memoized state document is shared by every placeholder and every Compose
+       * service, so each caller has to get its own copy — otherwise a mutation of
+       * one substituted object- or list-valued output would corrupt the memo for
+       * every later resolution.
        */
-      const value = _.get(terraformStateOutputs, key)
+      const value = _.cloneDeep(_.get(terraformStateOutputs, key))
       return value
     }
 
@@ -177,35 +284,36 @@ export class Terraform extends AbstractProvider {
 }
 
 /**
- * The main resolver for Terraform outputs from an AWS S3 bucket.
+ * Read the Terraform state file from S3 and return its outputs as
+ * `{ name: value }`.
+ *
+ * The request goes through the resolvers' shared AWS request layer as the
+ * `terraform` service: it inherits the SDK's standard retries for the request
+ * itself, and its traffic shows up under its own label in the `--debug`
+ * summary and in the rate-limit error. The body is read here, once; a failure
+ * while reading it is reported exactly as any other fetch failure.
  */
-const resolveTerraformOutputsFromS3 = async ({ bucket, key, region }) => {
-  const clientConfig = {}
-
-  /**
-   * If a region is provided, it is used to configure the S3 client.
-   */
-  if (region) {
-    clientConfig.region = region
-  }
-
+const resolveTerraformOutputsFromS3 = async ({
+  bucket,
+  key,
+  region,
+  logger,
+}) => {
   try {
-    /**
-     * This gets the contents of the Terraform state file from the S3 bucket.
-     */
-    const client = addProxyToAwsClient(new S3Client(clientConfig))
-    const command = new GetObjectCommand({
-      Bucket: bucket,
-      Key: key,
+    const response = await sendAwsRequest({
+      service: 'terraform',
+      credentials: getDefaultCredentials(),
+      region,
+      logger,
+      command: new GetObjectCommand({ Bucket: bucket, Key: key }),
+      target: `${bucket}/${key}`,
     })
-    const response = await client.send(command)
 
     /**
      * The content is a stream, this method reads the stream into a string. Then
      * the JSON is parsed to get the Terraform state, including the outputs.
      */
-    const stateFile = await text(response.Body)
-    const state = JSON.parse(stateFile)
+    const state = JSON.parse(await text(response.Body))
 
     /**
      * Lastly, the outputs field is formatted as {key:{value:"value"}}, so this
@@ -213,12 +321,15 @@ const resolveTerraformOutputsFromS3 = async ({ bucket, key, region }) => {
      * with the expected output format
      */
     return Object.fromEntries(
-      Object.entries(state.outputs || {}).map(([key, value]) => [
-        key,
-        value.value,
+      Object.entries(state.outputs || {}).map(([name, output]) => [
+        name,
+        output.value,
       ]),
     )
   } catch (error) {
+    // The shared layer's errors (rate limit exhausted) already name the API,
+    // the attempts and the remedy; wrapping them would bury that text.
+    if (error instanceof ServerlessError) throw error
     throw new Error(`Error fetching Terraform outputs from S3: ${error}`)
   }
 }
@@ -311,7 +422,7 @@ const resolveTerraformOutputsFromRemote = async ({
    * Enterprise may also be hosted on a different domain. The hostname option
    * allows using either of these services.
    */
-  const apiUrl = hostname || 'https://app.terraform.io/api/v2/'
+  const apiUrl = hostname || DEFAULT_TERRAFORM_API_URL
   const tokenEnvVarKey = getTokenEnvVarKey(apiUrl)
   const apiToken = token || getTerraformToken(apiUrl)
   if (!apiToken) {

--- a/packages/sf-core/src/lib/resolvers/providers/vault/vault.js
+++ b/packages/sf-core/src/lib/resolvers/providers/vault/vault.js
@@ -1,4 +1,4 @@
-import { AbstractProvider } from '../index.js'
+import { AbstractProvider, unrecognizedKeysMessage } from '../index.js'
 import _ from 'lodash'
 import { z } from 'zod'
 import * as fsPath from 'path'
@@ -10,17 +10,21 @@ export class Vault extends AbstractProvider {
 
   static validateConfig(providerConfig) {
     const baseSchema = z
-      .object({
-        type: z.literal('vault'),
-        token: z.string().optional(),
-        address: z.string().optional(),
-        version: z.string().optional(),
-        path: z.string().optional(),
-      })
-      .strict({
-        message:
-          "Only 'token', 'address', 'version', and 'path' are allowed in the Vault configuration",
-      })
+      .object(
+        {
+          type: z.literal('vault'),
+          token: z.string().optional(),
+          address: z.string().optional(),
+          version: z.string().optional(),
+          path: z.string().optional(),
+        },
+        {
+          error: unrecognizedKeysMessage(
+            "Only 'token', 'address', 'version', and 'path' are allowed in the Vault configuration",
+          ),
+        },
+      )
+      .strict()
 
     try {
       baseSchema.parse(providerConfig)

--- a/packages/sf-core/tests/integration/resolvers/cf-many/cf-many.test.js
+++ b/packages/sf-core/tests/integration/resolvers/cf-many/cf-many.test.js
@@ -1,6 +1,6 @@
 import path from 'path'
 import url from 'url'
-import { setGlobalRendererSettings } from '@serverless/util'
+import { log, setGlobalRendererSettings } from '@serverless/util'
 import { LambdaClient, GetFunctionCommand } from '@aws-sdk/client-lambda'
 import { jest } from '@jest/globals'
 import { getTestStageName, runSfCore } from '../../../utils/runSfCore.js'
@@ -25,20 +25,22 @@ describe('Serverless Framework Service - Resolvers - cf per-stack de-duplication
   const deployed = new Set()
   let stderr = []
   let stdout = []
+  let summarySpy = null
 
   const summaryLines = () =>
-    stderr
-      .join('')
-      .split('\n')
-      .filter((line) => line.includes('core:resolver:aws:'))
-      .map((line) => line.replace(/.*core:resolver:aws:\s*/, '').trim())
+    summarySpy ? summarySpy.mock.calls.map(([line]) => String(line)) : []
 
-  // The CLI logger writes to stderr; `print` writes the resolved config to
-  // stdout. Capture both so the assertions do not depend on which one the
-  // renderer picks for a given line.
+  // The resolvers' debug summary is read straight off the `core:resolver:aws`
+  // namespace logger: `Logger.get` hands out one cached instance per namespace,
+  // so a spy on the instance the runner uses sees every summary as the bare
+  // message, without turning debug output on for every other namespace.
+  // The CLI logger otherwise writes to stderr, and `print` writes the resolved
+  // config to stdout; capture both so the `print` assertions do not depend on
+  // which one the renderer picks for a given line.
   const captureOutput = () => {
     stderr = []
     stdout = []
+    summarySpy = jest.spyOn(log.get('core:resolver:aws'), 'debug')
     jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
       stderr.push(String(chunk))
       return true
@@ -77,7 +79,7 @@ describe('Serverless Framework Service - Resolvers - cf per-stack de-duplication
       if (value === undefined) delete options[key]
     }
     return runSfCore({
-      coreParams: { options, command, debug: true },
+      coreParams: { options, command },
       jest,
       expectError,
     })

--- a/packages/sf-core/tests/integration/resolvers/cf-many/cf-many.test.js
+++ b/packages/sf-core/tests/integration/resolvers/cf-many/cf-many.test.js
@@ -155,12 +155,15 @@ describe('Serverless Framework Service - Resolvers - cf per-stack de-duplication
     await run(configPath, ['deploy'], { region: undefined })
 
     const cfLines = summaryLines().filter((line) => line.startsWith('cf: '))
-    expect(cfLines.length).toBeGreaterThanOrEqual(2)
-    // The count stays at 2 because `svc-1` and `svc-2` declare no `dependsOn`:
-    // they resolve together at dispatch, before either deploy finishes and
-    // invalidates the resolver cache. Give that fixture an ordering and the
-    // second service re-reads both stacks, which moves this number — a change
-    // in the count then, not a flake.
+    expect(cfLines.length).toBeGreaterThanOrEqual(1)
+    // The stack count stays at 2 because `svc-1` and `svc-2` declare no
+    // `dependsOn`: they resolve together at dispatch, before either deploy
+    // finishes and invalidates the resolver cache. Give that fixture an
+    // ordering and the second service re-reads both stacks, which moves that
+    // number — a change in the count then, not a flake. The summary prints a
+    // line only when its numbers moved since the last print, so two services
+    // resolving concurrently may produce one `cf:` line or two; the last line
+    // is the cumulative total.
     for (const line of cfLines) {
       expect(line).toMatch(
         /^cf: \d+ placeholders, 2 stacks, 2 DescribeStacks calls, \d+ throttled attempts$/,

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/serverless-compose.yml
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/serverless-compose.yml
@@ -1,0 +1,7 @@
+org: serverlesstestaccount
+
+services:
+  svc-1:
+    path: svc-1
+  svc-2:
+    path: svc-2

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/svc-1/handler.mjs
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/svc-1/handler.mjs
@@ -1,0 +1,1 @@
+export const handler = async () => ({ statusCode: 200, body: 'ok' })

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/svc-1/serverless.yml
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/svc-1/serverless.yml
@@ -1,0 +1,24 @@
+org: serverlesstestaccount
+service: res-ts-compose-1
+
+stages:
+  default:
+    resolvers:
+      terraform:
+        type: terraform
+        backend: s3
+        bucket: terraform-s3-resolver-test-bucket
+        key: terraform-s3-resolver-test-state/tfstate
+        region: us-east-1
+
+provider:
+  name: aws
+  runtime: nodejs22.x
+  region: us-east-1
+  environment:
+    TEST: ${terraform:outputs:key-1-id}
+    TEST2: ${terraform:outputs:key-2-id}
+
+functions:
+  api:
+    handler: handler.handler

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/svc-2/handler.mjs
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/svc-2/handler.mjs
@@ -1,0 +1,1 @@
+export const handler = async () => ({ statusCode: 200, body: 'ok' })

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/svc-2/serverless.yml
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/fixture/compose/svc-2/serverless.yml
@@ -1,0 +1,24 @@
+org: serverlesstestaccount
+service: res-ts-compose-2
+
+stages:
+  default:
+    resolvers:
+      terraform:
+        type: terraform
+        backend: s3
+        bucket: terraform-s3-resolver-test-bucket
+        key: terraform-s3-resolver-test-state/tfstate
+        region: us-east-1
+
+provider:
+  name: aws
+  runtime: nodejs22.x
+  region: us-east-1
+  environment:
+    TEST: ${terraform:outputs:key-1-id}
+    TEST2: ${terraform:outputs:key-2-id}
+
+functions:
+  api:
+    handler: handler.handler

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-s3-output-compose.test.js
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-s3-output-compose.test.js
@@ -28,6 +28,7 @@ describe('Terraform Resolvers - S3 Output - one fetch per state across Compose s
   const lambdaClient = new LambdaClient({ region: 'us-east-1' })
   const originalEnv = process.env
   const stage = getTestStageName()
+  let deployed = false
   let stderr = []
 
   // The resolvers' debug summary is the only observable request count; the CLI
@@ -49,8 +50,22 @@ describe('Terraform Resolvers - S3 Output - one fetch per state across Compose s
     }
   })
 
-  afterAll(() => {
-    process.env = originalEnv
+  afterAll(async () => {
+    // The `Remove` test below is the asserted teardown path; this is only the
+    // safety net for a run where a test failed before it could remove them.
+    try {
+      if (deployed) {
+        await runSfCore({
+          coreParams: {
+            options: { stage, c: composeConfigPath },
+            command: ['remove'],
+          },
+          jest,
+        })
+      }
+    } finally {
+      process.env = originalEnv
+    }
   })
 
   afterEach(() => {
@@ -72,6 +87,7 @@ describe('Terraform Resolvers - S3 Output - one fetch per state across Compose s
       },
       jest,
     })
+    deployed = true
 
     /**
      * The memo sits in front of the shared request layer, so `1 GetObject
@@ -125,5 +141,6 @@ describe('Terraform Resolvers - S3 Output - one fetch per state across Compose s
       },
       jest,
     })
+    deployed = false
   })
 })

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-s3-output-compose.test.js
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-s3-output-compose.test.js
@@ -1,0 +1,129 @@
+import path from 'path'
+import url from 'url'
+import { jest } from '@jest/globals'
+import { LambdaClient, GetFunctionCommand } from '@aws-sdk/client-lambda'
+import { setGlobalRendererSettings } from '@serverless/util'
+import { getTestStageName, runSfCore } from '../../../../utils/runSfCore'
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+
+/**
+ * Live check that a Terraform state file is fetched once per process and the
+ * outputs are shared: two Compose services reading two outputs each from the
+ * same state must cost exactly one `GetObject`. The only observable call count
+ * is the resolvers' `--debug` summary line.
+ *
+ * This scenario lives in its own file so that the request counters and the
+ * resolver's state memo start empty: Jest gives every test file its own module
+ * registry, so the numbers below are this Compose run's own spend.
+ */
+describe('Terraform Resolvers - S3 Output - one fetch per state across Compose services', () => {
+  jest.setTimeout(900_000)
+  const composeConfigPath = path.join(
+    __dirname,
+    'fixture',
+    'compose',
+    'serverless-compose.yml',
+  )
+  const lambdaClient = new LambdaClient({ region: 'us-east-1' })
+  const originalEnv = process.env
+  const stage = getTestStageName()
+  let stderr = []
+
+  // The resolvers' debug summary is the only observable request count; the CLI
+  // logger writes it to stderr under the `core:resolver:aws` namespace.
+  const summaryLines = () =>
+    stderr
+      .join('')
+      .split('\n')
+      .filter((line) => line.includes('core:resolver:aws:'))
+      .map((line) => line.replace(/.*core:resolver:aws:\s*/, '').trim())
+
+  beforeAll(() => {
+    setGlobalRendererSettings({ isInteractive: false })
+    process.env = {
+      ...originalEnv,
+      SERVERLESS_PLATFORM_STAGE: 'dev',
+      SERVERLESS_LICENSE_KEY: process.env.SERVERLESS_LICENSE_KEY_DEV,
+      SERVERLESS_ACCESS_KEY: undefined,
+    }
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('Deploy: two services reading two outputs each cost one GetObject', async () => {
+    stderr = []
+    jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk))
+      return true
+    })
+
+    await runSfCore({
+      coreParams: {
+        options: { stage, c: composeConfigPath },
+        command: ['deploy'],
+        debug: true,
+      },
+      jest,
+    })
+
+    /**
+     * The memo sits in front of the shared request layer, so `1 GetObject
+     * calls` is the whole run's spend on this state: the second Compose
+     * service adds no request. The `terraform:` line leaves the placeholder
+     * figure out for that same reason — the layer only ever sees the one
+     * reference that missed the memo, not the four in the fixtures.
+     *
+     * A summary line prints when it first exists and again only when its
+     * numbers change, so a shared fetch is one `terraform:` line for the run,
+     * however many services print a summary after it.
+     *
+     * On its own this assertion cannot tell a shared fetch apart from four
+     * references that were never resolved at all - both spend one GetObject.
+     * The `Validate` test below is what proves the four references resolved,
+     * and to the same state, so it is not redundant with this one.
+     */
+    const terraformLines = summaryLines().filter((line) =>
+      line.startsWith('terraform:'),
+    )
+    expect(terraformLines).toHaveLength(1)
+    expect(terraformLines[0]).toMatch(
+      /^terraform: 1 state files, 1 GetObject calls, \d+ throttled attempts$/,
+    )
+  })
+
+  test('Validate: both services received both outputs', async () => {
+    const suffixes = new Set()
+    for (const service of ['res-ts-compose-1', 'res-ts-compose-2']) {
+      const { Configuration } = await lambdaClient.send(
+        new GetFunctionCommand({ FunctionName: `${service}-${stage}-api` }),
+      )
+      const env = Configuration.Environment.Variables
+      expect(env.TEST).toMatch(/^key-1-value-[a-fA-F0-9]{16}$/)
+      expect(env.TEST2).toMatch(/^key-2-value-[a-fA-F0-9]{16}$/)
+      expect(env.TEST.slice('key-1-value-'.length)).toBe(
+        env.TEST2.slice('key-2-value-'.length),
+      )
+      suffixes.add(env.TEST.slice('key-1-value-'.length))
+    }
+    // One suffix across both services: they read the same state, not two
+    // separate downloads that happened to see the same Terraform run.
+    expect(suffixes.size).toBe(1)
+  })
+
+  test('Remove', async () => {
+    await runSfCore({
+      coreParams: {
+        options: { stage, c: composeConfigPath },
+        command: ['remove'],
+      },
+      jest,
+    })
+  })
+})

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-s3-output-compose.test.js
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-s3-output-compose.test.js
@@ -2,7 +2,7 @@ import path from 'path'
 import url from 'url'
 import { jest } from '@jest/globals'
 import { LambdaClient, GetFunctionCommand } from '@aws-sdk/client-lambda'
-import { setGlobalRendererSettings } from '@serverless/util'
+import { log, setGlobalRendererSettings } from '@serverless/util'
 import { getTestStageName, runSfCore } from '../../../../utils/runSfCore'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
@@ -29,16 +29,13 @@ describe('Terraform Resolvers - S3 Output - one fetch per state across Compose s
   const originalEnv = process.env
   const stage = getTestStageName()
   let deployed = false
-  let stderr = []
 
-  // The resolvers' debug summary is the only observable request count; the CLI
-  // logger writes it to stderr under the `core:resolver:aws` namespace.
-  const summaryLines = () =>
-    stderr
-      .join('')
-      .split('\n')
-      .filter((line) => line.includes('core:resolver:aws:'))
-      .map((line) => line.replace(/.*core:resolver:aws:\s*/, '').trim())
+  // The resolvers' debug summary is the only observable request count. The
+  // runner writes it through the `core:resolver:aws` namespace logger, and
+  // `Logger.get` hands out one cached instance per namespace, so spying on
+  // this instance's `debug` captures the summary as the bare message — no
+  // prefix, and without turning debug output on for every other namespace.
+  const summaryLogger = log.get('core:resolver:aws')
 
   beforeAll(() => {
     setGlobalRendererSettings({ isInteractive: false })
@@ -73,17 +70,12 @@ describe('Terraform Resolvers - S3 Output - one fetch per state across Compose s
   })
 
   test('Deploy: two services reading two outputs each cost one GetObject', async () => {
-    stderr = []
-    jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
-      stderr.push(String(chunk))
-      return true
-    })
+    const debugSpy = jest.spyOn(summaryLogger, 'debug')
 
     await runSfCore({
       coreParams: {
         options: { stage, c: composeConfigPath },
         command: ['deploy'],
-        debug: true,
       },
       jest,
     })
@@ -105,9 +97,9 @@ describe('Terraform Resolvers - S3 Output - one fetch per state across Compose s
      * The `Validate` test below is what proves the four references resolved,
      * and to the same state, so it is not redundant with this one.
      */
-    const terraformLines = summaryLines().filter((line) =>
-      line.startsWith('terraform:'),
-    )
+    const terraformLines = debugSpy.mock.calls
+      .map(([line]) => String(line))
+      .filter((line) => line.startsWith('terraform:'))
     expect(terraformLines).toHaveLength(1)
     expect(terraformLines[0]).toMatch(
       /^terraform: 1 state files, 1 GetObject calls, \d+ throttled attempts$/,

--- a/packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-setup/main.tf
+++ b/packages/sf-core/tests/integration/resolvers/terraform/s3-output/terraform-setup/main.tf
@@ -20,3 +20,7 @@ resource "random_id" "resource_id" {
 output "key-1-id" {
   value = "key-1-value-${random_id.resource_id.hex}"
 }
+
+output "key-2-id" {
+  value = "key-2-value-${random_id.resource_id.hex}"
+}

--- a/packages/sf-core/tests/unit/resolvers/aws-clients.test.js
+++ b/packages/sf-core/tests/unit/resolvers/aws-clients.test.js
@@ -92,6 +92,17 @@ describe('AWS resolver client factory', () => {
     expect(s3.config.followRegionRedirects).toBe(true)
   })
 
+  test('builds an S3 client that follows region redirects for the terraform service', async () => {
+    const client = createClient({
+      service: 'terraform',
+      credentials,
+      region: 'eu-west-1',
+    })
+    expect(client).toBeInstanceOf(S3Client)
+    expect(client.config.followRegionRedirects).toBe(true)
+    expect(await client.config.region()).toBe('eu-west-1')
+  })
+
   test('every client shares one keep-alive request handler with a 500-socket pool', async () => {
     const a = createClient({ service: 'cloudformation', credentials, region })
     const b = createClient({ service: 'ssm', credentials, region })

--- a/packages/sf-core/tests/unit/resolvers/aws-requests.test.js
+++ b/packages/sf-core/tests/unit/resolvers/aws-requests.test.js
@@ -1,6 +1,7 @@
 import { Readable } from 'node:stream'
 import { jest } from '@jest/globals'
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation'
+import { GetObjectCommand } from '@aws-sdk/client-s3'
 import { GetParameterCommand } from '@aws-sdk/client-ssm'
 import { HttpResponse } from '@smithy/core/protocols'
 
@@ -58,6 +59,14 @@ const ok = (body, contentType = 'text/xml') => ({
 const throttled = () => ({
   status: 400,
   body: cfnErrorXml('Throttling', 'Rate exceeded'),
+})
+/** Amazon S3's own throttling response, as the Terraform state read sees it. */
+const s3Throttled = () => ({
+  status: 503,
+  body:
+    '<?xml version="1.0" encoding="UTF-8"?><Error><Code>SlowDown</Code>' +
+    '<Message>Please reduce your request rate.</Message>' +
+    '<RequestId>req-3</RequestId><HostId>host-3</HostId></Error>',
 })
 const validationError = () => ({
   status: 400,
@@ -216,6 +225,28 @@ describe('sendAwsRequest', () => {
     logAwsResolverSummary(logger)
     expect(logger.debug).toHaveBeenCalledWith(
       'cf: 3 placeholders, 1 stacks, 2 DescribeStacks calls, 0 throttled attempts',
+    )
+  })
+
+  test('terraform requests are reported under their own label and nouns', async () => {
+    resetAwsResolverState({
+      requestHandler: fakeHandler([ok('{"outputs":{}}', 'application/json')]),
+    })
+    const output = await sendAwsRequest({
+      service: 'terraform',
+      credentials,
+      region,
+      logger,
+      command: new GetObjectCommand({
+        Bucket: 'state-bucket',
+        Key: 'prod/network.tfstate',
+      }),
+      target: 'state-bucket/prod/network.tfstate',
+    })
+    expect(await output.Body.transformToString()).toBe('{"outputs":{}}')
+    logAwsResolverSummary(logger)
+    expect(logger.debug).toHaveBeenCalledWith(
+      'terraform: 1 state files, 1 GetObject calls, 0 throttled attempts',
     )
   })
 
@@ -404,6 +435,28 @@ describe('sendAwsRequest', () => {
     )
   })
 
+  test('exhausted throttling on a Terraform state read names state files and the terraform variable', async () => {
+    process.env.AWS_MAX_ATTEMPTS = '2'
+    const handler = fakeHandler([s3Throttled()])
+    resetAwsResolverState({ requestHandler: handler })
+    const error = await sendAwsRequest({
+      service: 'terraform',
+      credentials,
+      region,
+      logger,
+      command: new GetObjectCommand({
+        Bucket: 'state-bucket',
+        Key: 'prod/network.tfstate',
+      }),
+      target: 'state-bucket/prod/network.tfstate',
+    }).catch((e) => e)
+    expect(handler.handle).toHaveBeenCalledTimes(2)
+    expect(error.code).toBe('RESOLVER_AWS_RATE_EXCEEDED')
+    expect(error.message).toContain(
+      'This run needed 1 GetObject calls for 1 state files referenced by ${terraform:outputs:} variables.',
+    )
+  })
+
   test('the debug summary reports placeholders, distinct targets, calls and throttled attempts once', async () => {
     process.env.AWS_MAX_ATTEMPTS = '3'
     const handler = fakeHandler([
@@ -424,6 +477,70 @@ describe('sendAwsRequest', () => {
     logger.debug.mockClear()
     logAwsResolverSummary(logger)
     expect(logger.debug).not.toHaveBeenCalled()
+  })
+
+  test('an unchanged service is not reprinted by a later summary', async () => {
+    const handler = fakeHandler([
+      ok(describeStacksXml('stack-a', [['OutA', 'a-one']])),
+      ok(ssmParameterJson('/p', 'v'), 'application/x-amz-json-1.1'),
+      ok(describeStacksXml('stack-b', [['OutB', 'b-one']])),
+    ])
+    resetAwsResolverState({ requestHandler: handler })
+    const linesStartingWith = (prefix) =>
+      logger.debug.mock.calls
+        .map(([line]) => line)
+        .filter((line) => line.startsWith(prefix))
+
+    await describeStack()
+    logAwsResolverSummary(logger)
+    expect(linesStartingWith('cf:')).toEqual([
+      'cf: 1 placeholders, 1 stacks, 1 DescribeStacks calls, 0 throttled attempts',
+    ])
+
+    // Another service resolving something prints its own line only: the
+    // CloudFormation numbers did not move, so that line is not repeated.
+    await sendAwsRequest({
+      service: 'ssm',
+      credentials,
+      region,
+      logger,
+      command: new GetParameterCommand({ Name: '/p' }),
+      target: '/p',
+      cache: true,
+    })
+    logAwsResolverSummary(logger)
+    expect(linesStartingWith('ssm:')).toEqual([
+      'ssm: 1 placeholders, 1 parameters, 1 GetParameter calls, 0 throttled attempts',
+    ])
+    expect(linesStartingWith('cf:')).toHaveLength(1)
+    expect(logger.debug).toHaveBeenCalledTimes(2)
+
+    // Reading a second stack moves the CloudFormation numbers, so its line
+    // prints again - with the new totals.
+    await describeStack({
+      command: new DescribeStacksCommand({ StackName: 'stack-b' }),
+      target: 'stack-b',
+    })
+    logAwsResolverSummary(logger)
+    expect(linesStartingWith('cf:')).toEqual([
+      'cf: 1 placeholders, 1 stacks, 1 DescribeStacks calls, 0 throttled attempts',
+      'cf: 2 placeholders, 2 stacks, 2 DescribeStacks calls, 0 throttled attempts',
+    ])
+    expect(linesStartingWith('ssm:')).toHaveLength(1)
+  })
+
+  test('a summary with nothing new prints nothing', async () => {
+    const handler = fakeHandler([
+      ok(describeStacksXml('stack-a', [['OutA', 'a-one']])),
+    ])
+    resetAwsResolverState({ requestHandler: handler })
+    await describeStack()
+    logAwsResolverSummary(logger)
+    expect(logger.debug).toHaveBeenCalledTimes(1)
+
+    logAwsResolverSummary(logger)
+    logAwsResolverSummary(logger)
+    expect(logger.debug).toHaveBeenCalledTimes(1)
   })
 
   test('the debug summary counts one stack read with two credentials as one stack', async () => {

--- a/packages/sf-core/tests/unit/resolvers/doppler.test.js
+++ b/packages/sf-core/tests/unit/resolvers/doppler.test.js
@@ -1,0 +1,37 @@
+import { jest } from '@jest/globals'
+
+// The provider imports the Doppler SDK at module scope; validateConfig never
+// touches it, so a stub keeps the unit test off the real client.
+jest.unstable_mockModule('@dopplerhq/node-sdk', () => ({
+  default: class DopplerSDK {},
+}))
+
+const { Doppler } =
+  await import('../../../src/lib/resolvers/providers/doppler/doppler.js')
+
+describe('Doppler resolver', () => {
+  describe('validateConfig', () => {
+    test('accepts a valid configuration', () => {
+      expect(() =>
+        Doppler.validateConfig({
+          type: 'doppler',
+          token: 'dp.st.token',
+          project: 'my-project',
+          config: 'dev',
+        }),
+      ).not.toThrow()
+    })
+
+    test('rejects unknown keys with the allowed-keys message', () => {
+      expect(() =>
+        Doppler.validateConfig({
+          type: 'doppler',
+          project: 'my-project',
+          environment: 'dev',
+        }),
+      ).toThrow(
+        "Only 'token', 'project', and 'config' are allowed in the Doppler configuration (unrecognized: 'environment')",
+      )
+    })
+  })
+})

--- a/packages/sf-core/tests/unit/resolvers/service.test.js
+++ b/packages/sf-core/tests/unit/resolvers/service.test.js
@@ -1,0 +1,23 @@
+import { Service } from '../../../src/lib/resolvers/providers/service/service.js'
+
+describe('Service resolver', () => {
+  describe('validateConfig', () => {
+    test('accepts a valid configuration', () => {
+      expect(() =>
+        Service.validateConfig({ type: 'service', stage: 'prod' }),
+      ).not.toThrow()
+    })
+
+    test('rejects unknown keys with the allowed-keys message', () => {
+      expect(() =>
+        Service.validateConfig({
+          type: 'service',
+          stage: 'prod',
+          region: 'us-east-1',
+        }),
+      ).toThrow(
+        "Only 'type' and 'stage' are allowed in the service resolver configuration (unrecognized: 'region')",
+      )
+    })
+  })
+})

--- a/packages/sf-core/tests/unit/resolvers/terraform.test.js
+++ b/packages/sf-core/tests/unit/resolvers/terraform.test.js
@@ -1,0 +1,531 @@
+import { Readable } from 'node:stream'
+import { jest } from '@jest/globals'
+
+const mockSendAwsRequest = jest.fn()
+
+jest.unstable_mockModule(
+  '../../../src/lib/resolvers/providers/aws/clients.js',
+  () => ({ sendAwsRequest: mockSendAwsRequest }),
+)
+
+const { Terraform, resetTerraformOutputsCache } =
+  await import('../../../src/lib/resolvers/providers/terraform/terraform.js')
+
+/** A Terraform v4 state document with the given outputs, as S3 would return it. */
+const stateDocument = (outputs) =>
+  JSON.stringify({
+    version: 4,
+    terraform_version: '1.9.0',
+    outputs: Object.fromEntries(
+      Object.entries(outputs).map(([name, value]) => [
+        name,
+        { value, type: typeof value === 'string' ? 'string' : ['object', {}] },
+      ]),
+    ),
+  })
+
+/** One S3 GetObject output whose Body streams `body` exactly once. */
+const s3Response = (body) => ({ Body: Readable.from([Buffer.from(body)]) })
+
+const s3Config = (overrides = {}) => ({
+  type: 'terraform',
+  backend: 's3',
+  bucket: 'state-bucket',
+  key: 'prod/network.tfstate',
+  region: 'us-east-1',
+  ...overrides,
+})
+
+/** A provider instance the way the ResolverManager builds one — one per service. */
+const provider = (providerConfig) =>
+  new Terraform({
+    logger: { debug: jest.fn(), info: jest.fn() },
+    providerConfig,
+    serviceConfigFile: {},
+    configFileDirPath: '/tmp',
+    options: {},
+    stage: 'dev',
+  })
+
+const resolve = (instance, key) =>
+  instance.resolveVariable({
+    resolverType: 'outputs',
+    resolutionDetails: null,
+    key,
+  })
+
+describe('Terraform resolver', () => {
+  beforeEach(() => {
+    resetTerraformOutputsCache()
+    mockSendAwsRequest.mockReset()
+  })
+
+  describe('validateConfig', () => {
+    test('accepts the s3, remote and http backends', () => {
+      expect(() => Terraform.validateConfig(s3Config())).not.toThrow()
+      expect(() =>
+        Terraform.validateConfig({
+          type: 'terraform',
+          backend: 'remote',
+          organization: 'my-org',
+          workspace: 'my-workspace',
+        }),
+      ).not.toThrow()
+      expect(() =>
+        Terraform.validateConfig({
+          type: 'terraform',
+          backend: 'http',
+          address: 'https://state.example.com/prod',
+        }),
+      ).not.toThrow()
+    })
+
+    test('rejects an unknown backend with the documented message', () => {
+      expect(() =>
+        Terraform.validateConfig({ type: 'terraform', backend: 'gcs' }),
+      ).toThrow(
+        'Only the "s3", "remote", and "http" backends are supported at this time',
+      )
+    })
+
+    test('rejects an s3 backend without a bucket', () => {
+      const { bucket, ...withoutBucket } = s3Config()
+      expect(() => Terraform.validateConfig(withoutBucket)).toThrow(
+        "The 'bucket' property is required and must be a string",
+      )
+    })
+
+    test('rejects unknown keys on the s3 backend', () => {
+      expect(() =>
+        Terraform.validateConfig(s3Config({ profile: 'other' })),
+      ).toThrow(
+        "Only 'bucket', 'key', and 'region' are allowed in the s3 backend configuration (unrecognized: 'profile')",
+      )
+    })
+
+    test('rejects unknown keys on the http backend', () => {
+      expect(() =>
+        Terraform.validateConfig({
+          type: 'terraform',
+          backend: 'http',
+          address: 'https://state.example.com/prod',
+          profile: 'other',
+        }),
+      ).toThrow(
+        "Only 'address', 'username', and 'password' are allowed in the http backend configuration (unrecognized: 'profile')",
+      )
+    })
+
+    test('rejects unknown keys on the remote backend', () => {
+      expect(() =>
+        Terraform.validateConfig({
+          type: 'terraform',
+          backend: 'remote',
+          workspaceId: 'ws-123',
+          profile: 'other',
+        }),
+      ).toThrow(
+        "Only 'token', 'hostname', 'workspaceId', 'workspace', and 'organization' are allowed in the remote backend configuration (unrecognized: 'profile')",
+      )
+    })
+
+    test("keeps zod's own message for a wrong field type", () => {
+      // The allowed-keys text is attached to the object schema, so it must not
+      // replace the message a failing field raises.
+      let message
+      try {
+        Terraform.validateConfig({
+          type: 'terraform',
+          backend: 'http',
+          address: 42,
+        })
+      } catch (error) {
+        message = error.message
+      }
+      expect(message).toContain('expected string')
+      expect(message).not.toContain("Only 'address'")
+    })
+
+    test('rejects a remote backend with neither workspaceId nor organization/workspace', () => {
+      expect(() =>
+        Terraform.validateConfig({ type: 'terraform', backend: 'remote' }),
+      ).toThrow(
+        "Either 'workspaceId' or 'organization' and 'workspace' are required",
+      )
+    })
+  })
+
+  describe('s3 backend', () => {
+    test('sends one GetObject through the shared layer as the terraform service and returns the output', async () => {
+      mockSendAwsRequest.mockResolvedValue(
+        s3Response(stateDocument({ vpc_id: 'vpc-123' })),
+      )
+
+      const instance = provider(s3Config())
+      const value = await resolve(instance, 'vpc_id')
+
+      expect(value).toBe('vpc-123')
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(1)
+      const request = mockSendAwsRequest.mock.calls[0][0]
+      expect(request.service).toBe('terraform')
+      expect(request.region).toBe('us-east-1')
+      expect(request.target).toBe('state-bucket/prod/network.tfstate')
+      expect(request.command.input).toEqual({
+        Bucket: 'state-bucket',
+        Key: 'prod/network.tfstate',
+      })
+      expect(request.cache).toBeUndefined()
+      expect(typeof request.credentials).toBe('function')
+      expect(request.logger).toBe(instance.logger)
+    })
+
+    test('reads nested output values with dotted keys', async () => {
+      mockSendAwsRequest.mockResolvedValue(
+        s3Response(stateDocument({ network: { subnets: { a: 'subnet-a' } } })),
+      )
+
+      await expect(
+        resolve(provider(s3Config()), 'network.subnets.a'),
+      ).resolves.toBe('subnet-a')
+    })
+
+    test('returns undefined for an output that is not in the state', async () => {
+      mockSendAwsRequest.mockResolvedValue(
+        s3Response(stateDocument({ a: '1' })),
+      )
+
+      await expect(
+        resolve(provider(s3Config()), 'missing'),
+      ).resolves.toBeUndefined()
+    })
+
+    test('a state document without outputs resolves to undefined', async () => {
+      mockSendAwsRequest.mockResolvedValue(
+        s3Response(JSON.stringify({ version: 4, terraform_version: '1.9.0' })),
+      )
+
+      await expect(resolve(provider(s3Config()), 'a')).resolves.toBeUndefined()
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(1)
+    })
+
+    test('passes the same credential provider to every request', async () => {
+      // A fresh body per call: the response body is a stream, read once.
+      mockSendAwsRequest.mockImplementation(async () =>
+        s3Response(stateDocument({ a: '1' })),
+      )
+
+      await resolve(provider(s3Config()), 'a')
+      await resolve(provider(s3Config({ key: 'prod/other.tfstate' })), 'a')
+
+      const [first, second] = mockSendAwsRequest.mock.calls.map(([r]) => r)
+      expect(first.credentials).toBe(second.credentials)
+    })
+
+    test('leaves the region undefined when the resolver has none, so the SDK default chain applies', async () => {
+      mockSendAwsRequest.mockResolvedValue(
+        s3Response(stateDocument({ a: '1' })),
+      )
+      const { region, ...withoutRegion } = s3Config()
+
+      await resolve(provider(withoutRegion), 'a')
+
+      expect(mockSendAwsRequest.mock.calls[0][0].region).toBeUndefined()
+    })
+
+    test('wraps SDK errors exactly as before', async () => {
+      const noSuchKey = Object.assign(
+        new Error('The specified key does not exist.'),
+        { name: 'NoSuchKey' },
+      )
+      mockSendAwsRequest.mockRejectedValue(noSuchKey)
+
+      await expect(resolve(provider(s3Config()), 'a')).rejects.toThrow(
+        'Error fetching Terraform outputs from S3: NoSuchKey: The specified key does not exist.',
+      )
+    })
+
+    test('wraps a body-read failure exactly as before, without retrying', async () => {
+      const cut = new Readable({
+        read() {
+          this.push('{"outputs":')
+          this.destroy(
+            Object.assign(new Error('aborted'), { code: 'ECONNRESET' }),
+          )
+        },
+      })
+      mockSendAwsRequest.mockResolvedValue({ Body: cut })
+
+      await expect(resolve(provider(s3Config()), 'a')).rejects.toThrow(
+        'Error fetching Terraform outputs from S3: Error: aborted',
+      )
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(1)
+    })
+
+    test('lets a ServerlessError from the shared layer through untouched', async () => {
+      const { ServerlessError } = await import('@serverless/util')
+      const rateExceeded = new ServerlessError(
+        'Amazon S3 rejected GetObject with "SlowDown: Please reduce your request rate." after 10 attempts (58 s).',
+        'RESOLVER_AWS_RATE_EXCEEDED',
+      )
+      mockSendAwsRequest.mockRejectedValue(rateExceeded)
+
+      await expect(resolve(provider(s3Config()), 'a')).rejects.toBe(
+        rateExceeded,
+      )
+    })
+
+    test('fetches one state file once per process, shared across placeholders and provider instances', async () => {
+      mockSendAwsRequest.mockResolvedValue(
+        s3Response(stateDocument({ a: 'one', b: 'two', c: 'three' })),
+      )
+      const serviceA = provider(s3Config())
+      const serviceB = provider(s3Config())
+
+      const values = await Promise.all([
+        resolve(serviceA, 'a'),
+        resolve(serviceA, 'b'),
+        resolve(serviceA, 'c'),
+        resolve(serviceB, 'a'),
+        resolve(serviceB, 'b'),
+      ])
+
+      expect(values).toEqual(['one', 'two', 'three', 'one', 'two'])
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(1)
+    })
+
+    test('hands each placeholder its own copy of an object-valued output', async () => {
+      mockSendAwsRequest.mockResolvedValue(
+        s3Response(stateDocument({ network: { subnets: { a: 'subnet-a' } } })),
+      )
+      const serviceA = provider(s3Config())
+      const serviceB = provider(s3Config())
+
+      const first = await resolve(serviceA, 'network')
+      first.subnets.a = 'mutated'
+
+      const second = await resolve(serviceB, 'network')
+      const third = await resolve(serviceA, 'network.subnets')
+
+      expect(second).toEqual({ subnets: { a: 'subnet-a' } })
+      expect(third).toEqual({ a: 'subnet-a' })
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(1)
+    })
+
+    test('a different bucket, key or region is a different fetch', async () => {
+      mockSendAwsRequest.mockImplementation(async () =>
+        s3Response(stateDocument({ a: '1' })),
+      )
+
+      await resolve(provider(s3Config()), 'a')
+      await resolve(provider(s3Config({ key: 'prod/data.tfstate' })), 'a')
+      await resolve(provider(s3Config({ bucket: 'other-bucket' })), 'a')
+      await resolve(provider(s3Config({ region: 'eu-west-1' })), 'a')
+
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(4)
+    })
+
+    test('a failed fetch is shared by the placeholders in flight and then forgotten', async () => {
+      const noSuchKey = Object.assign(
+        new Error('The specified key does not exist.'),
+        { name: 'NoSuchKey' },
+      )
+      mockSendAwsRequest
+        .mockRejectedValueOnce(noSuchKey)
+        .mockResolvedValueOnce(s3Response(stateDocument({ a: 'later' })))
+      const instance = provider(s3Config())
+
+      const results = await Promise.allSettled([
+        resolve(instance, 'a'),
+        resolve(instance, 'b'),
+      ])
+      expect(results.map((r) => r.status)).toEqual(['rejected', 'rejected'])
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(1)
+
+      await expect(resolve(instance, 'a')).resolves.toBe('later')
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(2)
+    })
+
+    test('the runners cache invalidation does not drop Terraform state', async () => {
+      mockSendAwsRequest.mockResolvedValue(
+        s3Response(stateDocument({ a: '1' })),
+      )
+      const instance = provider(s3Config())
+
+      await resolve(instance, 'a')
+      Terraform.invalidateCaches()
+      await resolve(provider(s3Config()), 'a')
+
+      expect(mockSendAwsRequest).toHaveBeenCalledTimes(1)
+    })
+  })
+})
+
+describe('Terraform resolver — remote and http backends', () => {
+  const originalFetch = globalThis.fetch
+  const originalToken = process.env.TF_TOKEN_app_terraform_io
+  let fetchCalls
+
+  const outputsPayload = (outputs) => ({
+    data: Object.entries(outputs).map(([name, value]) => ({
+      attributes: { name, value },
+    })),
+  })
+
+  beforeEach(() => {
+    resetTerraformOutputsCache()
+    fetchCalls = []
+    process.env.TF_TOKEN_app_terraform_io = 'test-token'
+    globalThis.fetch = async (url) => {
+      const href = String(url)
+      fetchCalls.push(href)
+      if (href.includes('/organizations/')) {
+        return {
+          ok: true,
+          json: async () => ({ data: { id: 'ws-123' } }),
+        }
+      }
+      if (href.includes('current-state-version-outputs')) {
+        return {
+          ok: true,
+          json: async () => outputsPayload({ a: 'remote-a', b: 'remote-b' }),
+        }
+      }
+      // http backend: the state document itself
+      return {
+        ok: true,
+        json: async () => ({
+          outputs: { a: { value: 'http-a' }, b: { value: 'http-b' } },
+        }),
+      }
+    }
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalToken === undefined)
+      delete process.env.TF_TOKEN_app_terraform_io
+    else process.env.TF_TOKEN_app_terraform_io = originalToken
+  })
+
+  test('remote by organization and workspace: one workspace lookup and one outputs read per process', async () => {
+    const config = {
+      type: 'terraform',
+      backend: 'remote',
+      organization: 'my-org',
+      workspace: 'my-workspace',
+    }
+    const serviceA = provider(config)
+    const serviceB = provider(config)
+
+    const values = await Promise.all([
+      resolve(serviceA, 'a'),
+      resolve(serviceA, 'b'),
+      resolve(serviceB, 'a'),
+    ])
+
+    expect(values).toEqual(['remote-a', 'remote-b', 'remote-a'])
+    expect(fetchCalls).toHaveLength(2)
+    expect(fetchCalls[0]).toContain(
+      '/organizations/my-org/workspaces/my-workspace',
+    )
+    expect(fetchCalls[1]).toContain(
+      '/workspaces/ws-123/current-state-version-outputs',
+    )
+  })
+
+  test('remote by workspaceId: one outputs read per process; another workspace is another read', async () => {
+    const one = { type: 'terraform', backend: 'remote', workspaceId: 'ws-1' }
+    const two = { type: 'terraform', backend: 'remote', workspaceId: 'ws-2' }
+
+    await resolve(provider(one), 'a')
+    await resolve(provider(one), 'b')
+    await resolve(provider(two), 'a')
+
+    expect(fetchCalls).toHaveLength(2)
+  })
+
+  test('remote: organization and workspace outrank a workspaceId in the memo key too', async () => {
+    // The fetcher overwrites workspaceId with the id it looks up from
+    // organization/workspace, so the key has to name the workspace that is
+    // actually read - otherwise the second config is served the first one's
+    // outputs.
+    globalThis.fetch = async (url) => {
+      const href = String(url)
+      fetchCalls.push(href)
+      if (href.includes('/organizations/')) {
+        return { ok: true, json: async () => ({ data: { id: 'ws-2' } }) }
+      }
+      const [, readWorkspaceId] = href.match(/\/workspaces\/([^/]+)\//)
+      return {
+        ok: true,
+        json: async () => outputsPayload({ a: `from-${readWorkspaceId}` }),
+      }
+    }
+    const byId = { type: 'terraform', backend: 'remote', workspaceId: 'ws-1' }
+    const byName = {
+      type: 'terraform',
+      backend: 'remote',
+      workspaceId: 'ws-1',
+      organization: 'my-org',
+      workspace: 'w2',
+    }
+
+    await expect(resolve(provider(byId), 'a')).resolves.toBe('from-ws-1')
+    await expect(resolve(provider(byName), 'a')).resolves.toBe('from-ws-2')
+
+    expect(
+      fetchCalls.filter((href) =>
+        href.includes('current-state-version-outputs'),
+      ),
+    ).toHaveLength(2)
+  })
+
+  test('http: one read per address per process', async () => {
+    const config = {
+      type: 'terraform',
+      backend: 'http',
+      address: 'https://state.example.com/prod',
+    }
+
+    const values = await Promise.all([
+      resolve(provider(config), 'a'),
+      resolve(provider(config), 'b'),
+    ])
+    await resolve(
+      provider({ ...config, address: 'https://state.example.com/staging' }),
+      'a',
+    )
+
+    expect(values).toEqual(['http-a', 'http-b'])
+    expect(fetchCalls).toHaveLength(2)
+  })
+
+  test('http: a failed read is forgotten so the next placeholder retries', async () => {
+    let attempts = 0
+    globalThis.fetch = async () => {
+      attempts += 1
+      if (attempts === 1) {
+        return {
+          ok: false,
+          statusText: 'Not Found',
+          text: async () => '{"message":"404"}',
+        }
+      }
+      return {
+        ok: true,
+        json: async () => ({ outputs: { a: { value: 'ok' } } }),
+      }
+    }
+    const config = {
+      type: 'terraform',
+      backend: 'http',
+      address: 'https://state.example.com/prod',
+    }
+
+    await expect(resolve(provider(config), 'a')).rejects.toThrow(
+      'Error fetching Terraform outputs from HTTP backend: Error: Not Found: {"message":"404"}',
+    )
+    await expect(resolve(provider(config), 'a')).resolves.toBe('ok')
+    expect(attempts).toBe(2)
+  })
+})

--- a/packages/sf-core/tests/unit/resolvers/vault.test.js
+++ b/packages/sf-core/tests/unit/resolvers/vault.test.js
@@ -1,0 +1,29 @@
+import { Vault } from '../../../src/lib/resolvers/providers/vault/vault.js'
+
+describe('Vault resolver', () => {
+  describe('validateConfig', () => {
+    test('accepts a valid configuration', () => {
+      expect(() =>
+        Vault.validateConfig({
+          type: 'vault',
+          token: 'hvs.token',
+          address: 'https://vault.example.com',
+          version: 'v2',
+          path: 'secret/data/app',
+        }),
+      ).not.toThrow()
+    })
+
+    test('rejects unknown keys with the allowed-keys message', () => {
+      expect(() =>
+        Vault.validateConfig({
+          type: 'vault',
+          address: 'https://vault.example.com',
+          namespace: 'admin',
+        }),
+      ).toThrow(
+        "Only 'token', 'address', 'version', and 'path' are allowed in the Vault configuration (unrecognized: 'namespace')",
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

The Terraform variable resolver (`${terraform:outputs:…}`) reads each Terraform state once per run and shares it across every placeholder and every service deployed together with Serverless Framework Compose. Previously the whole state was downloaded and parsed once per referenced output, per service, so a Compose project with many services referencing the same state issued dozens of concurrent downloads of the same file.

- One read per state per run for all three backends (`s3`, `remote`, `http`). The state is kept for the duration of the process only, so a new run always reads the current state; a `serverless dev` session keeps the state it read at startup.
- The `s3` backend's request goes through the resolvers' shared AWS request layer: S3 throttling is retried with the AWS SDK's standard backoff (10 attempts by default; `AWS_MAX_ATTEMPTS`, `AWS_RETRY_MODE` and `~/.aws/config` are honoured), `--verbose` shows each retry, `--debug` prints a `terraform: … state files, … GetObject calls, … throttled attempts` request summary, and exhausted retries fail with the existing `RESOLVER_AWS_RATE_EXCEEDED` error.
- AWS credentials for the `s3` backend are resolved once per process instead of once per placeholder, so an SSO profile is no longer asked for role credentials in a burst.
- A state bucket in a different region than the configured one is now read by following S3's redirect instead of failing with `PermanentRedirect`.
- Every existing Terraform error message is unchanged. This change does not add a retry for a download interrupted mid-transfer: such an interruption still fails the run with `Error fetching Terraform outputs from S3: Error: aborted`, but can now happen at most once per state file per resolution pass instead of once per referenced output.
- Docs (`docs/sf/guides/variables/hashicorp/terraform.md`): the page now states where the resolver takes its region and credentials from (the AWS SDK's default settings, not `provider.region` / `provider.profile`), and gains a "Requests and rate limits" section matching the AWS resolver pages.

Two related fixes in the same area:

- The `--debug` request summary of the AWS-backed resolvers prints a service's line only when its numbers changed since the previous print, instead of reprinting every line after each Compose service. Counters stay cumulative and the line format is unchanged.
- Unknown keys in a resolver configuration (`terraform`, `doppler`, `vault`, `service`) are rejected with the intended message again, e.g. `Only 'bucket', 'key', and 'region' are allowed in the s3 backend configuration (unrecognized: 'profile')`, instead of the generic `Unrecognized key: "profile"`. The curated messages had stopped rendering after the zod 4 upgrade.

No `serverless.yml`, CLI, CloudFormation template, or IAM changes.

Not included on purpose: a concurrency cap on Terraform state fetches (the issue's second suggestion). After de-duplication a run issues one `GetObject` per distinct state file regardless of how many placeholders or services reference it, so there is no request burst left to bound; a cap was evaluated for the other AWS resolvers when the shared request layer was introduced and only turned a healthy burst into a slower throttled stream. If interrupted downloads still show up after this ships, a retry of the interrupted read is the next lever.

## Root cause

Each `${terraform:outputs:<key>}` placeholder fetched and parsed the whole state document independently, and Compose services never shared a fetch, so the number of S3 downloads scaled with placeholders × services. A connection closed by the network while a response body is streaming is not covered by the SDK's request retries, which apply before the body is handed to the caller, so under that fan-out an intermittent `Error: aborted` became likely on large deploys.

## Test plan

- [x] Unit: `packages/sf-core/tests/unit/resolvers/terraform.test.js` (new) covers config validation, the request shape, one fetch per state across provider instances, a shared in-flight failure followed by eviction, unchanged error texts, `ServerlessError` pass-through, `remote`/`http` de-duplication with a stubbed `fetch`, and per-placeholder value isolation. `aws-clients.test.js` and `aws-requests.test.js` cover the `terraform` service row, its summary line, the rate-limit message and the print-on-change summary. New `doppler.test.js`, `vault.test.js`, `service.test.js` cover the restored validation messages.
- [x] Full unit suites green: sf-core 74 suites / 1065 tests, framework 199 suites / 3840 tests; lint and prettier clean.
- [x] Live: `tests/integration/resolvers/terraform/s3-output` — the existing single-service suite plus a new Compose scenario (two services × two outputs) asserting the `--debug` summary reads `1 state files, 1 GetObject calls` and validating both deployed functions' environment; 6/6 passed. `tests/integration/resolvers/cf-many` 8/8 passed with the summary change.
- [x] Live probe with a connection counter: a single service with 6 references opened 1 TLS connection to the state bucket (was 5); a 3-service Compose project reading 2 state files opened 2 (was 17). `Region is missing` and `NoSuchKey` error texts unchanged.

Closes #13844


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Terraform S3 backend support for resolving Terraform outputs.
  * Added caching for repeated Terraform state reads and retry handling for temporary AWS throttling.
  * Improved support for Terraform remote and HCP Terraform configurations.
  * Added clearer configuration validation messages across resolver providers.

* **Documentation**
  * Updated Terraform resolver guidance for supported backends, AWS credentials and region behavior, caching, retries, and rate limits.

* **Bug Fixes**
  * Improved AWS resolver summaries so unchanged service statistics are not repeatedly displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->