### PR TITLE
test(esbuild): use native paths and file URLs in non-bundled build tests

### DIFF
--- a/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-build.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/nobundle-build.test.js
@@ -21,6 +21,7 @@ import { execFileSync, spawnSync } from 'child_process'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
+import { pathToFileURL } from 'url'
 import JsZip from 'jszip'
 import { log } from '@serverless/util'
 
@@ -111,7 +112,7 @@ const readIn = (serviceDir, rel) =>
  * extension or format produces, and it produces it at invocation time.
  */
 function loadBuiltHandler(serviceDir, rel, exportName) {
-  const target = path.join(buildDirOf(serviceDir), rel)
+  const target = pathToFileURL(path.join(buildDirOf(serviceDir), rel)).href
   const script =
     `import(${JSON.stringify(target)})` +
     `.then((m) => (m.${exportName} ?? m.default?.${exportName})())` +

--- a/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
+++ b/packages/serverless/test/unit/lib/plugins/esbuild/project-sweep.test.js
@@ -814,9 +814,8 @@ describe('applyTsconfigCompileFilter', () => {
       // Nothing is dropped: an unreadable config the user never pointed us at
       // must not be able to strip files out of the artifact.
       expect(result.compile).toEqual(['src/a.ts', 'scripts/seed.ts'])
-      expect(result.warning).toContain(
-        path.join(dir, 'tsconfig.json').replace(/\\/g, '/'),
-      )
+      // This warning names the anchor the sweep built itself, in native form.
+      expect(result.warning).toContain(path.join(dir, 'tsconfig.json'))
       expect(result.warning).toContain('@tsconfig/node20')
       expect(result.warning).toContain('build.esbuild.tsconfig')
     })


### PR DESCRIPTION
## Summary

- `project-sweep.test.js`: the "tsconfig cannot be resolved" case compares the warning against the tsconfig path in its native form. The warning interpolates the path the sweep built with `path.join`, so the expectation now uses the same form instead of a forward-slash-normalized copy. The neighbouring case that checks a path reported by `get-tsconfig` keeps its normalization, since that library reports POSIX-separated paths on every platform.
- `nobundle-build.test.js`: the `loadBuiltHandler` helper runs a built handler in a child Node process through a dynamic `import()`. It now passes a `file://` URL built with `pathToFileURL` rather than a bare absolute path, which is the form the ESM loader accepts on every platform.

No product code changes.

## Test plan

- [x] `project-sweep.test.js` and `nobundle-build.test.js`: 181 tests passing locally.
- [x] `eslint` and `prettier` clean on both files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation for loading built handlers across environments using standard file URLs.
  - Updated project-sweep coverage to verify TypeScript configuration paths in their native platform format.
  - Strengthened cross-platform test reliability for build and configuration diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->