### PR TITLE
fix(resolvers): show AWS credential-setup hint for the default resolver

### DIFF
--- a/packages/sf-core/src/lib/resolvers/manager.js
+++ b/packages/sf-core/src/lib/resolvers/manager.js
@@ -389,15 +389,17 @@ export class ResolverManager {
   addDefaultAwsCredentialResolver() {
     // If the default AWS credential resolver is used, add it to the resolver providers
     if (this.credentialResolverName === DEFAULT_AWS_CREDENTIAL_RESOLVER) {
+      const profile =
+        this.options?.['aws-profile'] ||
+        this.serviceConfigFile?.provider?.profile
+      // Only set `profile` when one was actually configured. The AWS provider
+      // treats a type-only config as "nothing set up", which is what enables the
+      // credential-setup hint when no credentials can be found; an explicit
+      // `profile: undefined` key would make it look configured.
       this.addResolverProvider(
         DEFAULT_AWS_CREDENTIAL_RESOLVER,
         createResolverProvider(
-          {
-            type: 'aws',
-            profile:
-              this.options?.['aws-profile'] ||
-              this.serviceConfigFile?.provider?.profile,
-          },
+          { type: 'aws', ...(profile ? { profile } : {}) },
           this.serviceConfigFile,
           this.configFileDirPath,
           this.options,

--- a/packages/sf-core/tests/unit/resolvers/aws.test.js
+++ b/packages/sf-core/tests/unit/resolvers/aws.test.js
@@ -528,6 +528,48 @@ describe('Aws Resolver', () => {
     })
   })
 
+  describe('isDefaultConfig', () => {
+    const build = (providerConfig) =>
+      new Aws({
+        logger: mockLogger,
+        providerConfig,
+        serviceConfigFile: {},
+        configFileDirPath: '/tmp',
+        options: {},
+        stage: 'dev',
+        dashboard: null,
+        composeParams: null,
+        resolveVariableFunc: jest.fn(),
+        resolveConfigurationPropertyFunc: jest.fn(),
+      })
+
+    test('is true when the config carries nothing but the type', () => {
+      expect(build({ type: 'aws' }).isDefaultConfig).toBe(true)
+    })
+
+    test('is true for an empty config', () => {
+      expect(build({}).isDefaultConfig).toBe(true)
+    })
+
+    test('is false when a profile is configured', () => {
+      expect(build({ type: 'aws', profile: 'x' }).isDefaultConfig).toBe(false)
+    })
+
+    test('is false when any other option is configured', () => {
+      expect(build({ type: 'aws', region: 'eu-west-1' }).isDefaultConfig).toBe(
+        false,
+      )
+    })
+
+    test('hands isDefaultConfig to getAwsCredentials', async () => {
+      mockGetAwsCredentials.mockResolvedValue(() => ({}))
+      await build({ type: 'aws' }).resolveCredentials()
+      expect(mockGetAwsCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({ isDefaultConfig: true }),
+      )
+    })
+  })
+
   describe('static properties', () => {
     test('has correct type', () => {
       expect(Aws.type).toBe('aws')

--- a/packages/sf-core/tests/unit/resolvers/credentials.test.js
+++ b/packages/sf-core/tests/unit/resolvers/credentials.test.js
@@ -98,4 +98,50 @@ describe('getAwsCredentials', () => {
     expect(mockCredentialProvider).toHaveBeenCalledTimes(1)
     expect(mockCredentialProvider.mock.calls[0][0]).toBe(providerOptions)
   })
+
+  it('adds the credential-setup hint when the implicit default resolver is used', async () => {
+    const providerError = Object.assign(
+      new Error('Could not load credentials from any providers'),
+      { name: 'CredentialsProviderError' },
+    )
+    mockFromNodeProviderChain.mockReturnValue(
+      jest.fn().mockRejectedValue(providerError),
+    )
+
+    const credentialProvider = await getAwsCredentials({
+      logger,
+      dashboard,
+      config,
+      isDefaultConfig: true,
+    })
+
+    await expect(credentialProvider()).rejects.toMatchObject({
+      code: 'AWS_CREDENTIALS_MISSING',
+      message:
+        'AWS credentials missing or invalid. Run "serverless" to set up AWS credentials, or learn more in our docs: https://slss.io/aws-creds-setup. Original error from AWS: Could not load credentials from any providers',
+    })
+  })
+
+  it('omits the credential-setup hint when the resolver is explicitly configured', async () => {
+    const providerError = Object.assign(
+      new Error('Could not load credentials from any providers'),
+      { name: 'CredentialsProviderError' },
+    )
+    mockFromNodeProviderChain.mockReturnValue(
+      jest.fn().mockRejectedValue(providerError),
+    )
+
+    const credentialProvider = await getAwsCredentials({
+      logger,
+      dashboard,
+      config: { profile: 'does-not-exist' },
+      isDefaultConfig: false,
+    })
+
+    await expect(credentialProvider()).rejects.toMatchObject({
+      code: 'AWS_CREDENTIALS_MISSING',
+      message:
+        'AWS credentials missing or invalid. Original error from AWS: Could not load credentials from any providers',
+    })
+  })
 })

--- a/packages/sf-core/tests/unit/resolvers/manager.test.js
+++ b/packages/sf-core/tests/unit/resolvers/manager.test.js
@@ -70,6 +70,8 @@ jest.unstable_mockModule(
 // Import after mocking
 const { ResolverManager } =
   await import('../../../src/lib/resolvers/manager.js')
+const { createResolverProvider } =
+  await import('../../../src/lib/resolvers/providers.js')
 
 describe('ResolverManager', () => {
   let manager
@@ -286,6 +288,56 @@ describe('ResolverManager', () => {
       expect(manager.credentialResolverName).toBe(
         'default-aws-credential-resolver',
       )
+    })
+  })
+
+  describe('addDefaultAwsCredentialResolver', () => {
+    const build = (serviceConfig, options = {}) => {
+      manager = new ResolverManager(
+        mockLogger,
+        serviceConfig,
+        '/path/to/config',
+        options,
+        null,
+        null,
+        null,
+        false,
+        '4.0.0',
+      )
+      manager.setCredentialResolver()
+      manager.addDefaultAwsCredentialResolver()
+      return createResolverProvider.mock.calls.at(-1)[0]
+    }
+
+    test('passes a type-only config when no profile is configured', () => {
+      const config = build({ provider: {} })
+
+      expect(config).toEqual({ type: 'aws' })
+      expect(config).not.toHaveProperty('profile')
+    })
+
+    test('passes provider.profile when the service configures one', () => {
+      expect(build({ provider: { profile: 'svc-profile' } })).toEqual({
+        type: 'aws',
+        profile: 'svc-profile',
+      })
+    })
+
+    test('prefers --aws-profile over provider.profile', () => {
+      expect(
+        build(
+          { provider: { profile: 'svc-profile' } },
+          { 'aws-profile': 'cli-profile' },
+        ),
+      ).toEqual({ type: 'aws', profile: 'cli-profile' })
+    })
+
+    test('registers the provider under the default resolver name', () => {
+      build({ provider: {} })
+
+      expect(
+        manager.resolverProviders['default-aws-credential-resolver'],
+      ).toBeDefined()
     })
   })
 


### PR DESCRIPTION
## Summary

- Show the credential-setup hint when the implicit default AWS credential resolver cannot find any credentials:

  ```text
  ✖ AWS credentials missing or invalid. Run "serverless" to set up AWS credentials, or learn more in our docs: https://slss.io/aws-creds-setup. Original error from AWS: Could not load credentials from any providers
  ```

- Keep the hint off when a profile is configured through `provider.profile` or `--aws-profile`. In that case the user has already chosen where credentials come from, so the message stays focused on the original AWS error and the profile itself rather than on first-time setup. Explicit `type: aws` resolvers declared under `stages.*.resolvers` are unaffected.
- Add unit coverage for the credentials wrapper (`isDefaultConfig` true and false), the `Aws` provider's `isDefaultConfig` computation, and the config the resolver manager hands to the default provider.

## Root cause

`ResolverManager.addDefaultAwsCredentialResolver()` built the default provider config as `{ type: 'aws', profile: <--aws-profile or provider.profile> }`. When neither was set, `profile` was still present as a key with value `undefined`, so the `Aws` provider's `isDefaultConfig` check (`Object.keys(config)` contains anything other than `type`) always evaluated to false and the hint branch in `getAwsCredentials` was never reached. The key is now omitted when no profile is configured.

The credential chain receives identical input in both shapes (`config?.profile` is `undefined` either way), and the provider config walker only acts on object values, so nothing beyond the message suffix changes.

## Test plan

- [x] `npm run test:unit -w packages/sf-core`: 74 suites, 1076 tests pass
- [x] New manager test fails on `main` (`profile` key present as `undefined`) and passes with the fix
- [x] `serverless package` from source with no credentials available (`AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` pointing at missing files, `AWS_EC2_METADATA_DISABLED=true`, no env keys, no `AWS_PROFILE`) prints the hint; the same command on `main` and on the released 4.41.1 prints the error without it
- [x] Same command with `--aws-profile does-not-exist` prints the error without the hint
- [x] `npm run lint` and `npm run prettier` clean

## How to test

From a minimal service directory with no credentials available:

```bash
env -u AWS_PROFILE -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN \
  AWS_SHARED_CREDENTIALS_FILE=/nonexistent/credentials AWS_CONFIG_FILE=/nonexistent/config \
  AWS_EC2_METADATA_DISABLED=true serverless package
```

The error now ends with the setup hint. Add `--aws-profile does-not-exist` and the hint is omitted, leaving the original AWS error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS credential error guidance when no profile is configured, including setup instructions and documentation links.
  * Ensured configured AWS profiles are handled correctly, with command-line profile settings taking precedence over provider configuration.

* **Tests**
  * Added coverage for AWS resolver defaults, profile and region overrides, and credential error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->