### PR TITLE
fix(resolvers): name AWS APIs without the bundler's class-name suffix

### DIFF
--- a/packages/sf-core/src/lib/resolvers/providers/aws/clients.js
+++ b/packages/sf-core/src/lib/resolvers/providers/aws/clients.js
@@ -162,7 +162,10 @@ export const createClient = ({ service, credentials, region }) => {
   return client
 }
 
-const apiNameOf = (command) => command.constructor.name.replace(/Command$/, '')
+// The bundled build renames duplicate class names with a numeric suffix
+// (`DescribeStacksCommand7`), so strip the suffix along with `Command`.
+const apiNameOf = (command) =>
+  command.constructor.name.replace(/Command\d*$/, '')
 
 const counterFor = (service, api, scope, region) => {
   const key = `${service}:${api}:${scope}`

--- a/packages/sf-core/tests/unit/resolvers/aws-requests.test.js
+++ b/packages/sf-core/tests/unit/resolvers/aws-requests.test.js
@@ -250,6 +250,24 @@ describe('sendAwsRequest', () => {
     )
   })
 
+  test('the API name drops the numeric suffix the bundler appends to duplicate class names', async () => {
+    // esbuild emits the SDK's command classes as e.g. `DescribeStacksCommand7`
+    // in the release bundle; the API must still read `DescribeStacks`.
+    class DescribeStacksCommand7 extends DescribeStacksCommand {}
+    resetAwsResolverState({
+      requestHandler: fakeHandler([
+        ok(describeStacksXml('stack-a', [['OutA', 'a-one']])),
+      ]),
+    })
+    await describeStack({
+      command: new DescribeStacksCommand7({ StackName: 'stack-a' }),
+    })
+    logAwsResolverSummary(logger)
+    expect(logger.debug).toHaveBeenCalledWith(
+      'cf: 1 placeholders, 1 stacks, 1 DescribeStacks calls, 0 throttled attempts',
+    )
+  })
+
   test('a request that fails after an invalidation does not evict the entry cached since', async () => {
     const handler = handlerHoldingFirstRequest()
     resetAwsResolverState({ requestHandler: handler })


### PR DESCRIPTION
## Summary

The AWS variable resolvers' request layer names the API it is calling from the command's class name (`command.constructor.name` minus the `Command` suffix). In the released bundle, esbuild renames classes that share a name across the bundled SDK clients with a numeric suffix, so users see `DescribeStacksCommand7`, `GetCallerIdentityCommand5` or `GetObjectCommand3` instead of `DescribeStacks` / `GetCallerIdentity` / `GetObject` in:

- the `--verbose` retry lines (`DescribeStacksCommand7 throttled (Throttling: Rate exceeded), retrying (attempt 2 of 10)`),
- the `--debug` request summary (`cf: 12 placeholders, 2 stacks, 2 DescribeStacksCommand7 calls, 0 throttled attempts`),
- the `RESOLVER_AWS_RATE_EXCEEDED` error text (three times in one sentence).

Unit and integration tests run unbundled and never see the suffix, which is why this only surfaced while validating the release build.

## Fix

Strip a trailing numeric suffix together with `Command` when deriving the API name (`/Command\d*$/`). API names that legitimately end in a digit before `Command` (e.g. `ListObjectsV2`) are unaffected.

## Test plan

- [x] New unit test: a command subclass named `DescribeStacksCommand7` is reported as `1 DescribeStacks calls` in the request summary — fails on `main`, passes with the fix.
- [x] `tests/unit/resolvers/aws-requests.test.js` + `aws-clients.test.js`: 37/37.
- [x] Reproduced on the release build before the fix: `serverless print --debug` on a service with 12 `${cf:}` references printed `2 DescribeStacksCommand7 calls`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected AWS API naming when bundled command names include numeric suffixes, ensuring names such as `DescribeStacks` remain accurate.

- **Tests**
  - Added regression coverage for AWS command names modified during bundling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->