### PR TITLE
fix(aws): reject package paths at or above the service directory

### DIFF
--- a/docs/sf/providers/aws/cli-reference/deploy.md
+++ b/docs/sf/providers/aws/cli-reference/deploy.md
@@ -36,7 +36,7 @@ serverless deploy
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--aws-profile` The AWS profile you want to use.
-- `--package` or `-p` path to a pre-packaged directory and skip packaging step. Relative paths are resolved from the service directory; the service directory itself or a directory that contains it is not accepted.
+- `--package` or `-p` path to a pre-packaged directory and skip packaging step. The service directory itself or a directory that contains it is not accepted.
 - `--verbose` Shows all stack events during deployment, and display any Stack Output.
 - `--force` Forces a deployment to take place.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.

--- a/docs/sf/providers/aws/cli-reference/deploy.md
+++ b/docs/sf/providers/aws/cli-reference/deploy.md
@@ -36,7 +36,7 @@ serverless deploy
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--aws-profile` The AWS profile you want to use.
-- `--package` or `-p` path to a pre-packaged directory and skip packaging step.
+- `--package` or `-p` path to a pre-packaged directory and skip packaging step. Relative paths are resolved from the service directory; the service directory itself or a directory that contains it is not accepted.
 - `--verbose` Shows all stack events during deployment, and display any Stack Output.
 - `--force` Forces a deployment to take place.
 - `--function` or `-f` Invoke `deploy function` (see above). Convenience shortcut - cannot be used with `--package`.

--- a/docs/sf/providers/aws/cli-reference/package.md
+++ b/docs/sf/providers/aws/cli-reference/package.md
@@ -24,7 +24,7 @@ serverless package
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--aws-profile` The AWS profile you want to use.
-- `--package` or `-p` path to the custom packaging directory you want. Relative paths are resolved from the service directory. The directory is replaced with the packaged output, so it cannot be the service directory itself or a directory that contains it.
+- `--package` or `-p` path to the custom packaging directory you want. The directory is replaced with the packaged output, so it cannot be the service directory itself or a directory that contains it.
 
 ## Examples
 

--- a/docs/sf/providers/aws/cli-reference/package.md
+++ b/docs/sf/providers/aws/cli-reference/package.md
@@ -24,7 +24,7 @@ serverless package
 - `--stage` or `-s` The stage in your service that you want to deploy to.
 - `--region` or `-r` The region in that stage that you want to deploy to.
 - `--aws-profile` The AWS profile you want to use.
-- `--package` or `-p` path to the custom packaging directory you want.
+- `--package` or `-p` path to the custom packaging directory you want. Relative paths are resolved from the service directory. The directory is replaced with the packaged output, so it cannot be the service directory itself or a directory that contains it.
 
 ## Examples
 

--- a/packages/serverless/lib/plugins/aws/common/lib/artifacts.js
+++ b/packages/serverless/lib/plugins/aws/common/lib/artifacts.js
@@ -1,5 +1,49 @@
 import path from 'path'
+import fs from 'fs'
 import fse from 'fs-extra'
+import ServerlessError from '../../../../serverless-error.js'
+
+// Canonical form of a path for containment comparison: symlinks followed and,
+// on case-insensitive filesystems, the on-disk casing. Paths that do not exist
+// yet are compared as resolved.
+function canonicalize(absolutePath) {
+  try {
+    return fs.realpathSync.native(absolutePath)
+  } catch {
+    return absolutePath
+  }
+}
+
+/**
+ * Resolve the user-supplied package path against the service directory and
+ * refuse it when it is the service directory itself or one of its ancestors.
+ * The package directory is replaced wholesale when artifacts are moved into
+ * it, so for those paths "replace the package directory" would delete the
+ * user's project. Returns the absolute package path to use for all
+ * filesystem operations, so the check and the operations agree on which
+ * directory is meant regardless of the process cwd.
+ */
+function resolvePackagePath(packagePath, serviceDir) {
+  const resolvedPackagePath = path.resolve(serviceDir, packagePath)
+  // Where the service directory lies, seen from the package directory. It is
+  // empty when both are the same directory and a downward path (no leading
+  // ".." segment) when the package directory is an ancestor of the service.
+  const serviceRelativeToPackage = path.relative(
+    canonicalize(resolvedPackagePath),
+    canonicalize(serviceDir),
+  )
+  const isOutsideService =
+    serviceRelativeToPackage === '..' ||
+    serviceRelativeToPackage.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(serviceRelativeToPackage)
+  if (!isOutsideService) {
+    throw new ServerlessError(
+      `The package path "${packagePath}" resolves to the service directory or to a directory containing it (${resolvedPackagePath}). Moving packaged artifacts there would replace the service's own files. Use a directory dedicated to packaged output instead, either inside the service (for example "--package .serverless-package") or outside it (for example "--package ../artifacts").`,
+      'PACKAGE_PATH_CONTAINS_SERVICE',
+    )
+  }
+  return resolvedPackagePath
+}
 
 export default {
   async moveArtifactsToPackage() {
@@ -10,19 +54,23 @@ export default {
 
     // Only move the artifacts if it was requested by the user
     if (this.serverless.serviceDir && !packagePath.endsWith('.serverless')) {
+      const resolvedPackagePath = resolvePackagePath(
+        packagePath,
+        this.serverless.serviceDir,
+      )
       const serverlessTmpDirPath = path.join(
         this.serverless.serviceDir,
         '.serverless',
       )
 
       if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
-        if (this.serverless.utils.dirExistsSync(packagePath)) {
-          fse.removeSync(packagePath)
+        if (this.serverless.utils.dirExistsSync(resolvedPackagePath)) {
+          fse.removeSync(resolvedPackagePath)
         }
-        this.serverless.utils.writeFileDir(packagePath)
+        this.serverless.utils.writeFileDir(resolvedPackagePath)
         this.serverless.utils.copyDirContentsSync(
           serverlessTmpDirPath,
-          packagePath,
+          resolvedPackagePath,
         )
         fse.removeSync(serverlessTmpDirPath)
       }
@@ -37,18 +85,22 @@ export default {
 
     // Only move the artifacts if it was requested by the user
     if (this.serverless.serviceDir && !packagePath.endsWith('.serverless')) {
+      const resolvedPackagePath = resolvePackagePath(
+        packagePath,
+        this.serverless.serviceDir,
+      )
       const serverlessTmpDirPath = path.join(
         this.serverless.serviceDir,
         '.serverless',
       )
 
-      if (this.serverless.utils.dirExistsSync(packagePath)) {
+      if (this.serverless.utils.dirExistsSync(resolvedPackagePath)) {
         if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
           fse.removeSync(serverlessTmpDirPath)
         }
         this.serverless.utils.writeFileDir(serverlessTmpDirPath)
         this.serverless.utils.copyDirContentsSync(
-          packagePath,
+          resolvedPackagePath,
           serverlessTmpDirPath,
         )
       }

--- a/packages/serverless/lib/plugins/aws/common/lib/artifacts.js
+++ b/packages/serverless/lib/plugins/aws/common/lib/artifacts.js
@@ -15,16 +15,16 @@ function canonicalize(absolutePath) {
 }
 
 /**
- * Resolve the user-supplied package path against the service directory and
- * refuse it when it is the service directory itself or one of its ancestors.
- * The package directory is replaced wholesale when artifacts are moved into
- * it, so for those paths "replace the package directory" would delete the
- * user's project. Returns the absolute package path to use for all
- * filesystem operations, so the check and the operations agree on which
- * directory is meant regardless of the process cwd.
+ * Resolve the user-supplied package path (relative paths are relative to the
+ * process cwd, as they always were for these moves) and refuse it when it is
+ * the service directory itself or one of its ancestors. The package directory
+ * is replaced wholesale when artifacts are moved into it, so for those paths
+ * "replace the package directory" would delete the user's project. Returns
+ * the absolute package path to use for all filesystem operations, so the
+ * check and the operations always refer to the same directory.
  */
 function resolvePackagePath(packagePath, serviceDir) {
-  const resolvedPackagePath = path.resolve(serviceDir, packagePath)
+  const resolvedPackagePath = path.resolve(packagePath)
   // Where the service directory lies, seen from the package directory. It is
   // empty when both are the same directory and a downward path (no leading
   // ".." segment) when the package directory is an ancestor of the service.

--- a/packages/serverless/lib/plugins/aws/common/lib/artifacts.js
+++ b/packages/serverless/lib/plugins/aws/common/lib/artifacts.js
@@ -45,65 +45,65 @@ function resolvePackagePath(packagePath, serviceDir) {
   return resolvedPackagePath
 }
 
+/**
+ * The package directory the user asked for, validated and absolute, or null
+ * when there is nothing to move: no service directory, no explicit
+ * `--package` / `package.path`, or a path ending in ".serverless", which
+ * designates the default location. The validation runs before that shortcut
+ * so an ancestor directory that happens to be named ".serverless" is still
+ * refused rather than silently skipped.
+ */
+function requestedPackagePath(plugin) {
+  const { serviceDir } = plugin.serverless
+  const requested =
+    plugin.options.package || plugin.serverless.service.package.path
+  if (!serviceDir || !requested) return null
+  const resolvedPackagePath = resolvePackagePath(requested, serviceDir)
+  if (requested.endsWith('.serverless')) return null
+  return resolvedPackagePath
+}
+
 export default {
   async moveArtifactsToPackage() {
-    const packagePath =
-      this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.serverless.serviceDir || '.', '.serverless')
+    const resolvedPackagePath = requestedPackagePath(this)
+    if (!resolvedPackagePath) return
 
-    // Only move the artifacts if it was requested by the user
-    if (this.serverless.serviceDir && !packagePath.endsWith('.serverless')) {
-      const resolvedPackagePath = resolvePackagePath(
-        packagePath,
-        this.serverless.serviceDir,
-      )
-      const serverlessTmpDirPath = path.join(
-        this.serverless.serviceDir,
-        '.serverless',
-      )
+    const serverlessTmpDirPath = path.join(
+      this.serverless.serviceDir,
+      '.serverless',
+    )
 
-      if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
-        if (this.serverless.utils.dirExistsSync(resolvedPackagePath)) {
-          fse.removeSync(resolvedPackagePath)
-        }
-        this.serverless.utils.writeFileDir(resolvedPackagePath)
-        this.serverless.utils.copyDirContentsSync(
-          serverlessTmpDirPath,
-          resolvedPackagePath,
-        )
-        fse.removeSync(serverlessTmpDirPath)
+    if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
+      if (this.serverless.utils.dirExistsSync(resolvedPackagePath)) {
+        fse.removeSync(resolvedPackagePath)
       }
+      this.serverless.utils.writeFileDir(resolvedPackagePath)
+      this.serverless.utils.copyDirContentsSync(
+        serverlessTmpDirPath,
+        resolvedPackagePath,
+      )
+      fse.removeSync(serverlessTmpDirPath)
     }
   },
 
   async moveArtifactsToTemp() {
-    const packagePath =
-      this.options.package ||
-      this.serverless.service.package.path ||
-      path.join(this.serverless.serviceDir || '.', '.serverless')
+    const resolvedPackagePath = requestedPackagePath(this)
+    if (!resolvedPackagePath) return
 
-    // Only move the artifacts if it was requested by the user
-    if (this.serverless.serviceDir && !packagePath.endsWith('.serverless')) {
-      const resolvedPackagePath = resolvePackagePath(
-        packagePath,
-        this.serverless.serviceDir,
-      )
-      const serverlessTmpDirPath = path.join(
-        this.serverless.serviceDir,
-        '.serverless',
-      )
+    const serverlessTmpDirPath = path.join(
+      this.serverless.serviceDir,
+      '.serverless',
+    )
 
-      if (this.serverless.utils.dirExistsSync(resolvedPackagePath)) {
-        if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
-          fse.removeSync(serverlessTmpDirPath)
-        }
-        this.serverless.utils.writeFileDir(serverlessTmpDirPath)
-        this.serverless.utils.copyDirContentsSync(
-          resolvedPackagePath,
-          serverlessTmpDirPath,
-        )
+    if (this.serverless.utils.dirExistsSync(resolvedPackagePath)) {
+      if (this.serverless.utils.dirExistsSync(serverlessTmpDirPath)) {
+        fse.removeSync(serverlessTmpDirPath)
       }
+      this.serverless.utils.writeFileDir(serverlessTmpDirPath)
+      this.serverless.utils.copyDirContentsSync(
+        resolvedPackagePath,
+        serverlessTmpDirPath,
+      )
     }
   },
 }

--- a/packages/serverless/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
@@ -130,17 +130,25 @@ describe('aws common artifacts', () => {
       expect(fs.existsSync(path.join(serviceDir, 'handler.js'))).toBe(true)
     })
 
-    it('resolves a relative package path against the service directory, not the cwd', async () => {
+    it('resolves a relative package path from the cwd, like the filesystem operations do', async () => {
       // With `--config sub/serverless.yml` (or Compose) the cwd is not the
-      // service directory. The guard and the filesystem operations must agree
-      // on what a relative path means, or the guard protects the wrong path.
+      // service directory. Relative paths keep their long-standing meaning
+      // (relative to the cwd) so existing output locations do not move.
       process.chdir(rootDir)
-      const plugin = createPlugin('service')
+      const plugin = createPlugin('out')
       await plugin.moveArtifactsToPackage()
       expectServiceIntact({ artifactsMoved: true })
-      expect(
-        fs.existsSync(path.join(serviceDir, 'service', 'service.zip')),
-      ).toBe(true)
+      expect(fs.existsSync(path.join(rootDir, 'out', 'service.zip'))).toBe(true)
+      expect(fs.existsSync(path.join(serviceDir, 'out'))).toBe(false)
+    })
+
+    it('refuses a relative path that names the service directory from another cwd', async () => {
+      process.chdir(rootDir)
+      const plugin = createPlugin('service')
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
     })
 
     it('refuses an ancestor even when an intermediate directory name starts with ".."', async () => {

--- a/packages/serverless/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import fsp from 'fs/promises'
+import artifacts from '../../../../../../../lib/plugins/aws/common/lib/artifacts.js'
+import Utils from '../../../../../../../lib/classes/utils.js'
+
+/**
+ * `moveArtifactsToPackage` replaces the target package directory with the
+ * contents of `<serviceDir>/.serverless`, and `moveArtifactsToTemp` does the
+ * reverse. Both assume the package directory is disjoint from the service
+ * directory: when the package path resolves to the service directory itself
+ * (`--package .`) or to one of its ancestors (`--package ..`), "replace the
+ * package directory" means deleting the user's project. These tests pin the
+ * guard that refuses such paths before any file is touched, and that ordinary
+ * sibling/child package paths keep working.
+ *
+ * SAFETY: relative package paths are resolved against the process cwd by the
+ * filesystem calls, so every test runs with cwd inside the throwaway temp
+ * tree. Never remove that chdir — a regression in the guard would otherwise
+ * delete the repository the test runs from.
+ */
+describe('aws common artifacts', () => {
+  let rootDir
+  let serviceDir
+  let originalCwd
+
+  const createPlugin = (packageOption) => {
+    const serverless = {
+      serviceDir,
+      service: { package: {} },
+    }
+    serverless.utils = new Utils(serverless)
+    const plugin = { serverless, options: { package: packageOption } }
+    Object.assign(plugin, artifacts)
+    return plugin
+  }
+
+  const seedServiceWithArtifacts = async () => {
+    await fsp.mkdir(path.join(serviceDir, '.serverless'), { recursive: true })
+    await fsp.writeFile(path.join(serviceDir, 'handler.js'), 'export {}\n')
+    await fsp.writeFile(path.join(serviceDir, 'serverless.yml'), 'service: s\n')
+    await fsp.writeFile(
+      path.join(serviceDir, '.serverless', 'service.zip'),
+      'zip',
+    )
+    await fsp.writeFile(path.join(rootDir, 'sibling-marker.txt'), 'keep')
+  }
+
+  const expectServiceIntact = ({ artifactsMoved = false } = {}) => {
+    expect(fs.existsSync(path.join(serviceDir, 'handler.js'))).toBe(true)
+    expect(fs.existsSync(path.join(serviceDir, 'serverless.yml'))).toBe(true)
+    expect(
+      fs.existsSync(path.join(serviceDir, '.serverless', 'service.zip')),
+    ).toBe(!artifactsMoved)
+    expect(fs.existsSync(path.join(rootDir, 'sibling-marker.txt'))).toBe(true)
+  }
+
+  beforeEach(async () => {
+    originalCwd = process.cwd()
+    rootDir = fs.realpathSync(
+      await fsp.mkdtemp(path.join(os.tmpdir(), 'sls-artifacts-')),
+    )
+    serviceDir = path.join(rootDir, 'service')
+    await seedServiceWithArtifacts()
+    process.chdir(serviceDir)
+  })
+
+  afterEach(async () => {
+    process.chdir(originalCwd)
+    await fsp.rm(rootDir, { recursive: true, force: true })
+  })
+
+  describe('moveArtifactsToPackage', () => {
+    it('refuses "." and leaves the service directory untouched', async () => {
+      const plugin = createPlugin('.')
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        name: 'ServerlessError',
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
+    })
+
+    it('refuses ".." and leaves the parent directory untouched', async () => {
+      const plugin = createPlugin('..')
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
+    })
+
+    it('refuses an absolute path to an ancestor of the service directory', async () => {
+      const plugin = createPlugin(rootDir)
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
+    })
+
+    it('refuses the service directory given as an absolute path', async () => {
+      const plugin = createPlugin(serviceDir)
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
+    })
+
+    it('names the offending path in the error message', async () => {
+      const plugin = createPlugin('..')
+      await expect(plugin.moveArtifactsToPackage()).rejects.toThrow(/"\.\."/)
+    })
+
+    it('moves artifacts to a sibling directory', async () => {
+      const packageDir = path.join(rootDir, 'out')
+      const plugin = createPlugin(packageDir)
+      await plugin.moveArtifactsToPackage()
+      expect(fs.existsSync(path.join(packageDir, 'service.zip'))).toBe(true)
+      expect(fs.existsSync(path.join(serviceDir, '.serverless'))).toBe(false)
+      expect(fs.existsSync(path.join(serviceDir, 'handler.js'))).toBe(true)
+    })
+
+    it('moves artifacts to a relative child directory of the service', async () => {
+      const plugin = createPlugin('build')
+      await plugin.moveArtifactsToPackage()
+      expect(fs.existsSync(path.join(serviceDir, 'build', 'service.zip'))).toBe(
+        true,
+      )
+      expect(fs.existsSync(path.join(serviceDir, '.serverless'))).toBe(false)
+      expect(fs.existsSync(path.join(serviceDir, 'handler.js'))).toBe(true)
+    })
+
+    it('resolves a relative package path against the service directory, not the cwd', async () => {
+      // With `--config sub/serverless.yml` (or Compose) the cwd is not the
+      // service directory. The guard and the filesystem operations must agree
+      // on what a relative path means, or the guard protects the wrong path.
+      process.chdir(rootDir)
+      const plugin = createPlugin('service')
+      await plugin.moveArtifactsToPackage()
+      expectServiceIntact({ artifactsMoved: true })
+      expect(
+        fs.existsSync(path.join(serviceDir, 'service', 'service.zip')),
+      ).toBe(true)
+    })
+
+    it('refuses an ancestor even when an intermediate directory name starts with ".."', async () => {
+      // path.relative(<root>, <root>/..cache/svc) is "..cache/svc": a
+      // string-prefix check on ".." would wrongly treat <root> as outside.
+      const nestedService = path.join(rootDir, '..cache', 'svc')
+      await fsp.mkdir(path.join(nestedService, '.serverless'), {
+        recursive: true,
+      })
+      await fsp.writeFile(path.join(nestedService, 'handler.js'), '')
+      const plugin = createPlugin(rootDir)
+      plugin.serverless.serviceDir = nestedService
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expect(fs.existsSync(path.join(nestedService, 'handler.js'))).toBe(true)
+    })
+
+    it('refuses the service directory spelled with different casing on a case-insensitive filesystem', async () => {
+      const caseVariant = path.join(rootDir, 'SERVICE')
+      if (!fs.existsSync(caseVariant)) return // case-sensitive filesystem
+      const plugin = createPlugin(caseVariant)
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
+    })
+
+    it('refuses the service directory reached through a symlink', async () => {
+      const link = path.join(rootDir, 'service-link')
+      await fsp.symlink(serviceDir, link, 'dir')
+      const plugin = createPlugin(link)
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
+    })
+
+    it('does not reject a sibling whose name merely starts with the service name', async () => {
+      // `path.relative(<root>/service-out, <root>/service)` is "../service":
+      // a string-prefix check would wrongly treat this as an ancestor.
+      const packageDir = `${serviceDir}-out`
+      const plugin = createPlugin(packageDir)
+      await plugin.moveArtifactsToPackage()
+      expect(fs.existsSync(path.join(packageDir, 'service.zip'))).toBe(true)
+    })
+  })
+
+  describe('moveArtifactsToTemp', () => {
+    it('refuses "." and leaves the service directory untouched', async () => {
+      const plugin = createPlugin('.')
+      await expect(plugin.moveArtifactsToTemp()).rejects.toMatchObject({
+        name: 'ServerlessError',
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
+    })
+
+    it('refuses ".."', async () => {
+      const plugin = createPlugin('..')
+      await expect(plugin.moveArtifactsToTemp()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expectServiceIntact()
+    })
+
+    it('copies a sibling package directory into .serverless', async () => {
+      const packageDir = path.join(rootDir, 'out')
+      await fsp.mkdir(packageDir)
+      await fsp.writeFile(path.join(packageDir, 'prebuilt.zip'), 'zip')
+      const plugin = createPlugin(packageDir)
+      await plugin.moveArtifactsToTemp()
+      expect(
+        fs.existsSync(path.join(serviceDir, '.serverless', 'prebuilt.zip')),
+      ).toBe(true)
+      expect(fs.existsSync(path.join(packageDir, 'prebuilt.zip'))).toBe(true)
+    })
+  })
+})

--- a/packages/serverless/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/common/lib/artifacts.test.js
@@ -177,6 +177,23 @@ describe('aws common artifacts', () => {
       expectServiceIntact()
     })
 
+    it('refuses an ancestor directory that is itself named ".serverless"', async () => {
+      // A path ending in ".serverless" is treated as the default location and
+      // skips the move. That shortcut must not skip the safety check.
+      const ancestor = path.join(rootDir, '.serverless')
+      const nestedService = path.join(ancestor, 'service')
+      await fsp.mkdir(path.join(nestedService, '.serverless'), {
+        recursive: true,
+      })
+      await fsp.writeFile(path.join(nestedService, 'handler.js'), '')
+      const plugin = createPlugin(ancestor)
+      plugin.serverless.serviceDir = nestedService
+      await expect(plugin.moveArtifactsToPackage()).rejects.toMatchObject({
+        code: 'PACKAGE_PATH_CONTAINS_SERVICE',
+      })
+      expect(fs.existsSync(path.join(nestedService, 'handler.js'))).toBe(true)
+    })
+
     it('refuses the service directory reached through a symlink', async () => {
       const link = path.join(rootDir, 'service-link')
       await fsp.symlink(serviceDir, link, 'dir')
@@ -194,6 +211,33 @@ describe('aws common artifacts', () => {
       const plugin = createPlugin(packageDir)
       await plugin.moveArtifactsToPackage()
       expect(fs.existsSync(path.join(packageDir, 'service.zip'))).toBe(true)
+    })
+  })
+
+  describe('paths ending in ".serverless" (the default location)', () => {
+    it('does nothing for the service\'s own ".serverless" directory', async () => {
+      const plugin = createPlugin('.serverless')
+      await expect(plugin.moveArtifactsToPackage()).resolves.toBeUndefined()
+      await expect(plugin.moveArtifactsToTemp()).resolves.toBeUndefined()
+      expectServiceIntact()
+    })
+
+    it('does nothing for a sibling directory named ".serverless"', async () => {
+      const packageDir = path.join(rootDir, 'other', '.serverless')
+      await fsp.mkdir(packageDir, { recursive: true })
+      await fsp.writeFile(path.join(packageDir, 'prebuilt.zip'), 'zip')
+      const plugin = createPlugin(packageDir)
+      await expect(plugin.moveArtifactsToPackage()).resolves.toBeUndefined()
+      await expect(plugin.moveArtifactsToTemp()).resolves.toBeUndefined()
+      expectServiceIntact()
+      expect(fs.existsSync(path.join(packageDir, 'prebuilt.zip'))).toBe(true)
+    })
+
+    it('does nothing when no package path is configured', async () => {
+      const plugin = createPlugin(undefined)
+      await expect(plugin.moveArtifactsToPackage()).resolves.toBeUndefined()
+      await expect(plugin.moveArtifactsToTemp()).resolves.toBeUndefined()
+      expectServiceIntact()
     })
   })
 


### PR DESCRIPTION
## Summary

- `serverless package --package <dir>` and `serverless deploy --package <dir>` now fail early with `PACKAGE_PATH_CONTAINS_SERVICE` when the package directory resolves to the service directory itself or to a directory that contains it (`.`, `..`, an absolute ancestor, or the same directory reached through a symlink or, on case-insensitive filesystems, different casing). No files are touched before the check.
- The check and the artifact moves use one resolved absolute path, so they always refer to the same directory. Relative paths keep their existing meaning.
- Document the constraint on the `--package` option in the `package` and `deploy` CLI references.

## Root cause

When artifacts are moved into the requested package directory, an existing directory at that path is removed and replaced with the contents of `.serverless`. For `--package .` that path is the service directory: its contents were deleted before the removal itself failed with `Invalid argument '.'`, leaving the project empty. `--package ..` did the same to the parent directory. The code assumed the package directory is always disjoint from the service directory and never checked it.

## Test plan

- [x] New unit tests in `packages/serverless/test/unit/lib/plugins/aws/common/lib/artifacts.test.js` (20 cases): `.`, `..`, absolute ancestor, the service directory itself, an ancestor named `.serverless`, symlinked and case-variant spellings, a `..`-prefixed intermediate directory name, a relative path naming the service directory from another cwd; valid sibling, child, and relative paths still move artifacts to the same location as before; paths ending in `.serverless` and the no-`--package` default remain no-ops; `moveArtifactsToTemp` covered for the same rejections and a valid sibling.
- [x] Full `@serverless/framework` unit suite: 200 suites, 3857 tests passing.
- [x] Source CLI on a scratch service: `package --package .`, `--package ..`, `--package <absolute parent>` fail with the new error and the service and parent directories are unchanged; `--package build` succeeds. From the parent directory with `--config svc/serverless.yml`: `--package .` and `--package svc` are refused, `--package out` writes to the same location as before.
- [x] `eslint` and `prettier` clean on the changed files.

## Notes for reviewers

- A `--package` directory inside the service is still swept into the classic zip on the next packaging run because it is not in the default excludes. Follow-up, separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to prevent packaging into the service directory or any of its parent directories.
  - Package paths are now resolved from the current working directory, improving consistency for relative paths.
  - Unsafe paths, including symlinks and equivalent path variations, are rejected while preserving service files.

- **Documentation**
  - Updated AWS CLI reference documentation to clarify package-directory restrictions.
  - Removed the statement describing how relative paths are resolved from the service directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->