### PR TITLE
chore: gitignore local agent-tooling and Terraform working directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,12 @@
 
 # Snyk Security Extension - AI Rules (auto-generated)
 .agent/rules/snyk_rules.md
+
+# Local AI-agent tooling directories
+.claude/
+.superpowers/
+.cursor/
+.codex/
+
+# Terraform working directories left behind by the Terraform resolver integration tests
+**/.terraform/


### PR DESCRIPTION
## Summary

- Add local AI-agent tooling directories (`.claude/`, `.superpowers/`, `.cursor/`, `.codex/`) to the repository `.gitignore`
- Add `**/.terraform/` for the working directories the Terraform resolver integration tests leave behind

`npm run prettier` (`prettier -c .`) fails in checkouts that contain any of these directories. Prettier 3 skips paths listed in the repository root `.gitignore` and `.prettierignore`, but not paths ignored only through a per-machine global excludes file or a nested `.gitignore`. So a checkout with a `.claude/` tree, or one where the Terraform integration test has run, gets format-checked on files the project does not own, while CI on a clean clone passes.

Listing them in the root `.gitignore` fixes both consumers at once: Prettier stops reaching them, and `git status` stays clean for contributors without a global excludes file. The Terraform entry is redundant for git (a nested `.gitignore` already covers it) but is the only way to make the root-level Prettier run skip it.

None of the affected paths are tracked today, so no existing file changes ignore status.

## Test plan

In a checkout with a `.claude/` tree and a `.terraform/` directory from the Terraform integration test:

- [x] `npx prettier -c .` on `main`: fails on 36 files under `.claude/` plus `terraform.tfstate`
- [x] `npx prettier -c .` on this branch: `All matched files use Prettier code style!`
- [x] `git ls-files -ci --exclude-standard` reports no tracked file newly ignored by these rules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project file exclusion rules to prevent local AI tooling and Terraform working files from appearing in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->