### PR TITLE
fix(resolvers): fail fast on variables that resolve back to themselves

### DIFF
--- a/packages/sf-core/src/lib/resolvers/manager.js
+++ b/packages/sf-core/src/lib/resolvers/manager.js
@@ -26,6 +26,9 @@ const { Graph } = graphlib
 
 export const DEFAULT_AWS_CREDENTIAL_RESOLVER = 'default-aws-credential-resolver'
 const STATE_RESOLVER = 'default-state-resolver'
+// Backstop for dynamic expansion chains that keep producing new placeholder
+// text without ever repeating exactly. Real configs nest a handful of levels.
+const MAX_DYNAMIC_EXPANSION_DEPTH = 50
 
 /**
  * Whether a registry provider type is compose-only (the `service` provider and
@@ -1158,6 +1161,7 @@ export class ResolverManager {
     selectedProviders,
     selectedPaths,
   ) {
+    this.#throwIfExpansionRepeats(nodeLabel)
     const {
       path,
       original,
@@ -1366,6 +1370,7 @@ export class ResolverManager {
       )
 
       if (newNodeIds.length > 0) {
+        this.#recordExpansionLineage(nodeLabel, newNodeIds, path)
         throwIfCyclesFound(this.placeholdersGraph)
       }
 
@@ -1397,6 +1402,65 @@ export class ResolverManager {
       return addedNodeIds
     }
     return []
+  }
+
+  /**
+   * Guard the dynamic-expansion path against non-terminating chains.
+   *
+   * A resolved value that contains placeholders spawns NEW graph nodes (fresh
+   * ids, no edge back to the node that produced them — that node is removed
+   * from the graph once handled), so `throwIfCyclesFound`, which works on
+   * edges, cannot see a chain such as `${param:X}` → "${param:X}" → … Each
+   * spawned node therefore carries the `original` texts of the chain that led
+   * to it. A spawned node whose text already appears in that chain would be
+   * handed the same input as before and produce the same value again, so it
+   * is reported as a cyclic reference instead of being expanded forever.
+   *
+   * @param {NodeLabel} nodeLabel - The node whose resolved value spawned the new nodes.
+   * @param {string[]} newNodeIds - Ids of the spawned nodes (in `placeholdersGraph`).
+   * @param {string[]} path - Config path the chain lives at (for the message).
+   */
+  #recordExpansionLineage(nodeLabel, newNodeIds, path) {
+    const lineage = [...(nodeLabel.lineage ?? []), nodeLabel.original]
+    if (lineage.length > MAX_DYNAMIC_EXPANSION_DEPTH) {
+      throw new ServerlessError(
+        `Variable expansion exceeded ${MAX_DYNAMIC_EXPANSION_DEPTH} nested levels at '${path?.join('.')}': ... -> ${lineage.slice(-3).join(' -> ')}`,
+        ServerlessErrorCodes.resolvers.RESOLVER_CYCLIC_REFERENCE,
+      )
+    }
+    for (const id of newNodeIds) {
+      const label = this.placeholdersGraph.node(id)
+      if (label) label.lineage = lineage
+    }
+  }
+
+  /**
+   * Fail a spawned node whose (fully substituted) text already occurred in
+   * the chain that spawned it. Runs when the node is about to resolve, i.e.
+   * after its own nested placeholders have been substituted into `original`,
+   * so the comparison is between like forms: the chain entries were recorded
+   * at their resolution time in the same substituted form.
+   *
+   * A repeat proves a loop, not merely suggests one, because
+   * `createResolverFunc` (providers.js) memoizes every resolver result per
+   * key and params for the whole run: the second evaluation of identical text
+   * is served from that cache and cannot answer differently — this holds for
+   * `param` and `self`, which read the live config, and for `${file(x.js)}`
+   * function exports alike. If that memoization ever allows mid-run eviction,
+   * this reasoning needs to be revisited.
+   *
+   * @param {NodeLabel} nodeLabel - The node about to be resolved.
+   */
+  #throwIfExpansionRepeats(nodeLabel) {
+    const { lineage, original, path } = nodeLabel
+    if (!lineage?.length) return
+    const repeatIndex = lineage.indexOf(original)
+    if (repeatIndex === -1) return
+    const chain = [...lineage.slice(repeatIndex), original]
+    throw new ServerlessError(
+      `Cyclic reference found: ${chain.join(' -> ')} at '${path?.join('.')}'`,
+      ServerlessErrorCodes.resolvers.RESOLVER_CYCLIC_REFERENCE,
+    )
   }
 
   /**

--- a/packages/sf-core/src/lib/resolvers/providers.js
+++ b/packages/sf-core/src/lib/resolvers/providers.js
@@ -147,6 +147,13 @@ export function createResolverFunc(
   resolverName,
   resolverConfig = null,
 ) {
+  // Per-run memoization by key and params. Besides de-duplicating reads, this
+  // is load-bearing for cycle detection: `ResolverManager`'s
+  // `#throwIfExpansionRepeats` treats a placeholder text that recurs while a
+  // value is being expanded as a proven loop, because the repeated evaluation
+  // is served from here and cannot answer differently. If entries can ever be
+  // evicted mid-run, a repeated placeholder may legitimately resolve
+  // differently and that check needs re-examining.
   const cache = new Map()
   return async (key, params) => {
     const cacheKey = `${key}#${JSON.stringify(params)}`

--- a/packages/sf-core/tests/resolvers/router.test.js
+++ b/packages/sf-core/tests/resolvers/router.test.js
@@ -152,6 +152,11 @@ describe('resolve variables and parameters', () => {
         'Cyclic reference found: ${self:custom.name1} -> ${self:custom.name3} -> ${self:custom.name2}',
       )
     })
+    it('parameter that resolves to itself', async () => {
+      await expect(runTest(path.join(dirPath, 'param-cycle'))).rejects.toThrow(
+        "Cyclic reference found: ${param:WAF_NAME, ''} -> ${param:WAF_NAME, ''} at 'stages.default.params.WAF_NAME'",
+      )
+    })
   })
 
   describe('env', () => {

--- a/packages/sf-core/tests/resolvers/validate/param-cycle/serverless.yml
+++ b/packages/sf-core/tests/resolvers/validate/param-cycle/serverless.yml
@@ -1,0 +1,13 @@
+org: serverlesstestaccount
+service: resolvers-validate-param-cycle
+
+# A parameter defined in serverless.yml shadows a Dashboard parameter of the
+# same name, so this value refers to itself.
+stages:
+  default:
+    params:
+      WAF_NAME: ${param:WAF_NAME, ''}
+
+functions:
+  hello:
+    handler: handler.hello

--- a/packages/sf-core/tests/unit/lib/resolvers/expansion-cycle.test.js
+++ b/packages/sf-core/tests/unit/lib/resolvers/expansion-cycle.test.js
@@ -1,0 +1,259 @@
+import { jest } from '@jest/globals'
+import path from 'path'
+import url from 'url'
+import { ResolverManager } from '../../../../src/lib/resolvers/manager.js'
+import { ServerlessErrorCodes } from '@serverless/util'
+
+/**
+ * Cycles that only appear while a value is being expanded.
+ *
+ * The up-front graph check finds cycles between placeholders that reference
+ * each other statically (`${self:...}`). A value that RESOLVES to text
+ * containing a placeholder spawns new graph nodes instead, and a chain of
+ * such expansions that leads back to itself has no edges for that check to
+ * see. Without a guard the manager expands forever.
+ *
+ * A regression here manifests as a hang, not a failure: the expansion loop is
+ * microtask-only, so Jest's own timeout never fires. Run under an external
+ * timeout when in doubt.
+ *
+ * Real registry, real providers, no module mocking.
+ */
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
+const fixturesDir = path.join(__dirname, 'fixtures', 'expansion-cycle')
+
+const buildLogger = () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  notice: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+})
+
+const resolveConfig = async (serviceConfigFile, options = { stage: 'dev' }) => {
+  const manager = new ResolverManager(
+    buildLogger(),
+    serviceConfigFile,
+    fixturesDir,
+    options,
+    null,
+    null,
+    null,
+    false,
+    '4.0.0',
+    { isComposeConfigFile: false },
+  )
+  await manager.loadPlaceholders()
+  await manager.resolveConfigFile({ printResolvedVariables: false })
+  return serviceConfigFile
+}
+
+const cyclic = (chainPattern, atPath) =>
+  expect.objectContaining({
+    code: ServerlessErrorCodes.resolvers.RESOLVER_CYCLIC_REFERENCE,
+    message: expect.stringMatching(
+      new RegExp(`Cyclic reference found: ${chainPattern} at '${atPath}'`),
+    ),
+  })
+
+const PARAM = (key) => `\\$\\{param:${key}\\}`
+
+describe('cycles that appear during value expansion', () => {
+  afterEach(() => {
+    delete process.env.EXPANSION_CYCLE_TEST_FLIPPED
+    delete process.env.EXPANSION_CYCLE_TEST_ENV
+  })
+
+  test('a parameter that references itself fails with a cyclic-reference error', async () => {
+    const config = {
+      stages: { default: { params: { WAF: "${param:WAF, ''}" } } },
+      custom: { waf: '${param:WAF}' },
+    }
+
+    await expect(resolveConfig(config)).rejects.toEqual(
+      cyclic(
+        "\\$\\{param:WAF, ''\\} -> \\$\\{param:WAF, ''\\}",
+        'stages.default.params.WAF',
+      ),
+    )
+  })
+
+  test('two parameters that reference each other fail with the chain named', async () => {
+    const config = {
+      stages: { default: { params: { A: '${param:B}', B: '${param:A}' } } },
+      custom: { a: '${param:A}' },
+    }
+
+    await expect(resolveConfig(config)).rejects.toEqual(
+      cyclic(
+        `${PARAM('[AB]')} -> ${PARAM('[AB]')} -> ${PARAM('[AB]')}`,
+        'stages.default.params.[AB]',
+      ),
+    )
+  })
+
+  test('a self-reference through a nested key is compared in substituted form', async () => {
+    // On stage "dev" the inner ${sls:stage} makes the key "devName" — the
+    // parameter being defined.
+    const config = {
+      stages: { default: { params: { devName: '${param:${sls:stage}Name}' } } },
+      custom: { x: '${param:devName}' },
+    }
+
+    await expect(resolveConfig(config)).rejects.toEqual(
+      cyclic(
+        `${PARAM('devName')} -> ${PARAM('devName')}`,
+        'stages.default.params.devName',
+      ),
+    )
+  })
+
+  test('a resolver function answering with its own placeholder is a cycle, not a retry', async () => {
+    // The function would answer "done" on a second call, but resolver results
+    // are memoized per key for the run, so a repeated text is served from
+    // cache and the second call never happens.
+    const config = { custom: { b: '${file(flip.mjs):v}' } }
+
+    await expect(resolveConfig(config)).rejects.toEqual(
+      cyclic(
+        '\\$\\{file\\(flip\\.mjs\\):v\\} -> \\$\\{file\\(flip\\.mjs\\):v\\}',
+        'custom.b',
+      ),
+    )
+  })
+
+  test('a chain deeper than the expansion limit fails instead of running unbounded', async () => {
+    const params = {}
+    for (let i = 1; i <= 60; i++) params[`p${i}`] = `\${param:p${i + 1}}`
+    params.p61 = 'end'
+    const config = {
+      stages: { default: { params } },
+      custom: { x: '${param:p1}' },
+    }
+
+    await expect(resolveConfig(config)).rejects.toEqual(
+      expect.objectContaining({
+        code: ServerlessErrorCodes.resolvers.RESOLVER_CYCLIC_REFERENCE,
+        message: expect.stringContaining('exceeded 50 nested levels'),
+      }),
+    )
+  })
+})
+
+describe('valid expansions keep resolving', () => {
+  afterEach(() => {
+    delete process.env.EXPANSION_CYCLE_TEST_ENV
+  })
+
+  const validParams = () => ({
+    chainA: '${param:chainB}',
+    chainB: '${param:chainC}',
+    chainC: 'c-value',
+    twice: '${param:chainC}-${param:chainC}',
+    devName: 'dev-name',
+    prodName: 'prod-name',
+    byStage: '${param:${sls:stage}Name}',
+    viaSelf: '${self:custom.plain}',
+    viaEnv: '${env:EXPANSION_CYCLE_TEST_ENV}',
+    fromFile: '${file(cfg.yml):derived}',
+    fileObj: '${file(cfg.yml)}',
+    inherit: "${param:inherit, 'default-layer'}",
+  })
+
+  const validCustom = () => ({
+    plain: 'plain-value',
+    a: '${param:chainA}',
+    b: '${param:twice}',
+    c: '${param:byStage}',
+    d: '${param:viaSelf}',
+    e: '${param:viaEnv}',
+    f: '${param:fromFile}',
+    g: '${param:fileObj}',
+    h: '${param:inherit}',
+    i: '${self:custom.a}/${param:chainB}',
+    j: '${file(cfg.yml):viaParam}',
+  })
+
+  const expectedCustom = (stageName, inherit) => ({
+    plain: 'plain-value',
+    a: 'c-value',
+    b: 'c-value-c-value',
+    c: `${stageName}-name`,
+    d: 'plain-value',
+    e: 'env-says-c-value',
+    f: 'from-file-derived',
+    g: {
+      base: 'from-file',
+      derived: 'from-file-derived',
+      viaParam: 'c-value',
+      nested: { deep: 'from-file/plain-value' },
+    },
+    h: inherit,
+    i: 'c-value/c-value',
+    j: 'c-value',
+  })
+
+  test('every dynamic-expansion shape resolves when a stage layer shadows the self-reference', async () => {
+    process.env.EXPANSION_CYCLE_TEST_ENV = 'env-says-${param:chainC}'
+    const config = {
+      stages: {
+        default: { params: validParams() },
+        prod: { params: { inherit: 'prod-layer' } },
+      },
+      custom: validCustom(),
+    }
+
+    const resolved = await resolveConfig(config, { stage: 'prod' })
+
+    expect(resolved.custom).toEqual(expectedCustom('prod', 'prod-layer'))
+  })
+
+  test('every dynamic-expansion shape resolves when a --param shadows the self-reference', async () => {
+    process.env.EXPANSION_CYCLE_TEST_ENV = 'env-says-${param:chainC}'
+    const config = {
+      stages: { default: { params: validParams() } },
+      custom: validCustom(),
+    }
+
+    const resolved = await resolveConfig(config, {
+      stage: 'dev',
+      param: ['inherit=cli-layer'],
+    })
+
+    expect(resolved.custom).toEqual(expectedCustom('dev', 'cli-layer'))
+  })
+
+  test('a long but finite parameter chain resolves', async () => {
+    const params = {}
+    for (let i = 1; i <= 10; i++) params[`p${i}`] = `\${param:p${i + 1}}`
+    params.p11 = 'end'
+    const config = {
+      stages: { default: { params } },
+      custom: { x: '${param:p1}' },
+    }
+
+    const resolved = await resolveConfig(config)
+
+    expect(resolved.custom.x).toBe('end')
+  })
+
+  test('the correct shape for "Dashboard value or empty" resolves to the fallback', async () => {
+    const config = {
+      stages: { default: { params: { wafName: "${param:WAF_NAME, ''}" } } },
+      provider: {
+        environment: {
+          WAF: '${param:wafName}',
+          WAF_DIRECT: "${param:WAF_NAME, 'none'}",
+        },
+      },
+    }
+
+    const resolved = await resolveConfig(config)
+
+    expect(resolved.provider.environment).toEqual({
+      WAF: '',
+      WAF_DIRECT: 'none',
+    })
+  })
+})

--- a/packages/sf-core/tests/unit/lib/resolvers/expansion-cycle.test.js
+++ b/packages/sf-core/tests/unit/lib/resolvers/expansion-cycle.test.js
@@ -79,18 +79,29 @@ describe('cycles that appear during value expansion', () => {
     )
   })
 
-  test('two parameters that reference each other fail with the chain named', async () => {
+  test('two parameters that reference each other fail with the alternating chain named', async () => {
     const config = {
       stages: { default: { params: { A: '${param:B}', B: '${param:A}' } } },
-      custom: { a: '${param:A}' },
     }
 
-    await expect(resolveConfig(config)).rejects.toEqual(
-      cyclic(
-        `${PARAM('[AB]')} -> ${PARAM('[AB]')} -> ${PARAM('[AB]')}`,
-        'stages.default.params.[AB]',
-      ),
+    // Both definitions expand concurrently and whichever reaches the repeat
+    // first reports it, so either consistent chain/path pair is correct — but
+    // the chain must alternate and be reported at the definition it started
+    // from. A self-cycle shape (A -> A -> A) must not satisfy this test.
+    const error = await resolveConfig(config).then(
+      () => {
+        throw new Error('expected resolution to fail')
+      },
+      (e) => e,
     )
+
+    expect(error.code).toBe(
+      ServerlessErrorCodes.resolvers.RESOLVER_CYCLIC_REFERENCE,
+    )
+    expect([
+      "Cyclic reference found: ${param:B} -> ${param:A} -> ${param:B} at 'stages.default.params.A'",
+      "Cyclic reference found: ${param:A} -> ${param:B} -> ${param:A} at 'stages.default.params.B'",
+    ]).toContain(error.message)
   })
 
   test('a self-reference through a nested key is compared in substituted form', async () => {

--- a/packages/sf-core/tests/unit/lib/resolvers/fixtures/expansion-cycle/cfg.yml
+++ b/packages/sf-core/tests/unit/lib/resolvers/fixtures/expansion-cycle/cfg.yml
@@ -1,0 +1,5 @@
+base: from-file
+derived: ${file(cfg.yml):base}-derived
+viaParam: ${param:chainC}
+nested:
+  deep: ${file(cfg.yml):base}/${self:custom.plain}

--- a/packages/sf-core/tests/unit/lib/resolvers/fixtures/expansion-cycle/flip.mjs
+++ b/packages/sf-core/tests/unit/lib/resolvers/fixtures/expansion-cycle/flip.mjs
@@ -1,0 +1,9 @@
+// A resolver function whose first call answers with its own placeholder text
+// and every later call with a literal. State lives outside the module so it
+// survives any re-import. Used to prove that a repeated placeholder text is
+// served from the resolver cache and never re-evaluates the function.
+export const v = () => {
+  if (process.env.EXPANSION_CYCLE_TEST_FLIPPED) return 'done'
+  process.env.EXPANSION_CYCLE_TEST_FLIPPED = '1'
+  return '${file(flip.mjs):v}'
+}


### PR DESCRIPTION
No corresponding GitHub issue: bug fix for a variable-resolution hang (a parameter looking itself up never finished resolving).

## Summary

- A variable whose value expands back to itself now fails immediately with a cyclic-reference error instead of resolving forever. The common shape is a parameter defined in `serverless.yml` that looks itself up with a fallback, for example `stages.default.params.NAME: ${param:NAME, ''}`: a parameter defined in `serverless.yml` takes precedence over a Dashboard parameter of the same name, so the lookup finds the definition itself. Two parameters referencing each other, and any other variable whose resolved value leads back to its own text, are handled the same way.
- The error names the chain and the location, e.g. `Cyclic reference found: ${param:NAME, ''} -> ${param:NAME, ''} at 'stages.default.params.NAME'`, using the existing `RESOLVER_CYCLIC_REFERENCE` code.
- A depth cap of 50 nested dynamic expansions backs the check up, so a chain that grows without repeating still ends in an error rather than exhausting memory.
- Configurations that resolve today are unchanged, including a self-referencing default that a stage-level parameter or `--param` overrides.

## Root cause

The resolver checks the placeholder graph for cycles before resolving, but that check works on graph edges. When a resolved value itself contains placeholders, they are parsed and added as new nodes with fresh ids and no edge back to the node that produced them (which is removed from the graph once handled). A value that resolves to its own text therefore produces a fresh, edge-less node on every iteration; the cycle check finds nothing, and the loop runs at full CPU while the unresolved promise chain and the replacements list grow without bound. The process ends in a heap-limit crash or a CI timeout, with no output unless `--debug` is on.

The fix records, on every node spawned from a resolved value, the chain of placeholder texts that led to it, and fails the node if its own text (compared after its nested placeholders are substituted) already appears in that chain. A repeat is a proven loop, not a heuristic: `createResolverFunc` memoizes every resolver result per key for the run, so the second evaluation of identical text is served from cache and cannot answer differently. That dependency is documented at both ends.

## Test plan

- [x] New unit tests in `packages/sf-core/tests/unit/lib/resolvers/expansion-cycle.test.js` (real provider registry, no mocks): self-reference, mutual reference, self-reference through a nested `${sls:stage}` key, a JS resolver function returning its own placeholder, and the depth cap. All hang on the unmodified code (verified under an external timeout) and fail fast with the guard.
- [x] Compatibility pins in the same file: 3-deep parameter chains, the same placeholder twice in one string, nested stage keys, parameter → `self`, `env` values containing placeholders, `file` → same file, `file` returning an object with placeholders, a self-referencing default shadowed by `stages.prod.params` and by `--param`, and the recommended "Dashboard value or empty" shape. Identical output before and after.
- [x] Router fixture `packages/sf-core/tests/resolvers/validate/param-cycle` pinning the exact message, next to the existing static `validate/cycle` case.
- [x] `npm run test:unit -w packages/sf-core` (75 suites), `tests/resolvers` golden suite (84 passed, 16 env-gated skips), repo `npm run lint` and `npm run prettier` all green.
- [x] Source CLI `print` against reproduction services: the looping shapes fail in 1–3 s with the chain named; a valid 11-shape fixture prints byte-identical output on `main` and on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved variable resolution to detect self-referencing and mutually referencing placeholders.
  - Prevented non-terminating expansion chains by reporting a clear cyclic-reference error.
  - Added protection for cycles involving nested values, fallback expressions, and custom resolvers.
  - Preserved valid multi-step expansion, including file, environment, stage, and command-line parameter references.

- **Tests**
  - Added coverage for cyclic expansion scenarios, deep expansion chains, and valid resolution patterns.
  - Added validation coverage confirming self-referencing parameters return the expected cyclic-reference error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->