### PR TITLE
fix(appsync): paginate API keys when gathering service info

### DIFF
--- a/packages/serverless/lib/plugins/aws/appsync/index.js
+++ b/packages/serverless/lib/plugins/aws/appsync/index.js
@@ -347,16 +347,26 @@ class ServerlessAppsyncPlugin {
       })
     })
 
-    const { apiKeys } = await this.provider.request('AppSync', 'listApiKeys', {
-      apiId: apiId,
-    })
+    let nextToken
+    do {
+      const params = { apiId }
+      if (nextToken) params.nextToken = nextToken
 
-    apiKeys?.forEach((apiKey) => {
-      this.gatheredData.apiKeys.push({
-        value: apiKey.id || 'unknown key',
-        description: apiKey.description,
+      const response = await this.provider.request(
+        'AppSync',
+        'listApiKeys',
+        params,
+      )
+
+      response.apiKeys?.forEach((apiKey) => {
+        this.gatheredData.apiKeys.push({
+          value: apiKey.id || 'unknown key',
+          description: apiKey.description,
+        })
       })
-    })
+
+      nextToken = response.nextToken
+    } while (nextToken)
   }
 
   async getIntrospection() {

--- a/packages/serverless/test/unit/lib/plugins/aws/appsync/index.test.js
+++ b/packages/serverless/test/unit/lib/plugins/aws/appsync/index.test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals'
 import * as given from './given.js'
 
 const plugin = given.plugin()
@@ -77,5 +78,39 @@ describe('variable', () => {
         },
       }
     `)
+  })
+})
+
+describe('gatherData', () => {
+  it('paginates API keys', async () => {
+    const appsyncPlugin = given.plugin()
+    appsyncPlugin.getApiIdFromStack = jest.fn().mockResolvedValue('api-id')
+    appsyncPlugin.provider.request = jest
+      .fn()
+      .mockResolvedValueOnce({ graphqlApi: {} })
+      .mockResolvedValueOnce({
+        apiKeys: [{ id: 'key-1' }],
+        nextToken: 'page-2',
+      })
+      .mockResolvedValueOnce({ apiKeys: [{ id: 'key-2' }] })
+
+    await appsyncPlugin.gatherData()
+
+    expect(appsyncPlugin.gatheredData.apiKeys).toEqual([
+      { value: 'key-1', description: undefined },
+      { value: 'key-2', description: undefined },
+    ])
+    expect(appsyncPlugin.provider.request).toHaveBeenNthCalledWith(
+      2,
+      'AppSync',
+      'listApiKeys',
+      { apiId: 'api-id' },
+    )
+    expect(appsyncPlugin.provider.request).toHaveBeenNthCalledWith(
+      3,
+      'AppSync',
+      'listApiKeys',
+      { apiId: 'api-id', nextToken: 'page-2' },
+    )
   })
 })


### PR DESCRIPTION
<!-- ⚠️⚠️ Acknowledge ALL below remarks -->
<!-- ⚠️⚠️ PR will not be processed if it doesn't meet outlined criteria -->

<!-- ⚠️⚠️ Do not propose PR's without prior agreement on a solution in the corresponding issue -->
<!-- ⚠️⚠️ Only documentation updates and obvious bug fixes are welcome without it -->

## Summary

AppSync's `ListApiKeys` API is paginated, but the AppSync `gatherData()` implementation only requested the first page of API keys.

When an API has more API keys than fit in one response, `serverless info` silently omitted the remaining keys because it did not read or use the response `nextToken`.

This change continues requesting pages until `nextToken` is empty, ensuring that all API keys are included in the gathered service information.

## Changes

- Paginate `AppSync.listApiKeys` requests using `nextToken`.
- Preserve the existing API key output format.
- Add a unit test covering multiple API key pages.

## Testing

- `npm run test:unit -w @serverless/framework`
- `npm run prettier --workspace @serverless/framework -- lib/plugins/aws/appsync/index.js test/unit/lib/plugins/aws/appsync/index.test.js`
- `npm run lint --workspace @serverless/framework -- lib/plugins/aws/appsync/index.js test/unit/lib/plugins/aws/appsync/index.test.js`

All checks pass.

This is an obvious bug fix and does not require a corresponding issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - AppSync deployments now retrieve all API keys across multiple result pages, preventing keys beyond the first page from being omitted.
  - Existing API and API key output remains unchanged aside from improved completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->